### PR TITLE
fix(core): populate event_time end-to-end in episodic memories

### DIFF
--- a/pensyve-core/src/storage/sqlite.rs
+++ b/pensyve-core/src/storage/sqlite.rs
@@ -1966,6 +1966,96 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // event_time tests
+    //
+    // Phase V of the benchmark sprint
+    // (pensyve-docs/research/benchmark-sprint/06-phase-v-verification.md)
+    // found event_time was structurally dead: save_episodic's INSERT did
+    // not write the column, and row_to_episodic hardcoded None on read.
+    // These tests pin the round-trip invariant through the sqlite backend.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_episodic_event_time_roundtrip() {
+        let (_dir, db) = setup();
+        let ns = make_namespace(&db);
+
+        let when = DateTime::parse_from_rfc3339("2023-03-04T08:09:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let mut mem = EpisodicMemory::new(
+            ns.id,
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            "I received the crystal chandelier from my aunt",
+        );
+        mem.event_time = Some(when);
+
+        db.save_episodic(&mem).unwrap();
+        let fetched = db.get_episodic(mem.id).unwrap().unwrap();
+        assert_eq!(
+            fetched.event_time,
+            Some(when),
+            "event_time must round-trip through save_episodic/get_episodic"
+        );
+    }
+
+    #[test]
+    fn test_episodic_event_time_null_roundtrip() {
+        // Regression guard: the None path must not silently become
+        // Some(Utc::now()) or Some(default) after the fix lands.
+        let (_dir, db) = setup();
+        let ns = make_namespace(&db);
+
+        let mem = EpisodicMemory::new(
+            ns.id,
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            "no timestamp on this memory",
+        );
+        assert!(mem.event_time.is_none(), "EpisodicMemory::new default must be None");
+
+        db.save_episodic(&mem).unwrap();
+        let fetched = db.get_episodic(mem.id).unwrap().unwrap();
+        assert!(
+            fetched.event_time.is_none(),
+            "event_time must stay None through save/get when not set at construction"
+        );
+    }
+
+    #[test]
+    fn test_list_episodic_by_entity_preserves_event_time() {
+        // list_episodic_by_entity has its own SELECT statement separate
+        // from get_episodic — must also read event_time.
+        let (_dir, db) = setup();
+        let ns = make_namespace(&db);
+        let about = Uuid::new_v4();
+
+        let when = DateTime::parse_from_rfc3339("2024-06-03T10:15:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let mut mem = EpisodicMemory::new(
+            ns.id,
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            about,
+            "a dated event",
+        );
+        mem.event_time = Some(when);
+        db.save_episodic(&mem).unwrap();
+
+        let results = db.list_episodic_by_entity(about, 10).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(
+            results[0].event_time,
+            Some(when),
+            "list_episodic_by_entity must read event_time from the DB"
+        );
+    }
+
+    // -----------------------------------------------------------------------
     // Semantic Memory tests
     // -----------------------------------------------------------------------
 

--- a/pensyve-core/src/storage/sqlite.rs
+++ b/pensyve-core/src/storage/sqlite.rs
@@ -98,7 +98,14 @@ impl SqliteBackend {
         for stmt in &[
             "ALTER TABLE episodic_memories ADD COLUMN salience REAL DEFAULT 0.5",
             "ALTER TABLE episodic_memories ADD COLUMN storage_strength REAL DEFAULT 0.0",
-            "ALTER TABLE episodic_memories ADD COLUMN event_time REAL",
+            // Migration v3: `event_time` was originally added as REAL but
+            // the schema is inconsistent with `timestamp` (TEXT, RFC3339).
+            // Pensyve benchmark sprint Phase V (2026-04-08) identified the
+            // REAL column as dead code — never written, never read. Drop
+            // and re-add as TEXT so save_episodic/row_to_episodic can
+            // write/read RFC3339 strings matching the rest of the schema.
+            "ALTER TABLE episodic_memories DROP COLUMN event_time",
+            "ALTER TABLE episodic_memories ADD COLUMN event_time TEXT",
             "ALTER TABLE episodic_memories ADD COLUMN superseded_by TEXT",
             "ALTER TABLE edges ADD COLUMN edge_type TEXT DEFAULT 'ENTITY'",
             "ALTER TABLE edges ADD COLUMN confidence REAL DEFAULT 1.0",
@@ -638,8 +645,8 @@ impl StorageTrait for SqliteBackend {
             r"INSERT OR REPLACE INTO episodic_memories
                (id, namespace_id, episode_id, source_entity, about_entity, content, content_type,
                 summary, embedding, context_intent, timestamp, stability, retrievability,
-                access_count, last_accessed)
-               VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)",
+                access_count, last_accessed, event_time)
+               VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)",
             params![
                 mem.id.to_string(),
                 mem.namespace_id.to_string(),
@@ -656,6 +663,7 @@ impl StorageTrait for SqliteBackend {
                 f64::from(mem.retrievability),
                 mem.access_count,
                 last_accessed,
+                opt_dt_to_str(mem.event_time),
             ],
         )?;
 
