### PR TITLE
Security hardening: metrics, timeout, GDPR, input limits

### DIFF
--- a/pensyve-core/src/gdpr.rs
+++ b/pensyve-core/src/gdpr.rs
@@ -61,10 +61,12 @@ pub fn erase_entity(
         Err(e) => result.warnings.push(format!("Edge query error: {e}")),
     }
 
-    // Step 3: Delete entity record
-    // Note: The StorageTrait doesn't have delete_entity yet.
-    // For now, we track this as a warning.
-    result.entities_deleted = 1;
+    // Step 3: Delete entity record (not found is OK — entity may not exist)
+    match storage.delete_entity(entity_id) {
+        Ok(true) => result.entities_deleted = 1,
+        Ok(false) => {} // Entity record didn't exist — nothing to delete
+        Err(e) => result.warnings.push(format!("Entity deletion error: {e}")),
+    }
 
     result.complete = result.warnings.is_empty();
     Ok(result)

--- a/pensyve-core/src/retrieval.rs
+++ b/pensyve-core/src/retrieval.rs
@@ -243,6 +243,8 @@ pub enum RecallError {
     Reranker(#[from] crate::reranker::RerankerError),
     #[error("RRF error: {0}")]
     Rrf(#[from] crate::rrf::RrfError),
+    #[error("Recall timed out after {0} seconds")]
+    Timeout(u64),
 }
 
 // ---------------------------------------------------------------------------
@@ -390,6 +392,7 @@ impl<'a> RecallEngine<'a> {
         target_entity: Option<Uuid>,
     ) -> Result<RecallResult, RecallError> {
         let start = std::time::Instant::now();
+        let timeout = std::time::Duration::from_secs(self.config.recall_timeout_secs);
         let max_candidates = self.config.max_candidates;
 
         // Steps 1–4: embed, search, merge candidates.
@@ -401,6 +404,10 @@ impl<'a> RecallEngine<'a> {
 
         if candidates.is_empty() {
             return Ok(RecallResult { memories: vec![] });
+        }
+
+        if start.elapsed() > timeout {
+            return Err(RecallError::Timeout(self.config.recall_timeout_secs));
         }
 
         // Step 5: Normalize BM25 scores (positional rank).
@@ -519,6 +526,10 @@ impl<'a> RecallEngine<'a> {
         // at small corpus sizes (k=60 was designed for web-scale IR).
         let effective_k = rrf::adaptive_k(candidates.len(), self.config.rrf_k);
         let rrf_results = rrf::reciprocal_rank_fusion(&rankings, &rrf_weights, effective_k)?;
+
+        if start.elapsed() > timeout {
+            return Err(RecallError::Timeout(self.config.recall_timeout_secs));
+        }
 
         // Pre-compute max_access for access_score normalization.
         let max_access = candidates

--- a/pensyve-core/src/storage/mod.rs
+++ b/pensyve-core/src/storage/mod.rs
@@ -128,6 +128,9 @@ pub trait StorageTrait: Send + Sync {
         confidence: Option<f32>,
     ) -> StorageResult<()>;
 
+    /// Delete an entity record by its UUID. Returns true if the entity was found and deleted.
+    fn delete_entity(&self, id: Uuid) -> StorageResult<bool>;
+
     // Entities (bulk)
     fn list_entities_by_namespace(&self, namespace_id: Uuid) -> StorageResult<Vec<Entity>>;
 

--- a/pensyve-core/src/storage/postgres.rs
+++ b/pensyve-core/src/storage/postgres.rs
@@ -1140,6 +1140,18 @@ impl StorageTrait for PostgresBackend {
         })
     }
 
+    fn delete_entity(&self, id: Uuid) -> StorageResult<bool> {
+        self.block_on(async {
+            let mut conn = self.maybe_scoped_conn().await?;
+            let result = query::<Postgres>("DELETE FROM entities WHERE id = $1")
+                .bind(id)
+                .execute(&mut *conn)
+                .await
+                .map_err(sqlx_to_io)?;
+            Ok(result.rows_affected() > 0)
+        })
+    }
+
     // -----------------------------------------------------------------------
     // Edges
     // -----------------------------------------------------------------------

--- a/pensyve-core/src/storage/sqlite.rs
+++ b/pensyve-core/src/storage/sqlite.rs
@@ -1330,6 +1330,13 @@ impl StorageTrait for SqliteBackend {
         Ok(entities)
     }
 
+    fn delete_entity(&self, id: Uuid) -> StorageResult<bool> {
+        let conn = lock_conn!(self);
+        let id_str = id.to_string();
+        let rows = conn.execute("DELETE FROM entities WHERE id = ?1", params![&id_str])?;
+        Ok(rows > 0)
+    }
+
     // -----------------------------------------------------------------------
     // Edges
     // -----------------------------------------------------------------------

--- a/pensyve-mcp-gateway/src/main.rs
+++ b/pensyve-mcp-gateway/src/main.rs
@@ -231,6 +231,8 @@ async fn async_main(config: GatewayConfig, res: InitResources) -> Result<()> {
         .nest_service("/mcp", mcp_service)
         .merge(rest::router())
         .route("/health", axum::routing::get(health_handler))
+        .route("/ready", axum::routing::get(readiness_handler))
+        .route("/metrics", axum::routing::get(metrics_handler))
         .route(
             "/.well-known/oauth-protected-resource",
             axum::routing::get(oauth::oauth_protected_resource),
@@ -301,6 +303,31 @@ async fn async_main(config: GatewayConfig, res: InitResources) -> Result<()> {
 
 async fn health_handler() -> &'static str {
     "ok"
+}
+
+async fn readiness_handler(
+    axum::extract::State(state): axum::extract::State<Arc<AppState>>,
+) -> axum::response::Response {
+    let default_state = state.tenant_mgr.default_state();
+    match default_state.storage.count_entities_by_namespace(default_state.namespace.id) {
+        Ok(_) => axum::response::Response::builder()
+            .status(200)
+            .body(axum::body::Body::from("ready"))
+            .unwrap(),
+        Err(e) => axum::response::Response::builder()
+            .status(503)
+            .body(axum::body::Body::from(format!("not ready: {e}")))
+            .unwrap(),
+    }
+}
+
+async fn metrics_handler() -> axum::response::Response {
+    use axum::http::header;
+    let body = pensyve_core::observability::metrics().prometheus_text();
+    axum::response::Response::builder()
+        .header(header::CONTENT_TYPE, "text/plain; version=0.0.4; charset=utf-8")
+        .body(axum::body::Body::from(body))
+        .unwrap()
 }
 
 // Task-local to pass tenant ID from axum middleware to the rmcp service factory.

--- a/pensyve-mcp-tools/src/server.rs
+++ b/pensyve-mcp-tools/src/server.rs
@@ -82,6 +82,9 @@ impl PensyveMcpServer {
         description = "Search memories by semantic similarity and text matching. Returns ranked results from episodic, semantic, and procedural memory."
     )]
     async fn recall(&self, Parameters(params): Parameters<RecallParams>) -> Result<String, String> {
+        if params.query.len() > 4096 {
+            return Err("Query too long (max 4096 bytes)".to_string());
+        }
         if let Some(mc) = params.min_confidence
             && !(0.0..=1.0).contains(&mc)
         {
@@ -167,6 +170,12 @@ impl PensyveMcpServer {
         &self,
         Parameters(params): Parameters<RememberParams>,
     ) -> Result<String, String> {
+        if params.fact.len() > 32768 {
+            return Err("Fact too long (max 32768 bytes)".to_string());
+        }
+        if params.entity.len() > 256 {
+            return Err("Entity name too long (max 256 bytes)".to_string());
+        }
         let state = &self.state;
         let confidence = params.confidence.unwrap_or(1.0) as f32;
 

--- a/pensyve-mcp/src/main.rs
+++ b/pensyve-mcp/src/main.rs
@@ -108,10 +108,16 @@ async fn main() -> Result<()> {
                     e
                 }
                 Err(mini_err) => {
-                    tracing::warn!(
-                        "ONNX embedders unavailable ({mini_err}), falling back to mock (768 dims)"
-                    );
-                    OnnxEmbedder::new_mock(768)
+                    if std::env::var("PENSYVE_ALLOW_MOCK_EMBEDDER").is_ok() {
+                        tracing::warn!(
+                            "ONNX embedders unavailable ({mini_err}), falling back to mock (768 dims)"
+                        );
+                        OnnxEmbedder::new_mock(768)
+                    } else {
+                        return Err(anyhow::anyhow!(
+                            "No ONNX model available. Set PENSYVE_ALLOW_MOCK_EMBEDDER=1 to use mock. Error: {mini_err}"
+                        ));
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- `/metrics` endpoint exposing Prometheus counters/histograms
- `/ready` endpoint with DB connectivity check for ALB health
- `recall_timeout_secs` enforced via `RecallError::Timeout` at two checkpoints in retrieval pipeline
- Mock embedder fallback in local MCP now requires `PENSYVE_ALLOW_MOCK_EMBEDDER` env var (matches gateway)
- `delete_entity` added to `StorageTrait` + SQLite/Postgres impls for complete GDPR entity erasure
- Input length limits on MCP tools: 4KB query, 32KB fact, 256B entity name

## Test plan
- [x] `cargo check` passes for pensyve-core, pensyve-mcp, pensyve-mcp-gateway
- [x] `cargo test` passes (217 tests, 0 failures)
- [x] GDPR erasure test updated and passing