### PR TITLE
chore(deps): bump rand 0.9→0.10 and rand_distr 0.5→0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -394,6 +394,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -582,6 +593,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -1268,6 +1288,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.0",
  "wasip2",
  "wasip3",
 ]
@@ -2429,7 +2450,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "pensyve-core",
- "rand 0.9.2",
+ "rand 0.10.0",
  "rand_distr",
  "rayon",
  "reqwest 0.13.2",
@@ -2836,6 +2857,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2874,13 +2906,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_distr"
-version = "0.5.1"
+name = "rand_core"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+
+[[package]]
+name = "rand_distr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d431c2703ccf129de4d45253c03f49ebb22b97d6ad79ee3ecfc7e3f4862c1d8"
 dependencies = [
  "num-traits",
- "rand 0.9.2",
+ "rand 0.10.0",
 ]
 
 [[package]]
@@ -3484,7 +3522,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 

--- a/pensyve-benchmarks/Cargo.toml
+++ b/pensyve-benchmarks/Cargo.toml
@@ -8,8 +8,8 @@ description = "Evaluation framework for Pensyve memory engine"
 
 [dependencies]
 pensyve-core = { path = "../pensyve-core" }
-rand = "0.9"
-rand_distr = "0.5"
+rand = "0.10"
+rand_distr = "0.6"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 chrono = { version = "0.4", features = ["serde"] }

--- a/pensyve-benchmarks/src/corpus.rs
+++ b/pensyve-benchmarks/src/corpus.rs
@@ -1,7 +1,7 @@
-use rand::Rng;
+use rand::RngExt;
 use rand::SeedableRng;
 use rand::rngs::StdRng;
-use rand_distr::Normal;
+use rand_distr::{Distribution, Normal};
 use uuid::Uuid;
 
 /// Configuration for synthetic corpus generation.
@@ -92,7 +92,7 @@ pub fn generate_corpus(config: &CorpusConfig, seed: u64) -> SyntheticCorpus {
     let centroids: Vec<Vec<f32>> = (0..config.n_clusters)
         .map(|_| {
             let raw: Vec<f32> = (0..config.dimensions)
-                .map(|_| rng.sample(noise_centroid))
+                .map(|_| noise_centroid.sample(&mut rng))
                 .collect();
             normalize(&raw)
         })
@@ -109,7 +109,7 @@ pub fn generate_corpus(config: &CorpusConfig, seed: u64) -> SyntheticCorpus {
 
             let raw: Vec<f32> = centroids[cluster_idx]
                 .iter()
-                .map(|&c| c + rng.sample(noise_memory))
+                .map(|&c| c + noise_memory.sample(&mut rng))
                 .collect();
             let embedding = normalize(&raw);
 
@@ -135,7 +135,7 @@ pub fn generate_corpus(config: &CorpusConfig, seed: u64) -> SyntheticCorpus {
 
             let raw: Vec<f32> = centroids[cluster_idx]
                 .iter()
-                .map(|&c| c + rng.sample(noise_query))
+                .map(|&c| c + noise_query.sample(&mut rng))
                 .collect();
             let embedding = normalize(&raw);
 

--- a/pensyve-benchmarks/src/resilience.rs
+++ b/pensyve-benchmarks/src/resilience.rs
@@ -1,5 +1,7 @@
-use rand::prelude::*;
-use rand_distr::Normal;
+use rand::RngExt;
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+use rand_distr::{Distribution, Normal};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/pensyve-benchmarks/src/stats.rs
+++ b/pensyve-benchmarks/src/stats.rs
@@ -3,7 +3,7 @@
 //! Provides bootstrap confidence intervals, effect-size measures, hypothesis
 //! tests, multiple-testing correction, and power analysis.
 
-use rand::Rng;
+use rand::RngExt;
 use rand::SeedableRng;
 use rand::rngs::StdRng;
 


### PR DESCRIPTION
## Summary
- Bumps `rand` from 0.9.2 to 0.10.0 and `rand_distr` from 0.5.1 to 0.6.0
- Migrates API: `Rng` → `RngExt`, `rng.sample(dist)` → `dist.sample(&mut rng)`
- Supersedes Dependabot PRs #12 and #18 (must be bumped together)

## Test plan
- [x] 275 tests passing, 0 failures
- [x] clippy clean
- [x] All workspace crates compile