@@ -679,7 +687,7 @@ impl StorageTrait for SqliteBackend {
             .query_row(
                 r"SELECT id, namespace_id, episode_id, source_entity, about_entity, content,
                           content_type, summary, embedding, context_intent, timestamp,
-                          stability, retrievability, access_count, last_accessed
+                          stability, retrievability, access_count, last_accessed, event_time
                    FROM episodic_memories WHERE id = ?1",
                 params![id.to_string()],
                 row_to_episodic,
@@ -697,7 +705,7 @@ impl StorageTrait for SqliteBackend {
         let mut stmt = conn.prepare(
             r"SELECT id, namespace_id, episode_id, source_entity, about_entity, content,
                       content_type, summary, embedding, context_intent, timestamp,
-                      stability, retrievability, access_count, last_accessed
+                      stability, retrievability, access_count, last_accessed, event_time
                FROM episodic_memories WHERE about_entity = ?1
                ORDER BY timestamp DESC LIMIT ?2",
         )?;
@@ -999,7 +1007,7 @@ impl StorageTrait for SqliteBackend {
                         .query_row(
                             r"SELECT id, namespace_id, episode_id, source_entity, about_entity, content,
                                       content_type, summary, embedding, context_intent, timestamp,
-                                      stability, retrievability, access_count, last_accessed
+                                      stability, retrievability, access_count, last_accessed, event_time
                                FROM episodic_memories WHERE id = ?1",
                             params![id.to_string()],
                             row_to_episodic,
@@ -1058,7 +1066,7 @@ impl StorageTrait for SqliteBackend {
             let mut stmt = conn.prepare(
                 r"SELECT id, namespace_id, episode_id, source_entity, about_entity, content,
                           content_type, summary, embedding, context_intent, timestamp,
-                          stability, retrievability, access_count, last_accessed
+                          stability, retrievability, access_count, last_accessed, event_time
                    FROM episodic_memories WHERE namespace_id = ?1",
             )?;
             let rows = stmt.query_map(params![&ns_str], row_to_episodic)?;
@@ -1601,6 +1609,7 @@ fn row_to_episodic(
     let retrievability: f64 = row.get(12)?;
     let access_count: u32 = row.get(13)?;
     let last_accessed_str: Option<String> = row.get(14)?;
+    let event_time_str: Option<String> = row.get(15)?;
 
     let id = match parse_uuid(&id_str) {
         Ok(v) => v,
@@ -1644,7 +1653,11 @@ fn row_to_episodic(
         last_accessed: str_to_opt_dt(last_accessed_str.as_deref()),
         salience: 0.5,
         storage_strength: 0.0,
-        event_time: None,
+        // Phase V benchmark sprint fix: read event_time from the DB
+        // via the existing str_to_opt_dt helper. Was hardcoded None
+        // in v1.0.5 and earlier, see
+        // pensyve-docs/research/benchmark-sprint/06-phase-v-verification.md.
+        event_time: str_to_opt_dt(event_time_str.as_deref()),
         superseded_by: None,
     }))
 }

--- a/pensyve-core/src/storage/sqlite.rs
+++ b/pensyve-core/src/storage/sqlite.rs
@@ -98,20 +98,43 @@ impl SqliteBackend {
         for stmt in &[
             "ALTER TABLE episodic_memories ADD COLUMN salience REAL DEFAULT 0.5",
             "ALTER TABLE episodic_memories ADD COLUMN storage_strength REAL DEFAULT 0.0",
-            // Migration v3: `event_time` was originally added as REAL but
-            // the schema is inconsistent with `timestamp` (TEXT, RFC3339).
-            // Pensyve benchmark sprint Phase V (2026-04-08) identified the
-            // REAL column as dead code — never written, never read. Drop
-            // and re-add as TEXT so save_episodic/row_to_episodic can
-            // write/read RFC3339 strings matching the rest of the schema.
-            "ALTER TABLE episodic_memories DROP COLUMN event_time",
-            "ALTER TABLE episodic_memories ADD COLUMN event_time TEXT",
             "ALTER TABLE episodic_memories ADD COLUMN superseded_by TEXT",
             "ALTER TABLE edges ADD COLUMN edge_type TEXT DEFAULT 'ENTITY'",
             "ALTER TABLE edges ADD COLUMN confidence REAL DEFAULT 1.0",
             "ALTER TABLE edges ADD COLUMN half_life_days REAL DEFAULT 90.0",
         ] {
             let _ = conn.execute(stmt, []);
+        }
+
+        // Migration v3: `event_time` was originally added as REAL in v2 but
+        // was never written or read (dead code). Convert to TEXT (RFC3339)
+        // to match the `timestamp` column's storage format. This is a
+        // one-time migration: once the column is TEXT, subsequent opens
+        // skip the destructive DROP.
+        {
+            let is_real = conn
+                .prepare("PRAGMA table_info(episodic_memories)")?
+                .query_map([], |row| {
+                    Ok((row.get::<_, String>(1)?, row.get::<_, String>(2)?))
+                })?
+                .filter_map(Result::ok)
+                .any(|(name, typ)| name == "event_time" && typ.eq_ignore_ascii_case("REAL"));
+            if is_real {
+                // Column exists as REAL from v2 migration — drop and recreate as TEXT.
+                conn.execute("ALTER TABLE episodic_memories DROP COLUMN event_time", [])?;
+                conn.execute(
+                    "ALTER TABLE episodic_memories ADD COLUMN event_time TEXT",
+                    [],
+                )?;
+            } else if !Self::column_exists(conn, "episodic_memories", "event_time")? {
+                // Fresh DB (no v2 migration ran) or column was already dropped —
+                // add as TEXT directly.
+                conn.execute(
+                    "ALTER TABLE episodic_memories ADD COLUMN event_time TEXT",
+                    [],
+                )?;
+            }
+            // If column already exists as TEXT, do nothing — migration complete.
         }
 
         Ok(())
@@ -2028,7 +2051,10 @@ mod tests {
             Uuid::new_v4(),
             "no timestamp on this memory",
         );
-        assert!(mem.event_time.is_none(), "EpisodicMemory::new default must be None");
+        assert!(
+            mem.event_time.is_none(),
+            "EpisodicMemory::new default must be None"
+        );
 
         db.save_episodic(&mem).unwrap();
         let fetched = db.get_episodic(mem.id).unwrap().unwrap();

--- a/pensyve-python/python/pensyve/_core.pyi
+++ b/pensyve-python/python/pensyve/_core.pyi
@@ -121,12 +121,23 @@ class Entity:
 class Episode:
     """An episode context manager that records messages and creates memories on exit."""
 
-    def message(self, role: str, content: str) -> None:
+    def message(
+        self,
+        role: str,
+        content: str,
+        when: str | None = None,
+    ) -> None:
         """Record a message in this episode.
 
         Args:
             role: The role of the speaker (e.g. "user", "assistant").
             content: The message content.
+            when: Optional RFC3339 / ISO 8601 timestamp describing when the
+                event in this message occurred (e.g. "2023-03-04T08:09:00Z").
+                Defaults to the current UTC time at episode commit. Pass an
+                explicit value when ingesting historical or backfilled data
+                where the real-world event time differs from the encoding
+                time. Raises `ValueError` if the string is not parseable.
         """
         ...
 

--- a/pensyve-python/src/lib.rs
+++ b/pensyve-python/src/lib.rs
@@ -1,7 +1,8 @@
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
-use pyo3::exceptions::PyRuntimeError;
+use chrono::{DateTime, Utc};
+use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use uuid::Uuid;
@@ -618,7 +619,10 @@ pub struct PyEpisode {
     episode_id: Uuid,
     namespace_id: Uuid,
     participants: Vec<Uuid>,
-    messages: Vec<(String, String)>, // (role, content)
+    // (role, content, optional per-message event time).
+    // `event_time` is `None` when the caller did not pass `when=...`; the
+    // default (`Utc::now()` at commit) is applied in `__exit__`.
+    messages: Vec<(String, String, Option<DateTime<Utc>>)>,
     outcome: Option<String>,
     closed: bool,
 }
@@ -630,11 +634,30 @@ impl PyEpisode {
     /// Args:
     ///     role: The role of the speaker (e.g. "user", "assistant").
     ///     content: The message content.
-    fn message(&mut self, role: &str, content: &str) -> PyResult<()> {
+    ///     when: Optional RFC3339 / ISO 8601 timestamp describing when the
+    ///         event in this message occurred (e.g. "2023-03-04T08:09:00Z").
+    ///         Defaults to `Utc::now()` at episode commit. Pass an explicit
+    ///         value when ingesting historical / backfilled data where the
+    ///         encoding time differs from the real-world event time.
+    #[pyo3(signature = (role, content, when=None))]
+    fn message(&mut self, role: &str, content: &str, when: Option<&str>) -> PyResult<()> {
         if self.closed {
             return Err(PyRuntimeError::new_err("Episode is already closed"));
         }
-        self.messages.push((role.to_string(), content.to_string()));
+        let parsed_when = match when {
+            None => None,
+            Some(s) => Some(
+                DateTime::parse_from_rfc3339(s)
+                    .map(|dt| dt.with_timezone(&Utc))
+                    .map_err(|e| {
+                        PyValueError::new_err(format!(
+                            "`when` must be an RFC3339 timestamp, got {s:?}: {e}"
+                        ))
+                    })?,
+            ),
+        };
+        self.messages
+            .push((role.to_string(), content.to_string(), parsed_when));
         Ok(())
     }
 
@@ -690,7 +713,7 @@ impl PyEpisode {
         let source_entity = self.participants.first().copied().unwrap_or(Uuid::nil());
         let about_entity = self.participants.get(1).copied().unwrap_or(source_entity);
 
-        for (_role, content) in &self.messages {
+        for (_role, content, when) in &self.messages {
             let mut mem = EpisodicMemory::new(
                 self.namespace_id,
                 self.episode_id,
@@ -698,6 +721,11 @@ impl PyEpisode {
                 about_entity,
                 content,
             );
+            // Populate event_time. Explicit `when` from the caller takes
+            // precedence; otherwise default to Utc::now() at commit,
+            // matching real-time conversational ingest semantics.
+            // `Option<DateTime<Utc>>` is Copy so `*when` works.
+            mem.event_time = Some((*when).unwrap_or_else(Utc::now));
 
             // Embed the content.
             let embedding = self

--- a/tests/python/test_event_time.py
+++ b/tests/python/test_event_time.py
@@ -1,0 +1,102 @@
+"""Tests for event_time population on Episode.message.
+
+Phase V of the benchmark sprint found event_time was structurally dead:
+PyEpisode.message buffered no timestamp, __exit__ never set the field,
+and the storage layer both ignored it on write and hardcoded None on
+read. See research/benchmark-sprint/06-phase-v-verification.md in
+pensyve-docs for the full evidence chain.
+
+These tests pin the fix end-to-end from Episode.message(..., when=...)
+through storage to Memory.event_time on recall.
+"""
+
+import tempfile
+from datetime import datetime, timedelta, timezone
+
+import pensyve
+import pytest
+
+
+def _open_pensyve(path):
+    p = pensyve.Pensyve(path=path)
+    user = p.entity("alice", kind="user")
+    agent = p.entity("bot", kind="agent")
+    return p, user, agent
+
+
+def test_message_with_when_persists_event_time():
+    """Passing `when=<RFC3339>` must persist through to Memory.event_time."""
+    with tempfile.TemporaryDirectory() as d:
+        p, user, agent = _open_pensyve(d)
+        with p.episode(user, agent) as ep:
+            ep.message(
+                "user",
+                "I received the crystal chandelier from my aunt",
+                when="2023-03-04T08:09:00+00:00",
+            )
+        results = p.recall("chandelier", entity=user)
+
+    assert len(results) > 0, "recall must return at least one memory"
+    m = results[0]
+    assert m.event_time is not None, (
+        "event_time must persist from the `when` kwarg, "
+        f"got None (Phase V finding — the write/read path is dead)"
+    )
+    assert "2023-03-04" in m.event_time, (
+        f"expected 2023-03-04 somewhere in event_time, got {m.event_time!r}"
+    )
+
+
+def test_message_without_when_defaults_to_now():
+    """Omitting `when` must default to the current UTC time at commit."""
+    before = datetime.now(timezone.utc) - timedelta(seconds=5)
+    with tempfile.TemporaryDirectory() as d:
+        p, user, agent = _open_pensyve(d)
+        with p.episode(user, agent) as ep:
+            ep.message("user", "something happening right now")
+        results = p.recall("happening", entity=user)
+    after = datetime.now(timezone.utc) + timedelta(seconds=5)
+
+    assert len(results) > 0
+    m = results[0]
+    assert m.event_time is not None, (
+        "event_time must default to Utc::now() when the `when` kwarg is omitted"
+    )
+    # Accept RFC3339 with Z or +00:00 suffix.
+    normalized = m.event_time.replace("Z", "+00:00")
+    parsed = datetime.fromisoformat(normalized)
+    assert before <= parsed <= after, (
+        f"default event_time {parsed} not within "
+        f"expected window [{before}, {after}]"
+    )
+
+
+def test_message_invalid_when_raises():
+    """An unparseable `when` string must raise at the call site."""
+    with tempfile.TemporaryDirectory() as d:
+        p, user, agent = _open_pensyve(d)
+        with p.episode(user, agent) as ep:
+            with pytest.raises((ValueError, RuntimeError)) as exc_info:
+                ep.message("user", "bad date", when="definitely-not-rfc3339")
+    msg = str(exc_info.value).lower()
+    assert any(
+        kw in msg for kw in ("when", "rfc3339", "parse", "date", "timestamp")
+    ), f"error message should mention the parameter or format, got: {exc_info.value!r}"
+
+
+def test_message_with_when_trailing_z():
+    """The trailing-Z variant of RFC3339 must also parse."""
+    with tempfile.TemporaryDirectory() as d:
+        p, user, agent = _open_pensyve(d)
+        with p.episode(user, agent) as ep:
+            ep.message(
+                "user",
+                "Z-terminated timestamp",
+                when="2024-06-03T10:15:00Z",
+            )
+        results = p.recall("terminated", entity=user)
+
+    assert len(results) > 0
+    m = results[0]
+    assert m.event_time is not None
+    assert "2024-06-03" in m.event_time

--- a/tests/python/test_event_time.py
+++ b/tests/python/test_event_time.py
@@ -13,8 +13,9 @@ through storage to Memory.event_time on recall.
 import tempfile
 from datetime import datetime, timedelta, timezone
 
-import pensyve
 import pytest
+
+import pensyve
 
 
 def _open_pensyve(path):
@@ -40,7 +41,7 @@ def test_message_with_when_persists_event_time():
     m = results[0]
     assert m.event_time is not None, (
         "event_time must persist from the `when` kwarg, "
-        f"got None (Phase V finding — the write/read path is dead)"
+        "got None (Phase V finding — the write/read path is dead)"
     )
     assert "2023-03-04" in m.event_time, (
         f"expected 2023-03-04 somewhere in event_time, got {m.event_time!r}"
@@ -75,9 +76,8 @@ def test_message_invalid_when_raises():
     """An unparseable `when` string must raise at the call site."""
     with tempfile.TemporaryDirectory() as d:
         p, user, agent = _open_pensyve(d)
-        with p.episode(user, agent) as ep:
-            with pytest.raises((ValueError, RuntimeError)) as exc_info:
-                ep.message("user", "bad date", when="definitely-not-rfc3339")
+        with p.episode(user, agent) as ep, pytest.raises((ValueError, RuntimeError)) as exc_info:
+            ep.message("user", "bad date", when="definitely-not-rfc3339")
     msg = str(exc_info.value).lower()
     assert any(
         kw in msg for kw in ("when", "rfc3339", "parse", "date", "timestamp")


### PR DESCRIPTION
## Summary

- Pensyve's `event_time` field on episodic memories was structurally dead — never written on save, hardcoded to `None` on load, and the `Episode.message()` API had no way to accept a timestamp. This caused LongMemEval_S temporal-reasoning accuracy to measure 27.1% (the reader was confabulating dates from context alone).
- This PR populates `event_time` end-to-end: adds a `when` kwarg to `Episode.message()`, persists through `save_episodic` INSERT, reads back through `row_to_episodic` SELECT, and surfaces on `Memory.event_time` at recall.
- Post-fix benchmark re-run: **52.0% → 58.0% (+6.0 pts)**. Temporal-reasoning **27.1% → 45.9% (+18.8 pts)**. Knowledge-update **60.3% → 71.8% (+11.5 pts)**.

## Changes

**pensyve-core/src/storage/sqlite.rs:**
- Migrate `event_time` column from REAL (dead) to TEXT (RFC3339, matching `timestamp` column)
- `save_episodic`: add `event_time` to INSERT column list + params via `opt_dt_to_str`
- `row_to_episodic`: read `event_time` via `str_to_opt_dt` instead of hardcoding `None`
- All four episodic SELECT statements updated to include `event_time` in column list
- Three new tests: roundtrip, null-roundtrip invariant guard, list_by_entity preservation

**pensyve-python/src/lib.rs:**
- `PyEpisode.messages` field: `Vec<(String, String)>` → `Vec<(String, String, Option<DateTime<Utc>>)>`
- `Episode.message(role, content, when=None)`: new `when` kwarg, parses RFC3339 via `chrono`, raises `ValueError` on bad input
- `PyEpisode::__exit__`: threads buffered timestamp to `mem.event_time`, defaults `None` → `Utc::now()`
- Imports: add `chrono::{DateTime, Utc}`, `PyValueError`

**pensyve-python/python/pensyve/_core.pyi:**
- Updated `Episode.message` signature + docstring

**tests/python/test_event_time.py** (new):
- `test_message_with_when_persists_event_time`
- `test_message_without_when_defaults_to_now`
- `test_message_invalid_when_raises`
- `test_message_with_when_trailing_z`

## Test plan

- [x] `cargo test -p pensyve-core --lib` — 222 passed / 0 failed / 8 ignored
- [x] `pytest tests/python/test_event_time.py` — 4 passed / 0 failed
- [x] `pytest tests/python/` full suite — 104 passed / 16 failed (all 16 are pre-existing `test_http_client.py` async failures from missing `pytest-asyncio` plugin — reproduce identically on `main`)
- [x] End-to-end LongMemEval re-run: 500/500 questions, judged by gpt-4o, temporal-reasoning +18.8 pts

## Out of scope

- **Postgres parity:** `postgres.rs` not modified. No inline postgres tests exist. Follow-up PR.
- **`salience` and `storage_strength` dead fields:** same hardcode pattern in `row_to_episodic` but requires FSRS wiring. Separate cleanup.
- **Version bump:** leaving at 1.0.5 — operator decides release timing.

## Background

See `pensyve-docs/research/benchmark-sprint/06-phase-v-verification.md` for the seven-layer evidence chain that identified this bug, and `09-phase-d-post-fix.md` for the full measurement report.