### PR TITLE
feat: observation extractor + hybrid classifier (v1.3.0) — 89.2% on LongMemEval_S

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2886,6 +2886,7 @@ dependencies = [
  "pensyve-core",
  "pyo3",
  "serde_json",
+ "tokio",
  "tracing",
  "tracing-subscriber",
  "uuid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,6 +198,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -990,6 +1000,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "der"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1604,6 +1632,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -2524,6 +2558,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2749,6 +2793,7 @@ dependencies = [
 name = "pensyve-core"
 version = "1.2.0"
 dependencies = [
+ "async-trait",
  "chrono",
  "criterion",
  "dashmap",
@@ -2757,6 +2802,7 @@ dependencies = [
  "petgraph",
  "rayon",
  "regex",
+ "reqwest 0.12.28",
  "rusqlite",
  "serde",
  "serde_json",
@@ -2767,6 +2813,7 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+ "wiremock",
 ]
 
 [[package]]
@@ -5407,6 +5454,29 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64 0.22.1",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/pensyve-cli/src/main.rs
+++ b/pensyve-cli/src/main.rs
@@ -180,6 +180,12 @@ fn build_vector_index(
     let all_memories = storage.get_all_memories_by_namespace(namespace_id)?;
     let mut index = VectorIndex::new(dimensions, all_memories.len().max(16));
     for mem in &all_memories {
+        // Observations are recall-time enrichment — they attach to top-k
+        // session groups via `recall_grouped::attach_observations_to_groups`
+        // and MUST NOT enter the RRF candidate pool.
+        if matches!(mem, pensyve_core::types::Memory::Observation(_)) {
+            continue;
+        }
         let emb = mem.embedding();
         if emb.len() == dimensions && !emb.is_empty() {
             // Best-effort: skip entries whose dimensions don't match.
@@ -190,9 +196,8 @@ fn build_vector_index(
                 pensyve_core::types::Memory::Episodic(e) => {
                     index.add_with_entity(mem.id(), emb, e.about_entity)
                 }
-                // Procedural + Observation carry no direct entity link.
-                pensyve_core::types::Memory::Procedural(_)
-                | pensyve_core::types::Memory::Observation(_) => index.add(mem.id(), emb),
+                pensyve_core::types::Memory::Procedural(_) => index.add(mem.id(), emb),
+                pensyve_core::types::Memory::Observation(_) => unreachable!(),
             };
         }
     }

--- a/pensyve-cli/src/main.rs
+++ b/pensyve-cli/src/main.rs
@@ -190,7 +190,9 @@ fn build_vector_index(
                 pensyve_core::types::Memory::Episodic(e) => {
                     index.add_with_entity(mem.id(), emb, e.about_entity)
                 }
-                pensyve_core::types::Memory::Procedural(_) => index.add(mem.id(), emb),
+                // Procedural + Observation carry no direct entity link.
+                pensyve_core::types::Memory::Procedural(_)
+                | pensyve_core::types::Memory::Observation(_) => index.add(mem.id(), emb),
             };
         }
     }
@@ -205,6 +207,7 @@ struct MemoryCounts {
     episodic: usize,
     semantic: usize,
     procedural: usize,
+    observation: usize,
     total: usize,
 }
 
@@ -216,18 +219,21 @@ fn count_memories(
     let mut episodic = 0usize;
     let mut semantic = 0usize;
     let mut procedural = 0usize;
+    let mut observation = 0usize;
     for mem in &all_memories {
         match mem {
             Memory::Episodic(_) => episodic += 1,
             Memory::Semantic(_) => semantic += 1,
             Memory::Procedural(_) => procedural += 1,
+            Memory::Observation(_) => observation += 1,
         }
     }
     Ok(MemoryCounts {
         episodic,
         semantic,
         procedural,
-        total: episodic + semantic + procedural,
+        observation,
+        total: episodic + semantic + procedural + observation,
     })
 }
 
@@ -296,7 +302,9 @@ fn cmd_recall(
                 match &c.memory {
                     Memory::Episodic(m) => m.about_entity == eid || m.source_entity == eid,
                     Memory::Semantic(m) => m.subject == eid,
-                    Memory::Procedural(_) => true,
+                    // Keep procedural / observation through the entity filter
+                    // — they don't carry a direct entity reference.
+                    Memory::Procedural(_) | Memory::Observation(_) => true,
                 }
             } else {
                 true
@@ -313,6 +321,7 @@ fn cmd_recall(
                         Memory::Episodic(_) => "episodic",
                         Memory::Semantic(_) => "semantic",
                         Memory::Procedural(_) => "procedural",
+                        Memory::Observation(_) => "observation",
                     };
                     let content = match &c.memory {
                         Memory::Episodic(m) => m.content.clone(),
@@ -320,6 +329,7 @@ fn cmd_recall(
                             format!("{} {} {}", m.subject, m.predicate, m.object)
                         }
                         Memory::Procedural(m) => format!("{} -> {}", m.trigger, m.action),
+                        Memory::Observation(m) => m.content.clone(),
                     };
                     serde_json::json!({
                         "id": c.memory_id.to_string(),
@@ -346,6 +356,7 @@ fn cmd_recall(
                         Memory::Episodic(_) => "episodic",
                         Memory::Semantic(_) => "semantic",
                         Memory::Procedural(_) => "procedural",
+                        Memory::Observation(_) => "observation",
                     };
                     let content = match &c.memory {
                         Memory::Episodic(m) => m.content.clone(),
@@ -353,6 +364,7 @@ fn cmd_recall(
                             format!("{} {} {}", m.subject, m.predicate, m.object)
                         }
                         Memory::Procedural(m) => format!("{} -> {}", m.trigger, m.action),
+                        Memory::Observation(m) => m.content.clone(),
                     };
                     println!(
                         "{:<6} {:<12} {:<8.4} {}",
@@ -385,6 +397,7 @@ fn cmd_stats(namespace_name: &str, format: OutputFormat) -> Result<(), Box<dyn s
                     "episodic": counts.episodic,
                     "semantic": counts.semantic,
                     "procedural": counts.procedural,
+                    "observation": counts.observation,
                     "total": counts.total,
                 },
                 "storage_bytes": storage_bytes,
@@ -401,6 +414,7 @@ fn cmd_stats(namespace_name: &str, format: OutputFormat) -> Result<(), Box<dyn s
             println!("{:<14} {}", "episodic", counts.episodic);
             println!("{:<14} {}", "semantic", counts.semantic);
             println!("{:<14} {}", "procedural", counts.procedural);
+            println!("{:<14} {}", "observation", counts.observation);
             println!("{:<14} {}", "total", counts.total);
         }
     }
@@ -434,6 +448,7 @@ fn cmd_status(
                     "episodic": counts.episodic,
                     "semantic": counts.semantic,
                     "procedural": counts.procedural,
+                    "observation": counts.observation,
                     "total": counts.total,
                 },
                 "storage_bytes": storage_bytes,
@@ -452,6 +467,7 @@ fn cmd_status(
             println!("{:<14} {}", "episodic", counts.episodic);
             println!("{:<14} {}", "semantic", counts.semantic);
             println!("{:<14} {}", "procedural", counts.procedural);
+            println!("{:<14} {}", "observation", counts.observation);
             println!("{:<14} {}", "total", counts.total);
         }
     }

--- a/pensyve-core/Cargo.toml
+++ b/pensyve-core/Cargo.toml
@@ -29,6 +29,8 @@ petgraph = "0.8"
 dashmap = "6"
 rayon = "1.10"
 tracing = "0.1"
+async-trait = "0.1"
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"], optional = true }
 sqlx-core = { version = "0.8.6", features = ["_rt-tokio", "_tls-rustls-aws-lc-rs", "json", "chrono", "uuid"], optional = true }
 sqlx-postgres = { version = "0.8.6", features = ["json", "chrono", "uuid"], optional = true }
 tokio = { version = "1", features = ["rt-multi-thread"], optional = true }
@@ -36,10 +38,15 @@ tokio = { version = "1", features = ["rt-multi-thread"], optional = true }
 [features]
 default = []
 postgres = ["dep:sqlx-core", "dep:sqlx-postgres", "dep:tokio"]
+# Feature-gate the Anthropic-API-backed observation extractor so users
+# who don't need observations pay no HTTP-client compile cost.
+observation-extraction = ["dep:reqwest", "dep:tokio"]
 
 [dev-dependencies]
 tempfile = "3"
 criterion = { version = "0.8", features = ["html_reports"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+wiremock = "0.6"
 
 [lints]
 workspace = true

--- a/pensyve-core/src/classifier.rs
+++ b/pensyve-core/src/classifier.rs
@@ -253,14 +253,31 @@ lookup, prefer `inject`. Respond with exactly one word (`inject` or \
             self
         }
 
-        /// Classify a query. Cache hits are ~nanoseconds; cache misses do
-        /// one Haiku request (~100 ms typical, ~$0.0002).
+        /// Classify a query using hybrid routing: `Inject` if EITHER the
+        /// naive regex OR the Haiku classifier says `Inject`. This is the
+        /// R7/Phase-3 calibrated default — pure Haiku loses obvious
+        /// "how many" counting questions it reads as single-session
+        /// lookups, and pure naive misses temporal/chronology questions
+        /// without counting keywords.
         ///
-        /// On any transport/parse error, degrades to the naive regex
-        /// classifier rather than returning an error — the caller already
-        /// has a usable fallback, surfacing the error would force every
-        /// SDK consumer to write the same degrade logic.
+        /// Phase 3 benchmark regression (89.2% on `LongMemEval_S` Haiku 4.5)
+        /// validated this composition vs. pure Haiku (87.6%) and pure naive
+        /// (~86.8% approximated).
+        ///
+        /// Cache hits are ~nanoseconds; cache misses do one Haiku request
+        /// (~100 ms typical, ~$0.0002). On any Haiku transport/parse error,
+        /// falls back to naive alone.
         pub async fn classify(&self, query: &str) -> Route {
+            if super::classify_naive(query) == Route::Inject {
+                return Route::Inject;
+            }
+            self.classify_haiku_only(query).await
+        }
+
+        /// Pure Haiku classification without the naive-OR hybrid. Use
+        /// `classify` instead unless you need to inspect Haiku's decision
+        /// in isolation (benchmarking, calibration, test fixtures).
+        pub async fn classify_haiku_only(&self, query: &str) -> Route {
             let key = normalize_query(query);
             if let Ok(mut cache) = self.cache.lock()
                 && let Some(hit) = cache.get(&key)
@@ -476,22 +493,71 @@ lookup, prefer `inject`. Respond with exactly one word (`inject` or \
 
         #[tokio::test]
         async fn classifier_caches_repeat_queries() {
-            // Wiremock server: second call would fail if the cache didn't hit.
+            // Wiremock server: the API must be called exactly once despite
+            // three `classify_haiku_only` invocations. Uses a non-counting
+            // phrasing so the hybrid `classify` would NOT short-circuit to
+            // naive — but this test exercises the pure-Haiku path directly.
             let server = MockServer::start().await;
             Mock::given(method("POST"))
                 .and(path("/v1/messages"))
                 .respond_with(
                     ResponseTemplate::new(200).set_body_json(anthropic_response("inject")),
                 )
-                .expect(1) // HARD bound — must be called exactly once
+                .expect(1)
                 .mount(&server)
                 .await;
             let c = HaikuQueryClassifier::new("k")
                 .unwrap()
                 .with_base_url(server.uri());
-            assert_eq!(c.classify("how many books?").await, Route::Inject);
-            assert_eq!(c.classify("how many books?").await, Route::Inject);
-            assert_eq!(c.classify("  How Many  Books?  ").await, Route::Inject);
+            assert_eq!(
+                c.classify_haiku_only("what was the last book I read?").await,
+                Route::Inject
+            );
+            assert_eq!(
+                c.classify_haiku_only("what was the last book I read?").await,
+                Route::Inject
+            );
+            assert_eq!(
+                c.classify_haiku_only("  What Was The  Last  Book I Read?  ").await,
+                Route::Inject
+            );
+        }
+
+        #[tokio::test]
+        async fn hybrid_classify_short_circuits_on_naive_inject() {
+            // "how many" trips the naive regex; Haiku API must NOT be called.
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path("/v1/messages"))
+                .respond_with(ResponseTemplate::new(500).set_body_string("should not be hit"))
+                .expect(0)
+                .mount(&server)
+                .await;
+            let c = HaikuQueryClassifier::new("k")
+                .unwrap()
+                .with_base_url(server.uri());
+            assert_eq!(c.classify("How many books did I read?").await, Route::Inject);
+        }
+
+        #[tokio::test]
+        async fn hybrid_classify_falls_through_to_haiku_when_naive_skips() {
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path("/v1/messages"))
+                .respond_with(
+                    ResponseTemplate::new(200).set_body_json(anthropic_response("inject")),
+                )
+                .expect(1)
+                .mount(&server)
+                .await;
+            let c = HaikuQueryClassifier::new("k")
+                .unwrap()
+                .with_base_url(server.uri());
+            // Temporal phrasing — naive misses it, Haiku catches it.
+            assert_eq!(
+                c.classify("When did I first start using Rust?").await,
+                Route::Inject
+            );
         }
 
         #[test]

--- a/pensyve-core/src/classifier.rs
+++ b/pensyve-core/src/classifier.rs
@@ -1,0 +1,609 @@
+//! Query routing classifier — decides whether to inject observations into
+//! the reader prompt.
+//!
+//! The R7 benchmark (89.0%) and Phase 0c ingest-variant (89.6%) both found
+//! that observations help counting questions but hurt non-counting ones
+//! when injected universally. The harness used dataset-metadata routing
+//! (`question_type`) as a ground-truth oracle — production has no such
+//! oracle, so we need a classifier.
+//!
+//! This module ships two routes:
+//!
+//! - [`classify_naive`] — deterministic regex over counting keywords. Always
+//!   available, zero dependencies, zero latency. Correct on the obvious
+//!   cases ("how many", "list every", etc.) and false-skips on everything
+//!   else.
+//! - [`HaikuQueryClassifier`] — Haiku 4.5 over a tiny zero-shot prompt.
+//!   Behind the `observation-extraction` feature flag. Calibrated in
+//!   `pensyve-docs/research/benchmark-sprint/21-classifier-calibration.md`.
+//!
+//! Both implementations return the same [`Route`] enum so callers can swap
+//! them out freely.
+
+use std::fmt::Debug;
+
+// ---------------------------------------------------------------------------
+// Route
+// ---------------------------------------------------------------------------
+
+/// Routing decision for whether to inject observations into a reader prompt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Route {
+    /// Inject the observation block — the query is counting/aggregation
+    /// shaped and observations demonstrably help on this class in R7/0c.
+    Inject,
+    /// Skip the observation block — observations risk regressing
+    /// non-counting categories. Fall back to the V4-equivalent prompt.
+    Skip,
+}
+
+impl Route {
+    /// `"inject"` or `"skip"` — the wire-stable string representation used
+    /// by SDK bindings and logs.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Route::Inject => "inject",
+            Route::Skip => "skip",
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Naive regex classifier
+// ---------------------------------------------------------------------------
+
+/// Deterministic keyword-based classifier. Returns [`Route::Inject`] when
+/// the query contains any of a small set of counting/aggregation triggers.
+///
+/// Matching is case-insensitive and whole-word: `"how many"` matches
+/// "How many", "How Many" but does NOT match "somehow many". The keyword
+/// list is intentionally conservative — low false-positive rate preferred
+/// over catching every edge case, since the cost of a false inject is
+/// routing a non-counting question through the observation block where it
+/// historically regresses accuracy (see R7 V7 all-inject: +0.6 pts overall
+/// because gains on multi-session were dragged down by regressions on
+/// knowledge-update and preference).
+pub fn classify_naive(query: &str) -> Route {
+    let q = query.to_ascii_lowercase();
+    for phrase in COUNTING_TRIGGERS {
+        if contains_whole_phrase(&q, phrase) {
+            return Route::Inject;
+        }
+    }
+    Route::Skip
+}
+
+/// Substring match with word-boundary guards on both ends, so `"how many"`
+/// inside `"somehow many"` does not match.
+fn contains_whole_phrase(haystack: &str, phrase: &str) -> bool {
+    let mut start = 0;
+    while let Some(idx) = haystack[start..].find(phrase) {
+        let abs = start + idx;
+        let before_ok = abs == 0
+            || !haystack.as_bytes()[abs - 1].is_ascii_alphanumeric();
+        let after_pos = abs + phrase.len();
+        let after_ok = after_pos >= haystack.len()
+            || !haystack.as_bytes()[after_pos].is_ascii_alphanumeric();
+        if before_ok && after_ok {
+            return true;
+        }
+        start = abs + 1;
+    }
+    false
+}
+
+/// Phrases that trigger [`Route::Inject`] when they appear as whole words.
+/// Order doesn't matter; first hit short-circuits.
+const COUNTING_TRIGGERS: &[&str] = &[
+    "how many",
+    "how often",
+    "how much",
+    "list every",
+    "list all",
+    "count",
+    "total number",
+    "in total",
+    "altogether",
+    "over the course",
+    "across sessions",
+    "across all",
+    "across the",
+    "so far",
+    "sum of",
+    "aggregate",
+];
+
+// ---------------------------------------------------------------------------
+// HaikuQueryClassifier
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "observation-extraction")]
+mod haiku {
+    use super::Route;
+    use serde::{Deserialize, Serialize};
+    use std::sync::{Arc, Mutex};
+    use std::time::{Duration, Instant};
+
+    const DEFAULT_MODEL: &str = "claude-haiku-4-5-20251001";
+    const DEFAULT_MAX_TOKENS: u32 = 16;
+    const DEFAULT_TIMEOUT_SECS: u64 = 10;
+    const ANTHROPIC_VERSION: &str = "2023-06-01";
+
+    pub const CLASSIFIER_PROMPT_V1: &str = "You are a query router. Decide \
+whether to inject pre-extracted structured facts from past conversations \
+into the reader's prompt. Reply `inject` when the question asks about \
+*either* of the following:\n\
+\n\
+1. COUNTING or ENUMERATION across conversations — \"how many\", \"list \
+every\", \"total X\", \"how often\", \"sum of\", \"in total\".\n\
+2. TEMPORAL reasoning or CHRONOLOGY — ordering events in time, asking \
+when something happened, tracking how things changed over time, or \
+comparing items mentioned in different sessions (e.g., \"what was the \
+last X\", \"when did I start Y\", \"which came first\", \"what did the \
+assistant recommend before suggesting Z\", \"what was I doing around \
+the time we discussed Y\").\n\
+\n\
+Reply `skip` for everything else, including: current-state preference \
+questions (\"what's my favorite…?\"), requests for advice or action \
+(\"should I…?\", \"remind me…\"), single-session factual lookups \
+(\"what did I tell you about X?\"), and assistant-output recall \
+(\"what did you recommend?\") unless the answer requires comparing \
+across sessions.\n\
+\n\
+When in doubt between a temporal/chronology question and a single-shot \
+lookup, prefer `inject`. Respond with exactly one word (`inject` or \
+`skip`), no punctuation, no explanation.";
+
+    /// Classification errors distinct from network/transport failures.
+    #[derive(Debug, thiserror::Error)]
+    pub enum ClassifierError {
+        #[error("classifier config error: {0}")]
+        Config(String),
+        #[error("classifier transport error: {0}")]
+        Transport(String),
+        #[error("classifier response parse error: {0}")]
+        Parse(String),
+    }
+
+    pub type ClassifierResult<T> = Result<T, ClassifierError>;
+
+    /// Bounded LRU-ish cache keyed on a normalized query string. Entries
+    /// expire after `ttl`; oldest entries evicted once `capacity` is hit.
+    /// Good enough for a single process — deployments that need shared
+    /// state should plug their own cache in.
+    #[derive(Debug)]
+    struct ClassifierCache {
+        capacity: usize,
+        ttl: Duration,
+        entries: Vec<(String, Route, Instant)>,
+    }
+
+    impl ClassifierCache {
+        fn new(capacity: usize, ttl: Duration) -> Self {
+            Self {
+                capacity,
+                ttl,
+                entries: Vec::with_capacity(capacity.min(1024)),
+            }
+        }
+
+        fn get(&mut self, key: &str) -> Option<Route> {
+            let now = Instant::now();
+            // Expire + look up in one pass. O(n) scan; n is bounded by capacity.
+            self.entries
+                .retain(|(_, _, ts)| now.duration_since(*ts) < self.ttl);
+            self.entries
+                .iter()
+                .find(|(k, _, _)| k == key)
+                .map(|(_, r, _)| *r)
+        }
+
+        fn put(&mut self, key: String, route: Route) {
+            if self.entries.len() >= self.capacity {
+                self.entries.remove(0);
+            }
+            self.entries.push((key, route, Instant::now()));
+        }
+    }
+
+    /// Haiku 4.5 classifier backed by the Anthropic Messages API, with a
+    /// per-process cache to keep the per-query cost bounded.
+    #[derive(Debug, Clone)]
+    pub struct HaikuQueryClassifier {
+        client: reqwest::Client,
+        api_key: String,
+        model: String,
+        base_url: String,
+        cache: Arc<Mutex<ClassifierCache>>,
+    }
+
+    impl HaikuQueryClassifier {
+        /// Build with an explicit API key. Default cache: 1024 entries,
+        /// 1-hour TTL.
+        pub fn new(api_key: impl Into<String>) -> ClassifierResult<Self> {
+            let client = reqwest::Client::builder()
+                .timeout(Duration::from_secs(DEFAULT_TIMEOUT_SECS))
+                .build()
+                .map_err(|e| ClassifierError::Config(format!("http client: {e}")))?;
+            Ok(Self {
+                client,
+                api_key: api_key.into(),
+                model: DEFAULT_MODEL.into(),
+                base_url: "https://api.anthropic.com".into(),
+                cache: Arc::new(Mutex::new(ClassifierCache::new(
+                    1024,
+                    Duration::from_secs(3600),
+                ))),
+            })
+        }
+
+        /// Build using the `ANTHROPIC_API_KEY` env var. Returns
+        /// `ClassifierError::Config` when the var is missing.
+        pub fn from_env() -> ClassifierResult<Self> {
+            let api_key = std::env::var("ANTHROPIC_API_KEY").map_err(|_| {
+                ClassifierError::Config("ANTHROPIC_API_KEY env var not set".into())
+            })?;
+            Self::new(api_key)
+        }
+
+        /// Override the base URL — used by tests against `wiremock`.
+        #[must_use]
+        pub fn with_base_url(mut self, base_url: impl Into<String>) -> Self {
+            self.base_url = base_url.into();
+            self
+        }
+
+        /// Classify a query. Cache hits are ~nanoseconds; cache misses do
+        /// one Haiku request (~100 ms typical, ~$0.0002).
+        ///
+        /// On any transport/parse error, degrades to the naive regex
+        /// classifier rather than returning an error — the caller already
+        /// has a usable fallback, surfacing the error would force every
+        /// SDK consumer to write the same degrade logic.
+        pub async fn classify(&self, query: &str) -> Route {
+            let key = normalize_query(query);
+            if let Ok(mut cache) = self.cache.lock()
+                && let Some(hit) = cache.get(&key)
+            {
+                return hit;
+            }
+
+            let route = match self.call_api(&key).await {
+                Ok(r) => r,
+                Err(e) => {
+                    tracing::warn!(
+                        target: "pensyve::classifier",
+                        error = %e,
+                        "Haiku classifier failed; falling back to naive regex"
+                    );
+                    super::classify_naive(query)
+                }
+            };
+
+            if let Ok(mut cache) = self.cache.lock() {
+                cache.put(key, route);
+            }
+            route
+        }
+
+        async fn call_api(&self, query: &str) -> ClassifierResult<Route> {
+            let req = AnthropicRequest {
+                model: &self.model,
+                max_tokens: DEFAULT_MAX_TOKENS,
+                temperature: 0.0,
+                system: CLASSIFIER_PROMPT_V1,
+                messages: vec![AnthropicMessage {
+                    role: "user",
+                    content: query,
+                }],
+            };
+
+            let url = format!("{}/v1/messages", self.base_url.trim_end_matches('/'));
+            let response = self
+                .client
+                .post(&url)
+                .header("x-api-key", &self.api_key)
+                .header("anthropic-version", ANTHROPIC_VERSION)
+                .header("content-type", "application/json")
+                .json(&req)
+                .send()
+                .await
+                .map_err(|e| ClassifierError::Transport(e.to_string()))?;
+
+            if !response.status().is_success() {
+                let status = response.status();
+                let body = response.text().await.unwrap_or_default();
+                return Err(ClassifierError::Transport(format!("HTTP {status}: {body}")));
+            }
+
+            let parsed: AnthropicResponse = response
+                .json()
+                .await
+                .map_err(|e| ClassifierError::Parse(e.to_string()))?;
+
+            let text = parsed
+                .content
+                .into_iter()
+                .find(|b| b.block_type == "text")
+                .map(|b| b.text)
+                .unwrap_or_default();
+
+            parse_route(&text)
+        }
+    }
+
+    /// Normalize a query for cache keying: lowercase + collapse internal
+    /// whitespace. Two semantically identical queries typed by different
+    /// users should hit the same cache entry.
+    fn normalize_query(q: &str) -> String {
+        q.trim().to_ascii_lowercase().split_whitespace().collect::<Vec<_>>().join(" ")
+    }
+
+    /// Parse Haiku's single-token response. Accepts any variant that
+    /// starts with the route word; `"inject"`, `"inject."`, `"inject\n"`
+    /// all round-trip. On ambiguous or missing output, defaults to `Skip`
+    /// — safer to miss an inject than to incorrectly route a non-counting
+    /// question through the observation block (the R7 V7 all-inject case
+    /// regressed non-counting categories).
+    fn parse_route(text: &str) -> ClassifierResult<Route> {
+        let trimmed = text.trim().to_ascii_lowercase();
+        if trimmed.starts_with("inject") {
+            Ok(Route::Inject)
+        } else if trimmed.starts_with("skip") {
+            Ok(Route::Skip)
+        } else {
+            Err(ClassifierError::Parse(format!(
+                "classifier returned unexpected output: {text:?}"
+            )))
+        }
+    }
+
+    #[derive(Debug, Serialize)]
+    struct AnthropicRequest<'a> {
+        model: &'a str,
+        max_tokens: u32,
+        temperature: f32,
+        system: &'a str,
+        messages: Vec<AnthropicMessage<'a>>,
+    }
+
+    #[derive(Debug, Serialize)]
+    struct AnthropicMessage<'a> {
+        role: &'a str,
+        content: &'a str,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct AnthropicResponse {
+        content: Vec<AnthropicContentBlock>,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct AnthropicContentBlock {
+        #[serde(rename = "type")]
+        block_type: String,
+        #[serde(default)]
+        text: String,
+    }
+
+    // -------------------------------------------------------------------
+    // Tests
+    // -------------------------------------------------------------------
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        fn anthropic_response(text: &str) -> serde_json::Value {
+            serde_json::json!({
+                "id": "msg_test",
+                "type": "message",
+                "role": "assistant",
+                "model": "claude-haiku-4-5-20251001",
+                "content": [{"type": "text", "text": text}],
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 0, "output_tokens": 0},
+            })
+        }
+
+        #[tokio::test]
+        async fn classifier_returns_inject_on_inject_reply() {
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path("/v1/messages"))
+                .respond_with(
+                    ResponseTemplate::new(200).set_body_json(anthropic_response("inject")),
+                )
+                .mount(&server)
+                .await;
+            let c = HaikuQueryClassifier::new("test-key")
+                .unwrap()
+                .with_base_url(server.uri());
+            assert_eq!(c.classify("how many books did I read?").await, Route::Inject);
+        }
+
+        #[tokio::test]
+        async fn classifier_returns_skip_on_skip_reply() {
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path("/v1/messages"))
+                .respond_with(
+                    ResponseTemplate::new(200).set_body_json(anthropic_response("skip")),
+                )
+                .mount(&server)
+                .await;
+            let c = HaikuQueryClassifier::new("test-key")
+                .unwrap()
+                .with_base_url(server.uri());
+            assert_eq!(c.classify("what's my favorite color?").await, Route::Skip);
+        }
+
+        #[tokio::test]
+        async fn classifier_handles_trailing_punctuation() {
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path("/v1/messages"))
+                .respond_with(
+                    ResponseTemplate::new(200)
+                        .set_body_json(anthropic_response("inject.\n")),
+                )
+                .mount(&server)
+                .await;
+            let c = HaikuQueryClassifier::new("k")
+                .unwrap()
+                .with_base_url(server.uri());
+            assert_eq!(c.classify("how many games?").await, Route::Inject);
+        }
+
+        #[tokio::test]
+        async fn classifier_falls_back_to_naive_on_http_error() {
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path("/v1/messages"))
+                .respond_with(ResponseTemplate::new(500).set_body_string("broken"))
+                .mount(&server)
+                .await;
+            let c = HaikuQueryClassifier::new("k")
+                .unwrap()
+                .with_base_url(server.uri());
+            // Naive regex matches "how many" → Inject.
+            assert_eq!(c.classify("how many books?").await, Route::Inject);
+            // Naive regex misses non-counting → Skip.
+            assert_eq!(c.classify("what did I eat?").await, Route::Skip);
+        }
+
+        #[tokio::test]
+        async fn classifier_caches_repeat_queries() {
+            // Wiremock server: second call would fail if the cache didn't hit.
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path("/v1/messages"))
+                .respond_with(
+                    ResponseTemplate::new(200).set_body_json(anthropic_response("inject")),
+                )
+                .expect(1) // HARD bound — must be called exactly once
+                .mount(&server)
+                .await;
+            let c = HaikuQueryClassifier::new("k")
+                .unwrap()
+                .with_base_url(server.uri());
+            assert_eq!(c.classify("how many books?").await, Route::Inject);
+            assert_eq!(c.classify("how many books?").await, Route::Inject);
+            assert_eq!(c.classify("  How Many  Books?  ").await, Route::Inject);
+        }
+
+        #[test]
+        fn parse_route_rejects_garbage() {
+            assert!(parse_route("").is_err());
+            assert!(parse_route("I think maybe").is_err());
+        }
+
+        #[test]
+        fn normalize_query_lowercases_and_collapses_whitespace() {
+            assert_eq!(normalize_query("  How   Many  "), "how many");
+            assert_eq!(normalize_query("how\tmany\n\nbooks"), "how many books");
+        }
+
+        #[test]
+        fn cache_expires_entries() {
+            let mut cache = ClassifierCache::new(4, Duration::from_millis(50));
+            cache.put("q".into(), Route::Inject);
+            assert_eq!(cache.get("q"), Some(Route::Inject));
+            std::thread::sleep(Duration::from_millis(60));
+            assert_eq!(cache.get("q"), None);
+        }
+
+        #[test]
+        fn cache_evicts_oldest_when_full() {
+            let mut cache = ClassifierCache::new(2, Duration::from_secs(3600));
+            cache.put("a".into(), Route::Inject);
+            cache.put("b".into(), Route::Inject);
+            cache.put("c".into(), Route::Skip);
+            assert_eq!(cache.get("a"), None); // evicted
+            assert_eq!(cache.get("b"), Some(Route::Inject));
+            assert_eq!(cache.get("c"), Some(Route::Skip));
+        }
+    }
+}
+
+#[cfg(feature = "observation-extraction")]
+pub use haiku::{CLASSIFIER_PROMPT_V1, ClassifierError, ClassifierResult, HaikuQueryClassifier};
+
+// ---------------------------------------------------------------------------
+// Tests (naive classifier, always available)
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn naive_classifier_catches_how_many() {
+        assert_eq!(classify_naive("how many games did I play?"), Route::Inject);
+        assert_eq!(classify_naive("How many books?"), Route::Inject);
+        assert_eq!(classify_naive("HOW MANY??"), Route::Inject);
+    }
+
+    #[test]
+    fn naive_classifier_catches_list_every() {
+        assert_eq!(
+            classify_naive("list every place I've visited"),
+            Route::Inject
+        );
+        assert_eq!(classify_naive("List all of the games"), Route::Inject);
+    }
+
+    #[test]
+    fn naive_classifier_catches_count() {
+        assert_eq!(classify_naive("count the total items"), Route::Inject);
+    }
+
+    #[test]
+    fn naive_classifier_catches_total() {
+        assert_eq!(
+            classify_naive("what's the total number of hours?"),
+            Route::Inject
+        );
+        assert_eq!(classify_naive("spent in total 40 hours"), Route::Inject);
+    }
+
+    #[test]
+    fn naive_classifier_catches_aggregation_phrases() {
+        assert_eq!(classify_naive("across all my sessions"), Route::Inject);
+        assert_eq!(classify_naive("over the course of a year"), Route::Inject);
+        assert_eq!(classify_naive("so far this year"), Route::Inject);
+    }
+
+    #[test]
+    fn naive_classifier_skips_non_counting_questions() {
+        assert_eq!(classify_naive("what is my favorite color?"), Route::Skip);
+        assert_eq!(classify_naive("who is my boss?"), Route::Skip);
+        assert_eq!(
+            classify_naive("remember to pick up milk tomorrow"),
+            Route::Skip
+        );
+    }
+
+    #[test]
+    fn naive_classifier_avoids_partial_word_matches() {
+        // "counter" and "discounted" should NOT trip the "count" trigger.
+        assert_eq!(classify_naive("my favorite counter"), Route::Skip);
+        assert_eq!(classify_naive("a discounted meal"), Route::Skip);
+        // But "the count was off" should, because "count" is whole-word.
+        assert_eq!(classify_naive("the count was off"), Route::Inject);
+    }
+
+    #[test]
+    fn naive_classifier_handles_empty_input() {
+        assert_eq!(classify_naive(""), Route::Skip);
+        assert_eq!(classify_naive("   "), Route::Skip);
+    }
+
+    #[test]
+    fn route_as_str_returns_stable_strings() {
+        assert_eq!(Route::Inject.as_str(), "inject");
+        assert_eq!(Route::Skip.as_str(), "skip");
+    }
+}

--- a/pensyve-core/src/classifier.rs
+++ b/pensyve-core/src/classifier.rs
@@ -79,11 +79,10 @@ fn contains_whole_phrase(haystack: &str, phrase: &str) -> bool {
     let mut start = 0;
     while let Some(idx) = haystack[start..].find(phrase) {
         let abs = start + idx;
-        let before_ok = abs == 0
-            || !haystack.as_bytes()[abs - 1].is_ascii_alphanumeric();
+        let before_ok = abs == 0 || !haystack.as_bytes()[abs - 1].is_ascii_alphanumeric();
         let after_pos = abs + phrase.len();
-        let after_ok = after_pos >= haystack.len()
-            || !haystack.as_bytes()[after_pos].is_ascii_alphanumeric();
+        let after_ok =
+            after_pos >= haystack.len() || !haystack.as_bytes()[after_pos].is_ascii_alphanumeric();
         if before_ok && after_ok {
             return true;
         }
@@ -240,9 +239,8 @@ lookup, prefer `inject`. Respond with exactly one word (`inject` or \
         /// Build using the `ANTHROPIC_API_KEY` env var. Returns
         /// `ClassifierError::Config` when the var is missing.
         pub fn from_env() -> ClassifierResult<Self> {
-            let api_key = std::env::var("ANTHROPIC_API_KEY").map_err(|_| {
-                ClassifierError::Config("ANTHROPIC_API_KEY env var not set".into())
-            })?;
+            let api_key = std::env::var("ANTHROPIC_API_KEY")
+                .map_err(|_| ClassifierError::Config("ANTHROPIC_API_KEY env var not set".into()))?;
             Self::new(api_key)
         }
 
@@ -279,10 +277,24 @@ lookup, prefer `inject`. Respond with exactly one word (`inject` or \
         /// in isolation (benchmarking, calibration, test fixtures).
         pub async fn classify_haiku_only(&self, query: &str) -> Route {
             let key = normalize_query(query);
-            if let Ok(mut cache) = self.cache.lock()
-                && let Some(hit) = cache.get(&key)
-            {
-                return hit;
+            match self.cache.lock() {
+                Ok(mut cache) => {
+                    if let Some(hit) = cache.get(&key) {
+                        return hit;
+                    }
+                }
+                Err(e) => {
+                    // Poisoned mutex — some prior caller panicked inside the
+                    // critical section. We can keep serving by bypassing the
+                    // cache, but a long-running process sees every request as
+                    // a miss from here on. Log once per occurrence so ops
+                    // has signal to investigate.
+                    tracing::warn!(
+                        target: "pensyve::classifier",
+                        error = %e,
+                        "classifier cache lock poisoned on get; bypassing cache"
+                    );
+                }
             }
 
             let route = match self.call_api(&key).await {
@@ -297,8 +309,15 @@ lookup, prefer `inject`. Respond with exactly one word (`inject` or \
                 }
             };
 
-            if let Ok(mut cache) = self.cache.lock() {
-                cache.put(key, route);
+            match self.cache.lock() {
+                Ok(mut cache) => cache.put(key, route),
+                Err(e) => {
+                    tracing::warn!(
+                        target: "pensyve::classifier",
+                        error = %e,
+                        "classifier cache lock poisoned on put; result not cached"
+                    );
+                }
             }
             route
         }
@@ -353,7 +372,11 @@ lookup, prefer `inject`. Respond with exactly one word (`inject` or \
     /// whitespace. Two semantically identical queries typed by different
     /// users should hit the same cache entry.
     fn normalize_query(q: &str) -> String {
-        q.trim().to_ascii_lowercase().split_whitespace().collect::<Vec<_>>().join(" ")
+        q.trim()
+            .to_ascii_lowercase()
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ")
     }
 
     /// Parse Haiku's single-token response. Accepts any variant that
@@ -438,7 +461,10 @@ lookup, prefer `inject`. Respond with exactly one word (`inject` or \
             let c = HaikuQueryClassifier::new("test-key")
                 .unwrap()
                 .with_base_url(server.uri());
-            assert_eq!(c.classify("how many books did I read?").await, Route::Inject);
+            assert_eq!(
+                c.classify("how many books did I read?").await,
+                Route::Inject
+            );
         }
 
         #[tokio::test]
@@ -446,9 +472,7 @@ lookup, prefer `inject`. Respond with exactly one word (`inject` or \
             let server = MockServer::start().await;
             Mock::given(method("POST"))
                 .and(path("/v1/messages"))
-                .respond_with(
-                    ResponseTemplate::new(200).set_body_json(anthropic_response("skip")),
-                )
+                .respond_with(ResponseTemplate::new(200).set_body_json(anthropic_response("skip")))
                 .mount(&server)
                 .await;
             let c = HaikuQueryClassifier::new("test-key")
@@ -463,8 +487,7 @@ lookup, prefer `inject`. Respond with exactly one word (`inject` or \
             Mock::given(method("POST"))
                 .and(path("/v1/messages"))
                 .respond_with(
-                    ResponseTemplate::new(200)
-                        .set_body_json(anthropic_response("inject.\n")),
+                    ResponseTemplate::new(200).set_body_json(anthropic_response("inject.\n")),
                 )
                 .mount(&server)
                 .await;
@@ -510,15 +533,18 @@ lookup, prefer `inject`. Respond with exactly one word (`inject` or \
                 .unwrap()
                 .with_base_url(server.uri());
             assert_eq!(
-                c.classify_haiku_only("what was the last book I read?").await,
+                c.classify_haiku_only("what was the last book I read?")
+                    .await,
                 Route::Inject
             );
             assert_eq!(
-                c.classify_haiku_only("what was the last book I read?").await,
+                c.classify_haiku_only("what was the last book I read?")
+                    .await,
                 Route::Inject
             );
             assert_eq!(
-                c.classify_haiku_only("  What Was The  Last  Book I Read?  ").await,
+                c.classify_haiku_only("  What Was The  Last  Book I Read?  ")
+                    .await,
                 Route::Inject
             );
         }
@@ -536,7 +562,10 @@ lookup, prefer `inject`. Respond with exactly one word (`inject` or \
             let c = HaikuQueryClassifier::new("k")
                 .unwrap()
                 .with_base_url(server.uri());
-            assert_eq!(c.classify("How many books did I read?").await, Route::Inject);
+            assert_eq!(
+                c.classify("How many books did I read?").await,
+                Route::Inject
+            );
         }
 
         #[tokio::test]

--- a/pensyve-core/src/consolidation.rs
+++ b/pensyve-core/src/consolidation.rs
@@ -277,6 +277,9 @@ impl ConsolidationEngine {
                     }
                     decayed += 1;
                 }
+
+                // Observations decay with their source episode, not independently.
+                Memory::Observation(_) => {}
             }
         }
 

--- a/pensyve-core/src/gdpr.rs
+++ b/pensyve-core/src/gdpr.rs
@@ -117,7 +117,10 @@ pub fn export_entity_data(
         .filter(|m| match m {
             Memory::Episodic(e) => e.about_entity == entity_id || e.source_entity == entity_id,
             Memory::Semantic(s) => s.subject == entity_id,
-            Memory::Procedural(_) => false,
+            // Procedurals carry no entity reference; observations cascade
+            // with their source episode via the storage FK and are included
+            // indirectly when their parent episode matches.
+            Memory::Procedural(_) | Memory::Observation(_) => false,
         })
         .map(|m| {
             let json = match m {
@@ -139,6 +142,14 @@ pub fn export_entity_data(
                     "id": p.id.to_string(),
                     "trigger": p.trigger,
                     "action": p.action,
+                }),
+                Memory::Observation(o) => serde_json::json!({
+                    "type": "observation",
+                    "id": o.id.to_string(),
+                    "episode_id": o.episode_id.to_string(),
+                    "entity_type": o.entity_type,
+                    "instance": o.instance,
+                    "action": o.action,
                 }),
             };
             json.to_string()

--- a/pensyve-core/src/gdpr.rs
+++ b/pensyve-core/src/gdpr.rs
@@ -12,8 +12,11 @@ use crate::types::Memory;
 /// Result of a GDPR erasure operation.
 #[derive(Debug, Clone, Default)]
 pub struct ErasureResult {
-    /// Number of memories deleted.
+    /// Number of memories deleted (episodic + semantic + procedural).
     pub memories_deleted: usize,
+    /// Number of observation memories deleted (derived from episodes the
+    /// entity participated in).
+    pub observations_deleted: usize,
     /// Number of graph edges deleted.
     pub edges_deleted: usize,
     /// Number of entities deleted.
@@ -49,19 +52,30 @@ pub fn erase_entity(
 ) -> Result<ErasureResult, StorageError> {
     let mut result = ErasureResult::default();
 
-    // Step 1: Delete all memories about this entity
+    // Step 1: Delete observations derived from episodes the entity
+    // participated in. MUST run BEFORE `delete_memories_by_entity` because
+    // the join uses `episodic_memories.about_entity / source_entity` — once
+    // the episodic rows are gone the association is lost.
+    match storage.delete_observations_by_entity(entity_id) {
+        Ok(count) => result.observations_deleted = count,
+        Err(e) => result
+            .warnings
+            .push(format!("Observation deletion error: {e}")),
+    }
+
+    // Step 2: Delete all episodic / semantic memories about this entity.
     match storage.delete_memories_by_entity(entity_id) {
         Ok(count) => result.memories_deleted = count,
         Err(e) => result.warnings.push(format!("Memory deletion error: {e}")),
     }
 
-    // Step 2: Delete graph edges
+    // Step 3: Delete graph edges
     match storage.get_edges_for_entity(entity_id) {
         Ok(edges) => result.edges_deleted = edges.len(),
         Err(e) => result.warnings.push(format!("Edge query error: {e}")),
     }
 
-    // Step 3: Delete entity record (not found is OK — entity may not exist)
+    // Step 4: Delete entity record (not found is OK — entity may not exist)
     match storage.delete_entity(entity_id) {
         Ok(true) => result.entities_deleted = 1,
         Ok(false) => {} // Entity record didn't exist — nothing to delete
@@ -88,6 +102,7 @@ pub fn erase_namespace(
         match erase_entity(storage, entity.id) {
             Ok(entity_result) => {
                 result.memories_deleted += entity_result.memories_deleted;
+                result.observations_deleted += entity_result.observations_deleted;
                 result.edges_deleted += entity_result.edges_deleted;
                 result.entities_deleted += entity_result.entities_deleted;
                 result.warnings.extend(entity_result.warnings);

--- a/pensyve-core/src/gdpr.rs
+++ b/pensyve-core/src/gdpr.rs
@@ -119,62 +119,88 @@ pub fn erase_namespace(
     Ok(result)
 }
 
-/// Export all data for an entity (DSAR -- Data Subject Access Request).
+/// Export all data for an entity (DSAR — Data Subject Access Request).
+///
+/// Under GDPR Art. 15 the data subject has the right to receive all personal
+/// data, including data **derived** from their conversations. Observations
+/// extracted from episodes the entity participated in are derived personal
+/// data and must be included in the export.
 pub fn export_entity_data(
     storage: &dyn StorageTrait,
     entity_id: Uuid,
     namespace_id: Uuid,
 ) -> Result<ExportResult, StorageError> {
+    use std::collections::HashSet;
+
     let all_memories = storage.get_all_memories_by_namespace(namespace_id)?;
 
-    let entity_memories: Vec<String> = all_memories
-        .into_iter()
-        .filter(|m| match m {
-            Memory::Episodic(e) => e.about_entity == entity_id || e.source_entity == entity_id,
-            Memory::Semantic(s) => s.subject == entity_id,
-            // Procedurals carry no entity reference; observations cascade
-            // with their source episode via the storage FK and are included
-            // indirectly when their parent episode matches.
-            Memory::Procedural(_) | Memory::Observation(_) => false,
-        })
-        .map(|m| {
-            let json = match m {
-                Memory::Episodic(e) => serde_json::json!({
-                    "type": "episodic",
-                    "id": e.id.to_string(),
-                    "content": e.content,
-                    "timestamp": e.timestamp.to_rfc3339(),
-                }),
-                Memory::Semantic(s) => serde_json::json!({
-                    "type": "semantic",
-                    "id": s.id.to_string(),
-                    "subject": s.subject.to_string(),
-                    "predicate": s.predicate,
-                    "object": s.object,
-                }),
-                Memory::Procedural(p) => serde_json::json!({
-                    "type": "procedural",
-                    "id": p.id.to_string(),
-                    "trigger": p.trigger,
-                    "action": p.action,
-                }),
-                Memory::Observation(o) => serde_json::json!({
+    // First pass: collect the entity's episodic + semantic memories AND the
+    // set of episode IDs that the entity participated in.
+    let mut entity_episode_ids: HashSet<Uuid> = HashSet::new();
+    let mut exports: Vec<String> = Vec::new();
+
+    for m in &all_memories {
+        match m {
+            Memory::Episodic(e) if e.about_entity == entity_id || e.source_entity == entity_id => {
+                entity_episode_ids.insert(e.episode_id);
+                exports.push(
+                    serde_json::json!({
+                        "type": "episodic",
+                        "id": e.id.to_string(),
+                        "episode_id": e.episode_id.to_string(),
+                        "content": e.content,
+                        "timestamp": e.timestamp.to_rfc3339(),
+                    })
+                    .to_string(),
+                );
+            }
+            Memory::Semantic(s) if s.subject == entity_id => {
+                exports.push(
+                    serde_json::json!({
+                        "type": "semantic",
+                        "id": s.id.to_string(),
+                        "subject": s.subject.to_string(),
+                        "predicate": s.predicate,
+                        "object": s.object,
+                    })
+                    .to_string(),
+                );
+            }
+            _ => {}
+        }
+    }
+
+    // Second pass: include observations whose source episode the entity
+    // participated in. Under GDPR these are derived personal data and must
+    // be part of the DSAR response.
+    for m in &all_memories {
+        if let Memory::Observation(o) = m
+            && entity_episode_ids.contains(&o.episode_id)
+        {
+            exports.push(
+                serde_json::json!({
                     "type": "observation",
                     "id": o.id.to_string(),
                     "episode_id": o.episode_id.to_string(),
                     "entity_type": o.entity_type,
                     "instance": o.instance,
                     "action": o.action,
-                }),
-            };
-            json.to_string()
-        })
-        .collect();
+                    "quantity": o.quantity,
+                    "unit": o.unit,
+                    "content": o.content,
+                    "confidence": o.confidence,
+                    "event_time": o.event_time.map(|t| t.to_rfc3339()),
+                    "created_at": o.created_at.to_rfc3339(),
+                })
+                .to_string(),
+            );
+        }
+    }
 
-    let total = entity_memories.len();
+    let total = exports.len();
 
     Ok(ExportResult {
-        memories: entity_memories,
+        memories: exports,
         entities: vec![serde_json::json!({"id": entity_id.to_string()}).to_string()],
         total_records: total + 1,
     })

--- a/pensyve-core/src/lib.rs
+++ b/pensyve-core/src/lib.rs
@@ -11,6 +11,7 @@ pub mod graph;
 pub mod mesh;
 pub mod multimodal;
 pub mod observability;
+pub mod observation;
 pub mod ocr;
 pub mod procedural;
 pub mod recall_grouped;

--- a/pensyve-core/src/lib.rs
+++ b/pensyve-core/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod a2a;
 pub mod activation;
+pub mod classifier;
 pub mod config;
 pub mod consolidation;
 pub mod decay;

--- a/pensyve-core/src/observation.rs
+++ b/pensyve-core/src/observation.rs
@@ -1,0 +1,743 @@
+//! Observation extraction — ingest-time structured-fact pipeline.
+//!
+//! After an episode closes the configured [`ObservationExtractor`] emits
+//! [`ObservationMemory`] rows that let the reader answer counting and
+//! aggregation questions by deterministic lookup at recall time instead of
+//! scanning raw turns. `recall_grouped` joins observations on the top-k
+//! episodes; they do **not** enter the RRF candidate pool.
+//!
+//! [`NoopExtractor`] is the default and costs nothing. [`AnthropicHaikuExtractor`]
+//! (behind the `observation-extraction` feature) reproduces the R7 benchmark
+//! pipeline — see `research/benchmark-sprint/19-observation-extractor-v1.md`
+//! and `20-observation-extractor-ingest-topk.md`.
+
+use std::fmt::Debug;
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::types::ObservationMemory;
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/// Non-fatal errors from the extractor. Ingest continues; observations are
+/// simply missing for the failing episode.
+#[derive(Debug, Error)]
+pub enum ExtractionError {
+    /// Misconfiguration at construction time (missing env var, bad HTTP
+    /// client setup, invalid base URL). Distinct from `Transport` because
+    /// retrying won't help — the caller needs to fix configuration.
+    #[error("extractor configuration error: {0}")]
+    Config(String),
+
+    /// The extractor's backing service (HTTP API, local model, etc.) failed.
+    #[error("extractor transport error: {0}")]
+    Transport(String),
+
+    /// The extractor returned malformed output that couldn't be parsed.
+    #[error("extractor response parse error: {0}")]
+    Parse(String),
+
+    /// The extractor exceeded a configured budget — cost cap, token limit,
+    /// or wall-clock timeout.
+    #[error("extractor budget exceeded: {0}")]
+    BudgetExceeded(String),
+
+    /// Unclassified runtime error.
+    #[error("extraction failed: {0}")]
+    Other(String),
+}
+
+pub type ExtractionResult<T> = Result<T, ExtractionError>;
+
+// ---------------------------------------------------------------------------
+// Message representation passed to the extractor
+// ---------------------------------------------------------------------------
+
+/// One turn from the episode, handed to the extractor verbatim.
+///
+/// The extractor sees the full conversation for the episode. Harness
+/// experiments in `research/benchmark-sprint/20-observation-extractor-ingest-topk.md`
+/// found that full-session context produces better countable-entity
+/// identification than per-turn or per-fragment extraction.
+#[derive(Debug, Clone)]
+pub struct ExtractionMessage {
+    pub role: String,
+    pub content: String,
+    pub event_time: Option<DateTime<Utc>>,
+}
+
+// ---------------------------------------------------------------------------
+// Trait
+// ---------------------------------------------------------------------------
+
+/// Pluggable extraction backend.
+///
+/// Implementations run asynchronously after episode close. They MUST be
+/// resilient to malformed input and NEVER panic — ingest latency depends on
+/// this. On error, return `Err(ExtractionError)`; the caller will log and
+/// continue without observations for the episode.
+#[async_trait]
+pub trait ObservationExtractor: Send + Sync + Debug {
+    /// Extract observations from a single episode's messages.
+    ///
+    /// Arguments:
+    ///
+    /// * `namespace_id` — namespace the episode belongs to; propagates into
+    ///   the returned `ObservationMemory` rows.
+    /// * `episode_id` — source episode; every returned observation carries
+    ///   this as its `episode_id` (verified by callers).
+    /// * `messages` — ordered turns in the episode. May be empty (in which
+    ///   case return an empty vec).
+    ///
+    /// Returns an owned `Vec` of observations. The caller is responsible for
+    /// computing embeddings and persisting to storage.
+    async fn extract(
+        &self,
+        namespace_id: Uuid,
+        episode_id: Uuid,
+        messages: &[ExtractionMessage],
+    ) -> ExtractionResult<Vec<ObservationMemory>>;
+}
+
+// ---------------------------------------------------------------------------
+// NoopExtractor (default)
+// ---------------------------------------------------------------------------
+
+/// Default extractor: produces no observations for any episode.
+///
+/// Wired into `Pensyve::builder()` as the default so users who don't opt in
+/// to observation extraction pay zero runtime cost. The ingest hook
+/// short-circuits when the extractor is `NoopExtractor` (Phase 1.5).
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NoopExtractor;
+
+#[async_trait]
+impl ObservationExtractor for NoopExtractor {
+    async fn extract(
+        &self,
+        _namespace_id: Uuid,
+        _episode_id: Uuid,
+        _messages: &[ExtractionMessage],
+    ) -> ExtractionResult<Vec<ObservationMemory>> {
+        Ok(Vec::new())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// AnthropicHaikuExtractor (feature-gated)
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "observation-extraction")]
+mod haiku {
+    use super::{
+        ExtractionError, ExtractionMessage, ExtractionResult, ObservationExtractor,
+        ObservationMemory,
+    };
+    use async_trait::async_trait;
+    use chrono::{DateTime, Utc};
+    use serde::{Deserialize, Serialize};
+    use std::fmt::Write as _;
+    use std::time::Duration;
+    use uuid::Uuid;
+
+    /// Exact prompt the R7 benchmark used to score 89.0% on `LongMemEval_S`.
+    /// See `research/benchmark-sprint/19-observation-extractor-v1.md` and
+    /// the harness copy at
+    /// `research/benchmark-sprint/harness/benchmarks/longmemeval/bench_v2/observation_extractor.py`.
+    pub const EXTRACTION_PROMPT_V1: &str = "You are a structured-data extractor. \
+Given recalled conversation memories between a user and an assistant, \
+extract every **countable entity instance** mentioned by the USER (not the \
+assistant's suggestions unless the user confirmed them).
+
+A countable entity is something that could answer a \"how many\", \"how often\", \
+or \"list every\" question: items purchased, hours spent on activities, places \
+visited, books read, projects worked on, meals cooked, clothing items, pets, \
+tanks, plants, games played, etc.
+
+For each instance, output a JSON object:
+{
+  \"entity_type\": \"<category, e.g. 'game_played', 'book_read', 'place_visited'>\",
+  \"instance\": \"<specific name, e.g. 'Assassin's Creed Odyssey'>\",
+  \"action\": \"<what the user did, e.g. 'played', 'read', 'visited'>\",
+  \"quantity\": <numeric value if stated, else null>,
+  \"unit\": \"<unit if applicable, e.g. 'hours', 'pages', else null>\",
+  \"confidence\": <0.0-1.0, lower for hedged/hypothetical mentions>
+}
+
+Rules:
+- Only extract things the USER actually did, owns, or experienced. Exclude \
+assistant suggestions that the user did not confirm, hypotheticals, and \
+\"I might...\" / \"I'm thinking about...\" statements.
+- If the user mentions doing the same thing multiple times with different \
+quantities (e.g., \"played 25 hours\" then later \"played another 30 hours\"), \
+extract EACH as a separate instance with its own quantity.
+- Set confidence < 0.5 for anything hedged, uncertain, merely planned but \
+not confirmed, or ambiguous.
+- Include items the user needs to pick up, return, buy, etc. — these are \
+countable actions even if not yet completed.
+- Pay attention to whether something was ACTUALLY done vs merely MENTIONED \
+or SUGGESTED. \"I bought boots\" = extract. \"You could try boots\" from the \
+assistant without user confirmation = do NOT extract.
+- If no countable entities are found, return an empty array: []
+
+Output ONLY a JSON array of objects. No prose, no explanation, no markdown fences.";
+
+    const DEFAULT_MODEL: &str = "claude-haiku-4-5-20251001";
+    const DEFAULT_MAX_TOKENS: u32 = 4096;
+    const DEFAULT_TIMEOUT_SECS: u64 = 60;
+    const ANTHROPIC_VERSION: &str = "2023-06-01";
+
+    /// Anthropic-Messages-API-backed observation extractor.
+    ///
+    /// Pinned to Haiku 4.5 by default — the model that reproduces the
+    /// benchmark headline. The API base URL is overridable for testing.
+    #[derive(Debug, Clone)]
+    pub struct AnthropicHaikuExtractor {
+        client: reqwest::Client,
+        api_key: String,
+        model: String,
+        max_tokens: u32,
+        base_url: String,
+    }
+
+    impl AnthropicHaikuExtractor {
+        /// Build an extractor using the `ANTHROPIC_API_KEY` env var.
+        ///
+        /// Returns `ExtractionError::Config` if the env var is missing.
+        pub fn from_env() -> ExtractionResult<Self> {
+            let api_key = std::env::var("ANTHROPIC_API_KEY").map_err(|_| {
+                ExtractionError::Config("ANTHROPIC_API_KEY env var not set".into())
+            })?;
+            Self::new(api_key)
+        }
+
+        /// Build an extractor with an explicit API key.
+        pub fn new(api_key: impl Into<String>) -> ExtractionResult<Self> {
+            let client = reqwest::Client::builder()
+                .timeout(Duration::from_secs(DEFAULT_TIMEOUT_SECS))
+                .build()
+                .map_err(|e| ExtractionError::Config(format!("http client build: {e}")))?;
+            Ok(Self {
+                client,
+                api_key: api_key.into(),
+                model: DEFAULT_MODEL.into(),
+                max_tokens: DEFAULT_MAX_TOKENS,
+                base_url: "https://api.anthropic.com".into(),
+            })
+        }
+
+        /// Override the model ID. Defaults to `claude-haiku-4-5-20251001`.
+        /// Changing the model invalidates any benchmark-reproducibility claim.
+        #[must_use]
+        pub fn with_model(mut self, model: impl Into<String>) -> Self {
+            self.model = model.into();
+            self
+        }
+
+        /// Override the base URL (primarily for test mocks).
+        #[must_use]
+        pub fn with_base_url(mut self, base_url: impl Into<String>) -> Self {
+            self.base_url = base_url.into();
+            self
+        }
+
+        fn build_prompt(messages: &[ExtractionMessage]) -> String {
+            if messages.is_empty() {
+                return format!("{EXTRACTION_PROMPT_V1}\n\n[No conversation memories provided.]\n");
+            }
+            let mut body = String::new();
+            for m in messages {
+                let date = m.event_time.map_or_else(
+                    || "unknown".to_string(),
+                    |t| t.format("%Y-%m-%d").to_string(),
+                );
+                let _ = writeln!(body, "[{date}] {}: {}", m.role, m.content);
+            }
+            format!(
+                "{EXTRACTION_PROMPT_V1}\n\n--- Recalled memories ---\n{body}--- End memories ---"
+            )
+        }
+    }
+
+    /// Raw response body from Anthropic Messages API.
+    #[derive(Debug, Deserialize)]
+    struct AnthropicResponse {
+        content: Vec<AnthropicContentBlock>,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct AnthropicContentBlock {
+        #[serde(rename = "type")]
+        block_type: String,
+        #[serde(default)]
+        text: String,
+    }
+
+    #[derive(Debug, Serialize)]
+    struct AnthropicRequest<'a> {
+        model: &'a str,
+        max_tokens: u32,
+        temperature: f32,
+        messages: Vec<AnthropicMessage<'a>>,
+    }
+
+    #[derive(Debug, Serialize)]
+    struct AnthropicMessage<'a> {
+        role: &'a str,
+        content: &'a str,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct RawObservation {
+        entity_type: String,
+        instance: String,
+        action: String,
+        #[serde(default)]
+        quantity: Option<f64>,
+        #[serde(default)]
+        unit: Option<String>,
+        #[serde(default = "default_raw_confidence")]
+        confidence: f32,
+    }
+
+    fn default_raw_confidence() -> f32 {
+        0.8
+    }
+
+    /// Strip markdown fences, extract the outermost `[ ... ]` JSON array,
+    /// parse. Returns an empty vec on any failure — matches the harness's
+    /// graceful-degradation behavior.
+    fn parse_response(text: &str) -> Vec<RawObservation> {
+        let trimmed = text.trim();
+        let no_fence = if let (Some(start), Some(end)) = (trimmed.find("```"), trimmed.rfind("```"))
+            && end > start
+        {
+            let inner = &trimmed[start..=end];
+            inner
+                .trim_start_matches("```json")
+                .trim_start_matches("```")
+                .trim_end_matches("```")
+                .trim()
+        } else {
+            trimmed
+        };
+
+        let bracket_start = no_fence.find('[');
+        let bracket_end = no_fence.rfind(']');
+        let slice = match (bracket_start, bracket_end) {
+            (Some(s), Some(e)) if e > s => &no_fence[s..=e],
+            _ => return Vec::new(),
+        };
+
+        serde_json::from_str(slice).unwrap_or_default()
+    }
+
+    fn raw_to_observation(
+        raw: RawObservation,
+        namespace_id: Uuid,
+        episode_id: Uuid,
+        event_time: Option<DateTime<Utc>>,
+    ) -> ObservationMemory {
+        let content = format_observation_content(&raw);
+        let mut obs = ObservationMemory::new(
+            namespace_id,
+            episode_id,
+            raw.entity_type,
+            raw.instance,
+            raw.action,
+            content,
+        );
+        obs.quantity = raw.quantity;
+        obs.unit = raw.unit;
+        obs.confidence = raw.confidence.clamp(0.0, 1.0);
+        obs.event_time = event_time;
+        obs
+    }
+
+    /// Render a human-readable sentence used as the embedding + display content.
+    /// Matches the format the Phase 0c reader prompt was trained against.
+    fn format_observation_content(raw: &RawObservation) -> String {
+        let base = format!("{} {}", raw.action, raw.instance);
+        match (raw.quantity, raw.unit.as_deref()) {
+            (Some(q), Some(u)) => format!("{base} ({q} {u})"),
+            (Some(q), None) => format!("{base} ({q})"),
+            (None, Some(u)) => format!("{base} ({u})"),
+            (None, None) => base,
+        }
+    }
+
+    #[async_trait]
+    impl ObservationExtractor for AnthropicHaikuExtractor {
+        async fn extract(
+            &self,
+            namespace_id: Uuid,
+            episode_id: Uuid,
+            messages: &[ExtractionMessage],
+        ) -> ExtractionResult<Vec<ObservationMemory>> {
+            let prompt = Self::build_prompt(messages);
+            let last_event_time = messages.iter().filter_map(|m| m.event_time).max();
+
+            let req = AnthropicRequest {
+                model: &self.model,
+                max_tokens: self.max_tokens,
+                temperature: 0.0,
+                messages: vec![AnthropicMessage {
+                    role: "user",
+                    content: &prompt,
+                }],
+            };
+
+            let url = format!("{}/v1/messages", self.base_url.trim_end_matches('/'));
+            let response = self
+                .client
+                .post(&url)
+                .header("x-api-key", &self.api_key)
+                .header("anthropic-version", ANTHROPIC_VERSION)
+                .header("content-type", "application/json")
+                .json(&req)
+                .send()
+                .await
+                .map_err(|e| ExtractionError::Transport(e.to_string()))?;
+
+            if !response.status().is_success() {
+                let status = response.status();
+                let body = response.text().await.unwrap_or_default();
+                return Err(ExtractionError::Transport(format!(
+                    "HTTP {status}: {body}"
+                )));
+            }
+
+            let parsed: AnthropicResponse = response
+                .json()
+                .await
+                .map_err(|e| ExtractionError::Parse(e.to_string()))?;
+
+            let text = parsed
+                .content
+                .into_iter()
+                .find(|b| b.block_type == "text")
+                .map(|b| b.text)
+                .unwrap_or_default();
+
+            let raws = parse_response(&text);
+            Ok(raws
+                .into_iter()
+                .map(|r| raw_to_observation(r, namespace_id, episode_id, last_event_time))
+                .collect())
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // Tests
+    // -------------------------------------------------------------------
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use wiremock::matchers::{header, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        fn anthropic_response_body(text: &str) -> serde_json::Value {
+            serde_json::json!({
+                "id": "msg_test",
+                "type": "message",
+                "role": "assistant",
+                "model": "claude-haiku-4-5-20251001",
+                "content": [{"type": "text", "text": text}],
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 0, "output_tokens": 0},
+            })
+        }
+
+        #[tokio::test]
+        async fn extractor_parses_successful_response() {
+            let server = MockServer::start().await;
+            let canned = serde_json::to_string(&serde_json::json!([
+                {
+                    "entity_type": "game_played",
+                    "instance": "Assassin's Creed Odyssey",
+                    "action": "played",
+                    "quantity": 70,
+                    "unit": "hours",
+                    "confidence": 0.9
+                },
+                {
+                    "entity_type": "book_read",
+                    "instance": "Dune",
+                    "action": "read",
+                    "quantity": null,
+                    "unit": null,
+                    "confidence": 0.8
+                }
+            ]))
+            .unwrap();
+
+            Mock::given(method("POST"))
+                .and(path("/v1/messages"))
+                .and(header("x-api-key", "test-key"))
+                .and(header("anthropic-version", ANTHROPIC_VERSION))
+                .respond_with(ResponseTemplate::new(200).set_body_json(anthropic_response_body(&canned)))
+                .mount(&server)
+                .await;
+
+            let extractor = AnthropicHaikuExtractor::new("test-key")
+                .unwrap()
+                .with_base_url(server.uri());
+            let ns = Uuid::new_v4();
+            let ep = Uuid::new_v4();
+            let result = extractor
+                .extract(
+                    ns,
+                    ep,
+                    &[ExtractionMessage {
+                        role: "user".into(),
+                        content: "I played AC Odyssey for 70 hours".into(),
+                        event_time: None,
+                    }],
+                )
+                .await
+                .unwrap();
+            assert_eq!(result.len(), 2);
+            assert_eq!(result[0].namespace_id, ns);
+            assert_eq!(result[0].episode_id, ep);
+            assert_eq!(result[0].instance, "Assassin's Creed Odyssey");
+            assert_eq!(result[0].quantity, Some(70.0));
+            assert_eq!(result[0].unit.as_deref(), Some("hours"));
+            assert_eq!(result[1].instance, "Dune");
+            assert!(result[1].quantity.is_none());
+        }
+
+        #[tokio::test]
+        async fn extractor_survives_markdown_fence_wrapper() {
+            let server = MockServer::start().await;
+            let fenced = "```json\n[{\"entity_type\":\"x\",\"instance\":\"y\",\"action\":\"z\",\"confidence\":0.8}]\n```";
+            Mock::given(method("POST"))
+                .and(path("/v1/messages"))
+                .respond_with(
+                    ResponseTemplate::new(200).set_body_json(anthropic_response_body(fenced)),
+                )
+                .mount(&server)
+                .await;
+
+            let extractor = AnthropicHaikuExtractor::new("k")
+                .unwrap()
+                .with_base_url(server.uri());
+            let out = extractor
+                .extract(Uuid::new_v4(), Uuid::new_v4(), &[])
+                .await
+                .unwrap();
+            assert_eq!(out.len(), 1);
+            assert_eq!(out[0].instance, "y");
+        }
+
+        #[tokio::test]
+        async fn extractor_returns_empty_on_unparseable_response() {
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path("/v1/messages"))
+                .respond_with(
+                    ResponseTemplate::new(200)
+                        .set_body_json(anthropic_response_body("sorry, I cannot help with that")),
+                )
+                .mount(&server)
+                .await;
+
+            let extractor = AnthropicHaikuExtractor::new("k")
+                .unwrap()
+                .with_base_url(server.uri());
+            let out = extractor
+                .extract(Uuid::new_v4(), Uuid::new_v4(), &[])
+                .await
+                .unwrap();
+            assert!(out.is_empty());
+        }
+
+        #[tokio::test]
+        async fn extractor_surfaces_http_errors_as_transport_error() {
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path("/v1/messages"))
+                .respond_with(ResponseTemplate::new(500).set_body_string("server broke"))
+                .mount(&server)
+                .await;
+
+            let extractor = AnthropicHaikuExtractor::new("k")
+                .unwrap()
+                .with_base_url(server.uri());
+            let err = extractor
+                .extract(Uuid::new_v4(), Uuid::new_v4(), &[])
+                .await
+                .unwrap_err();
+            assert!(matches!(err, ExtractionError::Transport(_)));
+        }
+
+        #[test]
+        fn new_rejects_when_api_key_lookup_fails() {
+            // Exercise the same error path as `from_env` without mutating
+            // the process env — that would race with other parallel tests.
+            // An empty key is accepted by `new()` but callers should not
+            // rely on that; the Config error variant is what `from_env`
+            // returns when the var is missing.
+            let err = AnthropicHaikuExtractor::new("")
+                .and_then(|e| {
+                    // Confirm construction doesn't validate key shape.
+                    // If the constructor starts validating, update this test.
+                    Ok(e)
+                })
+                .err();
+            assert!(err.is_none(), "constructor should not validate key shape");
+        }
+
+        #[test]
+        fn from_env_error_is_config_variant() {
+            // We can't remove the env var safely (process-wide race), but we
+            // can verify the error variant by inspecting the function
+            // signature via a direct Config construction.
+            let e = ExtractionError::Config("missing".into());
+            assert!(matches!(e, ExtractionError::Config(_)));
+        }
+
+        #[test]
+        fn prompt_contains_instruction_and_memory_body() {
+            let msgs = [ExtractionMessage {
+                role: "user".into(),
+                content: "I played AC Odyssey".into(),
+                event_time: None,
+            }];
+            let prompt = AnthropicHaikuExtractor::build_prompt(&msgs);
+            assert!(prompt.contains("countable entity"));
+            assert!(prompt.contains("user: I played AC Odyssey"));
+            assert!(prompt.contains("--- Recalled memories ---"));
+        }
+
+        #[test]
+        fn prompt_handles_empty_messages() {
+            let prompt = AnthropicHaikuExtractor::build_prompt(&[]);
+            assert!(prompt.contains("No conversation memories provided"));
+        }
+
+        #[test]
+        fn parse_response_clamps_confidence() {
+            let raw = r#"[{"entity_type":"x","instance":"y","action":"z","confidence":1.5}]"#;
+            let parsed = parse_response(raw);
+            let obs = raw_to_observation(parsed.into_iter().next().unwrap(), Uuid::new_v4(), Uuid::new_v4(), None);
+            assert!(obs.confidence <= 1.0);
+            assert!(obs.confidence >= 0.0);
+        }
+    }
+}
+
+#[cfg(feature = "observation-extraction")]
+pub use haiku::{AnthropicHaikuExtractor, EXTRACTION_PROMPT_V1};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn noop_returns_empty() {
+        let extractor = NoopExtractor;
+        let ns = Uuid::new_v4();
+        let ep = Uuid::new_v4();
+        let msgs = vec![ExtractionMessage {
+            role: "user".into(),
+            content: "I played Assassin's Creed Odyssey for 70 hours".into(),
+            event_time: None,
+        }];
+        let out = extractor.extract(ns, ep, &msgs).await.unwrap();
+        assert!(out.is_empty());
+    }
+
+    #[tokio::test]
+    async fn noop_accepts_empty_messages() {
+        let extractor = NoopExtractor;
+        let out = extractor
+            .extract(Uuid::new_v4(), Uuid::new_v4(), &[])
+            .await
+            .unwrap();
+        assert!(out.is_empty());
+    }
+
+    // Compile-time assertion: the trait is object-safe (dyn-compatible).
+    // If a non-dyn-safe signature is ever added (e.g., generic method), this
+    // fails to compile — fail loudly before it lands in production.
+    #[allow(dead_code)]
+    fn trait_is_object_safe() {
+        fn takes_dyn(_: &dyn ObservationExtractor) {}
+        takes_dyn(&NoopExtractor);
+    }
+
+    /// A canned extractor used by integration tests to exercise the ingest
+    /// hook without an external API. Returns `fixed` on every call.
+    #[derive(Debug, Clone)]
+    struct MockExtractor {
+        fixed: Vec<ObservationMemory>,
+    }
+
+    #[async_trait]
+    impl ObservationExtractor for MockExtractor {
+        async fn extract(
+            &self,
+            _namespace_id: Uuid,
+            _episode_id: Uuid,
+            _messages: &[ExtractionMessage],
+        ) -> ExtractionResult<Vec<ObservationMemory>> {
+            Ok(self.fixed.clone())
+        }
+    }
+
+    #[tokio::test]
+    async fn mock_extractor_passes_through_fixed_output() {
+        let ns = Uuid::new_v4();
+        let ep = Uuid::new_v4();
+        let fixed = vec![ObservationMemory::new(
+            ns,
+            ep,
+            "game_played",
+            "AC Odyssey",
+            "played",
+            "User played AC Odyssey",
+        )];
+        let extractor = MockExtractor {
+            fixed: fixed.clone(),
+        };
+        let out = extractor.extract(ns, ep, &[]).await.unwrap();
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].id, fixed[0].id);
+    }
+
+    /// An extractor that always fails, used to exercise the non-fatal
+    /// error path in Phase 1.5.
+    #[derive(Debug)]
+    struct FailingExtractor;
+
+    #[async_trait]
+    impl ObservationExtractor for FailingExtractor {
+        async fn extract(
+            &self,
+            _: Uuid,
+            _: Uuid,
+            _: &[ExtractionMessage],
+        ) -> ExtractionResult<Vec<ObservationMemory>> {
+            Err(ExtractionError::Transport("boom".into()))
+        }
+    }
+
+    #[tokio::test]
+    async fn failing_extractor_returns_error() {
+        let extractor = FailingExtractor;
+        let result = extractor
+            .extract(Uuid::new_v4(), Uuid::new_v4(), &[])
+            .await;
+        assert!(matches!(result, Err(ExtractionError::Transport(_))));
+    }
+}

--- a/pensyve-core/src/observation.rs
+++ b/pensyve-core/src/observation.rs
@@ -636,6 +636,119 @@ Output ONLY a JSON array of objects. No prose, no explanation, no markdown fence
 pub use haiku::{AnthropicHaikuExtractor, EXTRACTION_PROMPT_V1};
 
 // ---------------------------------------------------------------------------
+// Ingest helper — canonical post-episode-close extraction flow
+// ---------------------------------------------------------------------------
+
+/// Errors are logged via `tracing::warn!` and swallowed; the caller's
+/// episode is already durable regardless of what happens here.
+///
+/// `embed` receives each observation's `content` string and must return an
+/// embedding vector (or a boxed error). Taking a closure keeps `pensyve-core`
+/// independent of the concrete embedder implementation.
+///
+/// Returns the number of observations successfully persisted.
+pub async fn commit_extraction_for_episode<F, E>(
+    storage: &(dyn crate::storage::StorageTrait + Send + Sync),
+    extractor: &dyn ObservationExtractor,
+    namespace_id: Uuid,
+    episode_id: Uuid,
+    mut embed: F,
+) -> usize
+where
+    F: FnMut(&str) -> Result<Vec<f32>, E>,
+    E: std::fmt::Display,
+{
+    let raw_messages = match storage.list_episodic_by_episode(namespace_id, episode_id) {
+        Ok(m) => m,
+        Err(e) => {
+            tracing::warn!(
+                target: "pensyve::observation",
+                error = %e,
+                episode_id = %episode_id,
+                "failed to load episode messages for extraction"
+            );
+            return 0;
+        }
+    };
+
+    if raw_messages.is_empty() {
+        return 0;
+    }
+
+    let extraction_messages: Vec<ExtractionMessage> = raw_messages
+        .iter()
+        .map(|m| {
+            // Strip the "role: " prefix ingested by callers (see
+            // `run_pensyve_retrieve.py` / PyEpisode ingest pattern). If the
+            // content doesn't start with a role marker, keep as-is.
+            let (role, content) = split_role_prefix(&m.content);
+            ExtractionMessage {
+                role: role.to_string(),
+                content: content.to_string(),
+                event_time: m.event_time,
+            }
+        })
+        .collect();
+
+    let observations = match extractor
+        .extract(namespace_id, episode_id, &extraction_messages)
+        .await
+    {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(
+                target: "pensyve::observation",
+                error = %e,
+                episode_id = %episode_id,
+                "extractor failed — episode persists without observations"
+            );
+            return 0;
+        }
+    };
+
+    let mut persisted = 0usize;
+    for mut obs in observations {
+        match embed(&obs.content) {
+            Ok(v) => obs.embedding = v,
+            Err(e) => {
+                tracing::warn!(
+                    target: "pensyve::observation",
+                    error = %e,
+                    observation_id = %obs.id,
+                    "failed to embed observation content"
+                );
+                continue;
+            }
+        }
+        if let Err(e) = storage.save_observation(&obs) {
+            tracing::warn!(
+                target: "pensyve::observation",
+                error = %e,
+                observation_id = %obs.id,
+                "failed to persist observation"
+            );
+            continue;
+        }
+        persisted += 1;
+    }
+    persisted
+}
+
+/// Split `"role: content"` ingested form back into its two parts. If no
+/// colon is present or the prefix is empty, returns `("user", full)`.
+fn split_role_prefix(raw: &str) -> (&str, &str) {
+    let Some(idx) = raw.find(':') else {
+        return ("user", raw);
+    };
+    let (role, rest) = raw.split_at(idx);
+    if role.is_empty() {
+        return ("user", raw);
+    }
+    let content = rest.trim_start_matches(':').trim_start();
+    (role, content)
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -739,5 +852,139 @@ mod tests {
             .extract(Uuid::new_v4(), Uuid::new_v4(), &[])
             .await;
         assert!(matches!(result, Err(ExtractionError::Transport(_))));
+    }
+
+    // -----------------------------------------------------------------------
+    // commit_extraction_for_episode — integration with storage
+    // -----------------------------------------------------------------------
+
+    use crate::storage::StorageTrait;
+    use crate::storage::sqlite::SqliteBackend;
+    use crate::types::{EpisodicMemory, Namespace, ObservationMemory};
+    use tempfile::TempDir;
+
+    /// Closure that pretends to embed — returns a fixed-size vector of 1.0s.
+    /// Real flows plug in `OnnxEmbedder::embed`; this keeps the core test
+    /// independent of the embedding model.
+    fn fake_embed(_text: &str) -> Result<Vec<f32>, std::io::Error> {
+        Ok(vec![1.0_f32; 4])
+    }
+
+    fn setup_storage() -> (TempDir, SqliteBackend, Namespace, Uuid) {
+        let dir = TempDir::new().unwrap();
+        let db = SqliteBackend::open(dir.path()).unwrap();
+        let ns = Namespace::new("test-obs-ingest");
+        db.save_namespace(&ns).unwrap();
+
+        let episode_id = Uuid::new_v4();
+        let src = Uuid::new_v4();
+        let about = Uuid::new_v4();
+        // Two messages in the episode — the extractor should see both.
+        for content in ["user: I played AC Odyssey", "user: I finished Dune"] {
+            let mut mem = EpisodicMemory::new(ns.id, episode_id, src, about, content);
+            mem.event_time = Some(Utc::now());
+            db.save_episodic(&mem).unwrap();
+        }
+        (dir, db, ns, episode_id)
+    }
+
+    #[tokio::test]
+    async fn commit_extraction_noop_persists_nothing() {
+        let (_dir, db, ns, ep) = setup_storage();
+        let persisted =
+            commit_extraction_for_episode(&db, &NoopExtractor, ns.id, ep, fake_embed).await;
+        assert_eq!(persisted, 0);
+    }
+
+    #[tokio::test]
+    async fn commit_extraction_persists_mock_observations_with_embeddings() {
+        let (_dir, db, ns, ep) = setup_storage();
+        let fixed = vec![
+            ObservationMemory::new(ns.id, ep, "game_played", "AC Odyssey", "played", "played AC Odyssey"),
+            ObservationMemory::new(ns.id, ep, "book_read", "Dune", "read", "read Dune"),
+        ];
+        let extractor = MockExtractor { fixed };
+        let persisted =
+            commit_extraction_for_episode(&db, &extractor, ns.id, ep, fake_embed).await;
+        assert_eq!(persisted, 2);
+
+        // Verify the observations landed with embeddings attached.
+        let stored = db.list_observations_by_episode_ids(&[ep], 100).unwrap();
+        assert_eq!(stored.len(), 2);
+        for obs in &stored {
+            assert_eq!(obs.namespace_id, ns.id);
+            assert_eq!(obs.episode_id, ep);
+            assert_eq!(obs.embedding, vec![1.0_f32; 4]);
+        }
+        let instances: std::collections::HashSet<_> =
+            stored.iter().map(|o| o.instance.clone()).collect();
+        assert!(instances.contains("AC Odyssey"));
+        assert!(instances.contains("Dune"));
+    }
+
+    #[tokio::test]
+    async fn commit_extraction_swallows_extractor_failure() {
+        let (_dir, db, ns, ep) = setup_storage();
+        let persisted =
+            commit_extraction_for_episode(&db, &FailingExtractor, ns.id, ep, fake_embed).await;
+        assert_eq!(persisted, 0);
+
+        // Episode's raw memories are untouched — ingest is non-fatal.
+        let raw = db.list_episodic_by_episode(ns.id, ep).unwrap();
+        assert_eq!(raw.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn commit_extraction_swallows_embedding_failure() {
+        let (_dir, db, ns, ep) = setup_storage();
+        let extractor = MockExtractor {
+            fixed: vec![ObservationMemory::new(
+                ns.id, ep, "x", "y", "z", "z y",
+            )],
+        };
+        let fail_embed = |_: &str| -> Result<Vec<f32>, std::io::Error> {
+            Err(std::io::Error::other("embedder down"))
+        };
+        let persisted =
+            commit_extraction_for_episode(&db, &extractor, ns.id, ep, fail_embed).await;
+        assert_eq!(persisted, 0);
+
+        let stored = db.list_observations_by_episode_ids(&[ep], 100).unwrap();
+        assert!(stored.is_empty());
+    }
+
+    #[tokio::test]
+    async fn commit_extraction_skips_when_episode_has_no_messages() {
+        let dir = TempDir::new().unwrap();
+        let db = SqliteBackend::open(dir.path()).unwrap();
+        let ns = Namespace::new("empty");
+        db.save_namespace(&ns).unwrap();
+        let ep = Uuid::new_v4();
+
+        let extractor = MockExtractor {
+            fixed: vec![ObservationMemory::new(
+                ns.id, ep, "should", "not", "persist", "",
+            )],
+        };
+        let persisted =
+            commit_extraction_for_episode(&db, &extractor, ns.id, ep, fake_embed).await;
+        assert_eq!(persisted, 0);
+    }
+
+    #[test]
+    fn split_role_prefix_handles_role_colon_content() {
+        assert_eq!(split_role_prefix("user: hi"), ("user", "hi"));
+        assert_eq!(split_role_prefix("assistant: hello"), ("assistant", "hello"));
+    }
+
+    #[test]
+    fn split_role_prefix_handles_missing_prefix() {
+        assert_eq!(split_role_prefix("no prefix"), ("user", "no prefix"));
+        assert_eq!(split_role_prefix(""), ("user", ""));
+    }
+
+    #[test]
+    fn split_role_prefix_trims_trailing_whitespace_after_colon() {
+        assert_eq!(split_role_prefix("user:   spaces"), ("user", "spaces"));
     }
 }

--- a/pensyve-core/src/observation.rs
+++ b/pensyve-core/src/observation.rs
@@ -210,9 +210,8 @@ Output ONLY a JSON array of objects. No prose, no explanation, no markdown fence
         ///
         /// Returns `ExtractionError::Config` if the env var is missing.
         pub fn from_env() -> ExtractionResult<Self> {
-            let api_key = std::env::var("ANTHROPIC_API_KEY").map_err(|_| {
-                ExtractionError::Config("ANTHROPIC_API_KEY env var not set".into())
-            })?;
+            let api_key = std::env::var("ANTHROPIC_API_KEY")
+                .map_err(|_| ExtractionError::Config("ANTHROPIC_API_KEY env var not set".into()))?;
             Self::new(api_key)
         }
 
@@ -256,7 +255,16 @@ Output ONLY a JSON array of objects. No prose, no explanation, no markdown fence
                     || "unknown".to_string(),
                     |t| t.format("%Y-%m-%d").to_string(),
                 );
-                let _ = writeln!(body, "[{date}] {}: {}", m.role, m.content);
+                // Skip the role prefix when empty — engine ingest paths don't
+                // store role on `EpisodicMemory` (it lives in `source_entity`
+                // + `about_entity` UUIDs instead). Harness callers that DO
+                // know the role can still set it and get the
+                // `[date] role: content` format.
+                if m.role.is_empty() {
+                    let _ = writeln!(body, "[{date}] {}", m.content);
+                } else {
+                    let _ = writeln!(body, "[{date}] {}: {}", m.role, m.content);
+                }
             }
             format!(
                 "{EXTRACTION_PROMPT_V1}\n\n--- Recalled memories ---\n{body}--- End memories ---"
@@ -312,20 +320,15 @@ Output ONLY a JSON array of objects. No prose, no explanation, no markdown fence
     /// Strip markdown fences, extract the outermost `[ ... ]` JSON array,
     /// parse. Returns an empty vec on any failure — matches the harness's
     /// graceful-degradation behavior.
+    ///
+    /// Fence stripping handles the common triple-backtick shapes (with or
+    /// without a `json` language tag) by finding the opening fence, trimming
+    /// the language marker, and cutting at the closing fence. Bracket
+    /// extraction below is a second line of defence when the response
+    /// contains prose before/after the array.
     fn parse_response(text: &str) -> Vec<RawObservation> {
         let trimmed = text.trim();
-        let no_fence = if let (Some(start), Some(end)) = (trimmed.find("```"), trimmed.rfind("```"))
-            && end > start
-        {
-            let inner = &trimmed[start..=end];
-            inner
-                .trim_start_matches("```json")
-                .trim_start_matches("```")
-                .trim_end_matches("```")
-                .trim()
-        } else {
-            trimmed
-        };
+        let no_fence = strip_markdown_fence(trimmed);
 
         let bracket_start = no_fence.find('[');
         let bracket_end = no_fence.rfind(']');
@@ -335,6 +338,27 @@ Output ONLY a JSON array of objects. No prose, no explanation, no markdown fence
         };
 
         serde_json::from_str(slice).unwrap_or_default()
+    }
+
+    /// Remove ```` ``` ```` / ```` ```json ```` / ```` ```\n ```` wrappers
+    /// from an LLM response. Handles the common shapes without regex.
+    fn strip_markdown_fence(s: &str) -> &str {
+        let Some(start) = s.find("```") else {
+            return s;
+        };
+        // Advance past opening fence + optional "json" tag + newline.
+        let after_open = &s[start + 3..];
+        let after_lang = after_open
+            .strip_prefix("json")
+            .unwrap_or(after_open)
+            .trim_start();
+        // Find the CLOSING fence. rfind("```") finds the last one; if the
+        // opening fence is the only one (response wasn't closed), fall back
+        // to the trimmed remainder.
+        let Some(close_rel) = after_lang.rfind("```") else {
+            return after_lang.trim();
+        };
+        after_lang[..close_rel].trim()
     }
 
     fn raw_to_observation(
@@ -407,9 +431,7 @@ Output ONLY a JSON array of objects. No prose, no explanation, no markdown fence
             if !response.status().is_success() {
                 let status = response.status();
                 let body = response.text().await.unwrap_or_default();
-                return Err(ExtractionError::Transport(format!(
-                    "HTTP {status}: {body}"
-                )));
+                return Err(ExtractionError::Transport(format!("HTTP {status}: {body}")));
             }
 
             let parsed: AnthropicResponse = response
@@ -481,7 +503,9 @@ Output ONLY a JSON array of objects. No prose, no explanation, no markdown fence
                 .and(path("/v1/messages"))
                 .and(header("x-api-key", "test-key"))
                 .and(header("anthropic-version", ANTHROPIC_VERSION))
-                .respond_with(ResponseTemplate::new(200).set_body_json(anthropic_response_body(&canned)))
+                .respond_with(
+                    ResponseTemplate::new(200).set_body_json(anthropic_response_body(&canned)),
+                )
                 .mount(&server)
                 .await;
 
@@ -622,10 +646,33 @@ Output ONLY a JSON array of objects. No prose, no explanation, no markdown fence
         }
 
         #[test]
+        fn prompt_omits_role_prefix_when_role_empty() {
+            // Engine ingest path: `EpisodicMemory.content` has no role
+            // prefix. `commit_extraction_for_episode` passes role="" so the
+            // extractor prompt renders `[date] content` without mis-parsing
+            // URLs or timestamps as roles.
+            let msgs = [ExtractionMessage {
+                role: String::new(),
+                content: "Check http://example.com at 10:30".to_string(),
+                event_time: None,
+            }];
+            let prompt = AnthropicHaikuExtractor::build_prompt(&msgs);
+            assert!(prompt.contains("[unknown] Check http://example.com at 10:30"));
+            // And NO "10:" or "http:" being (mis)interpreted as a role marker.
+            assert!(!prompt.contains("10: 30"));
+            assert!(!prompt.contains("http: //"));
+        }
+
+        #[test]
         fn parse_response_clamps_confidence() {
             let raw = r#"[{"entity_type":"x","instance":"y","action":"z","confidence":1.5}]"#;
             let parsed = parse_response(raw);
-            let obs = raw_to_observation(parsed.into_iter().next().unwrap(), Uuid::new_v4(), Uuid::new_v4(), None);
+            let obs = raw_to_observation(
+                parsed.into_iter().next().unwrap(),
+                Uuid::new_v4(),
+                Uuid::new_v4(),
+                None,
+            );
             assert!(obs.confidence <= 1.0);
             assert!(obs.confidence >= 0.0);
         }
@@ -677,16 +724,16 @@ where
 
     let extraction_messages: Vec<ExtractionMessage> = raw_messages
         .iter()
-        .map(|m| {
-            // Strip the "role: " prefix ingested by callers (see
-            // `run_pensyve_retrieve.py` / PyEpisode ingest pattern). If the
-            // content doesn't start with a role marker, keep as-is.
-            let (role, content) = split_role_prefix(&m.content);
-            ExtractionMessage {
-                role: role.to_string(),
-                content: content.to_string(),
-                event_time: m.event_time,
-            }
+        .map(|m| ExtractionMessage {
+            // `EpisodicMemory.content` is the raw user/assistant turn with
+            // no role prefix — role lives in `source_entity` / `about_entity`
+            // UUIDs and would require an extra lookup we don't do here.
+            // The extractor prompt is self-guarding ("Only extract things
+            // the USER actually did…") so omitting role is safe; the
+            // extractor reads the text and decides.
+            role: String::new(),
+            content: m.content.clone(),
+            event_time: m.event_time,
         })
         .collect();
 
@@ -732,20 +779,6 @@ where
         persisted += 1;
     }
     persisted
-}
-
-/// Split `"role: content"` ingested form back into its two parts. If no
-/// colon is present or the prefix is empty, returns `("user", full)`.
-fn split_role_prefix(raw: &str) -> (&str, &str) {
-    let Some(idx) = raw.find(':') else {
-        return ("user", raw);
-    };
-    let (role, rest) = raw.split_at(idx);
-    if role.is_empty() {
-        return ("user", raw);
-    }
-    let content = rest.trim_start_matches(':').trim_start();
-    (role, content)
 }
 
 // ---------------------------------------------------------------------------
@@ -848,9 +881,7 @@ mod tests {
     #[tokio::test]
     async fn failing_extractor_returns_error() {
         let extractor = FailingExtractor;
-        let result = extractor
-            .extract(Uuid::new_v4(), Uuid::new_v4(), &[])
-            .await;
+        let result = extractor.extract(Uuid::new_v4(), Uuid::new_v4(), &[]).await;
         assert!(matches!(result, Err(ExtractionError::Transport(_))));
     }
 
@@ -900,12 +931,18 @@ mod tests {
     async fn commit_extraction_persists_mock_observations_with_embeddings() {
         let (_dir, db, ns, ep) = setup_storage();
         let fixed = vec![
-            ObservationMemory::new(ns.id, ep, "game_played", "AC Odyssey", "played", "played AC Odyssey"),
+            ObservationMemory::new(
+                ns.id,
+                ep,
+                "game_played",
+                "AC Odyssey",
+                "played",
+                "played AC Odyssey",
+            ),
             ObservationMemory::new(ns.id, ep, "book_read", "Dune", "read", "read Dune"),
         ];
         let extractor = MockExtractor { fixed };
-        let persisted =
-            commit_extraction_for_episode(&db, &extractor, ns.id, ep, fake_embed).await;
+        let persisted = commit_extraction_for_episode(&db, &extractor, ns.id, ep, fake_embed).await;
         assert_eq!(persisted, 2);
 
         // Verify the observations landed with embeddings attached.
@@ -938,15 +975,12 @@ mod tests {
     async fn commit_extraction_swallows_embedding_failure() {
         let (_dir, db, ns, ep) = setup_storage();
         let extractor = MockExtractor {
-            fixed: vec![ObservationMemory::new(
-                ns.id, ep, "x", "y", "z", "z y",
-            )],
+            fixed: vec![ObservationMemory::new(ns.id, ep, "x", "y", "z", "z y")],
         };
         let fail_embed = |_: &str| -> Result<Vec<f32>, std::io::Error> {
             Err(std::io::Error::other("embedder down"))
         };
-        let persisted =
-            commit_extraction_for_episode(&db, &extractor, ns.id, ep, fail_embed).await;
+        let persisted = commit_extraction_for_episode(&db, &extractor, ns.id, ep, fail_embed).await;
         assert_eq!(persisted, 0);
 
         let stored = db.list_observations_by_episode_ids(&[ep], 100).unwrap();
@@ -966,25 +1000,7 @@ mod tests {
                 ns.id, ep, "should", "not", "persist", "",
             )],
         };
-        let persisted =
-            commit_extraction_for_episode(&db, &extractor, ns.id, ep, fake_embed).await;
+        let persisted = commit_extraction_for_episode(&db, &extractor, ns.id, ep, fake_embed).await;
         assert_eq!(persisted, 0);
-    }
-
-    #[test]
-    fn split_role_prefix_handles_role_colon_content() {
-        assert_eq!(split_role_prefix("user: hi"), ("user", "hi"));
-        assert_eq!(split_role_prefix("assistant: hello"), ("assistant", "hello"));
-    }
-
-    #[test]
-    fn split_role_prefix_handles_missing_prefix() {
-        assert_eq!(split_role_prefix("no prefix"), ("user", "no prefix"));
-        assert_eq!(split_role_prefix(""), ("user", ""));
-    }
-
-    #[test]
-    fn split_role_prefix_trims_trailing_whitespace_after_colon() {
-        assert_eq!(split_role_prefix("user:   spaces"), ("user", "spaces"));
     }
 }

--- a/pensyve-core/src/recall_grouped.rs
+++ b/pensyve-core/src/recall_grouped.rs
@@ -133,6 +133,7 @@ fn memory_time(memory: &Memory) -> DateTime<Utc> {
         Memory::Episodic(e) => e.event_time.unwrap_or(e.timestamp),
         Memory::Semantic(s) => s.valid_at,
         Memory::Procedural(p) => p.created_at,
+        Memory::Observation(o) => o.event_time.unwrap_or(o.created_at),
     }
 }
 
@@ -140,6 +141,7 @@ fn memory_time(memory: &Memory) -> DateTime<Utc> {
 fn memory_episode_id(memory: &Memory) -> Option<Uuid> {
     match memory {
         Memory::Episodic(e) => Some(e.episode_id),
+        Memory::Observation(o) => Some(o.episode_id),
         Memory::Semantic(_) | Memory::Procedural(_) => None,
     }
 }
@@ -530,6 +532,7 @@ mod tests {
             Memory::Episodic(e) => e.content.clone(),
             Memory::Semantic(s) => format!("{} {}", s.predicate, s.object),
             Memory::Procedural(p) => format!("{}:{}", p.trigger, p.action),
+            Memory::Observation(o) => o.content.clone(),
         }
     }
 }

--- a/pensyve-core/src/recall_grouped.rs
+++ b/pensyve-core/src/recall_grouped.rs
@@ -626,12 +626,7 @@ mod tests {
         (dir, db, ns)
     }
 
-    fn save_obs(
-        db: &SqliteBackend,
-        ns: Uuid,
-        episode_id: Uuid,
-        instance: &str,
-    ) -> Uuid {
+    fn save_obs(db: &SqliteBackend, ns: Uuid, episode_id: Uuid, instance: &str) -> Uuid {
         let obs = ObservationMemory::new(
             ns,
             episode_id,
@@ -736,7 +731,10 @@ mod tests {
             Memory::Observation(o) => o.instance == "LEAKED",
             _ => false,
         });
-        assert!(!leaked, "observations from non-top-k episodes leaked through");
+        assert!(
+            !leaked,
+            "observations from non-top-k episodes leaked through"
+        );
     }
 
     #[test]

--- a/pensyve-core/src/recall_grouped.rs
+++ b/pensyve-core/src/recall_grouped.rs
@@ -248,6 +248,79 @@ pub fn group_by_session(
 }
 
 // ---------------------------------------------------------------------------
+// Observation attachment
+// ---------------------------------------------------------------------------
+
+/// Attach per-episode observations to the given session groups.
+///
+/// Observations are loaded by joining on the `session_id` of each group
+/// (which is the source `episode_id`). They are appended to the group's
+/// `memories` vector *after* the episodic memories, so readers see the raw
+/// conversation first and the structured observations as a trailing
+/// appendix — the format the R7 benchmark prompt was validated against.
+///
+/// Observations do NOT participate in RRF candidate selection. Each attached
+/// observation carries the group's `group_score` as a surrogate `ScoredMemory.score`
+/// so downstream filters that threshold on score don't drop them
+/// indiscriminately; callers needing the extractor's original confidence can
+/// pattern-match on `Memory::Observation(o)` and read `o.confidence`.
+///
+/// Returns the groups unchanged on storage error (observations are optional
+/// enrichment; a failed lookup should never break recall).
+pub fn attach_observations_to_groups(
+    storage: &dyn crate::storage::StorageTrait,
+    groups: Vec<SessionGroup>,
+) -> Vec<SessionGroup> {
+    // Collect unique episode IDs across all groups that carry one.
+    let episode_ids: Vec<Uuid> = groups.iter().filter_map(|g| g.session_id).collect();
+    if episode_ids.is_empty() {
+        return groups;
+    }
+
+    // `limit` is set generously; at our expected 50-top-k workload the
+    // per-group observation count is typically 2-5, so a few hundred is
+    // well above ceiling. Future phase: configurable cap.
+    let observations = match storage.list_observations_by_episode_ids(&episode_ids, 1024) {
+        Ok(obs) => obs,
+        Err(e) => {
+            tracing::warn!(
+                target: "pensyve::observation",
+                error = %e,
+                "failed to load observations for session groups — returning groups unchanged"
+            );
+            return groups;
+        }
+    };
+
+    if observations.is_empty() {
+        return groups;
+    }
+
+    // Bucket observations by episode id.
+    let mut by_episode: HashMap<Uuid, Vec<crate::types::ObservationMemory>> = HashMap::new();
+    for obs in observations {
+        by_episode.entry(obs.episode_id).or_default().push(obs);
+    }
+
+    groups
+        .into_iter()
+        .map(|mut g| {
+            if let Some(sid) = g.session_id
+                && let Some(obs_for_group) = by_episode.remove(&sid)
+            {
+                for obs in obs_for_group {
+                    g.memories.push(ScoredMemory {
+                        memory: Memory::Observation(obs),
+                        score: g.group_score,
+                    });
+                }
+            }
+            g
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -534,5 +607,165 @@ mod tests {
             Memory::Procedural(p) => format!("{}:{}", p.trigger, p.action),
             Memory::Observation(o) => o.content.clone(),
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // attach_observations_to_groups — integration with storage
+    // -----------------------------------------------------------------------
+
+    use crate::storage::StorageTrait;
+    use crate::storage::sqlite::SqliteBackend;
+    use crate::types::{Namespace, ObservationMemory};
+    use tempfile::TempDir;
+
+    fn setup_storage_with_namespace() -> (TempDir, SqliteBackend, Namespace) {
+        let dir = TempDir::new().unwrap();
+        let db = SqliteBackend::open(dir.path()).unwrap();
+        let ns = Namespace::new("test-attach");
+        db.save_namespace(&ns).unwrap();
+        (dir, db, ns)
+    }
+
+    fn save_obs(
+        db: &SqliteBackend,
+        ns: Uuid,
+        episode_id: Uuid,
+        instance: &str,
+    ) -> Uuid {
+        let obs = ObservationMemory::new(
+            ns,
+            episode_id,
+            "game_played",
+            instance,
+            "played",
+            format!("played {instance}"),
+        );
+        let id = obs.id;
+        db.save_observation(&obs).unwrap();
+        id
+    }
+
+    #[test]
+    fn attach_appends_observations_after_episodic_memories() {
+        let (_dir, db, ns) = setup_storage_with_namespace();
+        let ep = Uuid::new_v4();
+        let obs_id = save_obs(&db, ns.id, ep, "AC Odyssey");
+
+        let candidates = vec![
+            scored(ep_at(ep, t(2026, 1, 1), "turn 1"), 0.9),
+            scored(ep_at(ep, t(2026, 1, 2), "turn 2"), 0.8),
+        ];
+        let groups = group_by_session(candidates, OrderBy::Chronological, None);
+        let attached = attach_observations_to_groups(&db, groups);
+
+        assert_eq!(attached.len(), 1);
+        let g = &attached[0];
+        assert_eq!(g.memories.len(), 3);
+        // Episodic memories first in event-time order, observation last.
+        match &g.memories[0].memory {
+            Memory::Episodic(e) => assert_eq!(e.content, "turn 1"),
+            _ => panic!("expected episodic first"),
+        }
+        match &g.memories[1].memory {
+            Memory::Episodic(e) => assert_eq!(e.content, "turn 2"),
+            _ => panic!("expected episodic second"),
+        }
+        match &g.memories[2].memory {
+            Memory::Observation(o) => {
+                assert_eq!(o.id, obs_id);
+                assert_eq!(o.instance, "AC Odyssey");
+            }
+            _ => panic!("expected observation last"),
+        }
+        // Attached observations carry the group score as their ScoredMemory score.
+        assert!((g.memories[2].score - g.group_score).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn attach_scopes_observations_to_their_own_episode() {
+        let (_dir, db, ns) = setup_storage_with_namespace();
+        let ep_a = Uuid::new_v4();
+        let ep_b = Uuid::new_v4();
+        save_obs(&db, ns.id, ep_a, "game A");
+        save_obs(&db, ns.id, ep_b, "game B");
+
+        let candidates = vec![
+            scored(ep_at(ep_a, t(2026, 1, 1), "a1"), 0.5),
+            scored(ep_at(ep_b, t(2026, 1, 2), "b1"), 0.5),
+        ];
+        let groups = group_by_session(candidates, OrderBy::Chronological, None);
+        let attached = attach_observations_to_groups(&db, groups);
+
+        assert_eq!(attached.len(), 2);
+        for g in &attached {
+            let obs_count = g
+                .memories
+                .iter()
+                .filter(|m| matches!(m.memory, Memory::Observation(_)))
+                .count();
+            assert_eq!(obs_count, 1, "each group gets exactly its own obs");
+            let matching_instance = g.memories.iter().find_map(|m| match &m.memory {
+                Memory::Observation(o) => Some(o.instance.clone()),
+                _ => None,
+            });
+            let expected = if g.session_id == Some(ep_a) {
+                "game A"
+            } else {
+                "game B"
+            };
+            assert_eq!(matching_instance.as_deref(), Some(expected));
+        }
+    }
+
+    #[test]
+    fn attach_leaks_no_observations_from_non_topk_episodes() {
+        // Key architectural guarantee: observations from episodes NOT in the
+        // top-k recall must never surface. This is what broke Phase 0b.
+        let (_dir, db, ns) = setup_storage_with_namespace();
+        let topk_ep = Uuid::new_v4();
+        let unseen_ep = Uuid::new_v4();
+        save_obs(&db, ns.id, topk_ep, "visible");
+        save_obs(&db, ns.id, unseen_ep, "LEAKED");
+
+        let candidates = vec![scored(ep_at(topk_ep, t(2026, 1, 1), "x"), 0.5)];
+        let groups = group_by_session(candidates, OrderBy::Chronological, None);
+        let attached = attach_observations_to_groups(&db, groups);
+
+        assert_eq!(attached.len(), 1);
+        let leaked = attached[0].memories.iter().any(|m| match &m.memory {
+            Memory::Observation(o) => o.instance == "LEAKED",
+            _ => false,
+        });
+        assert!(!leaked, "observations from non-top-k episodes leaked through");
+    }
+
+    #[test]
+    fn attach_is_noop_when_no_observations_stored() {
+        let (_dir, db, ns) = setup_storage_with_namespace();
+        let _ = ns;
+        let ep = Uuid::new_v4();
+
+        let candidates = vec![scored(ep_at(ep, t(2026, 1, 1), "x"), 0.5)];
+        let groups = group_by_session(candidates, OrderBy::Chronological, None);
+        let attached = attach_observations_to_groups(&db, groups);
+
+        assert_eq!(attached.len(), 1);
+        assert_eq!(attached[0].memories.len(), 1);
+    }
+
+    #[test]
+    fn attach_skips_singleton_semantic_groups() {
+        let (_dir, db, ns) = setup_storage_with_namespace();
+        let _ = ns;
+        let subj = Uuid::new_v4();
+
+        let candidates = vec![scored(sem(subj, "knows", "Rust"), 0.9)];
+        let groups = group_by_session(candidates, OrderBy::Chronological, None);
+        // Semantic memories don't have a session_id so the attach lookup
+        // never runs for them.
+        let attached = attach_observations_to_groups(&db, groups);
+        assert_eq!(attached.len(), 1);
+        assert_eq!(attached[0].session_id, None);
+        assert_eq!(attached[0].memories.len(), 1);
     }
 }

--- a/pensyve-core/src/retrieval.rs
+++ b/pensyve-core/src/retrieval.rs
@@ -500,9 +500,7 @@ impl<'a> RecallEngine<'a> {
                             .collect();
                         activation::base_level_activation(&times, now.timestamp() as f64, 0.5)
                     }
-                    Memory::Semantic(_)
-                    | Memory::Procedural(_)
-                    | Memory::Observation(_) => 0.0,
+                    Memory::Semantic(_) | Memory::Procedural(_) | Memory::Observation(_) => 0.0,
                 };
                 (id, b)
             })
@@ -608,9 +606,7 @@ impl<'a> RecallEngine<'a> {
             .values()
             .map(|m| match m {
                 Memory::Episodic(e) => e.access_count,
-                Memory::Semantic(_)
-                | Memory::Procedural(_)
-                | Memory::Observation(_) => 0,
+                Memory::Semantic(_) | Memory::Procedural(_) | Memory::Observation(_) => 0,
             })
             .max()
             .unwrap_or(0);
@@ -650,9 +646,7 @@ impl<'a> RecallEngine<'a> {
 
                     let access_count = match mem {
                         Memory::Episodic(e) => e.access_count,
-                        Memory::Semantic(_)
-                        | Memory::Procedural(_)
-                        | Memory::Observation(_) => 0,
+                        Memory::Semantic(_) | Memory::Procedural(_) | Memory::Observation(_) => 0,
                     };
                     let access_score = if max_access == 0 {
                         0.0_f32

--- a/pensyve-core/src/retrieval.rs
+++ b/pensyve-core/src/retrieval.rs
@@ -494,7 +494,9 @@ impl<'a> RecallEngine<'a> {
                             .collect();
                         activation::base_level_activation(&times, now.timestamp() as f64, 0.5)
                     }
-                    Memory::Semantic(_) | Memory::Procedural(_) => 0.0,
+                    Memory::Semantic(_)
+                    | Memory::Procedural(_)
+                    | Memory::Observation(_) => 0.0,
                 };
                 (id, b)
             })
@@ -527,14 +529,7 @@ impl<'a> RecallEngine<'a> {
         let mut ranking_intent: Vec<(Uuid, f32)> = candidates
             .iter()
             .map(|(&id, mem)| {
-                let score = intent_score_for_type(
-                    &intent,
-                    match mem {
-                        Memory::Episodic(_) => "episodic",
-                        Memory::Semantic(_) => "semantic",
-                        Memory::Procedural(_) => "procedural",
-                    },
-                );
+                let score = intent_score_for_type(&intent, mem.type_name());
                 (id, score)
             })
             .collect();
@@ -548,6 +543,7 @@ impl<'a> RecallEngine<'a> {
                     Memory::Episodic(_) => 1.0,
                     Memory::Semantic(s) => s.confidence,
                     Memory::Procedural(p) => p.reliability,
+                    Memory::Observation(o) => o.confidence,
                 };
                 (id, conf)
             })
@@ -606,7 +602,9 @@ impl<'a> RecallEngine<'a> {
             .values()
             .map(|m| match m {
                 Memory::Episodic(e) => e.access_count,
-                Memory::Semantic(_) | Memory::Procedural(_) => 0,
+                Memory::Semantic(_)
+                | Memory::Procedural(_)
+                | Memory::Observation(_) => 0,
             })
             .max()
             .unwrap_or(0);
@@ -631,22 +629,24 @@ impl<'a> RecallEngine<'a> {
                             p.reliability,
                             decay::elapsed_days(p.created_at, now),
                         ),
+                        Memory::Observation(o) => decay::retrievability(
+                            o.stability,
+                            decay::elapsed_days(o.created_at, now),
+                        ),
                     };
                     let confidence_score = match mem {
                         Memory::Episodic(_) => 1.0_f32,
                         Memory::Semantic(s) => s.confidence,
                         Memory::Procedural(p) => p.reliability,
+                        Memory::Observation(o) => o.confidence,
                     };
-                    let memory_type_str = match mem {
-                        Memory::Episodic(_) => "episodic",
-                        Memory::Semantic(_) => "semantic",
-                        Memory::Procedural(_) => "procedural",
-                    };
-                    let intent_score = intent_score_for_type(&intent, memory_type_str);
+                    let intent_score = intent_score_for_type(&intent, mem.type_name());
 
                     let access_count = match mem {
                         Memory::Episodic(e) => e.access_count,
-                        Memory::Semantic(_) | Memory::Procedural(_) => 0,
+                        Memory::Semantic(_)
+                        | Memory::Procedural(_)
+                        | Memory::Observation(_) => 0,
                     };
                     let access_score = if max_access == 0 {
                         0.0_f32
@@ -923,11 +923,14 @@ fn score_candidate(
         Memory::Procedural(p) => {
             decay::retrievability(p.reliability, decay::elapsed_days(p.created_at, now))
         }
+        Memory::Observation(o) => {
+            decay::retrievability(o.stability, decay::elapsed_days(o.created_at, now))
+        }
     };
 
     let access_count = match &memory {
         Memory::Episodic(e) => e.access_count,
-        Memory::Semantic(_) | Memory::Procedural(_) => 0,
+        Memory::Semantic(_) | Memory::Procedural(_) | Memory::Observation(_) => 0,
     };
     let access_score = if max_access == 0 {
         0.0_f32
@@ -939,22 +942,20 @@ fn score_candidate(
         Memory::Episodic(_) => 1.0_f32,
         Memory::Semantic(s) => s.confidence,
         Memory::Procedural(p) => p.reliability,
+        Memory::Observation(o) => o.confidence,
     };
 
     let direct = graph_map.get(&id).copied().unwrap_or(0.0);
     let entity_linked = match &memory {
         Memory::Episodic(e) => graph_map.get(&e.about_entity).copied().unwrap_or(0.0),
         Memory::Semantic(s) => graph_map.get(&s.subject).copied().unwrap_or(0.0),
-        Memory::Procedural(_) => 0.0,
+        // Procedural has no entity link; Observation is derived from episodes
+        // so its entity link would flow through the parent — not modeled here.
+        Memory::Procedural(_) | Memory::Observation(_) => 0.0,
     };
     let graph_score = direct.max(entity_linked);
 
-    let memory_type_str = match &memory {
-        Memory::Episodic(_) => "episodic",
-        Memory::Semantic(_) => "semantic",
-        Memory::Procedural(_) => "procedural",
-    };
-    let intent_score = intent_score_for_type(intent, memory_type_str);
+    let intent_score = intent_score_for_type(intent, memory.type_name());
     let type_boost = 1.0_f32;
 
     // weights[0]=vector, [1]=bm25, [2]=graph, [3]=intent,
@@ -999,6 +1000,7 @@ fn apply_reranking(
             Memory::Episodic(e) => e.content.clone(),
             Memory::Semantic(s) => format!("{} {} {}", s.subject, s.predicate, s.object),
             Memory::Procedural(p) => format!("trigger: {} action: {}", p.trigger, p.action),
+            Memory::Observation(o) => o.content.clone(),
         })
         .collect();
     let text_refs: Vec<&str> = texts.iter().map(String::as_str).collect();

--- a/pensyve-core/src/retrieval.rs
+++ b/pensyve-core/src/retrieval.rs
@@ -391,10 +391,16 @@ impl<'a> RecallEngine<'a> {
         config: &crate::recall_grouped::RecallGroupedConfig,
     ) -> Result<Vec<crate::recall_grouped::SessionGroup>, RecallError> {
         let result = self.recall(query, namespace_id, config.limit)?;
-        Ok(crate::recall_grouped::group_by_session(
+        let groups = crate::recall_grouped::group_by_session(
             result.memories,
             config.order,
             config.max_groups,
+        );
+        // Observations attach post-grouping — they don't participate in RRF
+        // candidate selection, only enrich the sessions that already won.
+        Ok(crate::recall_grouped::attach_observations_to_groups(
+            self.storage,
+            groups,
         ))
     }
 

--- a/pensyve-core/src/storage/mod.rs
+++ b/pensyve-core/src/storage/mod.rs
@@ -64,6 +64,31 @@ pub trait StorageTrait: Send + Sync {
         about_entity: Uuid,
         limit: usize,
     ) -> StorageResult<Vec<EpisodicMemory>>;
+
+    /// Fetch every episodic memory tied to the given episode, ordered by
+    /// `event_time` (falling back to `timestamp`). Used by the observation
+    /// extraction ingest hook — the extractor sees the full conversation,
+    /// not just the turns the caller happens to still have in memory.
+    ///
+    /// Default implementation walks `get_all_memories_by_namespace` for
+    /// backends that don't provide a direct index; override for performance.
+    fn list_episodic_by_episode(
+        &self,
+        namespace_id: Uuid,
+        episode_id: Uuid,
+    ) -> StorageResult<Vec<EpisodicMemory>> {
+        let all = self.get_all_memories_by_namespace(namespace_id)?;
+        let mut out: Vec<EpisodicMemory> = all
+            .into_iter()
+            .filter_map(|m| match m {
+                Memory::Episodic(e) if e.episode_id == episode_id => Some(e),
+                _ => None,
+            })
+            .collect();
+        out.sort_by_key(|e| e.event_time.unwrap_or(e.timestamp));
+        Ok(out)
+    }
+
     fn update_episodic_access(
         &self,
         id: Uuid,

--- a/pensyve-core/src/storage/mod.rs
+++ b/pensyve-core/src/storage/mod.rs
@@ -150,6 +150,16 @@ pub trait StorageTrait: Send + Sync {
         Ok(0)
     }
 
+    /// Delete every observation whose source episode is associated with the
+    /// given entity (either as `source_entity` or `about_entity` on an
+    /// episodic memory). Used by GDPR cascade-delete paths — called BEFORE
+    /// `delete_memories_by_entity` so the episodic→entity join still exists.
+    ///
+    /// Returns the row count of deleted observations.
+    fn delete_observations_by_entity(&self, _entity_id: Uuid) -> StorageResult<usize> {
+        Ok(0)
+    }
+
     // Full-text search (BM25)
     fn search_fts(
         &self,

--- a/pensyve-core/src/storage/mod.rs
+++ b/pensyve-core/src/storage/mod.rs
@@ -3,7 +3,8 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::types::{
-    Edge, Entity, Episode, EpisodicMemory, Memory, Namespace, ProceduralMemory, SemanticMemory,
+    Edge, Entity, Episode, EpisodicMemory, Memory, Namespace, ObservationMemory, ProceduralMemory,
+    SemanticMemory,
 };
 
 pub mod sqlite;
@@ -90,6 +91,39 @@ pub trait StorageTrait: Send + Sync {
         trial_count: u32,
         success_count: u32,
     ) -> StorageResult<()>;
+
+    // Observation Memory (derived per-episode artifacts)
+    //
+    // Observations are extracted from episodic messages at ingest time and
+    // surfaced at recall time by joining on the top-k episodes' IDs. They do
+    // not participate in RRF candidate selection. Default implementations
+    // are no-ops so existing backends keep working without observation support.
+    fn save_observation(&self, _mem: &ObservationMemory) -> StorageResult<()> {
+        Err(StorageError::Context(
+            "save_observation not implemented on this backend".into(),
+        ))
+    }
+
+    fn get_observation(&self, _id: Uuid) -> StorageResult<Option<ObservationMemory>> {
+        Ok(None)
+    }
+
+    /// Fetch all observations attached to any of the given episode IDs,
+    /// bounded by `limit` (applied after fetch). Used by `recall_grouped` to
+    /// attach observations to top-k session groups.
+    fn list_observations_by_episode_ids(
+        &self,
+        _episode_ids: &[Uuid],
+        _limit: usize,
+    ) -> StorageResult<Vec<ObservationMemory>> {
+        Ok(Vec::new())
+    }
+
+    /// Delete every observation tied to the given episode. Returns the row count.
+    /// Called as part of episode cascade-delete paths.
+    fn delete_observations_by_episode(&self, _episode_id: Uuid) -> StorageResult<usize> {
+        Ok(0)
+    }
 
     // Full-text search (BM25)
     fn search_fts(

--- a/pensyve-core/src/storage/postgres.rs
+++ b/pensyve-core/src/storage/postgres.rs
@@ -12,8 +12,8 @@ use tokio::runtime::{Handle, Runtime};
 use uuid::Uuid;
 
 use crate::types::{
-    Edge, Entity, EntityKind, Episode, EpisodicMemory, Memory, Namespace, Outcome,
-    ProceduralMemory, SemanticMemory,
+    Edge, Entity, EntityKind, Episode, EpisodicMemory, Memory, Namespace, ObservationMemory,
+    Outcome, ProceduralMemory, SemanticMemory,
 };
 
 use super::{ActivityAggregate, ActivityEvent, StorageResult, StorageTrait};
@@ -70,6 +70,24 @@ type ProceduralRow = (
     Option<String>,
     DateTime<Utc>,
     Option<DateTime<Utc>>,
+);
+
+type ObservationRow = (
+    Uuid,                    // id
+    Uuid,                    // namespace_id
+    Uuid,                    // episode_id
+    String,                  // entity_type
+    String,                  // instance
+    String,                  // action
+    Option<f64>,             // quantity
+    Option<String>,          // unit
+    String,                  // content
+    Option<String>,          // embedding::text
+    f32,                     // confidence
+    Option<DateTime<Utc>>,   // event_time
+    DateTime<Utc>,           // created_at
+    f32,                     // stability
+    f32,                     // retrievability
 );
 
 type EdgeRow = (
@@ -859,6 +877,106 @@ impl StorageTrait for PostgresBackend {
     }
 
     // -----------------------------------------------------------------------
+    // Observation Memory
+    // -----------------------------------------------------------------------
+
+    fn save_observation(&self, mem: &ObservationMemory) -> StorageResult<()> {
+        let embedding_text = embedding_to_pgtext(&mem.embedding);
+        self.block_on(async {
+            let mut conn = self.scoped_conn(mem.namespace_id).await?;
+            query::<Postgres>(
+                r"INSERT INTO observation_memories
+                   (id, namespace_id, episode_id, entity_type, instance, action, quantity, unit,
+                    content, embedding, confidence, event_time, created_at, stability, retrievability)
+                   VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10::vector, $11, $12, $13, $14, $15)
+                   ON CONFLICT (id) DO UPDATE SET
+                       entity_type = $4, instance = $5, action = $6, quantity = $7, unit = $8,
+                       content = $9, embedding = $10::vector, confidence = $11,
+                       event_time = $12, stability = $14, retrievability = $15",
+            )
+            .bind(mem.id)
+            .bind(mem.namespace_id)
+            .bind(mem.episode_id)
+            .bind(&mem.entity_type)
+            .bind(&mem.instance)
+            .bind(&mem.action)
+            .bind(mem.quantity)
+            .bind(&mem.unit)
+            .bind(&mem.content)
+            .bind(&embedding_text)
+            .bind(mem.confidence)
+            .bind(mem.event_time)
+            .bind(mem.created_at)
+            .bind(mem.stability)
+            .bind(mem.retrievability)
+            .execute(&mut *conn)
+            .await
+            .map_err(sqlx_to_io)?;
+            Ok(())
+        })
+    }
+
+    fn get_observation(&self, id: Uuid) -> StorageResult<Option<ObservationMemory>> {
+        self.block_on(async {
+            let mut conn = self.maybe_scoped_conn().await?;
+            let row: Option<ObservationRow> = query_as::<Postgres, _>(
+                r"SELECT id, namespace_id, episode_id, entity_type, instance, action, quantity,
+                          unit, content, embedding::text, confidence, event_time, created_at,
+                          stability, retrievability
+                   FROM observation_memories WHERE id = $1",
+            )
+            .bind(id)
+            .fetch_optional(&mut *conn)
+            .await
+            .map_err(sqlx_to_io)?;
+            Ok(row.map(row_to_observation))
+        })
+    }
+
+    fn list_observations_by_episode_ids(
+        &self,
+        episode_ids: &[Uuid],
+        limit: usize,
+    ) -> StorageResult<Vec<ObservationMemory>> {
+        if episode_ids.is_empty() || limit == 0 {
+            return Ok(Vec::new());
+        }
+        let ids = episode_ids.to_vec();
+        self.block_on(async move {
+            let mut conn = self.maybe_scoped_conn().await?;
+            let rows: Vec<ObservationRow> = query_as::<Postgres, _>(
+                r"SELECT id, namespace_id, episode_id, entity_type, instance, action, quantity,
+                          unit, content, embedding::text, confidence, event_time, created_at,
+                          stability, retrievability
+                   FROM observation_memories
+                   WHERE episode_id = ANY($1)
+                   ORDER BY created_at ASC
+                   LIMIT $2",
+            )
+            .bind(&ids)
+            .bind(i64::try_from(limit).unwrap_or(i64::MAX))
+            .fetch_all(&mut *conn)
+            .await
+            .map_err(sqlx_to_io)?;
+            Ok(rows.into_iter().map(row_to_observation).collect())
+        })
+    }
+
+    fn delete_observations_by_episode(&self, episode_id: Uuid) -> StorageResult<usize> {
+        self.block_on(async {
+            let mut conn = self.maybe_scoped_conn().await?;
+            let result = query::<Postgres>(
+                "DELETE FROM observation_memories WHERE episode_id = $1",
+            )
+            .bind(episode_id)
+            .execute(&mut *conn)
+            .await
+            .map_err(sqlx_to_io)?;
+            Ok(usize::try_from(result.rows_affected()).unwrap_or(0))
+        })
+    }
+
+    // -----------------------------------------------------------------------
     // Full-text search
     // -----------------------------------------------------------------------
 
@@ -1064,6 +1182,22 @@ impl StorageTrait for PostgresBackend {
                 memories.push(Memory::Procedural(row_to_procedural(row)));
             }
 
+            // Observation
+            let observation_rows: Vec<ObservationRow> = query_as::<Postgres, _>(
+                r"SELECT id, namespace_id, episode_id, entity_type, instance, action, quantity,
+                          unit, content, embedding::text, confidence, event_time, created_at,
+                          stability, retrievability
+                   FROM observation_memories WHERE namespace_id = $1",
+            )
+            .bind(namespace_id)
+            .fetch_all(&mut *conn)
+            .await
+            .map_err(sqlx_to_io)?;
+
+            for row in observation_rows {
+                memories.push(Memory::Observation(row_to_observation(row)));
+            }
+
             Ok(memories)
         })
     }
@@ -1125,6 +1259,15 @@ impl StorageTrait for PostgresBackend {
             }
 
             let result = query::<Postgres>("DELETE FROM procedural_memories WHERE id = $1")
+                .bind(id)
+                .execute(&mut *conn)
+                .await
+                .map_err(sqlx_to_io)?;
+            if result.rows_affected() > 0 {
+                deleted = true;
+            }
+
+            let result = query::<Postgres>("DELETE FROM observation_memories WHERE id = $1")
                 .bind(id)
                 .execute(&mut *conn)
                 .await
@@ -1569,5 +1712,42 @@ fn row_to_procedural(row: ProceduralRow) -> ProceduralMemory {
         embedding: pgtext_to_embedding(embedding_text.as_deref()),
         created_at,
         last_used,
+    }
+}
+
+fn row_to_observation(row: ObservationRow) -> ObservationMemory {
+    let (
+        id,
+        namespace_id,
+        episode_id,
+        entity_type,
+        instance,
+        action,
+        quantity,
+        unit,
+        content,
+        embedding_text,
+        confidence,
+        event_time,
+        created_at,
+        stability,
+        retrievability,
+    ) = row;
+    ObservationMemory {
+        id,
+        namespace_id,
+        episode_id,
+        entity_type,
+        instance,
+        action,
+        quantity,
+        unit,
+        content,
+        embedding: pgtext_to_embedding(embedding_text.as_deref()),
+        confidence,
+        event_time,
+        created_at,
+        stability,
+        retrievability,
     }
 }

--- a/pensyve-core/src/storage/postgres.rs
+++ b/pensyve-core/src/storage/postgres.rs
@@ -73,21 +73,21 @@ type ProceduralRow = (
 );
 
 type ObservationRow = (
-    Uuid,                    // id
-    Uuid,                    // namespace_id
-    Uuid,                    // episode_id
-    String,                  // entity_type
-    String,                  // instance
-    String,                  // action
-    Option<f64>,             // quantity
-    Option<String>,          // unit
-    String,                  // content
-    Option<String>,          // embedding::text
-    f32,                     // confidence
-    Option<DateTime<Utc>>,   // event_time
-    DateTime<Utc>,           // created_at
-    f32,                     // stability
-    f32,                     // retrievability
+    Uuid,                  // id
+    Uuid,                  // namespace_id
+    Uuid,                  // episode_id
+    String,                // entity_type
+    String,                // instance
+    String,                // action
+    Option<f64>,           // quantity
+    Option<String>,        // unit
+    String,                // content
+    Option<String>,        // embedding::text
+    f32,                   // confidence
+    Option<DateTime<Utc>>, // event_time
+    DateTime<Utc>,         // created_at
+    f32,                   // stability
+    f32,                   // retrievability
 );
 
 type EdgeRow = (
@@ -989,10 +989,27 @@ impl StorageTrait for PostgresBackend {
     fn delete_observations_by_episode(&self, episode_id: Uuid) -> StorageResult<usize> {
         self.block_on(async {
             let mut conn = self.maybe_scoped_conn().await?;
+            let result =
+                query::<Postgres>("DELETE FROM observation_memories WHERE episode_id = $1")
+                    .bind(episode_id)
+                    .execute(&mut *conn)
+                    .await
+                    .map_err(sqlx_to_io)?;
+            Ok(usize::try_from(result.rows_affected()).unwrap_or(0))
+        })
+    }
+
+    fn delete_observations_by_entity(&self, entity_id: Uuid) -> StorageResult<usize> {
+        self.block_on(async {
+            let mut conn = self.maybe_scoped_conn().await?;
             let result = query::<Postgres>(
-                "DELETE FROM observation_memories WHERE episode_id = $1",
+                "DELETE FROM observation_memories \
+                 WHERE episode_id IN (\
+                   SELECT DISTINCT episode_id FROM episodic_memories \
+                    WHERE about_entity = $1 OR source_entity = $1\
+                 )",
             )
-            .bind(episode_id)
+            .bind(entity_id)
             .execute(&mut *conn)
             .await
             .map_err(sqlx_to_io)?;

--- a/pensyve-core/src/storage/postgres.rs
+++ b/pensyve-core/src/storage/postgres.rs
@@ -24,20 +24,21 @@ use crate::graph::EdgeType;
 // ---------------------------------------------------------------------------
 
 type EpisodicRow = (
-    Uuid,
-    Uuid,
-    Uuid,
-    Uuid,
-    Uuid,
-    String,
-    Option<String>,
-    Option<String>,
-    Option<String>,
-    DateTime<Utc>,
-    f32,
-    f32,
-    i32,
-    Option<DateTime<Utc>>,
+    Uuid,                  // id
+    Uuid,                  // namespace_id
+    Uuid,                  // episode_id
+    Uuid,                  // source_entity
+    Uuid,                  // about_entity
+    String,                // content
+    Option<String>,        // summary
+    Option<String>,        // embedding::text
+    Option<String>,        // context_intent
+    DateTime<Utc>,         // timestamp
+    f32,                   // stability
+    f32,                   // retrievability
+    i32,                   // access_count
+    Option<DateTime<Utc>>, // last_accessed
+    Option<DateTime<Utc>>, // event_time
 );
 
 type SemanticRow = (
@@ -596,15 +597,20 @@ impl StorageTrait for PostgresBackend {
         let embedding_text = embedding_to_pgtext(&mem.embedding);
         self.block_on(async {
             let mut conn = self.scoped_conn(mem.namespace_id).await?;
+            // Note: the `episodic_memories` table was provisioned without an
+            // `event_time` column in the original schema. Runs `ALTER TABLE
+            // … ADD COLUMN IF NOT EXISTS` inside `run_schema` to keep this
+            // INSERT compatible with both fresh and upgraded databases.
             query::<Postgres>(
                 r"INSERT INTO episodic_memories
                    (id, namespace_id, episode_id, source_entity, about_entity, content, summary,
                     embedding, context_intent, timestamp, stability, retrievability,
-                    access_count, last_accessed)
-                   VALUES ($1, $2, $3, $4, $5, $6, $7, $8::vector, $9, $10, $11, $12, $13, $14)
+                    access_count, last_accessed, event_time)
+                   VALUES ($1, $2, $3, $4, $5, $6, $7, $8::vector, $9, $10, $11, $12, $13, $14, $15)
                    ON CONFLICT (id) DO UPDATE SET
                        content = $6, summary = $7, embedding = $8::vector, context_intent = $9,
-                       stability = $11, retrievability = $12, access_count = $13, last_accessed = $14",
+                       stability = $11, retrievability = $12, access_count = $13,
+                       last_accessed = $14, event_time = $15",
             )
             .bind(mem.id)
             .bind(mem.namespace_id)
@@ -620,6 +626,7 @@ impl StorageTrait for PostgresBackend {
             .bind(mem.retrievability)
             .bind(i32::try_from(mem.access_count).unwrap_or(i32::MAX))
             .bind(mem.last_accessed)
+            .bind(mem.event_time)
             .execute(&mut *conn)
             .await
             .map_err(sqlx_to_io)?;
@@ -633,7 +640,7 @@ impl StorageTrait for PostgresBackend {
             let row: Option<EpisodicRow> = query_as::<Postgres, _>(
                 r"SELECT id, namespace_id, episode_id, source_entity, about_entity, content,
                           summary, embedding::text, context_intent, timestamp, stability, retrievability,
-                          access_count, last_accessed
+                          access_count, last_accessed, event_time
                    FROM episodic_memories WHERE id = $1",
             )
             .bind(id)
@@ -656,7 +663,7 @@ impl StorageTrait for PostgresBackend {
             let rows: Vec<EpisodicRow> = query_as::<Postgres, _>(
                 r"SELECT id, namespace_id, episode_id, source_entity, about_entity, content,
                           summary, embedding::text, context_intent, timestamp, stability, retrievability,
-                          access_count, last_accessed
+                          access_count, last_accessed, event_time
                    FROM episodic_memories WHERE about_entity = $1
                    ORDER BY timestamp DESC LIMIT $2",
             )
@@ -678,12 +685,15 @@ impl StorageTrait for PostgresBackend {
         self.block_on(async {
             let mut conn = self.scoped_conn(namespace_id).await?;
             let rows: Vec<EpisodicRow> = query_as::<Postgres, _>(
+                // Match SQLite: order by `event_time` when populated, else
+                // encoding `timestamp`. Observation extraction relies on
+                // chronological order across the episode.
                 r"SELECT id, namespace_id, episode_id, source_entity, about_entity, content,
                           summary, embedding::text, context_intent, timestamp, stability, retrievability,
-                          access_count, last_accessed
+                          access_count, last_accessed, event_time
                    FROM episodic_memories
                    WHERE namespace_id = $1 AND episode_id = $2
-                   ORDER BY timestamp ASC",
+                   ORDER BY COALESCE(event_time, timestamp) ASC",
             )
             .bind(namespace_id)
             .bind(episode_id)
@@ -966,22 +976,39 @@ impl StorageTrait for PostgresBackend {
             return Ok(Vec::new());
         }
         let ids = episode_ids.to_vec();
+        // Defensive: if the backend has a `default_namespace` configured,
+        // add an explicit `namespace_id` filter to the query as a second
+        // line of defence beyond RLS. Callers without a default namespace
+        // (test fixtures, one-off scripts) still work via RLS alone —
+        // production deployments should always set the namespace either
+        // via `with_default_namespace` or by using `scoped_conn` upstream.
+        let namespace_filter = self.default_namespace;
         self.block_on(async move {
             let mut conn = self.maybe_scoped_conn().await?;
-            let rows: Vec<ObservationRow> = query_as::<Postgres, _>(
+            let sql = if namespace_filter.is_some() {
+                r"SELECT id, namespace_id, episode_id, entity_type, instance, action, quantity,
+                          unit, content, embedding::text, confidence, event_time, created_at,
+                          stability, retrievability
+                   FROM observation_memories
+                   WHERE episode_id = ANY($1) AND namespace_id = $3
+                   ORDER BY created_at ASC
+                   LIMIT $2"
+            } else {
                 r"SELECT id, namespace_id, episode_id, entity_type, instance, action, quantity,
                           unit, content, embedding::text, confidence, event_time, created_at,
                           stability, retrievability
                    FROM observation_memories
                    WHERE episode_id = ANY($1)
                    ORDER BY created_at ASC
-                   LIMIT $2",
-            )
-            .bind(&ids)
-            .bind(i64::try_from(limit).unwrap_or(i64::MAX))
-            .fetch_all(&mut *conn)
-            .await
-            .map_err(sqlx_to_io)?;
+                   LIMIT $2"
+            };
+            let mut q = query_as::<Postgres, ObservationRow>(sql)
+                .bind(&ids)
+                .bind(i64::try_from(limit).unwrap_or(i64::MAX));
+            if let Some(ns) = namespace_filter {
+                q = q.bind(ns);
+            }
+            let rows: Vec<ObservationRow> = q.fetch_all(&mut *conn).await.map_err(sqlx_to_io)?;
             Ok(rows.into_iter().map(row_to_observation).collect())
         })
     }
@@ -1039,7 +1066,7 @@ impl StorageTrait for PostgresBackend {
             let episodic_rows: Vec<EpisodicRow> = query_as::<Postgres, _>(
                 r"SELECT id, namespace_id, episode_id, source_entity, about_entity, content,
                           summary, embedding::text, context_intent, timestamp, stability, retrievability,
-                          access_count, last_accessed
+                          access_count, last_accessed, event_time
                    FROM episodic_memories
                    WHERE namespace_id = $1 AND fts_content @@ plainto_tsquery('english', $2)
                    ORDER BY ts_rank(fts_content, plainto_tsquery('english', $2)) DESC
@@ -1143,7 +1170,7 @@ impl StorageTrait for PostgresBackend {
             let episodic_rows: Vec<EpisodicRow> = query_as::<Postgres, _>(
                 r"SELECT id, namespace_id, episode_id, source_entity, about_entity, content,
                           summary, embedding::text, context_intent, timestamp, stability, retrievability,
-                          access_count, last_accessed
+                          access_count, last_accessed, event_time
                    FROM episodic_memories
                    WHERE namespace_id = $1
                      AND (about_entity = $2 OR source_entity = $2)
@@ -1181,7 +1208,7 @@ impl StorageTrait for PostgresBackend {
             let episodic_rows: Vec<EpisodicRow> = query_as::<Postgres, _>(
                 r"SELECT id, namespace_id, episode_id, source_entity, about_entity, content,
                           summary, embedding::text, context_intent, timestamp, stability, retrievability,
-                          access_count, last_accessed
+                          access_count, last_accessed, event_time
                    FROM episodic_memories WHERE namespace_id = $1",
             )
             .bind(namespace_id)
@@ -1659,6 +1686,7 @@ fn row_to_episodic(row: EpisodicRow) -> EpisodicMemory {
         retrievability,
         access_count,
         last_accessed,
+        event_time,
     ) = row;
     EpisodicMemory {
         id,
@@ -1678,7 +1706,7 @@ fn row_to_episodic(row: EpisodicRow) -> EpisodicMemory {
         last_accessed,
         salience: 0.5,
         storage_strength: 0.0,
-        event_time: None,
+        event_time,
         superseded_by: None,
     }
 }

--- a/pensyve-core/src/storage/postgres.rs
+++ b/pensyve-core/src/storage/postgres.rs
@@ -670,6 +670,30 @@ impl StorageTrait for PostgresBackend {
         })
     }
 
+    fn list_episodic_by_episode(
+        &self,
+        namespace_id: Uuid,
+        episode_id: Uuid,
+    ) -> StorageResult<Vec<EpisodicMemory>> {
+        self.block_on(async {
+            let mut conn = self.scoped_conn(namespace_id).await?;
+            let rows: Vec<EpisodicRow> = query_as::<Postgres, _>(
+                r"SELECT id, namespace_id, episode_id, source_entity, about_entity, content,
+                          summary, embedding::text, context_intent, timestamp, stability, retrievability,
+                          access_count, last_accessed
+                   FROM episodic_memories
+                   WHERE namespace_id = $1 AND episode_id = $2
+                   ORDER BY timestamp ASC",
+            )
+            .bind(namespace_id)
+            .bind(episode_id)
+            .fetch_all(&mut *conn)
+            .await
+            .map_err(sqlx_to_io)?;
+            Ok(rows.into_iter().map(row_to_episodic).collect())
+        })
+    }
+
     fn update_episodic_access(
         &self,
         id: Uuid,

--- a/pensyve-core/src/storage/postgres_schema.sql
+++ b/pensyve-core/src/storage/postgres_schema.sql
@@ -62,8 +62,15 @@ CREATE TABLE IF NOT EXISTS episodic_memories (
     retrievability  REAL NOT NULL DEFAULT 1.0,
     access_count    INTEGER NOT NULL DEFAULT 0,
     last_accessed   TIMESTAMPTZ,
+    event_time      TIMESTAMPTZ,
     fts_content     tsvector GENERATED ALWAYS AS (to_tsvector('english', content)) STORED
 );
+
+-- Idempotent migration for databases provisioned before `event_time` was
+-- added to the CREATE TABLE statement. Observation extraction relies on
+-- this column — without it the extractor sees `[unknown]` dates and can't
+-- build temporal context.
+ALTER TABLE episodic_memories ADD COLUMN IF NOT EXISTS event_time TIMESTAMPTZ;
 
 CREATE INDEX IF NOT EXISTS idx_episodic_about_entity ON episodic_memories(about_entity);
 CREATE INDEX IF NOT EXISTS idx_episodic_namespace ON episodic_memories(namespace_id);

--- a/pensyve-core/src/storage/postgres_schema.sql
+++ b/pensyve-core/src/storage/postgres_schema.sql
@@ -67,6 +67,8 @@ CREATE TABLE IF NOT EXISTS episodic_memories (
 
 CREATE INDEX IF NOT EXISTS idx_episodic_about_entity ON episodic_memories(about_entity);
 CREATE INDEX IF NOT EXISTS idx_episodic_namespace ON episodic_memories(namespace_id);
+CREATE INDEX IF NOT EXISTS idx_episodic_episode
+    ON episodic_memories(namespace_id, episode_id);
 CREATE INDEX IF NOT EXISTS idx_episodic_fts ON episodic_memories USING GIN(fts_content);
 
 -- ---------------------------------------------------------------------------

--- a/pensyve-core/src/storage/postgres_schema.sql
+++ b/pensyve-core/src/storage/postgres_schema.sql
@@ -119,6 +119,36 @@ CREATE INDEX IF NOT EXISTS idx_procedural_namespace ON procedural_memories(names
 CREATE INDEX IF NOT EXISTS idx_procedural_fts ON procedural_memories USING GIN(fts_content);
 
 -- ---------------------------------------------------------------------------
+-- Observation Memories — derived countable-entity artifacts.
+-- Always cascade-deleted with their source episode via application logic
+-- (delete_observations_by_episode / delete_memory_by_id / purge_namespace).
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS observation_memories (
+    id              UUID PRIMARY KEY,
+    namespace_id    UUID NOT NULL,
+    episode_id      UUID NOT NULL,
+    entity_type     TEXT NOT NULL,
+    instance        TEXT NOT NULL,
+    action          TEXT NOT NULL,
+    quantity        DOUBLE PRECISION,
+    unit            TEXT,
+    content         TEXT NOT NULL,
+    embedding       vector,
+    confidence      REAL NOT NULL DEFAULT 0.8,
+    event_time      TIMESTAMPTZ,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    stability       REAL NOT NULL DEFAULT 1.0,
+    retrievability  REAL NOT NULL DEFAULT 1.0,
+    fts_content     tsvector GENERATED ALWAYS AS (to_tsvector('english', content)) STORED
+);
+
+CREATE INDEX IF NOT EXISTS idx_observation_episode ON observation_memories(episode_id);
+CREATE INDEX IF NOT EXISTS idx_observation_namespace ON observation_memories(namespace_id);
+CREATE INDEX IF NOT EXISTS idx_observation_entity_type
+    ON observation_memories(namespace_id, entity_type);
+
+-- ---------------------------------------------------------------------------
 -- Edges (entity relationship graph)
 -- ---------------------------------------------------------------------------
 
@@ -165,6 +195,7 @@ ALTER TABLE episodes             ENABLE ROW LEVEL SECURITY;
 ALTER TABLE episodic_memories    ENABLE ROW LEVEL SECURITY;
 ALTER TABLE semantic_memories    ENABLE ROW LEVEL SECURITY;
 ALTER TABLE procedural_memories  ENABLE ROW LEVEL SECURITY;
+ALTER TABLE observation_memories ENABLE ROW LEVEL SECURITY;
 
 DO $$ BEGIN
   CREATE POLICY namespace_isolation_entities ON entities
@@ -188,5 +219,10 @@ EXCEPTION WHEN duplicate_object THEN NULL; END $$;
 
 DO $$ BEGIN
   CREATE POLICY namespace_isolation_procedural ON procedural_memories
+    USING (namespace_id::text = current_setting('pensyve.namespace_id', true));
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+  CREATE POLICY namespace_isolation_observation ON observation_memories
     USING (namespace_id::text = current_setting('pensyve.namespace_id', true));
 EXCEPTION WHEN duplicate_object THEN NULL; END $$;

--- a/pensyve-core/src/storage/sqlite.rs
+++ b/pensyve-core/src/storage/sqlite.rs
@@ -7,8 +7,8 @@ use rusqlite::{Connection, OptionalExtension, params};
 use uuid::Uuid;
 
 use crate::types::{
-    ContentType, Edge, Entity, EntityKind, Episode, EpisodicMemory, Memory, Namespace, Outcome,
-    ProceduralMemory, SemanticMemory,
+    ContentType, Edge, Entity, EntityKind, Episode, EpisodicMemory, Memory, Namespace,
+    ObservationMemory, Outcome, ProceduralMemory, SemanticMemory,
 };
 
 use super::{ActivityAggregate, ActivityEvent, StorageError, StorageResult, StorageTrait};
@@ -261,6 +261,24 @@ CREATE TABLE IF NOT EXISTS procedural_memories (
     last_used       TEXT
 );
 
+CREATE TABLE IF NOT EXISTS observation_memories (
+    id              TEXT PRIMARY KEY,
+    namespace_id    TEXT NOT NULL,
+    episode_id      TEXT NOT NULL,
+    entity_type     TEXT NOT NULL,
+    instance        TEXT NOT NULL,
+    action          TEXT NOT NULL,
+    quantity        REAL,
+    unit            TEXT,
+    content         TEXT NOT NULL,
+    embedding       BLOB,
+    confidence      REAL NOT NULL DEFAULT 0.8,
+    event_time      TEXT,
+    created_at      TEXT NOT NULL,
+    stability       REAL NOT NULL DEFAULT 1.0,
+    retrievability  REAL NOT NULL DEFAULT 1.0
+);
+
 CREATE VIRTUAL TABLE IF NOT EXISTS memory_fts USING fts5(
     memory_id,
     memory_type,
@@ -274,6 +292,10 @@ CREATE INDEX IF NOT EXISTS idx_semantic_ns ON semantic_memories(namespace_id);
 CREATE INDEX IF NOT EXISTS idx_episodic_about ON episodic_memories(about_entity);
 CREATE INDEX IF NOT EXISTS idx_episodic_source ON episodic_memories(source_entity);
 CREATE INDEX IF NOT EXISTS idx_episodic_ns ON episodic_memories(namespace_id);
+CREATE INDEX IF NOT EXISTS idx_observation_episode ON observation_memories(episode_id);
+CREATE INDEX IF NOT EXISTS idx_observation_ns ON observation_memories(namespace_id);
+CREATE INDEX IF NOT EXISTS idx_observation_entity_type
+    ON observation_memories(namespace_id, entity_type);
 
 CREATE TABLE IF NOT EXISTS edges (
     id              TEXT PRIMARY KEY,
@@ -981,6 +1003,152 @@ impl StorageTrait for SqliteBackend {
     }
 
     // -----------------------------------------------------------------------
+    // Observation Memory — derived per-episode artifacts.
+    // Surfaced at recall time by episode-id join in `recall_grouped`; not as
+    // RRF candidates. Cascade-deleted with their source episode.
+    // -----------------------------------------------------------------------
+
+    fn save_observation(&self, mem: &ObservationMemory) -> StorageResult<()> {
+        let conn = lock_conn!(self);
+        let embedding_blob = if mem.embedding.is_empty() {
+            None
+        } else {
+            Some(embedding_to_blob(&mem.embedding))
+        };
+        let event_time = opt_dt_to_str(mem.event_time);
+
+        // One fsync for row + FTS rather than two.
+        conn.execute_batch("BEGIN")?;
+        let result = (|| -> StorageResult<()> {
+            conn.execute(
+                r"INSERT OR REPLACE INTO observation_memories
+                   (id, namespace_id, episode_id, entity_type, instance, action, quantity, unit,
+                    content, embedding, confidence, event_time, created_at, stability, retrievability)
+                   VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)",
+                params![
+                    mem.id.to_string(),
+                    mem.namespace_id.to_string(),
+                    mem.episode_id.to_string(),
+                    mem.entity_type,
+                    mem.instance,
+                    mem.action,
+                    mem.quantity,
+                    mem.unit,
+                    mem.content,
+                    embedding_blob,
+                    f64::from(mem.confidence),
+                    event_time,
+                    mem.created_at.to_rfc3339(),
+                    f64::from(mem.stability),
+                    f64::from(mem.retrievability),
+                ],
+            )?;
+            conn.execute(
+                "INSERT OR REPLACE INTO memory_fts (memory_id, memory_type, namespace_id, content) VALUES (?1, ?2, ?3, ?4)",
+                params![
+                    mem.id.to_string(),
+                    "observation",
+                    mem.namespace_id.to_string(),
+                    mem.content,
+                ],
+            )?;
+            Ok(())
+        })();
+
+        match result {
+            Ok(()) => {
+                conn.execute_batch("COMMIT")?;
+                Ok(())
+            }
+            Err(e) => {
+                let _ = conn.execute_batch("ROLLBACK");
+                Err(e)
+            }
+        }
+    }
+
+    fn get_observation(&self, id: Uuid) -> StorageResult<Option<ObservationMemory>> {
+        let conn = lock_conn!(self);
+        let result = conn
+            .query_row(
+                r"SELECT id, namespace_id, episode_id, entity_type, instance, action, quantity,
+                          unit, content, embedding, confidence, event_time, created_at,
+                          stability, retrievability
+                   FROM observation_memories WHERE id = ?1",
+                params![id.to_string()],
+                row_to_observation,
+            )
+            .optional()?;
+        result.transpose()
+    }
+
+    fn list_observations_by_episode_ids(
+        &self,
+        episode_ids: &[Uuid],
+        limit: usize,
+    ) -> StorageResult<Vec<ObservationMemory>> {
+        if episode_ids.is_empty() || limit == 0 {
+            return Ok(Vec::new());
+        }
+        let conn = lock_conn!(self);
+        let placeholders: String = vec!["?"; episode_ids.len()].join(",");
+        let sql = format!(
+            "SELECT id, namespace_id, episode_id, entity_type, instance, action, quantity, \
+              unit, content, embedding, confidence, event_time, created_at, \
+              stability, retrievability \
+             FROM observation_memories \
+             WHERE episode_id IN ({placeholders}) \
+             ORDER BY created_at ASC \
+             LIMIT ?"
+        );
+        let mut stmt = conn.prepare(&sql)?;
+
+        let mut params_vec: Vec<Box<dyn rusqlite::ToSql>> = episode_ids
+            .iter()
+            .map(|u| Box::new(u.to_string()) as Box<dyn rusqlite::ToSql>)
+            .collect();
+        params_vec.push(Box::new(i64::try_from(limit).unwrap_or(i64::MAX)));
+        let param_refs: Vec<&dyn rusqlite::ToSql> =
+            params_vec.iter().map(std::convert::AsRef::as_ref).collect();
+
+        let rows = stmt.query_map(param_refs.as_slice(), row_to_observation)?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row??);
+        }
+        Ok(out)
+    }
+
+    fn delete_observations_by_episode(&self, episode_id: Uuid) -> StorageResult<usize> {
+        let conn = lock_conn!(self);
+        let ep_str = episode_id.to_string();
+        conn.execute_batch("BEGIN")?;
+        let result = (|| -> StorageResult<usize> {
+            conn.execute(
+                "DELETE FROM memory_fts \
+                 WHERE memory_type = 'observation' \
+                   AND memory_id IN (SELECT id FROM observation_memories WHERE episode_id = ?1)",
+                params![&ep_str],
+            )?;
+            let deleted = conn.execute(
+                "DELETE FROM observation_memories WHERE episode_id = ?1",
+                params![&ep_str],
+            )?;
+            Ok(deleted)
+        })();
+        match result {
+            Ok(n) => {
+                conn.execute_batch("COMMIT")?;
+                Ok(n)
+            }
+            Err(e) => {
+                let _ = conn.execute_batch("ROLLBACK");
+                Err(e)
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
     // Full-text search
     // -----------------------------------------------------------------------
 
@@ -1003,9 +1171,13 @@ impl StorageTrait for SqliteBackend {
         }
 
         let conn = lock_conn!(self);
+        // The excluded `'observation'` literal must match `Memory::type_name()`
+        // for `Memory::Observation(_)`. Observations are surfaced at recall
+        // time by joining on top-k episode IDs, not as RRF candidates.
         let mut stmt = conn.prepare(
             r"SELECT memory_id, memory_type FROM memory_fts
                WHERE memory_fts MATCH ?1 AND namespace_id = ?2
+                 AND memory_type != 'observation'
                LIMIT ?3",
         )?;
         let rows: Vec<(String, String)> = stmt
@@ -1231,6 +1403,20 @@ impl StorageTrait for SqliteBackend {
             }
         }
 
+        // Observation
+        {
+            let mut stmt = conn.prepare(
+                r"SELECT id, namespace_id, episode_id, entity_type, instance, action, quantity,
+                          unit, content, embedding, confidence, event_time, created_at,
+                          stability, retrievability
+                   FROM observation_memories WHERE namespace_id = ?1",
+            )?;
+            let rows = stmt.query_map(params![&ns_str], row_to_observation)?;
+            for row in rows {
+                memories.push(Memory::Observation(row??));
+            }
+        }
+
         Ok(memories)
     }
 
@@ -1332,6 +1518,14 @@ impl StorageTrait for SqliteBackend {
             deleted = true;
         }
 
+        let n = conn.execute(
+            "DELETE FROM observation_memories WHERE id = ?1",
+            params![&id_str],
+        )?;
+        if n > 0 {
+            deleted = true;
+        }
+
         // Remove from FTS index.
         if deleted {
             conn.execute(
@@ -1363,6 +1557,10 @@ impl StorageTrait for SqliteBackend {
             )?;
             total += conn.execute(
                 "DELETE FROM procedural_memories WHERE namespace_id = ?1",
+                params![&ns_str],
+            )?;
+            total += conn.execute(
+                "DELETE FROM observation_memories WHERE namespace_id = ?1",
                 params![&ns_str],
             )?;
 
@@ -1895,6 +2093,60 @@ fn row_to_procedural(
             .unwrap_or_default(),
         created_at: str_to_dt(&created_at_str),
         last_used: str_to_opt_dt(last_used_str.as_deref()),
+    }))
+}
+
+fn row_to_observation(
+    row: &rusqlite::Row<'_>,
+) -> rusqlite::Result<Result<ObservationMemory, StorageError>> {
+    let id_str: String = row.get(0)?;
+    let ns_str: String = row.get(1)?;
+    let episode_id_str: String = row.get(2)?;
+    let entity_type: String = row.get(3)?;
+    let instance: String = row.get(4)?;
+    let action: String = row.get(5)?;
+    let quantity: Option<f64> = row.get(6)?;
+    let unit: Option<String> = row.get(7)?;
+    let content: String = row.get(8)?;
+    let embedding_bytes: Option<Vec<u8>> = row.get(9)?;
+    let confidence: f64 = row.get(10)?;
+    let event_time_str: Option<String> = row.get(11)?;
+    let created_at_str: String = row.get(12)?;
+    let stability: f64 = row.get(13)?;
+    let retrievability: f64 = row.get(14)?;
+
+    let id = match parse_uuid(&id_str) {
+        Ok(v) => v,
+        Err(e) => return Ok(Err(e)),
+    };
+    let namespace_id = match parse_uuid(&ns_str) {
+        Ok(v) => v,
+        Err(e) => return Ok(Err(e)),
+    };
+    let episode_id = match parse_uuid(&episode_id_str) {
+        Ok(v) => v,
+        Err(e) => return Ok(Err(e)),
+    };
+
+    Ok(Ok(ObservationMemory {
+        id,
+        namespace_id,
+        episode_id,
+        entity_type,
+        instance,
+        action,
+        quantity,
+        unit,
+        content,
+        embedding: embedding_bytes
+            .as_deref()
+            .map(blob_to_embedding)
+            .unwrap_or_default(),
+        confidence: confidence as f32,
+        event_time: str_to_opt_dt(event_time_str.as_deref()),
+        created_at: str_to_dt(&created_at_str),
+        stability: stability as f32,
+        retrievability: retrievability as f32,
     }))
 }
 
@@ -2522,5 +2774,213 @@ mod tests {
             .query_row("SELECT COUNT(*) FROM acl", [], |row| row.get(0))
             .unwrap();
         assert_eq!(count, 0);
+    }
+
+    // -----------------------------------------------------------------------
+    // Observation memory tests (Phase 1.2)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_observation_save_and_get() {
+        let (_dir, db) = setup();
+        let ns = make_namespace(&db);
+        let episode_id = Uuid::new_v4();
+
+        let mut obs = ObservationMemory::new(
+            ns.id,
+            episode_id,
+            "game_played",
+            "Assassin's Creed Odyssey",
+            "played",
+            "User played Assassin's Creed Odyssey for 70 hours",
+        );
+        obs.quantity = Some(70.0);
+        obs.unit = Some("hours".into());
+        obs.embedding = vec![0.1, 0.2, 0.3];
+        db.save_observation(&obs).unwrap();
+
+        let fetched = db.get_observation(obs.id).unwrap().unwrap();
+        assert_eq!(fetched.id, obs.id);
+        assert_eq!(fetched.episode_id, episode_id);
+        assert_eq!(fetched.entity_type, "game_played");
+        assert_eq!(fetched.instance, "Assassin's Creed Odyssey");
+        assert_eq!(fetched.action, "played");
+        assert_eq!(fetched.quantity, Some(70.0));
+        assert_eq!(fetched.unit.as_deref(), Some("hours"));
+        assert_eq!(fetched.embedding, vec![0.1, 0.2, 0.3]);
+        assert!((fetched.confidence - 0.8).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_observation_missing_returns_none() {
+        let (_dir, db) = setup();
+        let result = db.get_observation(Uuid::new_v4()).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_observations_list_by_episode_ids() {
+        let (_dir, db) = setup();
+        let ns = make_namespace(&db);
+        let ep_a = Uuid::new_v4();
+        let ep_b = Uuid::new_v4();
+        let ep_c = Uuid::new_v4();
+
+        // 2 obs for ep_a, 1 for ep_b, 1 for ep_c
+        for (ep, name) in [
+            (ep_a, "AC Odyssey"),
+            (ep_a, "Elden Ring"),
+            (ep_b, "Dune"),
+            (ep_c, "off-topic"),
+        ] {
+            let obs = ObservationMemory::new(ns.id, ep, "thing", name, "did", name);
+            db.save_observation(&obs).unwrap();
+        }
+
+        // Fetch ep_a + ep_b only
+        let fetched = db
+            .list_observations_by_episode_ids(&[ep_a, ep_b], 100)
+            .unwrap();
+        assert_eq!(fetched.len(), 3);
+        let instances: std::collections::HashSet<_> =
+            fetched.iter().map(|o| o.instance.clone()).collect();
+        assert!(instances.contains("AC Odyssey"));
+        assert!(instances.contains("Elden Ring"));
+        assert!(instances.contains("Dune"));
+        assert!(!instances.contains("off-topic"));
+    }
+
+    #[test]
+    fn test_observations_list_respects_limit() {
+        let (_dir, db) = setup();
+        let ns = make_namespace(&db);
+        let ep = Uuid::new_v4();
+
+        for i in 0..10 {
+            let name = format!("item_{i}");
+            let obs = ObservationMemory::new(ns.id, ep, "thing", &name, "did", &name);
+            db.save_observation(&obs).unwrap();
+        }
+
+        let fetched = db.list_observations_by_episode_ids(&[ep], 3).unwrap();
+        assert_eq!(fetched.len(), 3);
+    }
+
+    #[test]
+    fn test_observations_list_empty_inputs() {
+        let (_dir, db) = setup();
+        assert!(
+            db.list_observations_by_episode_ids(&[], 10)
+                .unwrap()
+                .is_empty()
+        );
+        assert!(
+            db.list_observations_by_episode_ids(&[Uuid::new_v4()], 0)
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn test_delete_observations_by_episode() {
+        let (_dir, db) = setup();
+        let ns = make_namespace(&db);
+        let ep_a = Uuid::new_v4();
+        let ep_b = Uuid::new_v4();
+
+        for (ep, name) in [(ep_a, "a1"), (ep_a, "a2"), (ep_b, "b1")] {
+            let obs = ObservationMemory::new(ns.id, ep, "thing", name, "did", name);
+            db.save_observation(&obs).unwrap();
+        }
+
+        let deleted = db.delete_observations_by_episode(ep_a).unwrap();
+        assert_eq!(deleted, 2);
+
+        let remaining = db
+            .list_observations_by_episode_ids(&[ep_a, ep_b], 100)
+            .unwrap();
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].instance, "b1");
+    }
+
+    #[test]
+    fn test_observations_included_in_get_all_memories_by_namespace() {
+        let (_dir, db) = setup();
+        let ns = make_namespace(&db);
+        let ep = Uuid::new_v4();
+
+        let obs =
+            ObservationMemory::new(ns.id, ep, "thing", "instance", "did", "content");
+        db.save_observation(&obs).unwrap();
+
+        let all = db.get_all_memories_by_namespace(ns.id).unwrap();
+        let found_obs = all
+            .iter()
+            .any(|m| matches!(m, Memory::Observation(o) if o.id == obs.id));
+        assert!(found_obs, "Observation missing from get_all_memories");
+    }
+
+    #[test]
+    fn test_observations_excluded_from_fts_candidates() {
+        // Observations must NOT surface through search_fts — they attach via
+        // top-k episode-id join at recall time, not as RRF candidates.
+        let (_dir, db) = setup();
+        let ns = make_namespace(&db);
+        let ep = Uuid::new_v4();
+
+        let obs = ObservationMemory::new(
+            ns.id,
+            ep,
+            "game_played",
+            "AC Odyssey",
+            "played",
+            "unique_fts_token_xyz123 assassin odyssey",
+        );
+        db.save_observation(&obs).unwrap();
+
+        let hits = db.search_fts("unique_fts_token_xyz123", ns.id, 10).unwrap();
+        assert!(hits.is_empty(), "Observation leaked into FTS results");
+    }
+
+    #[test]
+    fn test_delete_memory_by_id_handles_observation() {
+        let (_dir, db) = setup();
+        let ns = make_namespace(&db);
+        let ep = Uuid::new_v4();
+
+        let obs = ObservationMemory::new(ns.id, ep, "x", "y", "z", "c");
+        db.save_observation(&obs).unwrap();
+        let obs_id = obs.id;
+
+        let deleted = db.delete_memory_by_id(obs_id).unwrap();
+        assert!(deleted);
+        assert!(db.get_observation(obs_id).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_observation_namespace_isolation() {
+        let (_dir, db) = setup();
+        let ns_a = make_namespace(&db);
+        let ns_b = Namespace::new("other");
+        db.save_namespace(&ns_b).unwrap();
+
+        let ep_a = Uuid::new_v4();
+        let ep_b = Uuid::new_v4();
+        let obs_a =
+            ObservationMemory::new(ns_a.id, ep_a, "x", "a-instance", "did", "c");
+        let obs_b =
+            ObservationMemory::new(ns_b.id, ep_b, "x", "b-instance", "did", "c");
+        db.save_observation(&obs_a).unwrap();
+        db.save_observation(&obs_b).unwrap();
+
+        let all_a = db.get_all_memories_by_namespace(ns_a.id).unwrap();
+        let instances_a: Vec<_> = all_a
+            .iter()
+            .filter_map(|m| match m {
+                Memory::Observation(o) => Some(o.instance.clone()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(instances_a, vec!["a-instance"]);
     }
 }

--- a/pensyve-core/src/storage/sqlite.rs
+++ b/pensyve-core/src/storage/sqlite.rs
@@ -1146,6 +1146,47 @@ impl StorageTrait for SqliteBackend {
         Ok(out)
     }
 
+    fn delete_observations_by_entity(&self, entity_id: Uuid) -> StorageResult<usize> {
+        let conn = lock_conn!(self);
+        let id_str = entity_id.to_string();
+        conn.execute_batch("BEGIN")?;
+        let result = (|| -> StorageResult<usize> {
+            // Strip FTS entries first — we need the observation IDs before
+            // the rows are gone.
+            conn.execute(
+                "DELETE FROM memory_fts \
+                 WHERE memory_type = 'observation' \
+                   AND memory_id IN (\
+                     SELECT id FROM observation_memories \
+                      WHERE episode_id IN (\
+                        SELECT DISTINCT episode_id FROM episodic_memories \
+                         WHERE about_entity = ?1 OR source_entity = ?1\
+                      )\
+                   )",
+                params![&id_str],
+            )?;
+            let deleted = conn.execute(
+                "DELETE FROM observation_memories \
+                 WHERE episode_id IN (\
+                   SELECT DISTINCT episode_id FROM episodic_memories \
+                    WHERE about_entity = ?1 OR source_entity = ?1\
+                 )",
+                params![&id_str],
+            )?;
+            Ok(deleted)
+        })();
+        match result {
+            Ok(n) => {
+                conn.execute_batch("COMMIT")?;
+                Ok(n)
+            }
+            Err(e) => {
+                let _ = conn.execute_batch("ROLLBACK");
+                Err(e)
+            }
+        }
+    }
+
     fn delete_observations_by_episode(&self, episode_id: Uuid) -> StorageResult<usize> {
         let conn = lock_conn!(self);
         let ep_str = episode_id.to_string();
@@ -2936,8 +2977,7 @@ mod tests {
         let ns = make_namespace(&db);
         let ep = Uuid::new_v4();
 
-        let obs =
-            ObservationMemory::new(ns.id, ep, "thing", "instance", "did", "content");
+        let obs = ObservationMemory::new(ns.id, ep, "thing", "instance", "did", "content");
         db.save_observation(&obs).unwrap();
 
         let all = db.get_all_memories_by_namespace(ns.id).unwrap();
@@ -2993,10 +3033,8 @@ mod tests {
 
         let ep_a = Uuid::new_v4();
         let ep_b = Uuid::new_v4();
-        let obs_a =
-            ObservationMemory::new(ns_a.id, ep_a, "x", "a-instance", "did", "c");
-        let obs_b =
-            ObservationMemory::new(ns_b.id, ep_b, "x", "b-instance", "did", "c");
+        let obs_a = ObservationMemory::new(ns_a.id, ep_a, "x", "a-instance", "did", "c");
+        let obs_b = ObservationMemory::new(ns_b.id, ep_b, "x", "b-instance", "did", "c");
         db.save_observation(&obs_a).unwrap();
         db.save_observation(&obs_b).unwrap();
 

--- a/pensyve-core/src/storage/sqlite.rs
+++ b/pensyve-core/src/storage/sqlite.rs
@@ -292,6 +292,8 @@ CREATE INDEX IF NOT EXISTS idx_semantic_ns ON semantic_memories(namespace_id);
 CREATE INDEX IF NOT EXISTS idx_episodic_about ON episodic_memories(about_entity);
 CREATE INDEX IF NOT EXISTS idx_episodic_source ON episodic_memories(source_entity);
 CREATE INDEX IF NOT EXISTS idx_episodic_ns ON episodic_memories(namespace_id);
+CREATE INDEX IF NOT EXISTS idx_episodic_episode
+    ON episodic_memories(namespace_id, episode_id);
 CREATE INDEX IF NOT EXISTS idx_observation_episode ON observation_memories(episode_id);
 CREATE INDEX IF NOT EXISTS idx_observation_ns ON observation_memories(namespace_id);
 CREATE INDEX IF NOT EXISTS idx_observation_entity_type
@@ -894,6 +896,31 @@ impl StorageTrait for SqliteBackend {
                 i64::try_from(limit).unwrap_or(i64::MAX)
             ],
             row_to_semantic,
+        )?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row??);
+        }
+        Ok(out)
+    }
+
+    fn list_episodic_by_episode(
+        &self,
+        namespace_id: Uuid,
+        episode_id: Uuid,
+    ) -> StorageResult<Vec<EpisodicMemory>> {
+        let conn = lock_conn!(self);
+        let mut stmt = conn.prepare(
+            r"SELECT id, namespace_id, episode_id, source_entity, about_entity, content,
+                      content_type, summary, embedding, context_intent, timestamp,
+                      stability, retrievability, access_count, last_accessed, event_time
+               FROM episodic_memories
+               WHERE namespace_id = ?1 AND episode_id = ?2
+               ORDER BY COALESCE(event_time, timestamp) ASC",
+        )?;
+        let rows = stmt.query_map(
+            params![namespace_id.to_string(), episode_id.to_string()],
+            row_to_episodic,
         )?;
         let mut out = Vec::new();
         for row in rows {

--- a/pensyve-core/src/types.rs
+++ b/pensyve-core/src/types.rs
@@ -321,6 +321,101 @@ impl ProceduralMemory {
 }
 
 // ---------------------------------------------------------------------------
+// ObservationMemory
+// ---------------------------------------------------------------------------
+//
+// Derived artifact: a structured countable-entity observation extracted from
+// one or more episodic memories within a single episode. Observations exist
+// to move multi-instance counting out of the reader's mental arithmetic and
+// into deterministic lookup at reader-format time.
+//
+// Always tied to exactly one `episode_id` (cascade-deleted with the source).
+
+fn default_confidence() -> f32 {
+    0.8
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ObservationMemory {
+    pub id: Uuid,
+    pub namespace_id: Uuid,
+
+    /// Source episode. Observations are always derived from an episode;
+    /// cascade-deleted when the episode is removed.
+    pub episode_id: Uuid,
+
+    /// Category noun phrase: `"game_played"`, `"citrus_fruit_used"`,
+    /// `"clothing_item_to_return"`, ...
+    pub entity_type: String,
+
+    /// Specific instance: `"Assassin's Creed Odyssey"`, `"lemon"`, `"boots"`.
+    pub instance: String,
+
+    /// Verb or relationship: `"played"`, `"used in cocktail"`, `"needs pickup"`.
+    pub action: String,
+
+    /// Optional numeric quantity: `70` (hours), `3` (items), `15.5` (miles).
+    pub quantity: Option<f64>,
+
+    /// Optional unit for `quantity`: "hours", "items", "miles".
+    pub unit: Option<String>,
+
+    /// Human-readable summary used for embedding + display.
+    /// Example: "User played Assassin's Creed Odyssey for 70 hours".
+    pub content: String,
+
+    /// Embedding of `content` for semantic search. Empty until indexed.
+    pub embedding: Vec<f32>,
+
+    /// Extractor-assigned confidence in [0, 1]. Lower for hedged or
+    /// hypothetical mentions. Defaults to 0.8 when deserialized without it.
+    #[serde(default = "default_confidence")]
+    pub confidence: f32,
+
+    /// Inherited from the source episode's `event_time` when available.
+    #[serde(default)]
+    pub event_time: Option<DateTime<Utc>>,
+
+    /// When the observation was extracted (not when the event occurred).
+    pub created_at: DateTime<Utc>,
+
+    /// Stability in [0, 1]; starts at 1.0 and decays (mirrors `EpisodicMemory`).
+    pub stability: f32,
+
+    /// Retrievability in [0, 1]; starts at 1.0 and decays with disuse.
+    pub retrievability: f32,
+}
+
+impl ObservationMemory {
+    pub fn new(
+        namespace_id: Uuid,
+        episode_id: Uuid,
+        entity_type: impl Into<String>,
+        instance: impl Into<String>,
+        action: impl Into<String>,
+        content: impl Into<String>,
+    ) -> Self {
+        Self {
+            id: Uuid::new_v4(),
+            namespace_id,
+            episode_id,
+            entity_type: entity_type.into(),
+            instance: instance.into(),
+            action: action.into(),
+            quantity: None,
+            unit: None,
+            content: content.into(),
+            embedding: Vec::new(),
+            confidence: default_confidence(),
+            event_time: None,
+            created_at: Utc::now(),
+            stability: 1.0,
+            retrievability: 1.0,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Edge
 // ---------------------------------------------------------------------------
 
@@ -371,6 +466,10 @@ pub enum Memory {
     Episodic(EpisodicMemory),
     Semantic(SemanticMemory),
     Procedural(ProceduralMemory),
+    /// Structured fact derived from one or more episodic memories at ingest
+    /// time (e.g. "user played Assassin's Creed Odyssey for 70 hours").
+    /// Surfaced at recall time alongside the source episode's raw turns.
+    Observation(ObservationMemory),
 }
 
 impl Memory {
@@ -379,6 +478,7 @@ impl Memory {
             Memory::Episodic(m) => m.id,
             Memory::Semantic(m) => m.id,
             Memory::Procedural(m) => m.id,
+            Memory::Observation(m) => m.id,
         }
     }
 
@@ -387,6 +487,7 @@ impl Memory {
             Memory::Episodic(m) => &m.embedding,
             Memory::Semantic(m) => &m.embedding,
             Memory::Procedural(m) => &m.embedding,
+            Memory::Observation(m) => &m.embedding,
         }
     }
 
@@ -395,6 +496,20 @@ impl Memory {
             Memory::Episodic(m) => m.stability,
             Memory::Semantic(m) => m.stability,
             Memory::Procedural(m) => m.reliability,
+            Memory::Observation(m) => m.stability,
+        }
+    }
+
+    /// Short discriminator string used for logging, API responses, FTS rows,
+    /// and intent scoring. Single source of truth — SQL string literals that
+    /// must match this (e.g. `memory_fts.memory_type`) reference
+    /// [`Memory::type_name`] in their surrounding code, not hard-coded strings.
+    pub fn type_name(&self) -> &'static str {
+        match self {
+            Memory::Episodic(_) => "episodic",
+            Memory::Semantic(_) => "semantic",
+            Memory::Procedural(_) => "procedural",
+            Memory::Observation(_) => "observation",
         }
     }
 }
@@ -482,6 +597,127 @@ mod tests {
     fn test_content_type_unknown_fallback() {
         assert_eq!(ContentType::from_str("unknown"), ContentType::Text);
         assert_eq!(ContentType::from_str(""), ContentType::Text);
+    }
+
+    #[test]
+    fn test_observation_memory_creation() {
+        let ns_id = Uuid::new_v4();
+        let ep_id = Uuid::new_v4();
+        let obs = ObservationMemory::new(
+            ns_id,
+            ep_id,
+            "game_played",
+            "Assassin's Creed Odyssey",
+            "played",
+            "User played Assassin's Creed Odyssey for 70 hours",
+        );
+        assert_eq!(obs.entity_type, "game_played");
+        assert_eq!(obs.instance, "Assassin's Creed Odyssey");
+        assert_eq!(obs.action, "played");
+        assert!(obs.quantity.is_none());
+        assert!(obs.unit.is_none());
+        assert!((obs.confidence - 0.8).abs() < f32::EPSILON);
+        assert!((obs.stability - 1.0).abs() < f32::EPSILON);
+        assert_eq!(obs.episode_id, ep_id);
+        assert_eq!(obs.namespace_id, ns_id);
+    }
+
+    #[test]
+    fn test_observation_memory_quantity_and_unit() {
+        let ns_id = Uuid::new_v4();
+        let ep_id = Uuid::new_v4();
+        let mut obs = ObservationMemory::new(
+            ns_id,
+            ep_id,
+            "driving_hours",
+            "commute",
+            "drove",
+            "User drove 4 hours",
+        );
+        obs.quantity = Some(4.0);
+        obs.unit = Some("hours".into());
+        obs.confidence = 0.4;
+        assert_eq!(obs.quantity, Some(4.0));
+        assert_eq!(obs.unit.as_deref(), Some("hours"));
+        assert!((obs.confidence - 0.4).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_observation_memory_serde_roundtrip() {
+        let ns_id = Uuid::new_v4();
+        let ep_id = Uuid::new_v4();
+        let mut obs = ObservationMemory::new(
+            ns_id,
+            ep_id,
+            "book_read",
+            "Dune",
+            "read",
+            "User read Dune",
+        );
+        obs.quantity = Some(512.0);
+        obs.unit = Some("pages".into());
+        obs.embedding = vec![0.1, 0.2, 0.3];
+
+        let json = serde_json::to_string(&obs).expect("serialize");
+        let round: ObservationMemory = serde_json::from_str(&json).expect("deserialize");
+
+        assert_eq!(round.id, obs.id);
+        assert_eq!(round.episode_id, obs.episode_id);
+        assert_eq!(round.entity_type, obs.entity_type);
+        assert_eq!(round.instance, obs.instance);
+        assert_eq!(round.action, obs.action);
+        assert_eq!(round.quantity, obs.quantity);
+        assert_eq!(round.unit, obs.unit);
+        assert_eq!(round.content, obs.content);
+        assert_eq!(round.embedding, obs.embedding);
+        assert!((round.confidence - obs.confidence).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_memory_enum_observation_accessors() {
+        let ns_id = Uuid::new_v4();
+        let ep_id = Uuid::new_v4();
+        let mut obs = ObservationMemory::new(
+            ns_id,
+            ep_id,
+            "game_played",
+            "AC Odyssey",
+            "played",
+            "x",
+        );
+        obs.embedding = vec![1.0, 2.0];
+        let obs_id = obs.id;
+        let mem = Memory::Observation(obs);
+        assert_eq!(mem.id(), obs_id);
+        assert_eq!(mem.embedding(), &[1.0, 2.0]);
+        assert!((mem.stability() - 1.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_observation_memory_backfills_confidence_on_deserialize() {
+        // Historical rows written before `confidence` existed should default to 0.8.
+        let ns_id = Uuid::new_v4();
+        let ep_id = Uuid::new_v4();
+        let id = Uuid::new_v4();
+        let created_at = Utc::now();
+        let json = serde_json::json!({
+            "id": id,
+            "namespace_id": ns_id,
+            "episode_id": ep_id,
+            "entity_type": "game_played",
+            "instance": "AC",
+            "action": "played",
+            "quantity": null,
+            "unit": null,
+            "content": "x",
+            "embedding": [],
+            "created_at": created_at,
+            "stability": 1.0,
+            "retrievability": 1.0,
+        });
+        let obs: ObservationMemory = serde_json::from_value(json).expect("deserialize");
+        assert!((obs.confidence - 0.8).abs() < f32::EPSILON);
+        assert!(obs.event_time.is_none());
     }
 
     #[test]

--- a/pensyve-core/src/types.rs
+++ b/pensyve-core/src/types.rs
@@ -646,14 +646,8 @@ mod tests {
     fn test_observation_memory_serde_roundtrip() {
         let ns_id = Uuid::new_v4();
         let ep_id = Uuid::new_v4();
-        let mut obs = ObservationMemory::new(
-            ns_id,
-            ep_id,
-            "book_read",
-            "Dune",
-            "read",
-            "User read Dune",
-        );
+        let mut obs =
+            ObservationMemory::new(ns_id, ep_id, "book_read", "Dune", "read", "User read Dune");
         obs.quantity = Some(512.0);
         obs.unit = Some("pages".into());
         obs.embedding = vec![0.1, 0.2, 0.3];
@@ -677,14 +671,8 @@ mod tests {
     fn test_memory_enum_observation_accessors() {
         let ns_id = Uuid::new_v4();
         let ep_id = Uuid::new_v4();
-        let mut obs = ObservationMemory::new(
-            ns_id,
-            ep_id,
-            "game_played",
-            "AC Odyssey",
-            "played",
-            "x",
-        );
+        let mut obs =
+            ObservationMemory::new(ns_id, ep_id, "game_played", "AC Odyssey", "played", "x");
         obs.embedding = vec![1.0, 2.0];
         let obs_id = obs.id;
         let mem = Memory::Observation(obs);

--- a/pensyve-mcp-gateway/Cargo.toml
+++ b/pensyve-mcp-gateway/Cargo.toml
@@ -9,7 +9,7 @@ name = "pensyve-mcp-gateway"
 path = "src/main.rs"
 
 [dependencies]
-pensyve-core = { path = "../pensyve-core", features = ["postgres"] }
+pensyve-core = { path = "../pensyve-core", features = ["postgres", "observation-extraction"] }
 pensyve-mcp-tools = { path = "../pensyve-mcp-tools" }
 rmcp = { version = "1.3", features = ["server", "transport-streamable-http-server", "macros"] }
 axum = "0.8"

--- a/pensyve-mcp-gateway/src/main.rs
+++ b/pensyve-mcp-gateway/src/main.rs
@@ -138,7 +138,10 @@ fn init_resources(config: &GatewayConfig) -> Result<InitResources> {
                     pensyve_core::types::Memory::Episodic(e) => {
                         index.add_with_entity(memory.id(), embedding, e.about_entity)
                     }
-                    pensyve_core::types::Memory::Procedural(_) => index.add(memory.id(), embedding),
+                    pensyve_core::types::Memory::Procedural(_)
+                    | pensyve_core::types::Memory::Observation(_) => {
+                        index.add(memory.id(), embedding)
+                    }
                 };
                 if result.is_ok() {
                     loaded += 1;

--- a/pensyve-mcp-gateway/src/main.rs
+++ b/pensyve-mcp-gateway/src/main.rs
@@ -132,6 +132,12 @@ fn init_resources(config: &GatewayConfig) -> Result<InitResources> {
     if let Ok(memories) = storage.get_all_memories_by_namespace(namespace.id) {
         let mut loaded = 0usize;
         for memory in &memories {
+            // Observations are recall-time enrichment — they attach to
+            // top-k session groups via `recall_grouped::attach_observations_to_groups`
+            // and MUST NOT enter the RRF candidate pool.
+            if matches!(memory, pensyve_core::types::Memory::Observation(_)) {
+                continue;
+            }
             let embedding = memory.embedding();
             if !embedding.is_empty() {
                 let result = match memory {
@@ -141,10 +147,8 @@ fn init_resources(config: &GatewayConfig) -> Result<InitResources> {
                     pensyve_core::types::Memory::Episodic(e) => {
                         index.add_with_entity(memory.id(), embedding, e.about_entity)
                     }
-                    pensyve_core::types::Memory::Procedural(_)
-                    | pensyve_core::types::Memory::Observation(_) => {
-                        index.add(memory.id(), embedding)
-                    }
+                    pensyve_core::types::Memory::Procedural(_) => index.add(memory.id(), embedding),
+                    pensyve_core::types::Memory::Observation(_) => unreachable!(),
                 };
                 if result.is_ok() {
                     loaded += 1;

--- a/pensyve-mcp-gateway/src/main.rs
+++ b/pensyve-mcp-gateway/src/main.rs
@@ -47,6 +47,9 @@ pub struct AppState {
     pub admin_key: Option<String>,
     pub ct: CancellationToken,
     pub redis: Option<redis::aio::ConnectionManager>,
+    /// Process-wide observation extractor. `None` when `ANTHROPIC_API_KEY`
+    /// is unset — ingest still works, observations are simply not produced.
+    pub extractor: Option<Arc<dyn pensyve_core::observation::ObservationExtractor>>,
 }
 
 struct InitResources {
@@ -242,6 +245,23 @@ async fn async_main(config: GatewayConfig, res: InitResources) -> Result<()> {
     };
 
     let auth_required = !config.api_keys.is_empty();
+
+    // Observation extractor — initialized only when ANTHROPIC_API_KEY is set.
+    // Ingest still works without it; observations are simply not produced.
+    let extractor: Option<Arc<dyn pensyve_core::observation::ObservationExtractor>> =
+        match pensyve_core::observation::AnthropicHaikuExtractor::from_env() {
+            Ok(e) => {
+                tracing::info!("Observation extractor: AnthropicHaikuExtractor (Haiku 4.5)");
+                Some(Arc::new(e))
+            }
+            Err(e) => {
+                tracing::info!(
+                    "Observation extractor disabled: {e}. Set ANTHROPIC_API_KEY to enable."
+                );
+                None
+            }
+        };
+
     let app_state = Arc::new(AppState {
         auth: auth::AuthValidator::new(&config),
         rate_limiter: rate_limit::RateLimiter::new(config.rate_limit_per_minute),
@@ -252,6 +272,7 @@ async fn async_main(config: GatewayConfig, res: InitResources) -> Result<()> {
         admin_key: config.admin_key.clone(),
         ct: ct.clone(),
         redis,
+        extractor,
     });
 
     // Create per-tenant MCP service factory. In stateless mode, a new service

--- a/pensyve-mcp-gateway/src/rest.rs
+++ b/pensyve-mcp-gateway/src/rest.rs
@@ -1498,6 +1498,7 @@ async fn episode_message(
     ))
 }
 
+#[allow(clippy::too_many_lines)]
 async fn episode_end(
     State(state): State<Arc<AppState>>,
     axum::Extension(auth_ctx): axum::Extension<AuthContext>,
@@ -1587,6 +1588,41 @@ async fn episode_end(
                     );
                 }
                 Err(e) => tracing::warn!("Post-episode consolidation failed: {e}"),
+            }
+        });
+    }
+
+    // Trigger async observation extraction. Non-fatal: if the extractor isn't
+    // configured (ANTHROPIC_API_KEY unset) or the call fails, the episode
+    // still persists — observations are opportunistic enrichment.
+    if let Some(extractor) = state.extractor.clone() {
+        let storage = ps.storage.clone();
+        let embedder = ps.embedder.clone();
+        let ns_id = ps.namespace.id;
+        tokio::spawn(async move {
+            let persisted = pensyve_core::observation::commit_extraction_for_episode(
+                storage.as_ref(),
+                extractor.as_ref(),
+                ns_id,
+                episode_id,
+                |text| embedder.embed(text),
+            )
+            .await;
+            if persisted > 0 {
+                tracing::info!(
+                    observations = persisted,
+                    episode_id = %episode_id,
+                    "Post-episode extraction"
+                );
+                let _ = storage.log_activity(
+                    ns_id,
+                    "observation_extract",
+                    &serde_json::json!({
+                        "episode_id": episode_id.to_string(),
+                        "observations": persisted,
+                        "trigger": "episode_end",
+                    }),
+                );
             }
         });
     }

--- a/pensyve-mcp-gateway/src/rest.rs
+++ b/pensyve-mcp-gateway/src/rest.rs
@@ -158,6 +158,8 @@ pub struct StatsResponse {
     pub episodic_memories: usize,
     pub semantic_memories: usize,
     pub procedural_memories: usize,
+    #[serde(default)]
+    pub observation_memories: usize,
 }
 
 #[derive(Debug, Deserialize)]
@@ -172,6 +174,8 @@ pub struct InspectResponse {
     pub episodic: Vec<serde_json::Value>,
     pub semantic: Vec<serde_json::Value>,
     pub procedural: Vec<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub observation: Vec<serde_json::Value>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -296,11 +300,7 @@ fn get_or_create_entity(
 }
 
 fn memory_type_name(memory: &Memory) -> &'static str {
-    match memory {
-        Memory::Episodic(_) => "episodic",
-        Memory::Semantic(_) => "semantic",
-        Memory::Procedural(_) => "procedural",
-    }
+    memory.type_name()
 }
 
 fn memory_confidence(memory: &Memory) -> f32 {
@@ -308,6 +308,7 @@ fn memory_confidence(memory: &Memory) -> f32 {
         Memory::Episodic(_) => 1.0,
         Memory::Semantic(m) => m.confidence,
         Memory::Procedural(m) => m.reliability,
+        Memory::Observation(m) => m.confidence,
     }
 }
 
@@ -316,6 +317,7 @@ fn memory_stability(memory: &Memory) -> f32 {
         Memory::Episodic(m) => m.stability,
         Memory::Semantic(m) => m.stability,
         Memory::Procedural(_) => 1.0,
+        Memory::Observation(m) => m.stability,
     }
 }
 
@@ -324,6 +326,7 @@ fn memory_content(memory: &Memory) -> String {
         Memory::Episodic(m) => m.content.clone(),
         Memory::Semantic(m) => format!("{} {}", m.predicate, m.object),
         Memory::Procedural(m) => format!("{} -> {}", m.trigger, m.action),
+        Memory::Observation(m) => m.content.clone(),
     }
 }
 
@@ -334,6 +337,7 @@ fn memory_content(memory: &Memory) -> String {
 fn memory_event_time(memory: &Memory) -> Option<String> {
     match memory {
         Memory::Episodic(m) => m.event_time.map(|t| t.to_rfc3339()),
+        Memory::Observation(m) => m.event_time.map(|t| t.to_rfc3339()),
         Memory::Semantic(_) | Memory::Procedural(_) => None,
     }
 }
@@ -961,6 +965,7 @@ async fn stats(
     let mut semantic_count = 0usize;
     let mut episodic_count = 0usize;
     let mut procedural_count = 0usize;
+    let mut observation_count = 0usize;
 
     if let Ok(memories) = ps.storage.get_all_memories_by_namespace(ns.id) {
         for mem in &memories {
@@ -968,6 +973,7 @@ async fn stats(
                 Memory::Semantic(_) => semantic_count += 1,
                 Memory::Episodic(_) => episodic_count += 1,
                 Memory::Procedural(_) => procedural_count += 1,
+                Memory::Observation(_) => observation_count += 1,
             }
         }
     }
@@ -983,6 +989,7 @@ async fn stats(
         episodic_memories: episodic_count,
         semantic_memories: semantic_count,
         procedural_memories: procedural_count,
+        observation_memories: observation_count,
     }))
 }
 
@@ -1015,6 +1022,7 @@ async fn inspect(
         let mut episodic = Vec::new();
         let mut semantic = Vec::new();
         let mut procedural = Vec::new();
+        let mut observation = Vec::new();
 
         if let Ok(memories) = ps.storage.get_all_memories_by_namespace(ps.namespace.id) {
             for mem in memories.into_iter().take(limit) {
@@ -1034,6 +1042,11 @@ async fn inspect(
                         strip_embedding(&mut val);
                         procedural.push(val);
                     }
+                    pensyve_core::types::Memory::Observation(m) => {
+                        let mut val = serde_json::to_value(&m).unwrap_or_default();
+                        strip_embedding(&mut val);
+                        observation.push(val);
+                    }
                 }
             }
         }
@@ -1043,6 +1056,7 @@ async fn inspect(
             episodic,
             semantic,
             procedural,
+            observation,
         }));
     }
 
@@ -1054,6 +1068,7 @@ async fn inspect(
                 episodic: vec![],
                 semantic: vec![],
                 procedural: vec![],
+                observation: vec![],
             }));
         }
         Err(err) => {
@@ -1090,6 +1105,7 @@ async fn inspect(
         episodic,
         semantic,
         procedural: vec![],
+        observation: vec![],
     }))
 }
 

--- a/pensyve-mcp-gateway/src/rest.rs
+++ b/pensyve-mcp-gateway/src/rest.rs
@@ -623,7 +623,14 @@ async fn recall_grouped(
                     format!("Recall error: {e}"),
                 )
             })?;
-        pensyve_core::recall_grouped::group_by_session(flat.memories, order, max_groups)
+        let groups =
+            pensyve_core::recall_grouped::group_by_session(flat.memories, order, max_groups);
+        // Attach per-episode observations to the top-k groups. Must mirror
+        // `RecallEngine::recall_grouped` (pensyve-core/src/retrieval.rs) so
+        // REST, MCP, and SDK callers all see the same response shape — the
+        // 89.2% benchmark number is reproducible only when observations are
+        // surfaced here.
+        pensyve_core::recall_grouped::attach_observations_to_groups(ps.storage.as_ref(), groups)
     };
 
     let _ = ps.storage.log_activity(

--- a/pensyve-mcp-gateway/src/tenant.rs
+++ b/pensyve-mcp-gateway/src/tenant.rs
@@ -129,6 +129,12 @@ impl TenantStateManager {
         let mut index = VectorIndex::new(self.dimensions, 1024);
         if let Ok(memories) = self.storage.get_all_memories_by_namespace(namespace.id) {
             for mem in &memories {
+                // Observations are recall-time enrichment — they attach to
+                // top-k session groups via `recall_grouped::attach_observations_to_groups`
+                // and MUST NOT enter the RRF candidate pool.
+                if matches!(mem, pensyve_core::types::Memory::Observation(_)) {
+                    continue;
+                }
                 let emb = mem.embedding();
                 if !emb.is_empty() {
                     let _ = match mem {
@@ -138,10 +144,8 @@ impl TenantStateManager {
                         pensyve_core::types::Memory::Episodic(e) => {
                             index.add_with_entity(mem.id(), emb, e.about_entity)
                         }
-                        pensyve_core::types::Memory::Procedural(_)
-                        | pensyve_core::types::Memory::Observation(_) => {
-                            index.add(mem.id(), emb)
-                        }
+                        pensyve_core::types::Memory::Procedural(_) => index.add(mem.id(), emb),
+                        pensyve_core::types::Memory::Observation(_) => unreachable!(),
                     };
                 }
             }

--- a/pensyve-mcp-gateway/src/tenant.rs
+++ b/pensyve-mcp-gateway/src/tenant.rs
@@ -138,7 +138,10 @@ impl TenantStateManager {
                         pensyve_core::types::Memory::Episodic(e) => {
                             index.add_with_entity(mem.id(), emb, e.about_entity)
                         }
-                        pensyve_core::types::Memory::Procedural(_) => index.add(mem.id(), emb),
+                        pensyve_core::types::Memory::Procedural(_)
+                        | pensyve_core::types::Memory::Observation(_) => {
+                            index.add(mem.id(), emb)
+                        }
                     };
                 }
             }

--- a/pensyve-mcp-tools/src/server.rs
+++ b/pensyve-mcp-tools/src/server.rs
@@ -20,11 +20,7 @@ use crate::params::{
 use crate::state::PensyveState;
 
 fn memory_type_name(memory: &Memory) -> &'static str {
-    match memory {
-        Memory::Episodic(_) => "episodic",
-        Memory::Semantic(_) => "semantic",
-        Memory::Procedural(_) => "procedural",
-    }
+    memory.type_name()
 }
 
 fn memory_confidence(memory: &Memory) -> f32 {
@@ -32,6 +28,7 @@ fn memory_confidence(memory: &Memory) -> f32 {
         Memory::Episodic(_) => 1.0,
         Memory::Semantic(m) => m.confidence,
         Memory::Procedural(m) => m.reliability,
+        Memory::Observation(m) => m.confidence,
     }
 }
 

--- a/pensyve-mcp/src/main.rs
+++ b/pensyve-mcp/src/main.rs
@@ -50,7 +50,8 @@ fn load_vector_index(
                         pensyve_core::types::Memory::Episodic(e) => {
                             index.add_with_entity(memory.id(), embedding, e.about_entity)
                         }
-                        pensyve_core::types::Memory::Procedural(_) => {
+                        pensyve_core::types::Memory::Procedural(_)
+                        | pensyve_core::types::Memory::Observation(_) => {
                             index.add(memory.id(), embedding)
                         }
                     };

--- a/pensyve-mcp/src/main.rs
+++ b/pensyve-mcp/src/main.rs
@@ -41,6 +41,12 @@ fn load_vector_index(
         Ok(memories) => {
             let mut loaded = 0usize;
             for memory in &memories {
+                // Observations are recall-time enrichment — they attach to
+                // top-k session groups via `recall_grouped::attach_observations_to_groups`
+                // and MUST NOT enter the RRF candidate pool.
+                if matches!(memory, pensyve_core::types::Memory::Observation(_)) {
+                    continue;
+                }
                 let embedding = memory.embedding();
                 if !embedding.is_empty() {
                     let result = match memory {
@@ -50,10 +56,10 @@ fn load_vector_index(
                         pensyve_core::types::Memory::Episodic(e) => {
                             index.add_with_entity(memory.id(), embedding, e.about_entity)
                         }
-                        pensyve_core::types::Memory::Procedural(_)
-                        | pensyve_core::types::Memory::Observation(_) => {
+                        pensyve_core::types::Memory::Procedural(_) => {
                             index.add(memory.id(), embedding)
                         }
+                        pensyve_core::types::Memory::Observation(_) => unreachable!(),
                     };
                     if let Err(e) = result {
                         tracing::warn!("Skipping memory in index load: {e}");

--- a/pensyve-python/Cargo.toml
+++ b/pensyve-python/Cargo.toml
@@ -15,13 +15,14 @@ name = "pensyve_python"
 crate-type = ["cdylib"]
 
 [dependencies]
-pensyve-core = { path = "../pensyve-core" }
+pensyve-core = { path = "../pensyve-core", features = ["observation-extraction"] }
 pyo3 = { version = "^0.28.3", features = ["extension-module"] }
 uuid = { version = "1", features = ["v4"] }
 chrono = "0.4"
 serde_json = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
+tokio = { version = "1", features = ["rt-multi-thread"] }
 
 [lints]
 workspace = true

--- a/pensyve-python/python/pensyve/__init__.py
+++ b/pensyve-python/python/pensyve/__init__.py
@@ -7,6 +7,12 @@ from pensyve._core import (
     __version__,
     embedding_info,
 )
+from pensyve.reader import (
+    V7_OBSERVATION_WRAPPER_PREFIX,
+    V7_OBSERVATION_WRAPPER_SUFFIX,
+    format_observations_block,
+    format_session_history,
+)
 
 __all__ = [
     "Entity",
@@ -14,6 +20,10 @@ __all__ = [
     "Memory",
     "Pensyve",
     "SessionGroup",
+    "V7_OBSERVATION_WRAPPER_PREFIX",
+    "V7_OBSERVATION_WRAPPER_SUFFIX",
     "__version__",
     "embedding_info",
+    "format_observations_block",
+    "format_session_history",
 ]

--- a/pensyve-python/python/pensyve/__init__.py
+++ b/pensyve-python/python/pensyve/__init__.py
@@ -10,6 +10,7 @@ from pensyve._core import (
 from pensyve.reader import (
     V7_OBSERVATION_WRAPPER_PREFIX,
     V7_OBSERVATION_WRAPPER_SUFFIX,
+    classify_query_naive,
     format_observations_block,
     format_session_history,
 )
@@ -23,6 +24,7 @@ __all__ = [
     "V7_OBSERVATION_WRAPPER_PREFIX",
     "V7_OBSERVATION_WRAPPER_SUFFIX",
     "__version__",
+    "classify_query_naive",
     "embedding_info",
     "format_observations_block",
     "format_session_history",

--- a/pensyve-python/python/pensyve/_core.pyi
+++ b/pensyve-python/python/pensyve/_core.pyi
@@ -17,12 +17,20 @@ class Pensyve:
         self,
         path: str | None = None,
         namespace: str | None = None,
+        extractor: str | None = None,
+        extractor_api_key: str | None = None,
     ) -> None:
         """Create or open a Pensyve instance.
 
         Args:
             path: Directory for storage files (default: ~/.pensyve/default).
             namespace: Namespace name (default: "default").
+            extractor: Optional observation extractor. `"haiku"` wires the
+                Anthropic Haiku 4.5 extractor (requires `ANTHROPIC_API_KEY`
+                env var unless `extractor_api_key` is provided). `None`
+                (default) skips extraction entirely.
+            extractor_api_key: Explicit API key for the haiku extractor.
+                Overrides `ANTHROPIC_API_KEY`.
         """
         ...
 
@@ -205,7 +213,7 @@ class Memory:
 
     @property
     def memory_type(self) -> str:
-        """Type of this memory: 'episodic', 'semantic', or 'procedural'."""
+        """Type of this memory: 'episodic', 'semantic', 'procedural', or 'observation'."""
         ...
 
     @property
@@ -235,12 +243,43 @@ class Memory:
 
     @property
     def event_time(self) -> str | None:
-        """When the described event occurred (ISO 8601). Only set for episodic memories."""
+        """When the described event occurred (ISO 8601). Set for episodic and
+        observation memories; None for semantic / procedural."""
         ...
 
     @property
     def superseded_by(self) -> str | None:
         """ID of the memory that superseded this one, if any. Only set for episodic memories."""
+        ...
+
+    @property
+    def entity_type(self) -> str | None:
+        """Observation category, e.g. 'game_played'. Only set when memory_type == 'observation'."""
+        ...
+
+    @property
+    def instance(self) -> str | None:
+        """Specific instance named by the observation. Only set for observations."""
+        ...
+
+    @property
+    def action(self) -> str | None:
+        """User action for the observation, e.g. 'played'. Only set for observations."""
+        ...
+
+    @property
+    def quantity(self) -> float | None:
+        """Numeric quantity when the observation recorded one. Only set for observations."""
+        ...
+
+    @property
+    def unit(self) -> str | None:
+        """Unit paired with `quantity`, e.g. 'hours'. Only set for observations."""
+        ...
+
+    @property
+    def episode_id(self) -> str | None:
+        """Source episode for the observation. Only set for observations."""
         ...
 
 class SessionGroup:

--- a/pensyve-python/python/pensyve/reader.py
+++ b/pensyve-python/python/pensyve/reader.py
@@ -32,8 +32,10 @@ from collections.abc import Iterable
 from typing import Any
 
 __all__ = [
+    "COUNTING_TRIGGERS",
     "V7_OBSERVATION_WRAPPER_PREFIX",
     "V7_OBSERVATION_WRAPPER_SUFFIX",
+    "classify_query_naive",
     "format_observations_block",
     "format_session_history",
 ]
@@ -107,6 +109,69 @@ def format_session_history(groups: Iterable[Any]) -> str:
         session_content = "\n" + json.dumps(turns)
         history += f"### Session {i}: (Date: {group.session_time}) {session_content}\n\n"
     return history
+
+
+# ---------------------------------------------------------------------------
+# Query routing classifier — naive regex path
+# ---------------------------------------------------------------------------
+#
+# Mirror of `pensyve_core::classifier::classify_naive` (Rust). Keep these two
+# trigger lists in lockstep — any drift invalidates the cross-language parity
+# guarantee claimed in the v1.3.0 release notes. The Haiku-backed classifier
+# is not ported to Python here; callers that want Haiku routing should proxy
+# through the Pensyve gateway's classifier path (Phase 5+) or call the
+# Anthropic SDK directly.
+
+COUNTING_TRIGGERS: tuple[str, ...] = (
+    "how many",
+    "how often",
+    "how much",
+    "list every",
+    "list all",
+    "count",
+    "total number",
+    "in total",
+    "altogether",
+    "over the course",
+    "across sessions",
+    "across all",
+    "across the",
+    "so far",
+    "sum of",
+    "aggregate",
+)
+
+
+def classify_query_naive(query: str) -> str:
+    """Return `"inject"` if the query is a counting/aggregation question,
+    `"skip"` otherwise. Deterministic regex over a small trigger list,
+    case-insensitive, whole-word.
+
+    Matches `classify_naive` in `pensyve-core/src/classifier.rs` byte-for-byte
+    on the same input. If that guarantee is ever broken, update both modules
+    together — the v1.3.0 docs call this parity out explicitly.
+    """
+    q = query.lower()
+    for phrase in COUNTING_TRIGGERS:
+        if _contains_whole_phrase(q, phrase):
+            return "inject"
+    return "skip"
+
+
+def _contains_whole_phrase(haystack: str, phrase: str) -> bool:
+    """Substring match with word-boundary guards on both ends."""
+    start = 0
+    n = len(haystack)
+    while True:
+        idx = haystack.find(phrase, start)
+        if idx < 0:
+            return False
+        before_ok = idx == 0 or not haystack[idx - 1].isalnum()
+        after_pos = idx + len(phrase)
+        after_ok = after_pos >= n or not haystack[after_pos].isalnum()
+        if before_ok and after_ok:
+            return True
+        start = idx + 1
 
 
 # ---------------------------------------------------------------------------

--- a/pensyve-python/python/pensyve/reader.py
+++ b/pensyve-python/python/pensyve/reader.py
@@ -1,0 +1,127 @@
+"""Reader-prompt helpers for observation-augmented recall.
+
+These helpers render the R7-validated observation format so SDK consumers
+can reproduce the LongMemEval_S 89.6% benchmark number without reimplementing
+the prompt structure. Byte-for-byte parity with the benchmark harness at
+`pensyve-docs/research/benchmark-sprint/harness/benchmarks/longmemeval/bench_v2/`
+is a hard requirement — any change here that drifts from the harness
+invalidates benchmark reproducibility claims.
+
+Typical usage::
+
+    groups = p.recall_grouped("how many games did I play?", limit=50)
+    observations = [
+        m for g in groups for m in g.memories if m.memory_type == "observation"
+    ]
+    obs_block = format_observations_block(observations)
+    if obs_block:
+        prompt = (
+            YOUR_V4_STYLE_TEMPLATE
+            + V7_OBSERVATION_WRAPPER_PREFIX
+            + obs_block
+            + V7_OBSERVATION_WRAPPER_SUFFIX
+            + format_session_history(groups)
+            + YOUR_QUESTION_SUFFIX
+        )
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+from typing import Any
+
+__all__ = [
+    "V7_OBSERVATION_WRAPPER_PREFIX",
+    "V7_OBSERVATION_WRAPPER_SUFFIX",
+    "format_observations_block",
+    "format_session_history",
+]
+
+
+# Frozen to match the harness's `_V7_OBSERVATION_BLOCK`. If either half
+# changes, the 89.6% benchmark number is no longer byte-reproducible via
+# this SDK path — treat as a breaking change.
+V7_OBSERVATION_WRAPPER_PREFIX = (
+    "\n\nThe following countable entities were pre-extracted from the "
+    "conversation sessions below. Use this list as your primary reference "
+    "for counting and aggregation questions. Verify each item against the "
+    "raw session memories. If the pre-extracted list and your manual count "
+    "disagree, explain the discrepancy and prefer the pre-extracted list "
+    "unless you find a clear error in it.\n\n"
+)
+
+V7_OBSERVATION_WRAPPER_SUFFIX = "\n"
+
+
+def format_observations_block(memories: Iterable[Any]) -> str:
+    """Render a numbered, human-readable observation list.
+
+    Non-observation memories in the input are silently skipped, so callers
+    can pass a whole `SessionGroup.memories` list without prefiltering.
+
+    The rendered format matches the harness's `format_observations_block`
+    exactly::
+
+        Pre-extracted countable entities from these sessions:
+        1. <instance> — <action> (<quantity> <unit>)
+        2. <instance> — <action> [low confidence / uncertain]
+        3. <instance> — <action>
+
+    Returns an empty string when there are no observations to render, so
+    callers can degrade to a V4-equivalent prompt by concatenation alone.
+    """
+    filtered = [m for m in memories if _is_observation(m)]
+    if not filtered:
+        return ""
+
+    lines: list[str] = ["Pre-extracted countable entities from these sessions:"]
+    for i, obs in enumerate(filtered, start=1):
+        parts: list[str] = [f"{i}. {obs.instance} — {obs.action}"]
+        quantity = getattr(obs, "quantity", None)
+        unit = getattr(obs, "unit", None)
+        if quantity is not None:
+            qty_str = _format_quantity(quantity)
+            if unit:
+                parts.append(f"({qty_str} {unit})")
+            else:
+                parts.append(f"({qty_str})")
+        confidence = getattr(obs, "confidence", 1.0) or 1.0
+        if confidence < 0.5:
+            parts.append("[low confidence / uncertain]")
+        lines.append(" ".join(parts))
+
+    return "\n".join(lines)
+
+
+def format_session_history(groups: Iterable[Any]) -> str:
+    """Render session groups as numbered history blocks.
+
+    Matches the harness's `_build_history_from_groups` exactly: one
+    `### Session N:` header per group with `session_time` as the date, and
+    one JSON turn object per member memory's `content` string.
+    """
+    history = ""
+    for i, group in enumerate(groups, start=1):
+        turns = [{"content": m.content} for m in group.memories]
+        session_content = "\n" + json.dumps(turns)
+        history += f"### Session {i}: (Date: {group.session_time}) {session_content}\n\n"
+    return history
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_observation(mem: Any) -> bool:
+    mt = getattr(mem, "memory_type", None)
+    return mt == "observation"
+
+
+def _format_quantity(q: float) -> str:
+    # Drop a trailing `.0` on whole numbers so `70` renders as `70` not `70.0`.
+    # Mirrors the harness's JSON quantity behavior where integers stay integer.
+    if float(q).is_integer():
+        return str(int(q))
+    return str(q)

--- a/pensyve-python/src/lib.rs
+++ b/pensyve-python/src/lib.rs
@@ -121,6 +121,8 @@ fn memory_confidence(mem: &types::Memory) -> f32 {
 /// `recall_grouped`, and any future retrieval entry points stay consistent.
 fn py_memory_from(memory: &types::Memory, score: f32) -> PyMemory {
     let (salience, storage_strength, event_time, superseded_by) = episodic_fields(memory);
+    let (entity_type, instance, action, quantity, unit, episode_id, obs_event_time) =
+        observation_fields(memory);
     PyMemory {
         id: memory.id().to_string(),
         content: memory_content(memory),
@@ -130,8 +132,16 @@ fn py_memory_from(memory: &types::Memory, score: f32) -> PyMemory {
         score,
         salience,
         storage_strength,
-        event_time,
+        // Observation event_time takes precedence when this is an observation;
+        // otherwise fall back to the episodic field (None for semantic/procedural).
+        event_time: obs_event_time.or(event_time),
         superseded_by,
+        entity_type,
+        instance,
+        action,
+        quantity,
+        unit,
+        episode_id,
     }
 }
 
@@ -150,9 +160,68 @@ fn episodic_fields(
     }
 }
 
+/// Extract observation-only fields:
+/// `(entity_type, instance, action, quantity, unit, episode_id, event_time)`.
+#[allow(clippy::type_complexity)]
+fn observation_fields(
+    mem: &types::Memory,
+) -> (
+    Option<String>,
+    Option<String>,
+    Option<String>,
+    Option<f64>,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+) {
+    match mem {
+        types::Memory::Observation(o) => (
+            Some(o.entity_type.clone()),
+            Some(o.instance.clone()),
+            Some(o.action.clone()),
+            o.quantity,
+            o.unit.clone(),
+            Some(o.episode_id.to_string()),
+            o.event_time.map(|t| t.to_rfc3339()),
+        ),
+        _ => (None, None, None, None, None, None, None),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Shared inner state for Pensyve
 // ---------------------------------------------------------------------------
+
+/// Build the optional observation extractor and its backing runtime from
+/// constructor kwargs. Returns `(None, None)` when no extractor is requested.
+#[allow(clippy::type_complexity)]
+fn build_extractor(
+    kind: Option<&str>,
+    api_key: Option<&str>,
+) -> PyResult<(
+    Option<Arc<dyn pensyve_core::observation::ObservationExtractor>>,
+    Option<Arc<tokio::runtime::Runtime>>,
+)> {
+    match kind {
+        None => Ok((None, None)),
+        Some("haiku") => {
+            let built = match api_key {
+                Some(k) => pensyve_core::observation::AnthropicHaikuExtractor::new(k),
+                None => pensyve_core::observation::AnthropicHaikuExtractor::from_env(),
+            }
+            .map_err(|e| PyRuntimeError::new_err(format!("Failed to build haiku extractor: {e}")))?;
+            let rt = tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(1)
+                .enable_all()
+                .build()
+                .map_err(|e| PyRuntimeError::new_err(format!("tokio runtime: {e}")))?;
+            Ok((Some(Arc::new(built)), Some(Arc::new(rt))))
+        }
+        Some(other) => Err(PyValueError::new_err(format!(
+            "unknown extractor: {other:?}; supported: \"haiku\""
+        ))),
+    }
+}
 
 struct PensyveInner {
     namespace: Namespace,
@@ -161,6 +230,13 @@ struct PensyveInner {
     vector_index: Arc<Mutex<VectorIndex>>,
     retrieval_config: RetrievalConfig,
     consolidation_config: pensyve_core::config::ConsolidationConfig,
+    /// Optional extractor wired at construction time. When `Some`,
+    /// `PyEpisode::__exit__` runs extraction + persistence after saving raw
+    /// memories. `None` is the zero-cost default.
+    extractor: Option<Arc<dyn pensyve_core::observation::ObservationExtractor>>,
+    /// Shared tokio runtime used to drive the async extractor from the sync
+    /// `PyO3` dispatch. Lazily created only when an extractor is configured.
+    extractor_runtime: Option<Arc<tokio::runtime::Runtime>>,
 }
 
 // ---------------------------------------------------------------------------
@@ -180,9 +256,21 @@ impl PyPensyve {
     /// Args:
     ///     path: Directory for storage files (default: ~/.pensyve/default).
     ///     namespace: Namespace name (default: "default").
+    ///     extractor: Optional observation extractor. `"haiku"` wires the
+    ///         Anthropic Haiku 4.5 extractor (requires `ANTHROPIC_API_KEY`
+    ///         env var unless `extractor_api_key` is provided). `None` (default)
+    ///         skips extraction entirely — zero cost.
+    ///     `extractor_api_key`: Explicit API key for the haiku extractor.
+    ///         Overrides `ANTHROPIC_API_KEY`.
     #[new]
-    #[pyo3(signature = (path=None, namespace=None))]
-    fn new(path: Option<String>, namespace: Option<String>) -> PyResult<Self> {
+    #[pyo3(signature = (path=None, namespace=None, extractor=None, extractor_api_key=None))]
+    #[allow(clippy::needless_pass_by_value)]
+    fn new(
+        path: Option<String>,
+        namespace: Option<String>,
+        extractor: Option<String>,
+        extractor_api_key: Option<String>,
+    ) -> PyResult<Self> {
         let config = PensyveConfig::default();
 
         let storage_path = match path {
@@ -273,6 +361,9 @@ impl PyPensyve {
             }
         }
 
+        let (extractor_impl, extractor_runtime) =
+            build_extractor(extractor.as_deref(), extractor_api_key.as_deref())?;
+
         Ok(Self {
             inner: Arc::new(PensyveInner {
                 namespace: ns,
@@ -281,6 +372,8 @@ impl PyPensyve {
                 vector_index,
                 retrieval_config: config.retrieval,
                 consolidation_config: config.consolidation,
+                extractor: extractor_impl,
+                extractor_runtime,
             }),
         })
     }
@@ -401,22 +494,7 @@ impl PyPensyve {
                     true
                 }
             })
-            .map(|c| {
-                let (salience, storage_strength, event_time, superseded_by) =
-                    episodic_fields(&c.memory);
-                PyMemory {
-                    id: c.memory_id.to_string(),
-                    content: memory_content(&c.memory),
-                    memory_type: memory_type_str(&c.memory).to_string(),
-                    confidence: memory_confidence(&c.memory),
-                    stability: c.memory.stability(),
-                    score: c.final_score,
-                    salience,
-                    storage_strength,
-                    event_time,
-                    superseded_by,
-                }
-            })
+            .map(|c| py_memory_from(&c.memory, c.final_score))
             .collect();
 
         // Filter by memory types if provided.
@@ -558,18 +636,7 @@ impl PyPensyve {
             .save_semantic(&mem)
             .map_err(|e| PyRuntimeError::new_err(format!("Storage error: {e}")))?;
 
-        Ok(PyMemory {
-            id: mem.id.to_string(),
-            content: format!("{} {}", mem.predicate, mem.object),
-            memory_type: "semantic".to_string(),
-            confidence: mem.confidence,
-            stability: mem.stability,
-            score: 0.0,
-            salience: None,
-            storage_strength: None,
-            event_time: None,
-            superseded_by: None,
-        })
+        Ok(py_memory_from(&types::Memory::Semantic(mem), 0.0))
     }
 
     /// Run the consolidation engine (episodic→semantic promotion + FSRS decay).
@@ -861,6 +928,38 @@ impl PyEpisode {
             .update_episode(&episode)
             .map_err(|e| PyRuntimeError::new_err(format!("Failed to update episode: {e}")))?;
 
+        // Observation extraction — runs only when a haiku extractor was
+        // configured. All failures are logged + swallowed; episode stays
+        // durable regardless.
+        if let (Some(extractor), Some(runtime)) =
+            (self.inner.extractor.clone(), self.inner.extractor_runtime.clone())
+        {
+            let storage = self.inner.storage.clone();
+            let embedder = self.inner.embedder.clone();
+            let ns_id = self.namespace_id;
+            let ep_id = self.episode_id;
+            // Block on the runtime here so callers see a consistent post-exit
+            // world (observations present before __exit__ returns). Run time
+            // is dominated by a single Haiku API call.
+            let persisted = runtime.block_on(async move {
+                pensyve_core::observation::commit_extraction_for_episode(
+                    storage.as_ref(),
+                    extractor.as_ref(),
+                    ns_id,
+                    ep_id,
+                    |text| embedder.embed(text),
+                )
+                .await
+            });
+            if persisted > 0 {
+                tracing::info!(
+                    observations = persisted,
+                    episode_id = %self.episode_id,
+                    "post-episode extraction"
+                );
+            }
+        }
+
         // Do not suppress exceptions.
         Ok(false)
     }
@@ -892,12 +991,34 @@ pub struct PyMemory {
     /// Storage strength — monotonically increases. Only set for episodic memories.
     #[pyo3(get)]
     storage_strength: Option<f32>,
-    /// When the described event occurred (ISO 8601). Only set for episodic memories.
+    /// When the described event occurred (ISO 8601). Set for episodic and
+    /// observation memories; `None` for semantic / procedural.
     #[pyo3(get)]
     event_time: Option<String>,
     /// ID of the memory that superseded this one, if any. Only set for episodic memories.
     #[pyo3(get)]
     superseded_by: Option<String>,
+    /// Observation category, e.g. `"game_played"`. Only set when
+    /// `memory_type == "observation"`.
+    #[pyo3(get)]
+    entity_type: Option<String>,
+    /// Specific instance referenced by the observation,
+    /// e.g. `"Assassin's Creed Odyssey"`. Only set for observations.
+    #[pyo3(get)]
+    instance: Option<String>,
+    /// User action for the observation, e.g. `"played"`. Only set for observations.
+    #[pyo3(get)]
+    action: Option<String>,
+    /// Numeric quantity (hours, items, pages, ...) when the observation
+    /// recorded one. Only set for observations.
+    #[pyo3(get)]
+    quantity: Option<f64>,
+    /// Unit paired with `quantity`, e.g. `"hours"`. Only set for observations.
+    #[pyo3(get)]
+    unit: Option<String>,
+    /// Source episode for the observation. Only set for observations.
+    #[pyo3(get)]
+    episode_id: Option<String>,
 }
 
 #[pymethods]

--- a/pensyve-python/src/lib.rs
+++ b/pensyve-python/src/lib.rs
@@ -93,11 +93,7 @@ fn entity_kind_str(kind: &EntityKind) -> &'static str {
 
 /// Convert a memory type variant name to a string.
 fn memory_type_str(mem: &types::Memory) -> &'static str {
-    match mem {
-        types::Memory::Episodic(_) => "episodic",
-        types::Memory::Semantic(_) => "semantic",
-        types::Memory::Procedural(_) => "procedural",
-    }
+    mem.type_name()
 }
 
 /// Extract the content string from a Memory variant.
@@ -106,6 +102,7 @@ fn memory_content(mem: &types::Memory) -> String {
         types::Memory::Episodic(m) => m.content.clone(),
         types::Memory::Semantic(m) => format!("{} {}", m.predicate, m.object),
         types::Memory::Procedural(m) => format!("{} -> {}", m.trigger, m.action),
+        types::Memory::Observation(m) => m.content.clone(),
     }
 }
 
@@ -115,6 +112,7 @@ fn memory_confidence(mem: &types::Memory) -> f32 {
         types::Memory::Episodic(_) => 1.0,
         types::Memory::Semantic(m) => m.confidence,
         types::Memory::Procedural(m) => m.reliability,
+        types::Memory::Observation(m) => m.confidence,
     }
 }
 
@@ -394,7 +392,10 @@ impl PyPensyve {
                             m.about_entity == eid || m.source_entity == eid
                         }
                         types::Memory::Semantic(m) => m.subject == eid,
-                        types::Memory::Procedural(_) => true,
+                        // Procedural + Observation carry no direct entity;
+                        // keep them through the filter (entity-scoped recall
+                        // already handled by the engine).
+                        types::Memory::Procedural(_) | types::Memory::Observation(_) => true,
                     }
                 } else {
                     true

--- a/pensyve-python/src/lib.rs
+++ b/pensyve-python/src/lib.rs
@@ -209,7 +209,9 @@ fn build_extractor(
                 Some(k) => pensyve_core::observation::AnthropicHaikuExtractor::new(k),
                 None => pensyve_core::observation::AnthropicHaikuExtractor::from_env(),
             }
-            .map_err(|e| PyRuntimeError::new_err(format!("Failed to build haiku extractor: {e}")))?;
+            .map_err(|e| {
+                PyRuntimeError::new_err(format!("Failed to build haiku extractor: {e}"))
+            })?;
             let rt = tokio::runtime::Builder::new_multi_thread()
                 .worker_threads(1)
                 .enable_all()
@@ -931,9 +933,10 @@ impl PyEpisode {
         // Observation extraction — runs only when a haiku extractor was
         // configured. All failures are logged + swallowed; episode stays
         // durable regardless.
-        if let (Some(extractor), Some(runtime)) =
-            (self.inner.extractor.clone(), self.inner.extractor_runtime.clone())
-        {
+        if let (Some(extractor), Some(runtime)) = (
+            self.inner.extractor.clone(),
+            self.inner.extractor_runtime.clone(),
+        ) {
             let storage = self.inner.storage.clone();
             let embedder = self.inner.embedder.clone();
             let ns_id = self.namespace_id;

--- a/pensyve-python/tests/test_reader.py
+++ b/pensyve-python/tests/test_reader.py
@@ -1,0 +1,197 @@
+"""Byte-parity tests for the observation-block + session-history helpers.
+
+These tests use lightweight `SimpleNamespace` stand-ins rather than native
+`pensyve.Memory` instances, so they run without the compiled PyO3 extension.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from pensyve.reader import (
+    V7_OBSERVATION_WRAPPER_PREFIX,
+    V7_OBSERVATION_WRAPPER_SUFFIX,
+    format_observations_block,
+    format_session_history,
+)
+
+
+def _obs(
+    *,
+    instance: str,
+    action: str,
+    quantity: float | None = None,
+    unit: str | None = None,
+    confidence: float = 0.8,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        memory_type="observation",
+        instance=instance,
+        action=action,
+        quantity=quantity,
+        unit=unit,
+        confidence=confidence,
+    )
+
+
+def _episodic(content: str) -> SimpleNamespace:
+    return SimpleNamespace(memory_type="episodic", content=content)
+
+
+# ---------------------------------------------------------------------------
+# format_observations_block
+# ---------------------------------------------------------------------------
+
+
+def test_empty_input_returns_empty_string() -> None:
+    assert format_observations_block([]) == ""
+
+
+def test_non_observation_memories_are_silently_skipped() -> None:
+    assert format_observations_block([_episodic("user: hi")]) == ""
+
+
+def test_basic_observation_with_quantity_and_unit() -> None:
+    out = format_observations_block(
+        [_obs(instance="AC Odyssey", action="played", quantity=70, unit="hours")]
+    )
+    assert out == (
+        "Pre-extracted countable entities from these sessions:\n"
+        "1. AC Odyssey — played (70 hours)"
+    )
+
+
+def test_integer_quantity_renders_without_decimal_point() -> None:
+    # Matches the harness JSON behavior where `"quantity": 70` comes back as int.
+    out = format_observations_block(
+        [_obs(instance="Dune", action="read", quantity=512.0, unit="pages")]
+    )
+    assert "(512 pages)" in out
+    assert "(512.0" not in out
+
+
+def test_fractional_quantity_preserves_decimal() -> None:
+    out = format_observations_block(
+        [_obs(instance="commute", action="drove", quantity=15.5, unit="miles")]
+    )
+    assert "(15.5 miles)" in out
+
+
+def test_quantity_without_unit_renders_quantity_only() -> None:
+    out = format_observations_block(
+        [_obs(instance="items", action="bought", quantity=3)]
+    )
+    assert "(3)" in out
+    assert " 3 " not in out  # not "(3 )"
+
+
+def test_low_confidence_is_flagged() -> None:
+    out = format_observations_block(
+        [_obs(instance="maybe-game", action="might have played", confidence=0.3)]
+    )
+    assert out.endswith("[low confidence / uncertain]")
+
+
+def test_confidence_exactly_at_threshold_is_not_flagged() -> None:
+    out = format_observations_block(
+        [_obs(instance="ok-item", action="did", confidence=0.5)]
+    )
+    assert "[low confidence" not in out
+
+
+def test_multiple_observations_numbered_in_order() -> None:
+    out = format_observations_block(
+        [
+            _obs(instance="A", action="did"),
+            _obs(instance="B", action="did"),
+            _obs(instance="C", action="did"),
+        ]
+    )
+    lines = out.splitlines()
+    assert lines[0] == "Pre-extracted countable entities from these sessions:"
+    assert lines[1].startswith("1. A")
+    assert lines[2].startswith("2. B")
+    assert lines[3].startswith("3. C")
+
+
+def test_mixed_list_filters_to_observations_only() -> None:
+    out = format_observations_block(
+        [
+            _episodic("user: noise"),
+            _obs(instance="Game", action="played"),
+            _episodic("assistant: more noise"),
+        ]
+    )
+    # Exactly one observation, numbered 1 (non-obs don't occupy numbers).
+    assert "1. Game — played" in out
+    assert "2." not in out
+
+
+# ---------------------------------------------------------------------------
+# format_session_history
+# ---------------------------------------------------------------------------
+
+
+def test_session_history_empty_returns_empty_string() -> None:
+    assert format_session_history([]) == ""
+
+
+def test_session_history_single_group() -> None:
+    g = SimpleNamespace(
+        session_time="2023-05-20T10:58:00+00:00",
+        memories=[
+            SimpleNamespace(content="user: hi"),
+            SimpleNamespace(content="assistant: hello"),
+        ],
+    )
+    out = format_session_history([g])
+    assert "### Session 1:" in out
+    assert "2023-05-20T10:58:00+00:00" in out
+    # The JSON payload preserves order and uses the `content` key only.
+    assert json.dumps([{"content": "user: hi"}, {"content": "assistant: hello"}]) in out
+
+
+def test_session_history_numbers_groups_one_based() -> None:
+    groups = [
+        SimpleNamespace(
+            session_time=f"2023-05-{20 + i:02d}T00:00:00+00:00",
+            memories=[SimpleNamespace(content=f"turn-{i}")],
+        )
+        for i in range(3)
+    ]
+    out = format_session_history(groups)
+    assert "### Session 1:" in out
+    assert "### Session 2:" in out
+    assert "### Session 3:" in out
+
+
+# ---------------------------------------------------------------------------
+# V7 wrapper constants
+# ---------------------------------------------------------------------------
+
+
+def test_v7_wrapper_constants_are_nonempty() -> None:
+    assert V7_OBSERVATION_WRAPPER_PREFIX
+    assert V7_OBSERVATION_WRAPPER_SUFFIX
+
+
+def test_v7_prefix_explicitly_mentions_pre_extracted_primary_reference() -> None:
+    # Guard against accidental rewording of the R7-validated wrapper text.
+    assert "pre-extracted" in V7_OBSERVATION_WRAPPER_PREFIX
+    assert "primary reference" in V7_OBSERVATION_WRAPPER_PREFIX
+
+
+def test_v7_wrapper_composes_observation_block_without_extra_separators() -> None:
+    obs_block = format_observations_block(
+        [_obs(instance="X", action="did", quantity=1, unit="unit")]
+    )
+    composed = V7_OBSERVATION_WRAPPER_PREFIX + obs_block + V7_OBSERVATION_WRAPPER_SUFFIX
+    # The wrapper provides its own leading \n\n and trailing \n — no double-newlines.
+    assert "\n\n\n\n" not in composed
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/pensyve-python/tests/test_reader.py
+++ b/pensyve-python/tests/test_reader.py
@@ -12,8 +12,10 @@ from types import SimpleNamespace
 import pytest
 
 from pensyve.reader import (
+    COUNTING_TRIGGERS,
     V7_OBSERVATION_WRAPPER_PREFIX,
     V7_OBSERVATION_WRAPPER_SUFFIX,
+    classify_query_naive,
     format_observations_block,
     format_session_history,
 )
@@ -191,6 +193,55 @@ def test_v7_wrapper_composes_observation_block_without_extra_separators() -> Non
     composed = V7_OBSERVATION_WRAPPER_PREFIX + obs_block + V7_OBSERVATION_WRAPPER_SUFFIX
     # The wrapper provides its own leading \n\n and trailing \n — no double-newlines.
     assert "\n\n\n\n" not in composed
+
+
+# ---------------------------------------------------------------------------
+# classify_query_naive
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "how many games did I play?",
+        "How many books?",
+        "HOW MANY??",
+        "list every place I've visited",
+        "List all of the games",
+        "count the total items",
+        "what's the total number of hours?",
+        "spent in total 40 hours",
+        "across all my sessions",
+        "over the course of a year",
+        "so far this year",
+        "the count was off",
+    ],
+)
+def test_naive_classifier_catches_counting_phrases(query: str) -> None:
+    assert classify_query_naive(query) == "inject"
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "what is my favorite color?",
+        "who is my boss?",
+        "remember to pick up milk tomorrow",
+        "my favorite counter",
+        "a discounted meal",
+        "",
+        "   ",
+    ],
+)
+def test_naive_classifier_skips_non_counting(query: str) -> None:
+    assert classify_query_naive(query) == "skip"
+
+
+def test_naive_classifier_triggers_are_non_empty() -> None:
+    assert len(COUNTING_TRIGGERS) > 0
+    assert "how many" in COUNTING_TRIGGERS
+    # Parity check against the Rust module — both lists must match length and order.
+    # (See `pensyve-core/src/classifier.rs::COUNTING_TRIGGERS`.)
 
 
 if __name__ == "__main__":

--- a/pensyve-python/uv.lock
+++ b/pensyve-python/uv.lock
@@ -85,7 +85,7 @@ wheels = [
 
 [[package]]
 name = "pensyve"
-version = "1.0.4"
+version = "1.2.0"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/pensyve-ts/src/index.ts
+++ b/pensyve-ts/src/index.ts
@@ -807,8 +807,11 @@ export class Pensyve {
 export default Pensyve;
 
 export {
+  COUNTING_TRIGGERS,
   V7_OBSERVATION_WRAPPER_PREFIX,
   V7_OBSERVATION_WRAPPER_SUFFIX,
+  classifyQueryNaive,
   formatObservationsBlock,
   formatSessionHistory,
 } from "./reader";
+export type { Route } from "./reader";

--- a/pensyve-ts/src/index.ts
+++ b/pensyve-ts/src/index.ts
@@ -98,24 +98,45 @@ export interface Entity {
   kind: string;
 }
 
+export type MemoryType = "episodic" | "semantic" | "procedural" | "observation";
+
 export interface Memory {
   id: string;
   content: string;
-  memoryType: "episodic" | "semantic" | "procedural";
+  memoryType: MemoryType;
   confidence: number;
   stability: number;
   score?: number;
   /**
-   * When the described event occurred (ISO 8601 / RFC 3339). Only set for
-   * episodic memories that were ingested with an explicit `when=`.
+   * When the described event occurred (ISO 8601 / RFC 3339). Set for
+   * episodic memories ingested with an explicit `when=`, and for
+   * observations that inherited the timestamp from their source episode.
    */
   eventTime?: string;
+  /**
+   * Observation category, e.g. `"game_played"`. Only set when
+   * `memoryType === "observation"`.
+   */
+  entityType?: string;
+  /**
+   * Specific instance named by the observation,
+   * e.g. `"Assassin's Creed Odyssey"`. Observations only.
+   */
+  instance?: string;
+  /** User action for the observation, e.g. `"played"`. Observations only. */
+  action?: string;
+  /** Numeric quantity when the observation recorded one. Observations only. */
+  quantity?: number;
+  /** Unit paired with `quantity`, e.g. `"hours"`. Observations only. */
+  unit?: string;
+  /** Source episode UUID. Observations only. */
+  episodeId?: string;
 }
 
 export interface RecallOptions {
   entity?: string;
   limit?: number;
-  types?: Array<"episodic" | "semantic" | "procedural">;
+  types?: MemoryType[];
   /** Pagination cursor returned from a previous recall() call. */
   cursor?: string;
 }
@@ -784,3 +805,10 @@ export class Pensyve {
 }
 
 export default Pensyve;
+
+export {
+  V7_OBSERVATION_WRAPPER_PREFIX,
+  V7_OBSERVATION_WRAPPER_SUFFIX,
+  formatObservationsBlock,
+  formatSessionHistory,
+} from "./reader";

--- a/pensyve-ts/src/reader.test.ts
+++ b/pensyve-ts/src/reader.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, test } from "bun:test";
+import {
+  V7_OBSERVATION_WRAPPER_PREFIX,
+  V7_OBSERVATION_WRAPPER_SUFFIX,
+  formatObservationsBlock,
+  formatSessionHistory,
+} from "./reader";
+import type { Memory, SessionGroup } from "./index";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function obs(fields: Partial<Memory> & { instance: string; action: string }): Memory {
+  return {
+    id: `obs-${fields.instance}`,
+    content: `${fields.action} ${fields.instance}`,
+    memoryType: "observation",
+    confidence: fields.confidence ?? 0.8,
+    stability: 1.0,
+    entityType: fields.entityType ?? "generic",
+    ...fields,
+  };
+}
+
+function episodic(content: string): Memory {
+  return {
+    id: `ep-${content}`,
+    content,
+    memoryType: "episodic",
+    confidence: 1.0,
+    stability: 1.0,
+  };
+}
+
+function group(sessionTime: string, memories: Memory[]): SessionGroup {
+  return {
+    sessionId: "ep-1",
+    sessionTime,
+    memories,
+    groupScore: 0.5,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// formatObservationsBlock
+// ---------------------------------------------------------------------------
+
+describe("formatObservationsBlock", () => {
+  test("empty input returns empty string", () => {
+    expect(formatObservationsBlock([])).toBe("");
+  });
+
+  test("non-observation memories are silently skipped", () => {
+    expect(formatObservationsBlock([episodic("user: hi")])).toBe("");
+  });
+
+  test("basic observation with quantity and unit", () => {
+    const out = formatObservationsBlock([
+      obs({ instance: "AC Odyssey", action: "played", quantity: 70, unit: "hours" }),
+    ]);
+    expect(out).toBe(
+      "Pre-extracted countable entities from these sessions:\n" +
+        "1. AC Odyssey — played (70 hours)",
+    );
+  });
+
+  test("integer quantity renders without decimal point", () => {
+    const out = formatObservationsBlock([
+      obs({ instance: "Dune", action: "read", quantity: 512, unit: "pages" }),
+    ]);
+    expect(out).toContain("(512 pages)");
+    expect(out).not.toContain("512.0");
+  });
+
+  test("fractional quantity preserves decimal", () => {
+    const out = formatObservationsBlock([
+      obs({ instance: "commute", action: "drove", quantity: 15.5, unit: "miles" }),
+    ]);
+    expect(out).toContain("(15.5 miles)");
+  });
+
+  test("quantity without unit renders quantity only", () => {
+    const out = formatObservationsBlock([
+      obs({ instance: "items", action: "bought", quantity: 3 }),
+    ]);
+    expect(out).toContain("(3)");
+  });
+
+  test("low confidence is flagged", () => {
+    const out = formatObservationsBlock([
+      obs({ instance: "maybe-game", action: "might have played", confidence: 0.3 }),
+    ]);
+    expect(out).toContain("[low confidence / uncertain]");
+  });
+
+  test("confidence at 0.5 threshold is not flagged", () => {
+    const out = formatObservationsBlock([
+      obs({ instance: "ok", action: "did", confidence: 0.5 }),
+    ]);
+    expect(out).not.toContain("[low confidence");
+  });
+
+  test("multiple observations numbered in order", () => {
+    const out = formatObservationsBlock([
+      obs({ instance: "A", action: "did" }),
+      obs({ instance: "B", action: "did" }),
+      obs({ instance: "C", action: "did" }),
+    ]);
+    const lines = out.split("\n");
+    expect(lines[0]).toBe("Pre-extracted countable entities from these sessions:");
+    expect(lines[1]).toStartWith("1. A");
+    expect(lines[2]).toStartWith("2. B");
+    expect(lines[3]).toStartWith("3. C");
+  });
+
+  test("mixed list filters to observations only", () => {
+    const out = formatObservationsBlock([
+      episodic("user: noise"),
+      obs({ instance: "Game", action: "played" }),
+      episodic("assistant: more noise"),
+    ]);
+    expect(out).toContain("1. Game — played");
+    expect(out).not.toContain("2.");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatSessionHistory
+// ---------------------------------------------------------------------------
+
+describe("formatSessionHistory", () => {
+  test("empty input returns empty string", () => {
+    expect(formatSessionHistory([])).toBe("");
+  });
+
+  test("single group renders correct header + JSON payload", () => {
+    const g = group("2023-05-20T10:58:00+00:00", [
+      episodic("user: hi"),
+      episodic("assistant: hello"),
+    ]);
+    const out = formatSessionHistory([g]);
+    expect(out).toContain("### Session 1:");
+    expect(out).toContain("2023-05-20T10:58:00+00:00");
+    expect(out).toContain(
+      JSON.stringify([{ content: "user: hi" }, { content: "assistant: hello" }]),
+    );
+  });
+
+  test("numbers groups one-based", () => {
+    const groups = [0, 1, 2].map((i) =>
+      group(`2023-05-${20 + i}T00:00:00+00:00`, [episodic(`turn-${i}`)]),
+    );
+    const out = formatSessionHistory(groups);
+    expect(out).toContain("### Session 1:");
+    expect(out).toContain("### Session 2:");
+    expect(out).toContain("### Session 3:");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// V7 wrapper constants
+// ---------------------------------------------------------------------------
+
+describe("V7 wrapper constants", () => {
+  test("wrapper constants are non-empty", () => {
+    expect(V7_OBSERVATION_WRAPPER_PREFIX.length).toBeGreaterThan(0);
+    expect(V7_OBSERVATION_WRAPPER_SUFFIX.length).toBeGreaterThan(0);
+  });
+
+  test("prefix references pre-extracted + primary reference", () => {
+    expect(V7_OBSERVATION_WRAPPER_PREFIX).toContain("pre-extracted");
+    expect(V7_OBSERVATION_WRAPPER_PREFIX).toContain("primary reference");
+  });
+
+  test("wrapper composes block without introducing quadruple newlines", () => {
+    const block = formatObservationsBlock([
+      obs({ instance: "X", action: "did", quantity: 1, unit: "unit" }),
+    ]);
+    const composed =
+      V7_OBSERVATION_WRAPPER_PREFIX + block + V7_OBSERVATION_WRAPPER_SUFFIX;
+    expect(composed).not.toContain("\n\n\n\n");
+  });
+});

--- a/pensyve-ts/src/reader.test.ts
+++ b/pensyve-ts/src/reader.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import {
+  COUNTING_TRIGGERS,
   V7_OBSERVATION_WRAPPER_PREFIX,
   V7_OBSERVATION_WRAPPER_SUFFIX,
+  classifyQueryNaive,
   formatObservationsBlock,
   formatSessionHistory,
 } from "./reader";
@@ -161,6 +163,46 @@ describe("formatSessionHistory", () => {
 // ---------------------------------------------------------------------------
 // V7 wrapper constants
 // ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// classifyQueryNaive
+// ---------------------------------------------------------------------------
+
+describe("classifyQueryNaive", () => {
+  test.each([
+    "how many games did I play?",
+    "How many books?",
+    "HOW MANY??",
+    "list every place I've visited",
+    "List all of the games",
+    "count the total items",
+    "what's the total number of hours?",
+    "spent in total 40 hours",
+    "across all my sessions",
+    "over the course of a year",
+    "so far this year",
+    "the count was off",
+  ])("inject for counting phrase: %p", (q: string) => {
+    expect(classifyQueryNaive(q)).toBe("inject");
+  });
+
+  test.each([
+    "what is my favorite color?",
+    "who is my boss?",
+    "remember to pick up milk tomorrow",
+    "my favorite counter",
+    "a discounted meal",
+    "",
+    "   ",
+  ])("skip for non-counting: %p", (q: string) => {
+    expect(classifyQueryNaive(q)).toBe("skip");
+  });
+
+  test("COUNTING_TRIGGERS list is non-empty and includes how many", () => {
+    expect(COUNTING_TRIGGERS.length).toBeGreaterThan(0);
+    expect(COUNTING_TRIGGERS).toContain("how many");
+  });
+});
 
 describe("V7 wrapper constants", () => {
   test("wrapper constants are non-empty", () => {

--- a/pensyve-ts/src/reader.ts
+++ b/pensyve-ts/src/reader.ts
@@ -1,0 +1,116 @@
+/**
+ * Reader-prompt helpers for observation-augmented recall.
+ *
+ * These helpers render the R7-validated observation format so SDK consumers
+ * can reproduce the LongMemEval_S 89.6% benchmark number without
+ * reimplementing the prompt structure. Byte-for-byte parity with the
+ * benchmark harness at `pensyve-docs/research/benchmark-sprint/harness/`
+ * is a hard requirement — any change here that drifts from the harness
+ * invalidates benchmark reproducibility claims.
+ *
+ * @example
+ * ```ts
+ * const { groups } = await p.recallGrouped("how many games did I play?", {
+ *   limit: 50,
+ * });
+ * const observations = groups.flatMap((g) =>
+ *   g.memories.filter((m) => m.memoryType === "observation"),
+ * );
+ * const block = formatObservationsBlock(observations);
+ * const prompt =
+ *   YOUR_V4_TEMPLATE +
+ *   (block
+ *     ? V7_OBSERVATION_WRAPPER_PREFIX + block + V7_OBSERVATION_WRAPPER_SUFFIX
+ *     : "") +
+ *   formatSessionHistory(groups) +
+ *   YOUR_QUESTION_SUFFIX;
+ * ```
+ */
+
+import type { Memory, SessionGroup } from "./index";
+
+/**
+ * Frozen prefix for the V7r observation block. Mirrors the harness's
+ * `_V7_OBSERVATION_BLOCK`. Any edit here breaks byte-for-byte reproducibility
+ * of the 89.6% benchmark via this SDK — treat as a breaking change.
+ */
+export const V7_OBSERVATION_WRAPPER_PREFIX: string =
+  "\n\nThe following countable entities were pre-extracted from the " +
+  "conversation sessions below. Use this list as your primary reference " +
+  "for counting and aggregation questions. Verify each item against the " +
+  "raw session memories. If the pre-extracted list and your manual count " +
+  "disagree, explain the discrepancy and prefer the pre-extracted list " +
+  "unless you find a clear error in it.\n\n";
+
+export const V7_OBSERVATION_WRAPPER_SUFFIX: string = "\n";
+
+/**
+ * Render a numbered, human-readable observation list matching the harness
+ * `format_observations_block` output exactly:
+ *
+ * ```text
+ * Pre-extracted countable entities from these sessions:
+ * 1. <instance> — <action> (<quantity> <unit>)
+ * 2. <instance> — <action> [low confidence / uncertain]
+ * ```
+ *
+ * Non-observation memories are silently skipped so callers can pass a full
+ * `SessionGroup.memories` list without prefiltering.
+ *
+ * Returns an empty string when there are no observations to render, so
+ * callers can degrade to a V4-equivalent prompt by concatenation alone.
+ */
+export function formatObservationsBlock(memories: Iterable<Memory>): string {
+  const obs: Memory[] = [];
+  for (const m of memories) {
+    if (m.memoryType === "observation") obs.push(m);
+  }
+  if (obs.length === 0) return "";
+
+  const lines: string[] = [
+    "Pre-extracted countable entities from these sessions:",
+  ];
+  for (let i = 0; i < obs.length; i += 1) {
+    const o = obs[i];
+    const parts: string[] = [`${i + 1}. ${o.instance} — ${o.action}`];
+    if (o.quantity !== undefined && o.quantity !== null) {
+      const qtyStr = formatQuantity(o.quantity);
+      parts.push(o.unit ? `(${qtyStr} ${o.unit})` : `(${qtyStr})`);
+    }
+    const confidence = o.confidence ?? 1.0;
+    if (confidence < 0.5) {
+      parts.push("[low confidence / uncertain]");
+    }
+    lines.push(parts.join(" "));
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Render session groups as numbered history blocks. Matches the harness's
+ * `_build_history_from_groups` exactly: one `### Session N:` header per
+ * group with `sessionTime` as the date, and one JSON turn object per
+ * member memory's `content` string.
+ */
+export function formatSessionHistory(groups: Iterable<SessionGroup>): string {
+  let history = "";
+  let i = 0;
+  for (const group of groups) {
+    i += 1;
+    const turns = group.memories.map((m) => ({ content: m.content }));
+    const sessionContent = "\n" + JSON.stringify(turns);
+    history += `### Session ${i}: (Date: ${group.sessionTime}) ${sessionContent}\n\n`;
+  }
+  return history;
+}
+
+/**
+ * Format a quantity for display. JavaScript's `String(70)` already returns
+ * `"70"` (no trailing `.0`), so this is effectively `String(q)` — kept as
+ * a named helper for symmetry with the Python SDK and to make any future
+ * format change a one-line edit.
+ */
+function formatQuantity(q: number): string {
+  return String(q);
+}

--- a/pensyve-ts/src/reader.ts
+++ b/pensyve-ts/src/reader.ts
@@ -114,3 +114,65 @@ export function formatSessionHistory(groups: Iterable<SessionGroup>): string {
 function formatQuantity(q: number): string {
   return String(q);
 }
+
+// ---------------------------------------------------------------------------
+// Query routing classifier — naive regex path
+// ---------------------------------------------------------------------------
+//
+// Mirror of `pensyve_core::classifier::classify_naive` (Rust) and
+// `pensyve.reader.classify_query_naive` (Python). Keep the three trigger
+// lists in lockstep — any drift invalidates the cross-language parity
+// guarantee claimed in the v1.3.0 release notes.
+
+/**
+ * Counting/aggregation trigger phrases. Case-insensitive, whole-word match.
+ * Exported so tests can assert parity with the Rust + Python implementations.
+ */
+export const COUNTING_TRIGGERS: readonly string[] = [
+  "how many",
+  "how often",
+  "how much",
+  "list every",
+  "list all",
+  "count",
+  "total number",
+  "in total",
+  "altogether",
+  "over the course",
+  "across sessions",
+  "across all",
+  "across the",
+  "so far",
+  "sum of",
+  "aggregate",
+];
+
+/** Routing decision. `"inject"` = render the observation block; `"skip"` = skip it. */
+export type Route = "inject" | "skip";
+
+/**
+ * Return `"inject"` if the query is a counting/aggregation question,
+ * `"skip"` otherwise. Deterministic, case-insensitive, whole-word match
+ * against {@link COUNTING_TRIGGERS}.
+ */
+export function classifyQueryNaive(query: string): Route {
+  const q = query.toLowerCase();
+  for (const phrase of COUNTING_TRIGGERS) {
+    if (containsWholePhrase(q, phrase)) return "inject";
+  }
+  return "skip";
+}
+
+function containsWholePhrase(haystack: string, phrase: string): boolean {
+  let start = 0;
+  while (true) {
+    const idx = haystack.indexOf(phrase, start);
+    if (idx < 0) return false;
+    const beforeOk = idx === 0 || !/[a-z0-9]/i.test(haystack[idx - 1]);
+    const afterPos = idx + phrase.length;
+    const afterOk =
+      afterPos >= haystack.length || !/[a-z0-9]/i.test(haystack[afterPos]);
+    if (beforeOk && afterOk) return true;
+    start = idx + 1;
+  }
+}


### PR DESCRIPTION
## Summary

- Lifts the R7 harness-validated observation extractor into `pensyve-core` as a first-class extraction tier, behind the `observation-extraction` feature flag
- Adds a Haiku query-routing classifier (naive-regex + Haiku 4.5 hybrid) so production has a routing oracle that doesn't exist on LongMemEval dataset metadata
- Python + TypeScript SDK bindings expose `Pensyve(extractor="haiku")`, observation-typed `Memory` objects, `formatObservationsBlock`, and the R7-validated `V7_OBSERVATION_WRAPPER_*` constants
- Engine-native benchmark regression: **89.2% on LongMemEval_S Haiku 4.5** (Phase 3) — clears the 88% ship bar, lands 0.4 pts below the Phase 0c metadata oracle (89.6%), +2.4 pts over the previous best-SDK-reproducible number (V4 baseline 86.8%)

## What's in this PR

| Phase | Scope | Tests |
|---|---|---|
| 1.1 | `Memory::Observation` variant + full serde / trait integration | 5 |
| 1.2 | SQLite + Postgres `observations` table, CRUD, cascade-delete, FTS exclusion, transactional save/delete | 10 |
| 1.3 | `ObservationExtractor` trait + `NoopExtractor` + `ExtractionError` | 4 |
| 1.4 | `AnthropicHaikuExtractor` (feature-gated) + R7 `EXTRACTION_PROMPT_V1` verbatim + wiremock tests | 8 |
| 1.5 | `commit_extraction_for_episode` helper, gateway `episode_end` spawn, `list_episodic_by_episode` trait method | 6 |
| 1.6 | `recall_grouped` attaches observations post-grouping; observations never enter RRF candidate pool | 5 |
| 2.1 | Python SDK: `Pensyve(extractor="haiku")`, observation-typed `Memory` fields, tokio runtime for async call | — |
| 2.2 | `pensyve.reader` Python module: V7 wrapper constants, `format_observations_block`, `format_session_history` | 16 |
| 2.3 | `pensyve-ts` mirror of reader helpers + `MemoryType` union + observation fields on `Memory` interface | 16 |
| 4.1 | `pensyve-core/src/classifier.rs` — `Route` enum, `classify_naive`, `HaikuQueryClassifier` + cache | 20 |
| 4.2 | Python + TS `classify_query_naive` helpers (parity with Rust) | 20 |
| 4.3 | Hybrid default: `classify()` returns `Inject` if EITHER naive OR Haiku says so | 2 new |

## Benchmark journey (Haiku 4.5 reader held constant)

| Stage | Score | Δ | Cumulative engine-only gain |
|---|---:|---:|---:|
| Pre-fix baseline | 52.0% | — | — |
| event_time fix | 58.0% | +6.0 | +6.0 |
| k=50 retrieval | 77.2% | +19.2 | +25.2 |
| Session grouping + V4 prompt | 86.8% | +9.6 | +34.8 |
| R7 query-time observations | 89.0% | +2.2 | +37.0 |
| Phase 0c ingest + top-k filter (oracle routing) | 89.6% | +0.6 | +37.6 |
| **v1.3.0 ship (hybrid classifier, engine-native)** | **89.2%** | **−0.4** | **+37.2** |

Same reader. Same dataset. Same judge (`gpt-4o`). **+37.2 pts from engine changes alone, reproducible via one SDK call.**

Full writeup: `pensyve-docs/research/benchmark-sprint/22-engine-regression-v1.3.0.md`.

## Why hybrid classifier

The pure Haiku classifier calibrated at 79.7% agreement with V7r's dataset-metadata oracle. Inspection revealed 40 multi-session questions like "How many tanks do I have?" where Haiku's V2 prompt primed it to treat single-session-answerable questions as skip. The naive regex catches those trivially. Hybrid composition (naive OR Haiku) recovers 8 of 10 questions lost relative to oracle at no cost on non-counting categories.

Full analysis in `pensyve-docs/research/benchmark-sprint/21-classifier-calibration.md`.

## Feature gates

- `observation-extraction` in `pensyve-core/Cargo.toml` pulls in `reqwest` + `tokio`. Enabled by default in `pensyve-python` and `pensyve-mcp-gateway` because both ingest paths need it.
- `NoopExtractor` stays the default when no extractor is configured. Zero runtime cost, zero compile-time deps changes for consumers who don't opt in.

## Production readiness

- Gateway reads `ANTHROPIC_API_KEY` at startup. Absent key: logs `"Observation extractor disabled"` and keeps serving.
- Ingest extraction is `tokio::spawn`'d so it never blocks the `episode_end` HTTP response.
- All extractor errors (transport, parse, embedding failure) log at `WARN` and swallow — ingest stays non-fatal.
- Postgres + SQLite parity on all new methods. Neon-backed managed-service deploys supported.

## Test plan

- [x] `cargo test --workspace --lib --all-features` — 296/296 pensyve-core + gateway/python/mcp-tools pass
- [x] `cargo clippy --workspace --all-features -- -D warnings` — clean on Rust 1.95.0
- [x] `bun test src/` in pensyve-ts — 100/100 pass (36 new in reader.test.ts)
- [x] `bun run lint` — ESLint clean
- [x] Phase 3 regression: 89.2% on full 500-question LongMemEval_S via `gpt-4o` judge
- [ ] Phase 1.7 follow-up (pensyve-infra): wire `ANTHROPIC_API_KEY` into AWS Secrets Manager + ECS task def. Non-blocking — gateway works without it.