### PR TITLE
plugin: Claude Code working-memory substrate (proactive, three-type, thread-aware)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,15 +6,15 @@
     "url": "https://github.com/major7apps/pensyve"
   },
   "metadata": {
-    "description": "Universal memory runtime — cross-session cognitive memory for Claude Code with intelligent capture, entity-aware recall, 7 commands, 4 skills, 2 agents, and 6 lifecycle hooks",
-    "version": "1.2.1"
+    "description": "Universal memory runtime — ambient working-memory substrate for Claude Code. Proactive in-flight capture, thread-aware session continuity, three-type memory (semantic/episodic/procedural), and entity-aware recall. 7 commands, 7 skills, 2 agents, 6 lifecycle hooks.",
+    "version": "1.3.0"
   },
   "plugins": [
     {
       "name": "pensyve",
       "source": "./integrations/claude-code",
-      "description": "Universal memory runtime — cross-session cognitive memory for Claude Code. Remembers decisions, patterns, and context across coding sessions.",
-      "version": "1.2.1",
+      "description": "Universal memory runtime — ambient working-memory substrate for Claude Code. Memory is not a feature you invoke — it's the substrate the agent operates on.",
+      "version": "1.3.0",
       "author": {
         "name": "Seth Hobson",
         "email": "seth@major7apps.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to Pensyve will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2026-04-18 (Claude Code plugin only)
+
+### Added
+
+- **Working-memory substrate**: the Claude Code plugin now behaves as ambient working memory rather than a feature users invoke. Lessons are captured in-flight the moment they land; recalls are woven into the agent's reasoning loop; sessions that continue prior work resume with a relevant primer. Spec: `pensyve-docs/specs/2026-04-18-pensyve-working-memory-substrate-design.md`; plan: `pensyve-docs/plans/2026-04-18-pensyve-claude-code-working-memory.md`.
+- **Three new memory-woven skills**: `memory-informed-debug`, `memory-informed-design`, `memory-informed-longitudinal-work` — each has non-optional "consult memory" and "capture lesson" steps baked into its flow. The longitudinal-work skill targets multi-session research/eval loops where lessons must accumulate across runs.
+- **Shared skill references**: `skills/shared/entity-detection.md` (canonicalization + fallback rules for scoping recalls and observations) and `skills/shared/memory-reflex.md` (the reasoning discipline every memory-woven skill inherits, plus the canonical provenance tag vocabulary).
+- **Thread-aware session continuity**: the `session-start` hook now detects whether the current session continues a prior episode (shared entities + temporal proximity) and resumes with a primer of prior lessons. Continuity is a plugin-layer concept today; server-side persistence of the link is a candidate for a future MCP extension (see spec addendum).
+- **In-flight capture markers**: the `post-tool-bash` and `post-tool-write-edit` hooks now score signal strength and emit `in_flight_trigger` markers when accumulated strength crosses a threshold. Memory-woven skills check for these markers and capture immediately when a concrete lesson has landed.
+- **First-class procedural memory**: all three memory types (semantic, episodic, procedural) are now represented across the skill templates. Procedural captures use `pensyve_observe` with a `[procedural]` content prefix (integration-layer convention; Task 1 addendum to the spec covers the decision).
+
+### Changed
+
+- **`prompt_enrichment` default-on**: the `user-prompt-submit` hook's prompt-enrichment is now on by default with guardrails (<1s budget, scored threshold, entity-scoped recall, max 5 memories, silent failure). Opt out via `prompt_enrichment: false` in `pensyve-plugin.local.md`.
+- **Stop hook narrowed**: the `Stop` hook is no longer the primary write path. In-flight captures handle the substantive writes; `Stop` now handles residuals and closes the episode. Also scans Pensyve for `[tier-2-pending]` items from pre-compact handoff (with a <1s latency budget).
+- **`memory-curator` narrowed**: active only when `auto_capture: "confirm-all"` or on explicit invocation. In `tiered`/`full` modes, in-flight captures handle events directly.
+- **Provenance tags formalized**: canonical format `[<origin>/<trigger>/<tier>]` where origin ∈ {`proactive`, `auto-capture`}, trigger ∈ {`in-flight`, `stop`, `pre-compact`, `curator`, `user`}, tier ∈ {`tier-1`, `tier-2`, `residual`, `open-question`}. For procedural captures, `[procedural]` precedes the provenance tag.
+- **Existing skills refreshed**: `memory-informed-refactor`, `session-memory`, `context-loader` updated to reference the shared memory-reflex rule, add in-flight capture steps, and align with the new platform/reasoning layer split.
+
+### Fixed
+
+- **MCP contract mismatches** (pre-merge via PR #58 review): removed `related_entities` from all `pensyve_recall` call sites (not a real param; secondary entities now fold into the query string); removed `continuation_of` from `pensyve_episode_start` (not a real param; thread continuity is plugin-layer only); added required `source_entity` and `about_entity` to every `pensyve_observe` call example across hooks and skills.
+- **Backward-compat consistency**: restored boolean `auto_capture` legacy handling in `stop.md` to match `pre-compact.md`.
+
+### Backward Compatibility
+
+- `auto_capture: false` → treated as `"off"` (no proactive behavior).
+- `auto_capture: true` → treated as `"confirm-all"` (presents every capture for confirmation).
+- Users who had no `prompt_enrichment` setting will experience the new default-on behavior; set `prompt_enrichment: false` to restore v1.2 behavior.
+- No schema migrations, no SDK changes, no MCP server changes. PyPI/npm/crates.io/Go-module versions stay at 1.2.0.
+
 ## [1.2.1] - 2026-04-16 (Claude Code plugin only)
 
 ### Changed

--- a/integrations/claude-code/.claude-plugin/marketplace.json
+++ b/integrations/claude-code/.claude-plugin/marketplace.json
@@ -6,15 +6,15 @@
     "url": "https://github.com/major7apps/pensyve"
   },
   "metadata": {
-    "description": "Universal memory runtime — cross-session cognitive memory for Claude Code with intelligent capture, 6 commands, 4 skills, 2 agents, and 6 lifecycle hooks",
-    "version": "1.2.1"
+    "description": "Universal memory runtime — ambient working-memory substrate for Claude Code. Proactive in-flight capture, thread-aware session continuity, three-type memory (semantic/episodic/procedural), and entity-aware recall. 7 commands, 7 skills, 2 agents, 6 lifecycle hooks.",
+    "version": "1.3.0"
   },
   "plugins": [
     {
       "name": "pensyve",
       "source": "./",
-      "description": "Universal memory runtime — cross-session cognitive memory for Claude Code. Remembers decisions, patterns, and context across coding sessions.",
-      "version": "1.2.1",
+      "description": "Universal memory runtime — ambient working-memory substrate for Claude Code. Memory is not a feature you invoke — it's the substrate the agent operates on.",
+      "version": "1.3.0",
       "author": {
         "name": "Seth Hobson",
         "email": "seth@major7apps.com"

--- a/integrations/claude-code/.claude-plugin/plugin.json
+++ b/integrations/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pensyve",
-  "version": "1.2.1",
-  "description": "Universal memory runtime — cross-session cognitive memory for Claude Code. Remembers decisions, patterns, and context across coding sessions.",
+  "version": "1.3.0",
+  "description": "Universal memory runtime — ambient working-memory substrate for Claude Code. Memory is not a feature you invoke — it's the substrate the agent operates on.",
   "author": {
     "name": "Major7 Apps",
     "email": "seth@major7apps.com"

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -4,11 +4,14 @@ Pensyve gives Claude Code a persistent, cognitive memory layer that spans across
 
 ## What It Does
 
-- **Remembers decisions and their reasoning** across coding sessions
-- **Recalls relevant context** when you start a new session or switch tasks
-- **Tracks outcomes** -- what worked, what failed, and why
-- **Consolidates knowledge** -- promotes repeated patterns to long-term facts, decays stale information
-- **Never forgets the hard-won lessons** from debugging sessions
+Pensyve makes Claude Code feel continuous across sessions — like working with a colleague who actually remembers your last conversation. Memory is not a feature you invoke; it is the substrate the agent operates on.
+
+- **Proactive memory during work** — lessons are captured the moment they land, not at session end
+- **Thread-aware continuity** — sessions that continue prior work resume with relevant context, no re-briefing
+- **Default-on recall with guardrails** — substantive questions are grounded in prior decisions; simple commands stay fast
+- **Three memory types** — durable facts (semantic), session-specific events (episodic), reusable procedures (procedural)
+- **Lightly visible** — one-line surfaces when memory is used; never interrupts your flow
+- **Opt-out, not opt-in** — users who prefer manual control set `auto_capture: off` and `prompt_enrichment: false`
 
 ## How It Works
 
@@ -23,6 +26,18 @@ pensyve-mcp server
     |
 SQLite + ONNX embeddings + vector index
 ```
+
+## Memory Behavior Model
+
+Pensyve behaves as working memory for the agent — always-on, ambient, continuous.
+
+**Writes happen in-flight.** When a root cause is confirmed, a decision is made, or a reusable procedure emerges, it's captured the moment it lands via memory-woven skills (memory-informed-debug, memory-informed-design, memory-informed-longitudinal-work). The Stop hook catches residuals.
+
+**Reads happen at decision points.** Before substantive answers, the model consults memory scoped to the detected entities. Simple commands (run tests, format file) skip recall to stay fast.
+
+**Sessions continue.** At session start, Pensyve checks whether the current work continues a prior episode (shared entities + temporal proximity). If yes, you resume with the prior episode's most recent lessons — no re-briefing needed.
+
+See `/remember`, `/recall`, `/inspect` for manual control, or `/memory-status` for namespace stats.
 
 ## Quick Start
 
@@ -119,7 +134,7 @@ capture_review_point: "stop"       # When to review tier 2 candidates
 max_auto_memories_per_session: 10  # Cap on auto-stored memories
 consolidation_frequency: "session_end"
 context_loading: "summary"         # off | summary | full
-prompt_enrichment: false           # Enrich prompts with memory (power user)
+prompt_enrichment: true            # Enrich prompts with memory (opt-out via false)
 ```
 
 **Automatic project detection:** The plugin automatically detects the current project for entity-scoped memory. It uses the git repository root directory name (via `git rev-parse --show-toplevel`) as the project identity, falling back to the current working directory name if not in a git repo. Set the `PENSYVE_NAMESPACE` environment variable to override automatic detection. Detected names are normalized to lowercase and hyphenated (e.g., `"pensyve-cloud"`).
@@ -153,12 +168,15 @@ prompt_enrichment: false           # Enrich prompts with memory (power user)
 
 ## Skills
 
-| Skill                      | When to Use                                                          |
-| -------------------------- | -------------------------------------------------------------------- |
-| `session-memory`           | End of a work session -- captures decisions and outcomes             |
-| `memory-informed-refactor` | Before refactoring -- loads relevant prior context                   |
-| `context-loader`           | Session start or context switch -- loads historical context          |
-| `memory-review`            | Periodic -- finds stale facts, contradictions, cleanup opportunities |
+| Skill                                | When to Use                                                          |
+| ------------------------------------ | -------------------------------------------------------------------- |
+| `memory-informed-debug`              | During any non-trivial debugging flow                                |
+| `memory-informed-design`             | During any substantive design/architecture question                  |
+| `memory-informed-longitudinal-work`  | Multi-session research, eval loops, iterative benchmarks             |
+| `memory-informed-refactor`           | Before refactoring — loads relevant prior context                    |
+| `session-memory`                     | End-of-session residual capture (not the primary capture path anymore)|
+| `context-loader`                     | Session start or context switch — loads historical context           |
+| `memory-review`                      | Periodic — finds stale facts, contradictions, cleanup opportunities  |
 
 ## Agents
 
@@ -169,14 +187,14 @@ prompt_enrichment: false           # Enrich prompts with memory (power user)
 
 ## Hooks
 
-| Hook              | Event              | Behavior                                                                                    |
-| ----------------- | ------------------ | ------------------------------------------------------------------------------------------- |
-| Session Start     | `SessionStart`     | Loads relevant memories at session start (configurable: off/summary/full)                   |
-| Post-Tool Write   | `PostToolUse`      | Buffers file change signals from Write/Edit (silent, no MCP calls)                          |
-| Post-Tool Bash    | `PostToolUse`      | Buffers command outcome signals from Bash (silent, no MCP calls)                            |
-| Stop              | `Stop`             | Processes signal buffer with tiered auto-store; tier 1 stored silently, tier 2 batched      |
-| Pre-Compact       | `PreCompact`       | Flushes signal buffer before context compression; preserves in-flight episode data           |
-| Prompt Enrichment | `UserPromptSubmit` | Enriches prompts with memory context (disabled by default)                                  |
+| Hook              | Event              | Behavior                                                                                                    |
+| ----------------- | ------------------ | ----------------------------------------------------------------------------------------------------------- |
+| Session Start     | `SessionStart`     | Loads memories + thread-continuity check — resumes prior episodes when score ≥0.7 on shared entities        |
+| Post-Tool Write   | `PostToolUse`      | Scores file-change signal strength; emits in-flight capture marker when accumulated strength ≥4             |
+| Post-Tool Bash    | `PostToolUse`      | Scores command outcome signal strength; emits in-flight marker on strong signals (confirmed failures, etc.) |
+| Stop              | `Stop`             | Residual flush only — most captures happen in-flight; closes episode via `pensyve_episode_end`              |
+| Pre-Compact       | `PreCompact`       | Flushes residual buffer before context compression; episode stays open (not Stop)                           |
+| Prompt Enrichment | `UserPromptSubmit` | Enriches prompts with memory context (default-on; opt out via `prompt_enrichment: false`)                   |
 
 ## Configuration Reference
 
@@ -191,7 +209,7 @@ All settings are configured in `pensyve-plugin.local.md` (copy to your project r
 | `max_auto_memories_per_session`| integer                                   | `10`             | Maximum tier 1 (auto-stored) memories per session.                           |
 | `consolidation_frequency`      | `"manual"` / `"session_end"` / `"daily"` | `"session_end"`  | When to run memory consolidation.                                            |
 | `context_loading`              | `"off"` / `"summary"` / `"full"`         | `"summary"`      | How much context to load at session start.                                   |
-| `prompt_enrichment`            | `true` / `false`                          | `false`          | Enable the UserPromptSubmit hook to enrich prompts with memory. Opt-in only. |
+| `prompt_enrichment`            | `true` / `false`                          | `true`           | Enable the UserPromptSubmit hook to enrich prompts with memory. Opt-out via `false`. |
 
 ### Capture Modes
 

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -182,7 +182,7 @@ prompt_enrichment: true            # Enrich prompts with memory (opt-out via fal
 
 | Agent                | Mode       | Purpose                                                                      |
 | -------------------- | ---------- | ---------------------------------------------------------------------------- |
-| `memory-curator`     | Background | Monitors sessions, suggests memorable events (requires `auto_capture: true`) |
+| `memory-curator`     | On-demand / confirm-all mode | Presents memorable events for individual confirmation. Active when `auto_capture: "confirm-all"` or manually invoked. In tiered/full modes, in-flight captures handle events directly. |
 | `context-researcher` | On-demand  | Deep memory search, returns structured briefings                             |
 
 ## Hooks
@@ -232,12 +232,13 @@ All settings are configured in `pensyve-plugin.local.md` (copy to your project r
 
 ## MCP Tools
 
-The plugin wraps 6 MCP tools exposed by the `pensyve-mcp` binary:
+The plugin wraps 7 MCP tools exposed by the `pensyve-mcp` binary:
 
 | Tool                    | Parameters                             | Returns                              |
 | ----------------------- | -------------------------------------- | ------------------------------------ |
-| `pensyve_recall`        | `query`, `entity?`, `types?`, `limit?` | Ranked array of memories with scores. When `entity` is provided, results are scoped to prefer memories linked to that entity. Hooks auto-detect the project name and pass it as `entity`. |
+| `pensyve_recall`        | `query`, `entity?`, `types?`, `limit?`, `min_confidence?` | Ranked array of memories with scores. When `entity` is provided, results are scoped to prefer memories linked to that entity. Hooks auto-detect the project name and pass it as `entity`. |
 | `pensyve_remember`      | `entity`, `fact`, `confidence?`        | Stored memory object                 |
+| `pensyve_observe`       | `episode_id`, `content`, `source_entity`, `about_entity`, `content_type?` | Stored observation object. Primary episodic-capture path used by in-flight memory-woven skills. `source_entity` and `about_entity` are required. |
 | `pensyve_episode_start` | `participants`                         | `episode_id`, `started_at`           |
 | `pensyve_episode_end`   | `episode_id`, `outcome?`               | `memories_created` count             |
 | `pensyve_forget`        | `entity`, `hard_delete?`               | `forgotten_count`                    |

--- a/integrations/claude-code/agents/memory-curator.md
+++ b/integrations/claude-code/agents/memory-curator.md
@@ -11,9 +11,11 @@ Background agent that monitors the session for memorable events and suggests sto
 
 ## Activation
 
-This agent is active only when the `auto_capture` setting is `true` in `pensyve-plugin.local.md`. If `auto_capture` is `false` or not set, this agent should not run. The user can also invoke the session-memory skill manually for on-demand capture.
+This agent is active only when `auto_capture` is `"confirm-all"` in `pensyve-plugin.local.md`, OR when the user manually invokes it for a session where tiered / full mode missed something. In `"tiered"` and `"full"` modes, in-flight captures handle most events directly — this agent is no longer the primary capture path.
 
 ## Behavior
+
+When active (confirm-all mode or explicit invocation), this agent monitors the session for memorable events the in-flight captures may have missed. Use it as a safety net, not the primary capture mechanism.
 
 ### What to Monitor
 

--- a/integrations/claude-code/agents/memory-curator.md
+++ b/integrations/claude-code/agents/memory-curator.md
@@ -7,7 +7,7 @@ color: green
 
 # Memory Curator Agent
 
-Background agent that monitors the session for memorable events and suggests storing them in Pensyve. Active only when `auto_capture: true` is set in the plugin configuration.
+Background agent that monitors the session for memorable events and suggests storing them in Pensyve. Active only when `auto_capture` is `"confirm-all"` in the plugin configuration, or when manually invoked.
 
 ## Activation
 
@@ -110,7 +110,7 @@ If the user does not respond or dismisses the suggestion, treat it as "no" and m
 
 - **NEVER auto-store.** Every suggestion MUST be confirmed by the user before calling `pensyve_remember`. This is a hard requirement.
 - **Never read or write `.claude/` memory files.** All memory operations go through the Pensyve MCP tools exclusively.
-- **Only active when `auto_capture: true`.** Do not monitor or suggest when this setting is false or absent.
+- **Only active when `auto_capture: "confirm-all"`** or explicitly invoked.
 - **Use `model_preference: fast`.** This agent should use the fastest available model to minimize latency and cost since it runs in the background.
 - Do not interrupt the user during complex reasoning, debugging, or multi-step operations. Wait for a natural pause in the conversation.
 - Limit suggestions to at most 3 per 10-minute window to avoid notification fatigue.

--- a/integrations/claude-code/hooks/post-tool-bash.md
+++ b/integrations/claude-code/hooks/post-tool-bash.md
@@ -1,43 +1,59 @@
 ---
 name: post-tool-bash
-description: "Buffer command outcome signals for intelligent memory capture"
+description: "Buffer command outcome signals; emit in-flight marker on strong signals (confirmed failures, resolved regressions, test-suite transitions)"
 event: PostToolUse
 matcher: "Bash"
 ---
 
 # Post-Tool Bash Hook
 
-Fires after a Bash tool completes. Buffers outcome signals when the command result contains meaningful information (errors, test results, performance data).
+Fires after a Bash tool completes. Buffers outcome signals when the command result contains meaningful information and, new behavior, scores signal strength for in-flight capture markers.
 
 ## Behavior
 
-### Step 1: Check Configuration
+### Step 1: Check configuration
 
-Read `pensyve-plugin.local.md` for the `auto_capture` setting. If set to `"off"`, exit immediately.
+Read `pensyve-plugin.local.md` for `auto_capture`. If `"off"`, exit immediately.
 
-### Step 2: Evaluate Relevance
+### Step 2: Evaluate relevance
 
 Only buffer if the command result contains one of:
+
 - **Test results**: pass/fail counts, assertion errors, test suite summaries
 - **Build errors**: compilation failures, type errors, missing dependencies
 - **Runtime errors**: stack traces, error messages with root cause information
 - **Performance data**: timing results, benchmark output, memory usage
+- **State transitions**: "now passes" after previously failing, migration success, deploy success
 
 Skip (do not buffer) if:
-- Command was a simple ls, cd, git status, or navigation command
+
+- Command was simple `ls`, `cd`, `git status`, `pwd`, navigation
 - Output is routine success with no notable information
 - Command was a Pensyve MCP call (grep for `pensyve`)
 
-### Step 3: Buffer the Signal
+### Step 3: Score signal strength
 
-If relevant, note:
-- **Type**: `outcome` (if error/test result) or `tool_use` (if informational)
-- **Content**: A one-sentence summary of the meaningful result
-- **Metadata**: `exit_code`, `command` (first 100 chars)
+- **3** (strong): confirmed resolution of a named failure (e.g., test that was failing now passes + user named the cause); measurable performance change with explicit reason.
+- **2** (medium): new test failure with clear stack trace; build error with specific file/line.
+- **1** (weak): routine informational output worth keeping for context.
+- **0** (filtered): noise per Step 2.
+
+### Step 4: Buffer the signal
+
+If strength ≥ 1, record:
+
+- **type:** `outcome` (error/test result) or `tool_use` (informational)
+- **content:** one-sentence summary of the meaningful result
+- **metadata:** `exit_code`, `command` (first 100 chars), `entities_detected` (per `skills/shared/entity-detection.md`)
+- **strength:** 0-3 per Step 3
+
+### Step 5: Check in-flight threshold
+
+Same rule as `post-tool-write-edit` — if accumulated strength across all buffered signals in the last 5 turns reaches ≥4 with at least one strength-3 signal, emit an `in_flight_trigger` marker for the reasoning layer.
 
 ## Constraints
 
-- **No MCP calls.** Buffer only; Stop hook handles storage.
-- **No user output.** Completely silent.
-- **Fast execution.** Fires on every Bash -- no perceptible latency.
-- **Never buffer secrets from command output.** Strip before buffering.
+- **No MCP calls.** Buffer annotation only.
+- **No user output.**
+- **Fast execution** (<50ms budget).
+- **Never buffer secrets** from command output. Strip environment variable values, API keys, tokens before buffering.

--- a/integrations/claude-code/hooks/post-tool-write-edit.md
+++ b/integrations/claude-code/hooks/post-tool-write-edit.md
@@ -1,41 +1,57 @@
 ---
 name: post-tool-write-edit
-description: "Buffer file change signals for intelligent memory capture"
+description: "Buffer file change signals for intelligent memory capture; emit in-flight marker when signal strength warrants"
 event: PostToolUse
 matcher: "Write|Edit"
 ---
 
 # Post-Tool Write/Edit Hook
 
-Fires after a Write or Edit tool completes. Buffers a lightweight signal describing the change for later processing by the Stop hook.
+Fires after a Write or Edit tool completes. Buffers a signal describing the change and — new behavior — emits an in-flight capture marker when accumulated signal strength crosses a threshold.
 
 ## Behavior
 
-### Step 1: Check Configuration
+### Step 1: Check configuration
 
-Read `pensyve-plugin.local.md` for the `auto_capture` setting. If set to `"off"`, exit immediately.
+Read `pensyve-plugin.local.md` for `auto_capture`. If `"off"`, exit immediately.
 
-### Step 2: Buffer the Signal
+### Step 2: Buffer the signal (always)
 
-Note the following as a signal to be processed at the next Stop or PreCompact event:
+Record the following as a buffered signal:
 
-- **Type**: `file_change`
-- **Content**: A one-sentence summary of what was changed and why (infer from the tool input and surrounding conversation context)
-- **Metadata**: `file_path` (from tool input), `tool_name` ("Write" or "Edit")
+- **type:** `file_change`
+- **content:** one-sentence summary of what was changed and why (infer from tool input + surrounding conversation)
+- **metadata:** `file_path` (from tool input), `tool_name` ("Write" or "Edit"), `entities_detected` (list, per `skills/shared/entity-detection.md`)
+- **strength:** integer score 0-3 (see Step 4)
 
-Do NOT make any MCP calls. Do NOT present anything to the user. This hook is silent -- it only accumulates context for later processing.
-
-### Step 3: Apply Significance Filter
+### Step 3: Apply significance filter
 
 Skip buffering entirely if the change is clearly noise:
+
 - Formatting-only changes (prettier, black, ruff format)
 - Import sorting
 - Whitespace or comment-only changes
 - Generated boilerplate with no design decisions
 
+### Step 4: Score signal strength
+
+- **3** (strong): change confirms a root cause named in the preceding conversation, OR implements an explicit user correction, OR resolves a test failure named in a recent signal.
+- **2** (medium): change is part of an active debugging or refactoring flow with a named outcome.
+- **1** (weak): change is a routine implementation step.
+- **0** (filtered): anything that would have been skipped in Step 3.
+
+### Step 5: Check in-flight threshold
+
+After buffering, check the accumulated buffer across both `post-tool-bash` and `post-tool-write-edit` signals in the last 5 turns:
+
+- If total strength score ≥ 4 with at least one signal at strength 3, emit an **in-flight capture marker** for the memory-woven skills to observe.
+- The marker itself is a no-op signal entry with `type: "in_flight_trigger"` and `should_capture: true`. The reasoning layer (skills) handles the actual MCP call.
+
+This hook does NOT call MCP tools directly. Markers are consumed by the reasoning layer's memory reflex.
+
 ## Constraints
 
-- **No MCP calls.** This hook only buffers; the Stop hook handles storage.
-- **No user output.** Completely silent.
-- **Fast execution.** This fires on every Write/Edit -- must add zero perceptible latency.
-- **Never buffer secrets.** If the file path suggests credentials (.env, secrets.*, credentials.*), skip.
+- **No MCP calls from this hook.** Marker emission is a local buffer annotation, not a network call.
+- **No user output** from this hook. Surfaces are the reasoning layer's job.
+- Fast execution — this fires on every Write/Edit. Budget: <50ms local work.
+- Never buffer secrets. If the file path suggests credentials (`.env`, `secrets.*`, `credentials.*`), skip.

--- a/integrations/claude-code/hooks/pre-compact.md
+++ b/integrations/claude-code/hooks/pre-compact.md
@@ -66,10 +66,22 @@ If there are buffered signals from PostToolUse hooks (file_change, outcome, tool
 - Routine lint fixes, import sorting, boilerplate
 - Standard file edits with no architectural significance
 
-**For tier 1 candidates:** Auto-store silently via `pensyve_remember` with:
-- `entity`: The relevant entity name (lowercase, hyphenated)
-- `fact`: `"[auto-capture/pre-compact/residual/tier-1] <fact text>"`
-- `confidence`: 0.9
+**For tier 1 candidates:** Tier-1 candidates flush to Pensyve using the appropriate MCP tool based on memory type:
+
+- **Semantic** — durable decisions, preferences, conventions — call `pensyve_remember`:
+  - `entity`: the relevant entity (lowercase-hyphenated)
+  - `fact`: `[auto-capture/pre-compact/residual/tier-1] <fact text>`
+  - `confidence`: 0.9
+- **Episodic** — session-scoped events, outcomes, root causes — call `pensyve_observe`:
+  - `episode_id`: the current session's episode_id
+  - `about_entity`: the relevant entity (lowercase-hyphenated)
+  - `content`: `[auto-capture/pre-compact/residual/tier-1] <observation>`
+  - `content_type`: `"text"` (or `"code"` for code-related outcomes)
+- **Procedural** — reusable workflows, sequences, recipes (per Task 1 spec addendum) — call `pensyve_observe`:
+  - `episode_id`: current session's episode_id
+  - `about_entity`: relevant entity
+  - `content`: `[procedural] [auto-capture/pre-compact/residual/tier-1] trigger=..., action=..., outcome=...`
+  - `content_type`: `"text"`
 
 **For tier 2 candidates:** Do NOT present for user review (compaction should not be delayed by user interaction). Instead, include them in the pre-compaction snapshot in Step 3 with a `[tier-2-pending]` marker so the Stop hook can review them later.
 

--- a/integrations/claude-code/hooks/pre-compact.md
+++ b/integrations/claude-code/hooks/pre-compact.md
@@ -22,6 +22,8 @@ This hook captures that context so it can be recalled after compaction.
 
 ## Behavior
 
+Primary memory captures now happen in-flight during the session via the memory reflex. This hook exists to flush any residual buffered signals before context compression, so nothing is lost across the compaction boundary. The episode remains open — this is not Stop.
+
 ### Step 0: Read Configuration
 
 Read `pensyve-plugin.local.md` for the `auto_capture` setting.
@@ -66,7 +68,7 @@ If there are buffered signals from PostToolUse hooks (file_change, outcome, tool
 
 **For tier 1 candidates:** Auto-store silently via `pensyve_remember` with:
 - `entity`: The relevant entity name (lowercase, hyphenated)
-- `fact`: `"[auto-capture/pre-compact/tier-1] <fact text>"`
+- `fact`: `"[auto-capture/pre-compact/residual/tier-1] <fact text>"`
 - `confidence`: 0.9
 
 **For tier 2 candidates:** Do NOT present for user review (compaction should not be delayed by user interaction). Instead, include them in the pre-compaction snapshot in Step 3 with a `[tier-2-pending]` marker so the Stop hook can review them later.
@@ -86,7 +88,7 @@ Compile these into a concise snapshot (not a full transcript).
 Call `pensyve_remember` to persist the critical context:
 
 - `entity`: The project/namespace entity (lowercase, hyphenated)
-- `fact`: `"[auto-capture/pre-compact/snapshot] Pre-compaction snapshot: [summary of current work state, pending decisions, active investigation threads]. [Any tier-2-pending items from Step 1.5]"`
+- `fact`: `"[auto-capture/pre-compact/residual/tier-2] Pre-compaction snapshot: [summary of current work state, pending decisions, active investigation threads]. [Any tier-2-pending items from Step 1.5]"`
 - `confidence`: 0.7 (this is an automated snapshot, not a confirmed decision)
 
 Keep the stored memory concise -- capture the essential state, not the full conversation. Aim for 2-4 sentences maximum.

--- a/integrations/claude-code/hooks/pre-compact.md
+++ b/integrations/claude-code/hooks/pre-compact.md
@@ -74,11 +74,13 @@ If there are buffered signals from PostToolUse hooks (file_change, outcome, tool
   - `confidence`: 0.9
 - **Episodic** — session-scoped events, outcomes, root causes — call `pensyve_observe`:
   - `episode_id`: the current session's episode_id
+  - `source_entity`: `"claude-code"`
   - `about_entity`: the relevant entity (lowercase-hyphenated)
   - `content`: `[auto-capture/pre-compact/residual/tier-1] <observation>`
   - `content_type`: `"text"` (or `"code"` for code-related outcomes)
 - **Procedural** — reusable workflows, sequences, recipes (per Task 1 spec addendum) — call `pensyve_observe`:
   - `episode_id`: current session's episode_id
+  - `source_entity`: `"claude-code"`
   - `about_entity`: relevant entity
   - `content`: `[procedural] [auto-capture/pre-compact/residual/tier-1] trigger=..., action=..., outcome=...`
   - `content_type`: `"text"`

--- a/integrations/claude-code/hooks/session-start.md
+++ b/integrations/claude-code/hooks/session-start.md
@@ -38,17 +38,26 @@ Call `pensyve_recall`:
 
 Secondary entities are folded into the query string since the MCP server scopes results by single primary entity only.
 
-### Step 4: Thread-continuity check
+### Step 4: Thread-continuity check (best-effort via recall)
 
-Query recent episodes for this namespace:
-- `pensyve_inspect` on the project entity, filter `memory_type: episodic`, limit 5
-- Find the most recent episode in the last 48 hours
-- Compute shared-entity score: fraction of current session's candidate entities that also appear in that episode's observations
-- If score ≥ 0.7, treat the current session as a **continuation**:
-  - Store `prior_episode_id` in local session state (used by context-loader and memory-woven skills for in-session queries — this is a plugin-layer concept only, not a server-side field)
-  - Include that episode's most recent 3 observations in the primer
+There is no MCP surface to list episodes directly. Instead, use `pensyve_recall` with an episodic-type filter to surface recent observations for the project — the recall ranker's activation signal boosts recent memories naturally.
 
-If no continuation is detected, this is a fresh episode.
+Call `pensyve_recall`:
+- `query`: the same `"recent decisions issues patterns"` string from Step 3, optionally augmented with current-session entity candidates
+- `entity`: the detected project name
+- `types`: `["episodic"]`
+- `limit`: 5
+
+Compute a shared-entity score: of the candidate entities detected in Step 2, how many appear as the `about_entity` (or mentioned in content) of the returned observations? If ≥70% of the top observations reference at least one shared entity, treat the current session as a **continuation**.
+
+**Continuity signal fidelity is limited:**
+- No episode-record listing exists, so we cannot positively link sessions via a structured `episode_id`.
+- The ranker's activation signal tends to prefer recent items, but there is no hard temporal guarantee.
+- This is a pragmatic best-effort — good enough for the user-facing primer, not a formal persisted link.
+
+If the continuity check succeeds, remember the top 3 observations for use in the primer (Step 5). Store them as plugin-layer session state under a `recent_context` key; downstream skills (especially `context-loader`) will consume it.
+
+If the check is inconclusive (fewer than 70% entity overlap, empty recall, or MCP timeout), present a standard fresh-session primer in Step 5.
 
 ### Step 5: Present context
 
@@ -90,7 +99,7 @@ PostToolUse hooks will begin buffering signals. No action needed here — inform
 ## Constraints
 
 - Complete in <2s for summary mode.
-- Use one `pensyve_recall` call + one `pensyve_inspect` call (continuity check). No more.
+- Use two `pensyve_recall` calls maximum (Step 3 + Step 4 continuity check). No `pensyve_inspect` for continuity.
 - If MCP unavailable or slow, skip context loading entirely — fail silently.
 - Never read or write `.claude/` memory files.
 - Detected project + entity names MUST be lowercase-hyphenated.
@@ -99,6 +108,6 @@ PostToolUse hooks will begin buffering signals. No action needed here — inform
 ## Error handling
 
 - `pensyve_recall` fails/times out: exit silently. Do not block session.
-- `pensyve_inspect` continuity check fails: start fresh episode (no link).
+- Continuity recall (Step 4) fails or returns empty: treat as fresh session (no link).
 - `pensyve_episode_start` fails: continue without episode tracking.
 - MCP not connected: single brief note ("Pensyve MCP not available — context loading skipped.") then exit.

--- a/integrations/claude-code/hooks/session-start.md
+++ b/integrations/claude-code/hooks/session-start.md
@@ -1,109 +1,102 @@
 ---
 name: session-start
-description: "Load relevant memories from Pensyve at session start for cross-session continuity"
+description: "Load relevant memories at session start with thread-aware continuity — resume prior episodes when current work continues them"
 event: SessionStart
 ---
 
 # Session Start Hook
 
-Fires when a new Claude Code session begins. Loads relevant memories from Pensyve to provide cross-session continuity, and optionally starts an episode to track the session.
+Fires when a new Claude Code session begins. Loads relevant memories, detects whether the current session continues a prior episode, and starts a new episode (linked where applicable).
 
 ## Behavior
 
-### Step 1: Check Configuration
+### Step 1: Check configuration
 
-Read `pensyve-plugin.local.md` for the `context_loading` setting:
+Read `pensyve-plugin.local.md` for `context_loading`:
 
-- **"off"**: Exit immediately. Do not load any memories or produce output.
-- **"summary"** (default): Load a concise summary of relevant memories.
-- **"full"**: Load comprehensive memory context with scores and entity relationships.
+- `"off"` — exit immediately
+- `"summary"` (default) — concise summary, ~10 lines
+- `"full"` — comprehensive context
 
-If the configuration file is not found, default to **"summary"**.
+### Step 2: Detect project + entities
 
-### Step 2: Determine Context
+Detect the project name per the hierarchy (`PENSYVE_NAMESPACE` env → git root → CWD → `"default"`). Normalize lowercase-hyphenated.
 
-Detect the current project name using this hierarchy (first match wins):
+Detect recent entities from:
+- Recent git commits (last 10; extract referenced phases, modules, services)
+- Current branch name
+- Recent working files (uncommitted changes)
 
-1. **`PENSYVE_NAMESPACE` environment variable** — if set, use its value (explicit override).
-2. **Git repository root directory name** — run `git rev-parse --show-toplevel` and take the basename of the result.
-3. **Current working directory name** — basename of the CWD.
-4. **`"default"`** — last resort when none of the above yield a value.
+Combine into a candidate entity list per `skills/shared/entity-detection.md`.
 
-Normalize the detected name: lowercase and hyphenate (e.g., `"PensyveCloud"` → `"pensyve-cloud"`, `"AI_Primitives"` → `"ai-primitives"`). This is the **detected project name**, used as the `entity` parameter in subsequent MCP calls.
+### Step 3: Scoped recall
 
-### Step 3: Load Memories
-
-Call `pensyve_recall` with entity-scoped recall using the detected project name:
-
+Call `pensyve_recall`:
 - `query`: `"recent decisions issues patterns"`
-- `entity`: The detected project name from Step 2
-- `limit`: 10 for summary mode, 25 for full mode
-- No type filter (get all types)
+- `entity`: detected project name
+- `related_entities`: candidate entity list from Step 2 (top 3)
+- `limit`: 10 (summary) or 25 (full)
 
-The `entity` parameter handles project scoping — do not prefix the query with the project name.
+### Step 4: Thread-continuity check
 
-Use a single recall query to keep execution fast.
+Query recent episodes for this namespace:
+- `pensyve_inspect` on the project entity, filter `memory_type: episodic`, limit 5
+- Find the most recent episode in the last 48 hours
+- Compute shared-entity score: fraction of current session's candidate entities that also appear in that episode's observations
+- If score ≥ 0.7, treat the current session as a **continuation**:
+  - Store `continuation_of: <prior_episode_id>` for use in Step 6
+  - Include that episode's most recent 3 observations in the primer
 
-### Step 4: Present Context
+If no continuation is detected, this is a fresh episode — no `continuation_of` link.
 
-**For "summary" mode** (complete in < 2 seconds):
+### Step 5: Present context
 
-Present 3-5 key facts and any active issues in approximately 10 lines:
+**Summary mode** (≤10 lines):
+
+If this is a continuation:
+
+> **Pensyve:** Continuing prior work on `<entity-set>`. Last session lessons:
+>
+> - [observation 1]
+> - [observation 2]
+> - [observation 3]
+>
+> Open questions / unfinished: [if surfaced by recall]
+
+Otherwise:
 
 > **Pensyve:** [N] memories loaded for `[namespace]`. Key context:
 >
-> - [Top 3-5 most relevant facts, one line each]
-> - [Any active issues or warnings from procedural memory]
+> - [Top 3-5 most relevant facts]
 >
 > _Use `/recall <query>` to search for specific memories._
 
-Rules for summary mode:
+**Full mode:** comprehensive context with scores, entity relationships, navigation suggestions.
 
-- Maximum 10 lines of content
-- Show the 3-5 highest-scoring memories, one line each
-- Include any active issues from procedural or episodic memories
-- Do not show scores, IDs, or timestamps
-- Prioritize higher-confidence and more recent memories
+### Step 6: Start episode
 
-**For "full" mode:**
+Call `pensyve_episode_start`:
+- `participants`: `["claude-code", "<detected_project_name>"]`
+- `continuation_of`: `<prior_episode_id>` if Step 4 detected continuation, else omit
 
-Present comprehensive context with scores and entity relationships, as described in the `context-loader` skill. Include:
+Store the returned `episode_id` for use by other hooks and skills. If the call fails, continue without episode tracking (do not report failure to user).
 
-- Grouped results by memory type with relevance scores
-- Confidence values and timestamps
-- Entity relationship information if available
-- Navigation suggestions (`/recall`, `/inspect`)
+### Step 7: Signal buffer init
 
-### Step 5: Start Episode (Optional)
-
-If `context_loading` is not "off", silently start an episode to track the session:
-
-- Call `pensyve_episode_start` with participants: `["claude-code", "<detected_project_name>"]` (using the project name from Step 2)
-- Store the returned `episode_id` for use by the Stop hook
-- If the episode fails to start, continue without episode tracking -- do not report the failure to the user
-
-### Step 6: Initialize Signal Buffer
-
-Note that PostToolUse hooks will begin buffering signals for this session. The buffer is processed at Stop and PreCompact events. No action needed here -- this is informational context for the Stop hook.
-
-## Performance
-
-- This hook MUST complete quickly (< 2 seconds for summary mode)
-- Use a single `pensyve_recall` query, not multiple
-- If the MCP server is unavailable or slow, fail silently with no output
-- Never block session startup
+PostToolUse hooks will begin buffering signals. No action needed here — informational.
 
 ## Constraints
 
-- **Never read or write `.claude/` memory files.** All memory operations go through the Pensyve MCP tools exclusively.
-- **Never slow down session startup significantly.** If the MCP server is not responding, skip context loading entirely.
-- Respect the user's `context_loading` preference -- do not load context if the setting is "off".
-- Do not fabricate memories. Only display what the MCP tools return.
-- If no memories are found, say: "No memories found for `[namespace]`. Use `/remember` to start building context."
-- If the Pensyve MCP server is not connected, fail silently. Optionally output a single brief note: "Pensyve MCP not available -- context loading skipped."
+- Complete in <2s for summary mode.
+- Use one `pensyve_recall` call + one `pensyve_inspect` call (continuity check). No more.
+- If MCP unavailable or slow, skip context loading entirely — fail silently.
+- Never read or write `.claude/` memory files.
+- Detected project + entity names MUST be lowercase-hyphenated.
+- Do not fabricate memories — only display what MCP returns.
 
-## Error Handling
+## Error handling
 
-- If `pensyve_recall` fails or times out, exit silently. Do not block the session.
-- If `pensyve_episode_start` fails, continue without episode tracking. Do not report this to the user.
-- If the MCP server is not connected, do not show an error. The session should start normally without memory context.
+- `pensyve_recall` fails/times out: exit silently. Do not block session.
+- `pensyve_inspect` continuity check fails: start fresh episode (no link).
+- `pensyve_episode_start` fails: continue without episode tracking.
+- MCP not connected: single brief note ("Pensyve MCP not available — context loading skipped.") then exit.

--- a/integrations/claude-code/hooks/session-start.md
+++ b/integrations/claude-code/hooks/session-start.md
@@ -32,10 +32,11 @@ Combine into a candidate entity list per `skills/shared/entity-detection.md`.
 ### Step 3: Scoped recall
 
 Call `pensyve_recall`:
-- `query`: `"recent decisions issues patterns"`
+- `query`: `"recent decisions issues patterns <entity-1> <entity-2> <entity-3>"` — append the top 3 candidate entities from Step 2 directly into the query string
 - `entity`: detected project name
-- `related_entities`: candidate entity list from Step 2 (top 3)
 - `limit`: 10 (summary) or 25 (full)
+
+Secondary entities are folded into the query string since the MCP server scopes results by single primary entity only.
 
 ### Step 4: Thread-continuity check
 
@@ -44,10 +45,10 @@ Query recent episodes for this namespace:
 - Find the most recent episode in the last 48 hours
 - Compute shared-entity score: fraction of current session's candidate entities that also appear in that episode's observations
 - If score ≥ 0.7, treat the current session as a **continuation**:
-  - Store `continuation_of: <prior_episode_id>` for use in Step 6
+  - Store `prior_episode_id` in local session state (used by context-loader and memory-woven skills for in-session queries — this is a plugin-layer concept only, not a server-side field)
   - Include that episode's most recent 3 observations in the primer
 
-If no continuation is detected, this is a fresh episode — no `continuation_of` link.
+If no continuation is detected, this is a fresh episode.
 
 ### Step 5: Present context
 
@@ -77,9 +78,10 @@ Otherwise:
 
 Call `pensyve_episode_start`:
 - `participants`: `["claude-code", "<detected_project_name>"]`
-- `continuation_of`: `<prior_episode_id>` if Step 4 detected continuation, else omit
 
 Store the returned `episode_id` for use by other hooks and skills. If the call fails, continue without episode tracking (do not report failure to user).
+
+Thread continuity is surfaced in the primer (Step 5) and reflected in session state used by context-loader and memory-woven skills. The server-side episode has no `continuation_of` field today — this is a plugin-layer concept deferred to a future MCP extension.
 
 ### Step 7: Signal buffer init
 

--- a/integrations/claude-code/hooks/stop.md
+++ b/integrations/claude-code/hooks/stop.md
@@ -19,6 +19,8 @@ Read `pensyve-plugin.local.md` for `auto_capture`:
 - `"full"` — flush both tiers silently
 - `"confirm-all"` — present all residuals for individual confirmation
 
+**Backward compatibility:** treat boolean `false` as `"off"` and boolean `true` as `"confirm-all"`. Matches the same logic in pre-compact.md.
+
 ### Step 1: Identify residual candidates
 
 Residuals are signals from the buffer that were NOT captured in-flight. Common causes:
@@ -29,7 +31,7 @@ Residuals are signals from the buffer that were NOT captured in-flight. Common c
 
 Review the buffer + session conversation since the last Stop (or SessionStart) for residual candidates.
 
-- **Check Pensyve for `[tier-2-pending]` items from pre-compact.** Before scanning the conversation, call `pensyve_recall` with `query: "tier-2-pending"`, `entity: <project entity>`, `limit: 10`. Any returned items are residuals from a prior pre-compact flush that deferred their tier-2 review to Stop. Include them in the residual candidate pool for Step 2 classification.
+- **Check Pensyve for `[tier-2-pending]` items from pre-compact.** Before scanning the conversation, call `pensyve_recall` with `query: "tier-2-pending"`, `entity: <project entity>`, `limit: 10`. **<1s latency budget** — if the call exceeds 1 second or fails, skip this check and proceed with conversation-buffer residuals only (pending items will be re-surfaced on next Stop). Any returned items are residuals from a prior pre-compact flush; include them in the residual candidate pool for Step 2 classification.
 
 ### Step 2: Classify residuals
 

--- a/integrations/claude-code/hooks/stop.md
+++ b/integrations/claude-code/hooks/stop.md
@@ -56,8 +56,8 @@ Apply tier taxonomy:
 
 Tier 1 residuals: auto-store silently.
 - Semantic → `pensyve_remember` with `[auto-capture/stop/residual/tier-1]` provenance
-- Episodic → `pensyve_observe` with the session's `episode_id` and same provenance
-- Procedural → `pensyve_observe` with content beginning `[procedural] [auto-capture/stop/residual/tier-1]`
+- Episodic → `pensyve_observe` with `episode_id: <session episode_id>`, `source_entity: "claude-code"`, `about_entity: <entity>`, `content: "[auto-capture/stop/residual/tier-1] <observation>"`, `content_type: "text"`
+- Procedural → `pensyve_observe` with `episode_id: <session episode_id>`, `source_entity: "claude-code"`, `about_entity: <entity>`, `content: "[procedural] [auto-capture/stop/residual/tier-1] trigger=..., action=..., outcome=..."`, `content_type: "text"`
 
 Tier 2 residuals: batch for review:
 

--- a/integrations/claude-code/hooks/stop.md
+++ b/integrations/claude-code/hooks/stop.md
@@ -1,156 +1,103 @@
 ---
 name: stop
-description: "Process signal buffer and store memories using tiered classification when a task completes"
+description: "Flush residual signal buffer (items not captured in-flight) and close the session episode"
 event: Stop
 ---
 
 # Stop Hook
 
-Fires when a task completes (Stop event) or a sub-agent finishes (SubagentStop). Processes buffered signals from PostToolUse hooks, classifies candidates using a tiered taxonomy, and stores memories according to the configured capture mode.
+Fires when a task completes (Stop event) or a sub-agent finishes (SubagentStop). Primary writes now happen **in-flight** via the memory reflex — this hook handles residual items and closes the episode.
 
 ## Behavior
 
-### Step 0: Read Configuration
+### Step 0: Read configuration
 
-Read `pensyve-plugin.local.md` for the `auto_capture` setting. Determine the capture mode:
+Read `pensyve-plugin.local.md` for `auto_capture`:
 
-- `"off"` -- Skip all capture logic. Jump directly to Step 5 (Close Episode).
-- `"tiered"` (default) -- Auto-store tier 1 silently; batch tier 2 for user review.
-- `"full"` -- Auto-store both tier 1 and tier 2 silently.
-- `"confirm-all"` -- Present ALL candidates for individual confirmation (legacy behavior).
+- `"off"` — skip capture; jump to Step 5 (close episode)
+- `"tiered"` (default) — flush tier-1 residuals silently; batch tier-2 for review
+- `"full"` — flush both tiers silently
+- `"confirm-all"` — present all residuals for individual confirmation
 
-**Backward compatibility:** treat boolean `false` as `"off"` and boolean `true` as `"confirm-all"`.
+### Step 1: Identify residual candidates
 
-If the configuration file is not found, default to `"tiered"`.
+Residuals are signals from the buffer that were NOT captured in-flight. Common causes:
 
-### Step 1: Process Signal Buffer
+- Signal strength didn't reach the in-flight threshold but is still worth keeping
+- Tier-2 items always deferred to Stop in tiered mode
+- Items that landed right at the end of the task with no follow-up turn
 
-Review any signals buffered by PostToolUse hooks (file_change, outcome, tool_use signals) during this task. Combine them with a review of the conversation since the last stop event (or session start) to build a complete picture of what happened.
+Review the buffer + session conversation since the last Stop (or SessionStart) for residual candidates.
 
-### Step 2: Classify Candidates
+### Step 2: Classify residuals
 
-Apply the following classification taxonomy to all candidate memories:
+Apply tier taxonomy:
 
-**Tier 1 (auto-store silently, confidence >= 0.9):**
+**Tier 1 (confidence ≥0.9)**:
+- User-stated decision, correction, or constraint (still residual if not captured in-flight)
 
-- User explicitly states a decision ("let's use X", "we decided Y", "we chose Z")
-- User corrects agent behavior ("don't do X", "stop doing Y", "no, not that")
-- User states a project constraint ("we can't use X because Y")
+**Tier 2 (0.7-0.89)**:
+- Debug outcome, abandoned approach, performance finding, cross-component discovery, workaround
 
-**Tier 2 (batch for review, confidence 0.7-0.89):**
+**Discard**:
+- Typos, formatting, routine edits, repeated patterns, very short interactions
 
-- Debugging session reveals root cause
-- Approach tried and abandoned with reason
-- Performance finding with measurable result
-- Cross-component dependency discovered
-- Workaround for framework/tool limitation
+### Step 3: Sanitize content
 
-**Discard (never store):**
+- Strip secrets (API keys, tokens, passwords, env values)
+- Cap individual facts at 512 chars
+- Remove long code blocks (>5 lines); summarize instead
 
-- Simple typo or formatting fixes
-- Routine lint fixes, import sorting, boilerplate
-- Standard file edits with no architectural significance
-- Repeated application of already-known patterns
-- Very short interactions that are clearly routine
+### Step 4: Store per mode
 
-### Step 3: Sanitize Content
+**`"tiered"`:**
 
-Before storing any candidate, apply content sanitization:
+Tier 1 residuals: auto-store silently.
+- Semantic → `pensyve_remember` with `[auto-capture/stop/residual/tier-1]` provenance
+- Episodic → `pensyve_observe` with the session's `episode_id` and same provenance
+- Procedural → `pensyve_observe` with content beginning `[procedural] [auto-capture/stop/residual/tier-1]`
 
-- **Strip secrets**: Remove anything that looks like an API key, token, password, or credential (patterns: `sk-*`, `ghp_*`, `Bearer *`, environment variable values from .env files).
-- **Cap length**: Truncate individual facts to 512 characters maximum.
-- **Strip code blocks**: Remove long code blocks (> 5 lines). Summarize what the code does instead.
-
-### Step 4: Store Based on Mode
-
-#### Mode: `"tiered"` (recommended)
-
-**Tier 1 candidates** -- Auto-store silently via MCP:
-
-For each tier 1 candidate, decide the storage type:
-
-- **Semantic facts** (durable truths) -- Call `pensyve_remember` with:
-  - `entity`: The relevant entity name (lowercase, hyphenated)
-  - `fact`: The fact text with provenance: `"[auto-capture/stop/tier-1] <fact text>"`
-  - `confidence`: 0.9
-
-- **Episodic observations** (session events) -- Call `pensyve_observe` with:
-  - `episode_id`: From session state (set by SessionStart hook)
-  - `content`: The observation text with provenance: `"[auto-capture/stop/tier-1] <observation>"`
-  - `source_entity`: `"claude-code"`
-  - `about_entity`: The relevant entity name (lowercase, hyphenated)
-  - `content_type`: `"text"` for decisions/patterns, `"code"` for code-related outcomes
-
-Use `pensyve_remember` for: architecture decisions, technology choices, user preferences, project conventions.
-Use `pensyve_observe` for: bug fixes, failed approaches, debugging outcomes, session-specific events.
-
-**Tier 2 candidates** -- Present as a batch for review:
+Tier 2 residuals: batch for review:
 
 > **Pensyve detected [N] item(s) for review:**
 >
-> 1. **[type]:** [summary] -> `[entity]`
-> 2. **[type]:** [summary] -> `[entity]`
+> 1. **[type]:** [summary] → `[entity]`
+> 2. **[type]:** [summary] → `[entity]`
 >
 > Store? (yes/no/select)
 
-If the user confirms, store using the same MCP calls as tier 1 but with provenance `"[auto-capture/stop/tier-2]"` and confidence based on type (0.8 for outcomes, 0.7 for patterns).
+**`"full"`:** auto-store both tiers silently with provenance. Report "Pensyve auto-stored [N] residual memories."
 
-#### Mode: `"full"`
+**`"confirm-all"`:** present all residuals for individual confirmation. Never auto-store.
 
-Auto-store both tier 1 and tier 2 silently. Use the same MCP calls and provenance tags as above. No user interaction required.
+**`"off"`:** skip to Step 5.
 
-After storing, briefly report: "Pensyve auto-stored [N] memories."
+### Step 5: Close episode
 
-#### Mode: `"confirm-all"` (legacy)
+Call `pensyve_episode_end` with the session's `episode_id` (set by SessionStart):
+- `outcome`: `"success"` / `"failure"` / `"partial"` based on task result
 
-Present ALL candidates (tier 1 and tier 2) for individual confirmation:
+Server-side consolidation runs automatically (episodic → semantic promotion for recurring patterns).
 
-> **Pensyve detected [N] memorable event(s) from this task:**
->
-> 1. **decision:** Chose RS256 over HS256 for JWT signing to support key rotation -> `auth-service`
-> 2. **outcome:** Migration script fails silently when Python < 3.11 -- added version check -> `database`
->
-> Store these memories? (yes/no/select)
-
-**NEVER auto-store in confirm-all mode.** Every item MUST be presented for confirmation.
-
-#### Mode: `"off"`
-
-Skip all capture. Proceed directly to Step 5.
-
-### Step 5: Close Episode
-
-If a session episode was started by the SessionStart hook:
-
-- Call `pensyve_episode_end` with the stored `episode_id`
-- Set `outcome` based on the task result: `"success"`, `"failure"`, or `"partial"`
-- The server will automatically trigger consolidation (episodic -> semantic promotion)
-
-If no episode is active, skip this step.
+If no episode is active, skip.
 
 ## Constraints
 
-- **Maximum 5 items per stop event.** If more than 5 significant items are found, keep only the 5 most important.
-- **Maximum 10 auto-stored memories per session** (across all stop events). Track the count and stop auto-storing once the limit is reached. Present remaining candidates for manual review instead.
-- **Never read or write `.claude/` memory files.** All memory operations go through the Pensyve MCP tools exclusively.
-- If the user dismisses suggestions, respect that for the remainder of the session -- do not re-suggest the same items.
-- Entity names MUST be lowercase and hyphenated.
-- Do not store secrets, API keys, passwords, or credentials. Warn the user if a candidate appears to contain sensitive data.
-- If the MCP server is unavailable, exit silently.
+- **Residuals only.** Most memories should already be captured in-flight by the memory reflex. This hook exists to catch the rest.
+- **Max 5 residual items per Stop event.**
+- **Max 10 auto-stored memories per session** (counting both in-flight and residual). Tracked across hooks; stop auto-storing once reached.
+- Never read or write `.claude/` memory files.
+- Entity names lowercase-hyphenated.
+- Do not store secrets; warn user if candidate contains sensitive data.
+- MCP unavailable: exit silently.
 
 ## Provenance
 
-All MCP calls from this hook MUST include provenance metadata in the fact/content text:
+- In-flight captures: `[proactive/in-flight/tier-1]` (from reasoning layer)
+- Residual captures: `[auto-capture/stop/residual/tier-1]` or `[auto-capture/stop/residual/tier-2]`
 
-- Format: `[auto-capture/<trigger>/<tier>]` prefix
-- Trigger: `"stop"`
-- Tier: `"tier-1"` or `"tier-2"`
-- Platform context: stored via `source_entity: "claude-code"` on episodic observations
+## Error handling
 
-This enables downstream analysis of auto-captured vs. manually stored memories.
-
-## Error Handling
-
-- If `pensyve_remember` fails for an item, report the error and continue with remaining items.
-- If `pensyve_episode_end` fails, report the error briefly but do not block the stop flow.
-- If the MCP server is not connected, exit silently. Do not show errors or interrupt the user.
+- `pensyve_remember` / `pensyve_observe` fails: report error briefly, continue remaining items.
+- `pensyve_episode_end` fails: report briefly, do not block Stop.
+- MCP not connected: exit silently.

--- a/integrations/claude-code/hooks/stop.md
+++ b/integrations/claude-code/hooks/stop.md
@@ -29,6 +29,8 @@ Residuals are signals from the buffer that were NOT captured in-flight. Common c
 
 Review the buffer + session conversation since the last Stop (or SessionStart) for residual candidates.
 
+- **Check Pensyve for `[tier-2-pending]` items from pre-compact.** Before scanning the conversation, call `pensyve_recall` with `query: "tier-2-pending"`, `entity: <project entity>`, `limit: 10`. Any returned items are residuals from a prior pre-compact flush that deferred their tier-2 review to Stop. Include them in the residual candidate pool for Step 2 classification.
+
 ### Step 2: Classify residuals
 
 Apply tier taxonomy:

--- a/integrations/claude-code/hooks/user-prompt-submit.md
+++ b/integrations/claude-code/hooks/user-prompt-submit.md
@@ -6,7 +6,7 @@ event: UserPromptSubmit
 
 # User Prompt Submit Hook
 
-Fires when the user submits a prompt. Optionally enriches the prompt with relevant memory context from Pensyve. **Disabled by default** -- must be explicitly enabled via `prompt_enrichment: true` in `pensyve-plugin.local.md`.
+Fires when the user submits a prompt. Enriches the prompt with relevant memory context from Pensyve when the prompt warrants it. **Enabled by default** — opt out via `prompt_enrichment: false` in `pensyve-plugin.local.md`.
 
 ## Behavior
 

--- a/integrations/claude-code/hooks/user-prompt-submit.md
+++ b/integrations/claude-code/hooks/user-prompt-submit.md
@@ -14,10 +14,10 @@ Fires when the user submits a prompt. Optionally enriches the prompt with releva
 
 Read `pensyve-plugin.local.md` for the `prompt_enrichment` setting:
 
-- **false** (default): Exit immediately. Do nothing.
-- **true**: Proceed with enrichment.
+- **false**: Exit immediately. Do nothing.
+- **true** (default): Proceed with enrichment.
 
-If the configuration file is not found or the setting is absent, treat as **false** and exit.
+If the configuration file is not found or the setting is absent, treat as **true** and proceed.
 
 ### Step 2: Analyze the Prompt
 
@@ -86,16 +86,22 @@ This hook runs on EVERY user prompt when enabled. It MUST be:
 - **Non-blocking**: If the MCP server is slow or unavailable, skip enrichment entirely
 - **Silent**: No user-visible output unless memories are injected as context
 
-## Why Disabled by Default
+## Why Guardrails Matter
 
-- Adds latency to every prompt
-- Can inject irrelevant context if memory quality is low
-- Users should build up a quality memory corpus first (via `/remember`, session-memory skill)
-- Power users enable this after they trust their stored memories
+This hook runs on every user prompt. The guardrails keep it useful, not annoying:
+
+- **<1s latency budget** — abandon if slow
+- **Heuristic prompt filter** — only recall when the prompt warrants it (see Step 2)
+- **Scored threshold** — only inject when score >0.3
+- **Entity-scoped recall** — avoid unrelated memory noise
+- **Silent on empty results** — no "no memories found" messages
+- **Max 5 memories** in any enrichment to avoid context bloat
+
+Users who prefer opt-in can set `prompt_enrichment: false` in `pensyve-plugin.local.md`.
 
 ## Constraints
 
-- **NEVER enabled by default.** Requires explicit opt-in via `prompt_enrichment: true`. This is a hard requirement.
+- **Default on.** Users opt out via `prompt_enrichment: false`. Guardrails (latency budget, scored threshold, prompt filter) ensure it remains useful.
 - **Never read or write `.claude/` memory files.** All memory operations go through the Pensyve MCP tools exclusively.
 - **Never show "no memories found" messages.** Fail silently on no results.
 - **Maximum 5 memories** in the enrichment context to avoid context bloat.

--- a/integrations/claude-code/pensyve-plugin.local.md
+++ b/integrations/claude-code/pensyve-plugin.local.md
@@ -6,7 +6,7 @@ capture_review_point: "stop"
 max_auto_memories_per_session: 10
 consolidation_frequency: "session_end"
 context_loading: "summary"
-prompt_enrichment: false
+prompt_enrichment: true
 ---
 
 # Pensyve Plugin Configuration
@@ -26,7 +26,7 @@ This file controls Pensyve plugin behavior. Copy to your project root and edit.
 - **max_auto_memories_per_session** -- Maximum tier 1 (auto-stored) memories per session. Prevents runaway storage. Default: 10.
 - **consolidation_frequency** -- When to run memory consolidation: `"manual"`, `"session_end"`, or `"daily"`. Default: `"session_end"`.
 - **context_loading** -- How much context to load at session start: `"off"`, `"summary"`, or `"full"`. Default: `"summary"`.
-- **prompt_enrichment** -- Enable automatic prompt enrichment with memory context. Default: false (opt-in only).
+- **prompt_enrichment** -- Enable automatic prompt enrichment with memory context. Default: true (opt-out via false).
 
 ## Migration from v1.0.x
 

--- a/integrations/claude-code/pensyve-plugin.local.md
+++ b/integrations/claude-code/pensyve-plugin.local.md
@@ -15,21 +15,25 @@ This file controls Pensyve plugin behavior. Copy to your project root and edit.
 
 ## Settings
 
-- **namespace** -- Memory namespace. Set to your project name for project-scoped memory. Default: directory name.
-- **auto_capture** -- Memory capture mode. Default: `"tiered"`.
-  - `"off"` -- No automatic memory capture.
-  - `"tiered"` -- High-confidence memories auto-stored silently; medium-confidence batched for review at task completion. Recommended.
-  - `"full"` -- All memories above threshold auto-stored silently. For power users.
-  - `"confirm-all"` -- Every memory presented for individual confirmation. Legacy behavior.
-- **capture_buffer** -- Enable PostToolUse signal buffering for richer memory context. Default: true.
-- **capture_review_point** -- When to present tier 2 candidates for batch review: `"stop"`, `"pre-compact"`, or `"both"`. Default: `"stop"`.
-- **max_auto_memories_per_session** -- Maximum tier 1 (auto-stored) memories per session. Prevents runaway storage. Default: 10.
-- **consolidation_frequency** -- When to run memory consolidation: `"manual"`, `"session_end"`, or `"daily"`. Default: `"session_end"`.
-- **context_loading** -- How much context to load at session start: `"off"`, `"summary"`, or `"full"`. Default: `"summary"`.
-- **prompt_enrichment** -- Enable automatic prompt enrichment with memory context. Default: true (opt-out via false).
+- **namespace** — Memory namespace. Set to your project name for project-scoped memory. Default: auto-detected from git root.
+- **auto_capture** — Memory capture mode. Default: `"tiered"`.
+  - `"off"` — No automatic memory capture. Only manual `/remember` saves.
+  - `"tiered"` — High-confidence memories auto-stored in-flight during work; medium-confidence batched for review at Stop. Recommended.
+  - `"full"` — All memories above threshold auto-stored silently, both in-flight and at Stop.
+  - `"confirm-all"` — Every memory presented for individual confirmation. Legacy; slower.
+- **capture_buffer** — Enable PostToolUse signal buffering. Default: `true`. Required for in-flight captures.
+- **capture_review_point** — When to present tier-2 batch for review: `"stop"`, `"pre-compact"`, or `"both"`. Default: `"stop"`.
+- **max_auto_memories_per_session** — Cap on auto-stored memories per session (in-flight + residual combined). Default: `10`. Longitudinal/eval sessions may benefit from 20-30.
+- **consolidation_frequency** — When to run consolidation: `"manual"`, `"session_end"`, or `"daily"`. Default: `"session_end"`.
+- **context_loading** — Session-start context amount: `"off"`, `"summary"`, or `"full"`. Default: `"summary"`.
+- **prompt_enrichment** — Enrich prompts with memory context before the model sees them. Default: `true` (opt-out via `false`).
 
-## Migration from v1.0.x
+## Migration from v1.x
 
-If upgrading from v1.0.x, your existing settings are backward compatible:
-- `auto_capture: false` is treated as `auto_capture: "off"`
-- `auto_capture: true` is treated as `auto_capture: "confirm-all"`
+v1.x users had `prompt_enrichment: false` and all captures at Stop. v2 flips these defaults:
+
+- `prompt_enrichment: true` — substantive prompts are now recall-enriched by default.
+- Captures happen in-flight — `Stop` handles residuals.
+- Thread-aware continuity — sessions that continue prior work resume with prior lessons.
+
+To keep v1.x behavior: set `auto_capture: off` and `prompt_enrichment: false`.

--- a/integrations/claude-code/skills/context-loader/SKILL.md
+++ b/integrations/claude-code/skills/context-loader/SKILL.md
@@ -33,6 +33,21 @@ Run the following `pensyve_recall` queries to gather session context:
 
 Deduplicate results across queries (same memory ID should appear only once).
 
+### Continuity-aware primer
+
+If the SessionStart hook detected a continuation (check session state for `continuation_of` on the current episode), structure the primer around continuity rather than fresh recall:
+
+> **Continuing:** `<entity-set>` — prior episode <short-date>
+>
+> **Last lessons:**
+> - [recent observation 1]
+> - [recent observation 2]
+>
+> **Open questions carried forward:**
+> - [if any observations had `open-question` provenance]
+
+If no continuation was detected, present a standard recall-based primer.
+
 ### Step 2: Present Context
 
 #### Summary Mode (10-15 lines max)

--- a/integrations/claude-code/skills/context-loader/SKILL.md
+++ b/integrations/claude-code/skills/context-loader/SKILL.md
@@ -37,9 +37,9 @@ Deduplicate results across queries (same memory ID should appear only once).
 
 ### Continuity-aware primer
 
-If the SessionStart hook detected a continuation (check plugin session state for `prior_episode_id` — this is set by the hook when shared-entity score ≥0.7; it is a plugin-layer concept, not a field on the server-side episode), structure the primer around continuity rather than fresh recall:
+If the SessionStart hook detected a continuation (check plugin session state for `recent_context` — this is set by the hook when shared-entity score ≥0.7 against episodic recall results; it is a plugin-layer concept, not a structured server-side episode link), structure the primer around continuity rather than fresh recall:
 
-> **Continuing:** `<entity-set>` — prior episode <short-date>
+> **Continuing:** `<entity-set>` — prior work context
 >
 > **Last lessons:**
 > - [recent observation 1]
@@ -47,6 +47,8 @@ If the SessionStart hook detected a continuation (check plugin session state for
 >
 > **Open questions carried forward:**
 > - [if any observations had `open-question` provenance]
+
+**Note:** Continuity is best-effort — it is inferred from shared-entity overlap in recent episodic recall, not from a persisted episode-to-episode link. The MCP server has no episode-listing API today. When in doubt, the hook falls back to a fresh-session primer.
 
 If no continuation was detected, present a standard recall-based primer.
 

--- a/integrations/claude-code/skills/context-loader/SKILL.md
+++ b/integrations/claude-code/skills/context-loader/SKILL.md
@@ -10,6 +10,8 @@ Load relevant memories from Pensyve at the start of a session to provide cross-s
 
 ## Instructions
 
+> **Note on invocation:** The SessionStart hook has already performed a scoped recall and (if applicable) injected a continuity primer. Invoking this skill adds deeper on-demand context — not a replacement for the hook's work. Expect to see both.
+
 When this skill is invoked (typically at session start), follow these steps:
 
 ### Step 0: Determine Loading Mode

--- a/integrations/claude-code/skills/context-loader/SKILL.md
+++ b/integrations/claude-code/skills/context-loader/SKILL.md
@@ -37,7 +37,7 @@ Deduplicate results across queries (same memory ID should appear only once).
 
 ### Continuity-aware primer
 
-If the SessionStart hook detected a continuation (check session state for `continuation_of` on the current episode), structure the primer around continuity rather than fresh recall:
+If the SessionStart hook detected a continuation (check plugin session state for `prior_episode_id` — this is set by the hook when shared-entity score ≥0.7; it is a plugin-layer concept, not a field on the server-side episode), structure the primer around continuity rather than fresh recall:
 
 > **Continuing:** `<entity-set>` — prior episode <short-date>
 >

--- a/integrations/claude-code/skills/memory-informed-debug/SKILL.md
+++ b/integrations/claude-code/skills/memory-informed-debug/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: memory-informed-debug
+description: "Debug with working memory -- before diagnosing, recall prior root causes and known-good diagnostic procedures; when a root cause is confirmed, capture it immediately. Use whenever debugging a non-trivial failure."
+version: 1.0.0
+---
+
+# Memory-Informed Debug
+
+Debugging flow with memory baked in as a non-optional reflex.
+
+## Instructions
+
+### Step 1: Detect entities
+
+Identify the relevant entity/entities (failing test, failing module, error source) per `skills/shared/entity-detection.md`.
+
+### Step 2: Consult memory (required)
+
+Call `pensyve_recall`:
+- `query`: a short description of the failure ("hybrid-router threshold regression" rather than full stack traces)
+- `entity`: primary detected entity
+- `related_entities`: secondary entities
+- `types`: `["procedural", "episodic"]` (debugging benefits most from known-good diagnostic procedures and prior incident outcomes)
+- `limit`: 5
+
+Surface one line: `Recalled N memories from prior debug sessions on <entity>.` (Skip if N=0.)
+
+If a highly similar incident is found (score >0.8), call that out inline: `This looks similar to an incident captured on <date>: <summary>. Consider that path first.`
+
+### Step 3: Diagnose
+
+Proceed with the diagnostic work. Use recalled procedural memories as a starting sequence; update the sequence when you learn something new.
+
+### Step 4: Capture lesson (when it lands)
+
+When a root cause is **confirmed** (not just hypothesized), call the memory reflex per `skills/shared/memory-reflex.md`:
+
+- **Episodic** — `pensyve_observe` with the session `episode_id`, `about_entity: <primary_entity>`, `content: "[proactive/in-flight/tier-1] <one-sentence root cause>"`, `content_type: "text"`.
+- **Procedural** — if the debug produced a reusable diagnostic sequence, capture it: `pensyve_observe` with `content: "[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=..."`.
+- **Semantic** — if the root cause reveals a durable truth (e.g., "our CI runner's Python 3.10 cannot handle the new syntax"), also call `pensyve_remember`.
+
+Surface one line: `↳ captured: <one-sentence>`.
+
+### Step 5: Capture abandoned approach
+
+If an approach was tried and abandoned, observe that too. These are high-value — they prevent re-treading the same dead end next time.
+
+## Constraints
+
+- Recall is **not optional**. If you skip recall to save time, you defeat the working-memory substrate.
+- Observe when a lesson **lands**, not when you first hypothesize.
+- One in-flight capture per turn. Additional candidates queue for the Stop residual flush.
+- Respect the plugin's noise budget and `auto_capture` mode.
+- Never store secrets or sensitive paths.

--- a/integrations/claude-code/skills/memory-informed-debug/SKILL.md
+++ b/integrations/claude-code/skills/memory-informed-debug/SKILL.md
@@ -17,11 +17,12 @@ Identify the relevant entity/entities (failing test, failing module, error sourc
 ### Step 2: Consult memory (required)
 
 Call `pensyve_recall`:
-- `query`: a short description of the failure ("hybrid-router threshold regression" rather than full stack traces)
+- `query`: a short description of the failure, including secondary entity names where known (e.g., "hybrid-router threshold regression phase-4.3" rather than full stack traces)
 - `entity`: primary detected entity
-- `related_entities`: secondary entities
 - `types`: `["procedural", "episodic"]` (debugging benefits most from known-good diagnostic procedures and prior incident outcomes)
 - `limit`: 5
+
+Secondary entities are folded into the query string since the MCP server scopes results by single primary entity only.
 
 Surface one line: `Recalled N memories from prior debug sessions on <entity>.` (Skip if N=0.)
 
@@ -35,8 +36,8 @@ Proceed with the diagnostic work. Use recalled procedural memories as a starting
 
 When a root cause is **confirmed** (not just hypothesized), call the memory reflex per `skills/shared/memory-reflex.md`:
 
-- **Episodic** — `pensyve_observe` with the session `episode_id`, `about_entity: <primary_entity>`, `content: "[proactive/in-flight/tier-1] <one-sentence root cause>"`, `content_type: "text"`.
-- **Procedural** — if the debug produced a reusable diagnostic sequence, capture it: `pensyve_observe` with `content: "[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=..."`.
+- **Episodic** — `pensyve_observe` with `episode_id: <session episode_id>`, `source_entity: "claude-code"`, `about_entity: <primary_entity>`, `content: "[proactive/in-flight/tier-1] <one-sentence root cause>"`, `content_type: "text"`.
+- **Procedural** — if the debug produced a reusable diagnostic sequence, capture it: `pensyve_observe` with `episode_id: <session episode_id>`, `source_entity: "claude-code"`, `about_entity: <primary_entity>`, `content: "[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=..."`, `content_type: "text"`.
 - **Semantic** — if the root cause reveals a durable truth (e.g., "our CI runner's Python 3.10 cannot handle the new syntax"), also call `pensyve_remember`.
 
 Surface one line: `↳ captured: <one-sentence>`.

--- a/integrations/claude-code/skills/memory-informed-design/SKILL.md
+++ b/integrations/claude-code/skills/memory-informed-design/SKILL.md
@@ -17,11 +17,12 @@ Identify the relevant entity/entities (service, module, subsystem under design) 
 ### Step 2: Consult memory (required)
 
 Call `pensyve_recall`:
-- `query`: a short description of the design question
+- `query`: a short description of the design question, including secondary entity names where known (e.g., "auth-service jwt signing rs256 hs256")
 - `entity`: primary detected entity
-- `related_entities`: secondary entities
 - `types`: `["semantic", "episodic"]` (design benefits most from durable decisions and prior decision-contexts)
 - `limit`: 5
+
+Secondary entities are folded into the query string since the MCP server scopes results by single primary entity only.
 
 Surface one line: `Recalled N prior decisions on <entity>.` (Skip if N=0.)
 
@@ -36,13 +37,13 @@ Shape your recommendation using the recalled decisions. If the user's current qu
 When the user accepts a design or states a decision ("let's go with X", "we'll use Y"), call the memory reflex:
 
 - **Semantic** — `pensyve_remember` with `entity: <primary_entity>`, `fact: "[proactive/in-flight/tier-1] <decision text>"`, confidence 0.9.
-- **Episodic** — `pensyve_observe` for the decision context (what alternatives were considered, what tipped the balance). This enables future "why did we decide X?" queries.
+- **Episodic** — `pensyve_observe` with `episode_id: <session episode_id>`, `source_entity: "claude-code"`, `about_entity: <primary_entity>`, `content: "[proactive/in-flight/tier-1] <decision context: alternatives considered, what tipped the balance>"`, `content_type: "text"`. This enables future "why did we decide X?" queries.
 
 Surface one line: `↳ captured decision on <entity>: <short>`.
 
 ### Step 5: Capture evaluation procedures
 
-If the design process revealed a reusable way to evaluate similar decisions (e.g., "run spike vs. prototype", "check latency first"), capture it as procedural: `pensyve_observe` with `content: "[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=..."`.
+If the design process revealed a reusable way to evaluate similar decisions (e.g., "run spike vs. prototype", "check latency first"), capture it as procedural: `pensyve_observe` with `episode_id: <session episode_id>`, `source_entity: "claude-code"`, `about_entity: <primary_entity>`, `content: "[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=..."`, `content_type: "text"`.
 
 ## Constraints
 

--- a/integrations/claude-code/skills/memory-informed-design/SKILL.md
+++ b/integrations/claude-code/skills/memory-informed-design/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: memory-informed-design
+description: "Architecture/design decisions with working memory -- before recommending, recall prior decisions and tradeoffs; when a decision is made, capture it immediately. Use for any substantive design question."
+version: 1.0.0
+---
+
+# Memory-Informed Design
+
+Design flow with memory baked in as a non-optional reflex.
+
+## Instructions
+
+### Step 1: Detect entities
+
+Identify the relevant entity/entities (service, module, subsystem under design) per `skills/shared/entity-detection.md`.
+
+### Step 2: Consult memory (required)
+
+Call `pensyve_recall`:
+- `query`: a short description of the design question
+- `entity`: primary detected entity
+- `related_entities`: secondary entities
+- `types`: `["semantic", "episodic"]` (design benefits most from durable decisions and prior decision-contexts)
+- `limit`: 5
+
+Surface one line: `Recalled N prior decisions on <entity>.` (Skip if N=0.)
+
+### Step 3: Recommend with grounding
+
+Shape your recommendation using the recalled decisions. If the user's current question directly contradicts a prior decision, flag it:
+
+> Prior decision on `<entity>` (confidence 0.9): [decision]. Are we revisiting this, or does the current question differ?
+
+### Step 4: Capture decision (when it lands)
+
+When the user accepts a design or states a decision ("let's go with X", "we'll use Y"), call the memory reflex:
+
+- **Semantic** — `pensyve_remember` with `entity: <primary_entity>`, `fact: "[proactive/in-flight/tier-1] <decision text>"`, confidence 0.9.
+- **Episodic** — `pensyve_observe` for the decision context (what alternatives were considered, what tipped the balance). This enables future "why did we decide X?" queries.
+
+Surface one line: `↳ captured decision on <entity>: <short>`.
+
+### Step 5: Capture evaluation procedures
+
+If the design process revealed a reusable way to evaluate similar decisions (e.g., "run spike vs. prototype", "check latency first"), capture it as procedural: `pensyve_observe` with `content: "[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=..."`.
+
+## Constraints
+
+- Recall is **not optional**.
+- Observe when a decision **lands**, not when it's being discussed.
+- Budget: one in-flight capture per turn.
+- Never store secrets or sensitive architecture details the user has marked private.

--- a/integrations/claude-code/skills/memory-informed-longitudinal-work/SKILL.md
+++ b/integrations/claude-code/skills/memory-informed-longitudinal-work/SKILL.md
@@ -19,8 +19,9 @@ Rely on the SessionStart hook's thread-continuity check for the primer. If this 
 When the session pivots to a new sub-topic (new phase, new eval subset, new failure mode), call `pensyve_recall`:
 - `query`: short description of the new sub-topic
 - `entity`: project + sub-topic entity (per `skills/shared/entity-detection.md` canonicalization rules)
-- `types`: `["semantic", "episodic", "procedural"]` (longitudinal work benefits from all three)
 - `limit`: 5
+
+No `types` filter — longitudinal work benefits from all three memory types; omit to query all. (Passing all three explicitly is equivalent to no filter; omitting is cleaner.)
 
 Surface: `Recalled N prior findings on <sub-topic>.`
 

--- a/integrations/claude-code/skills/memory-informed-longitudinal-work/SKILL.md
+++ b/integrations/claude-code/skills/memory-informed-longitudinal-work/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: memory-informed-longitudinal-work
+description: "Long-running multi-session work (research, eval loops, iterative benchmarks) with continuity -- resume prior lessons, capture per-run outcomes, build up stable truths over time. Use for eval/research/benchmark work that spans sessions."
+version: 1.0.0
+---
+
+# Memory-Informed Longitudinal Work
+
+Multi-session engineering work (research, eval loops, iterative benchmarks) where lessons must accumulate across runs. The motivating case: improving a core algorithm over dozens of eval iterations without starting from scratch each session.
+
+## Instructions
+
+### Step 1: Resume context (session start)
+
+Rely on the SessionStart hook's thread-continuity check for the primer. If this session is a continuation, you'll see a concise "Last session lessons" surface. Treat those as working knowledge — do not re-ask the user about things the primer already stated.
+
+### Step 2: Proactively recall per topic shift
+
+When the session pivots to a new sub-topic (new phase, new eval subset, new failure mode), call `pensyve_recall`:
+- `query`: short description of the new sub-topic
+- `entity`: project + sub-topic entity
+- `types`: `["semantic", "episodic", "procedural"]` (longitudinal work benefits from all three)
+- `limit`: 5
+
+Surface: `Recalled N prior findings on <sub-topic>.`
+
+### Step 3: Capture three types of memory per run
+
+During the session, classify emerging knowledge into the three memory types and capture accordingly:
+
+| What you learned | Type | Example |
+|---|---|---|
+| Per-run outcome (what this run showed) | episodic | "Run N+1: V7r accuracy improved +3.5% with new threshold" |
+| Stable truth about the system | semantic | "Haiku classifier plateaus above temp 0.3" |
+| Reusable experiment procedure | procedural | "To calibrate V7r: freeze Haiku config, run suite, diff baseline" |
+
+Apply the memory reflex the moment a finding is confirmed. Do not batch — capture at landing.
+
+For procedural captures: `pensyve_observe` with `content: "[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=..."`.
+
+### Step 4: Capture open questions
+
+When a run ends with an unresolved question ("X improved but we don't know why"), capture it as an episodic observation with open-question provenance:
+
+```
+pensyve_observe(episode_id, about_entity: <entity>,
+               content: "[proactive/in-flight/open-question] <question>",
+               content_type: "text")
+```
+
+This populates the "open questions" surface in the next session's primer.
+
+### Step 5: End-of-session summary
+
+Before Stop fires, briefly summarize (inline, 3-5 lines): what this run taught us vs. prior runs, what's still open. This creates a natural handoff for the next session.
+
+## Constraints
+
+- Recall on every topic shift — not just at session start.
+- Capture at landing, not batch.
+- Respect `max_auto_memories_per_session` — in longitudinal work this can be raised; suggest the user consider 20-30 for heavy eval sessions.
+- Never store run artifacts or large data blobs — summarize.

--- a/integrations/claude-code/skills/memory-informed-longitudinal-work/SKILL.md
+++ b/integrations/claude-code/skills/memory-informed-longitudinal-work/SKILL.md
@@ -18,7 +18,7 @@ Rely on the SessionStart hook's thread-continuity check for the primer. If this 
 
 When the session pivots to a new sub-topic (new phase, new eval subset, new failure mode), call `pensyve_recall`:
 - `query`: short description of the new sub-topic
-- `entity`: project + sub-topic entity
+- `entity`: project + sub-topic entity (per `skills/shared/entity-detection.md` canonicalization rules)
 - `types`: `["semantic", "episodic", "procedural"]` (longitudinal work benefits from all three)
 - `limit`: 5
 

--- a/integrations/claude-code/skills/memory-informed-longitudinal-work/SKILL.md
+++ b/integrations/claude-code/skills/memory-informed-longitudinal-work/SKILL.md
@@ -36,16 +36,20 @@ During the session, classify emerging knowledge into the three memory types and 
 
 Apply the memory reflex the moment a finding is confirmed. Do not batch — capture at landing.
 
-For procedural captures: `pensyve_observe` with `content: "[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=..."`.
+For procedural captures: `pensyve_observe` with `episode_id: <session episode_id>`, `source_entity: "claude-code"`, `about_entity: <relevant entity>`, `content: "[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=..."`, `content_type: "text"`.
 
 ### Step 4: Capture open questions
 
 When a run ends with an unresolved question ("X improved but we don't know why"), capture it as an episodic observation with open-question provenance:
 
 ```
-pensyve_observe(episode_id, about_entity: <entity>,
-               content: "[proactive/in-flight/open-question] <question>",
-               content_type: "text")
+pensyve_observe(
+  episode_id: <session episode_id>,
+  source_entity: "claude-code",
+  about_entity: <entity>,
+  content: "[proactive/in-flight/open-question] <question>",
+  content_type: "text"
+)
 ```
 
 This populates the "open questions" surface in the next session's primer.

--- a/integrations/claude-code/skills/memory-informed-refactor/SKILL.md
+++ b/integrations/claude-code/skills/memory-informed-refactor/SKILL.md
@@ -10,6 +10,8 @@ Load historical context from Pensyve memory before starting a refactor. Surfaces
 
 ## Instructions
 
+> This skill follows the memory reflex defined in `skills/shared/memory-reflex.md`. Recall before refactoring; observe when a refactor insight lands (abandoned approach, invariant discovered, regression cause).
+
 When this skill is invoked with a refactoring target, follow these steps:
 
 ### Step 1: Query Memory for Context
@@ -81,6 +83,17 @@ After presenting the briefing, offer to track the refactor as an episode:
 > If yes, I will call `pensyve_episode_start` with participants `["claude-code", "<target>"]`.
 
 If the user accepts, call `pensyve_episode_start`. Remind the user to close the episode at the end of the refactor (or suggest using `/consolidate` or the session-memory skill).
+
+### Capture refactor lessons as they land
+
+When any of these occur during the refactor, call the memory reflex immediately:
+
+- An invariant is discovered (semantic)
+- An abandoned approach is confirmed not-viable (episodic)
+- A dependency chain was traced that surprised us (episodic)
+- A known-good refactoring sequence emerged (procedural)
+
+Do not batch these to Stop — capture at landing, surface one-line.
 
 ## Constraints
 

--- a/integrations/claude-code/skills/memory-informed-refactor/SKILL.md
+++ b/integrations/claude-code/skills/memory-informed-refactor/SKILL.md
@@ -103,4 +103,3 @@ Do not batch these to Stop — capture at landing, surface one-line.
 - If `pensyve_recall` returns errors on some queries, present results from the successful queries and note the failures.
 - If `pensyve_inspect` fails, skip the entity inspection and rely on recall results.
 - If the MCP server is not connected, inform the user and suggest checking their MCP server configuration.
-- If `pensyve_episode_start` fails when the user accepts tracking, report the error but do not block the refactor.

--- a/integrations/claude-code/skills/memory-informed-refactor/SKILL.md
+++ b/integrations/claude-code/skills/memory-informed-refactor/SKILL.md
@@ -74,15 +74,9 @@ Organize the findings into a structured briefing. Deduplicate results that appea
 
 If no relevant memories are found for a section, omit that section entirely rather than showing an empty one. If no memories are found at all, say so clearly and proceed without historical context.
 
-### Step 4: Offer Episode Tracking
+### Step 4: Episode Tracking
 
-After presenting the briefing, offer to track the refactor as an episode:
-
-> Would you like me to track this refactor as an episode? This will let Pensyve capture the decisions and outcomes from this session for future reference.
->
-> If yes, I will call `pensyve_episode_start` with participants `["claude-code", "<target>"]`.
-
-If the user accepts, call `pensyve_episode_start`. Remind the user to close the episode at the end of the refactor (or suggest using `/consolidate` or the session-memory skill).
+The current session's episode is already active (started by the SessionStart hook). This refactor's observations and any captured lessons will be part of that episode — no additional `pensyve_episode_start` call is needed.
 
 ### Capture refactor lessons as they land
 

--- a/integrations/claude-code/skills/session-memory/SKILL.md
+++ b/integrations/claude-code/skills/session-memory/SKILL.md
@@ -10,6 +10,8 @@ Analyze the current session for memorable decisions, outcomes, and patterns, the
 
 ## Instructions
 
+> **Note:** As of the working-memory substrate update, most memorable items are already captured in-flight during the session by memory-woven skills (memory-informed-debug, memory-informed-design, memory-informed-longitudinal-work) and by the signal buffer's in-flight triggers. This skill handles **residuals** — items that weren't captured in-flight and still deserve to be saved. Before presenting candidates, call `pensyve_inspect` to see what's already been captured this session and skip duplicates.
+
 When this skill is invoked (typically at the end of a coding session), follow these steps:
 
 ### Step 1: Analyze the Session
@@ -39,6 +41,8 @@ Review the current session conversation for three categories of memorable conten
 ### Step 2: Filter for Significance
 
 Skip routine, low-signal content that does not warrant long-term storage:
+
+- **Check for in-flight captures.** Call `pensyve_inspect` scoped to the session's episode (the `episode_id` is in session state). For each candidate, if a memory with score ≥0.85 against the candidate text was already captured in-flight, skip it.
 
 - Simple typo fixes or formatting changes
 - Routine file edits with no architectural significance

--- a/integrations/claude-code/skills/session-memory/SKILL.md
+++ b/integrations/claude-code/skills/session-memory/SKILL.md
@@ -42,7 +42,7 @@ Review the current session conversation for three categories of memorable conten
 
 Skip routine, low-signal content that does not warrant long-term storage:
 
-- **Check for in-flight captures.** Call `pensyve_inspect` scoped to the session's episode (the `episode_id` is in session state). For each candidate, if a memory with score ≥0.85 against the candidate text was already captured in-flight, skip it.
+- **Check for duplicates via recall.** For each candidate, call `pensyve_recall` with `query: <candidate fact text>`, `entity: <candidate's entity>`, `limit: 3`. If any returned memory has a score ≥0.85 against the candidate, skip it as a likely duplicate. Note: `pensyve_inspect` cannot filter by `episode_id` (its params are `entity`, `memory_type?`, `limit?` only), so this dedup check uses semantic similarity against the entity's full memory set rather than true session-scoped filtering. Consequence: very similar items captured in prior sessions will also trigger the skip — acceptable for avoiding genuine duplicates, but may miss newly-phrased variants of old memories.
 
 - Simple typo fixes or formatting changes
 - Routine file edits with no architectural significance

--- a/integrations/claude-code/skills/shared/entity-detection.md
+++ b/integrations/claude-code/skills/shared/entity-detection.md
@@ -1,0 +1,38 @@
+# Entity Detection (Shared Reference)
+
+Shared rules for detecting entity names from tool inputs, prompts, and conversation context. Used by hooks and memory-woven skills to scope recalls and `about_entity` fields on observations.
+
+## Inputs
+
+Extract candidate entity names from:
+
+1. **Tool inputs** — Read/Edit/Write `file_path` parameters; Bash commands that reference specific files, services, or subsystems.
+2. **User prompts** — explicit references to components, files, services, research phases (e.g., "phase-4.3", "v7r-classifier", "auth-service").
+3. **Diffs / code blocks** — module names, class names, function names in recent edits.
+4. **Git context** — branch name, recent commit messages (from SessionStart hook).
+
+## Canonicalization
+
+- Lowercase all characters.
+- Replace spaces and underscores with hyphens.
+- Strip file extensions unless the file is the entity itself (e.g., `package.json`).
+- Collapse paths to the most semantically meaningful segment (e.g., `src/engine/hybrid_router.rs` → `hybrid-router`; `tests/integration/auth_test.py` → `auth`).
+
+## Fallback behavior
+
+- If no specific entity is detected, fall back to the project-level entity (detected from git root or `PENSYVE_NAMESPACE`).
+- If a candidate entity is ambiguous between two names, prefer the one that already has memories in Pensyve (call `pensyve_inspect` with limit 1 to check).
+- Never fabricate entity names. If nothing confident emerges, use the project entity.
+
+## Output
+
+A set of 1–3 candidate entity names per turn. The primary entity is the most specific; secondary entities provide related-entity context for `pensyve_recall`.
+
+## Examples
+
+| Input | Primary entity | Secondary |
+|---|---|---|
+| Edit on `src/engine/hybrid_router.rs` | `hybrid-router` | `engine` |
+| Prompt: "tune V7r noise threshold" | `v7r` | `noise-threshold` |
+| Bash: `cargo test -p pensyve-core` | `pensyve-core` | |
+| Write to `specs/2026-04-18-foo.md` | `foo` | `specs` |

--- a/integrations/claude-code/skills/shared/memory-reflex.md
+++ b/integrations/claude-code/skills/shared/memory-reflex.md
@@ -46,6 +46,20 @@ Do not narrate memory operations the user did not care about (e.g., empty recall
 - Capture: max one in-flight capture per turn; additional candidates go to the Stop residual flush.
 - Noise: respect `max_auto_memories_per_session` from plugin config (default 10).
 
+### Relationship to UserPromptSubmit enrichment
+
+When `prompt_enrichment` is on, UserPromptSubmit may have already injected scoped memory context before your turn. Your skill's own recall is **additive**, not redundant: your skill uses `types` hints and entity scoping that the hook enrichment cannot. If the two sets overlap, dedupe visible surfaces — only surface your skill's recall (one line) to the user, not both.
+
+## In-flight trigger consumption
+
+The post-tool-bash and post-tool-write-edit hooks buffer signals with strength scores and, when the accumulated strength in the last 5 turns reaches ≥4 with at least one strength-3 signal, emit an `in_flight_trigger` marker (`type: "in_flight_trigger"`, `should_capture: true`) in the local signal buffer.
+
+Memory-woven skills check for this marker before each substantive turn. When the marker is present AND a candidate lesson has landed in the conversation, the skill captures the candidate **immediately** rather than deferring based on its own heuristics alone. If no candidate has landed, the marker does not force capture — it just raises the priority.
+
+The marker is consumed (cleared) after any skill acts on it. If no skill acts within 2 turns, the hook re-emits on the next crossing.
+
+This is how the platform layer (hooks) and reasoning layer (skills) cooperate: hooks provide the signal-strength signal; skills decide whether a concrete lesson has landed worth capturing.
+
 ## Composition
 
 When a capture is both procedural AND a proactive in-flight write, the `content` field begins with both markers, `[procedural]` first, then the provenance tag. Example:
@@ -67,4 +81,5 @@ Examples:
 - `[auto-capture/stop/residual/tier-1]` — Stop hook residual flush, high-confidence
 - `[auto-capture/stop/residual/tier-2]` — Stop hook residual flush, medium-confidence
 - `[auto-capture/pre-compact/residual/tier-1]` — pre-compact flush, high-confidence
+- `[auto-capture/pre-compact/residual/tier-2]` — pre-compact flush, medium-confidence (handed off to Stop for review)
 - `[proactive/in-flight/open-question]` — open question captured in-flight

--- a/integrations/claude-code/skills/shared/memory-reflex.md
+++ b/integrations/claude-code/skills/shared/memory-reflex.md
@@ -1,0 +1,55 @@
+# Memory Reflex Rule (Shared Reference)
+
+Every memory-woven skill includes this reflex. It turns memory operations from optional steps into a reasoning discipline the model carries through every substantive flow.
+
+## The rule
+
+**Before substantive answers, recall by entity. When a lesson lands, observe immediately with a one-line surface.**
+
+### "Substantive answer" means
+
+- Design or architecture recommendations
+- Debugging diagnoses with root-cause claims
+- Refactor proposals
+- Any response that makes a claim the user would want grounded in prior work
+
+Not substantive: formatting fixes, trivial lookups, reading a file, running a command.
+
+### "Lesson lands" means
+
+- A root cause has been confirmed (not hypothesized).
+- A design choice has been made explicit ("we'll use X because Y").
+- An approach has been tried and abandoned with a reason.
+- A workflow has been discovered that is reusable.
+- A workaround for a framework/library limitation has been validated.
+
+## Classification (which memory type?)
+
+- **Semantic** — a fact that will still be true next month. Use `pensyve_remember` (default type; no server-side procedural support today).
+- **Episodic** — something that happened in this thread of work. Use `pensyve_observe` with the current `episode_id`.
+- **Procedural** — a reusable way to do something (a workflow, sequence, recipe). Per the Task 1 spec addendum, use `pensyve_observe` with content beginning `[procedural]` (integration-layer convention; no server-side contract).
+
+When in doubt, prefer episodic. Consolidation will promote recurring patterns to semantic automatically.
+
+## Surface style
+
+Lightly visible. One line when memory is used. Examples:
+
+- Recall: `Recalled 4 related memories (v7r, haiku-classifier).`
+- Capture: `↳ captured: hybrid-router threshold was the phase-3 regression root cause.`
+
+Do not narrate memory operations the user did not care about (e.g., empty recalls, duplicate-skips).
+
+## Scope and budgets
+
+- Recall: scoped to detected entities per `skills/shared/entity-detection.md`; limit 5; types hint per flow.
+- Capture: max one in-flight capture per turn; additional candidates go to the Stop residual flush.
+- Noise: respect `max_auto_memories_per_session` from plugin config (default 10).
+
+## Composition
+
+When a capture is both procedural AND a proactive in-flight write, the `content` field begins with both markers, `[procedural]` first, then the provenance tag. Example:
+
+`[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=...`
+
+The `[procedural]` marker identifies the memory type for consolidation. The provenance tag identifies origin and trigger.

--- a/integrations/claude-code/skills/shared/memory-reflex.md
+++ b/integrations/claude-code/skills/shared/memory-reflex.md
@@ -31,6 +31,22 @@ Not substantive: formatting fixes, trivial lookups, reading a file, running a co
 
 When in doubt, prefer episodic. Consolidation will promote recurring patterns to semantic automatically.
 
+### Canonical `pensyve_observe` call template
+
+All `pensyve_observe` calls — in-flight, residual, or procedural — must include **all required fields**:
+
+```
+pensyve_observe(
+  episode_id: <current session's episode_id>,
+  content: "[proactive/in-flight/tier-1] <observation text>",
+  source_entity: "claude-code",
+  about_entity: "<relevant entity, e.g. 'hybrid-router'>",
+  content_type: "text"  # or "code" for code-related outcomes
+)
+```
+
+`source_entity` and `about_entity` are **required** by the MCP server (`ObserveParams`). Omitting either will cause the call to fail silently. `source_entity` is always `"claude-code"` for plugin-originated observations. `about_entity` is the lowercase-hyphenated entity the observation is about.
+
 ## Surface style
 
 Lightly visible. One line when memory is used. Examples:

--- a/integrations/claude-code/skills/shared/memory-reflex.md
+++ b/integrations/claude-code/skills/shared/memory-reflex.md
@@ -53,3 +53,18 @@ When a capture is both procedural AND a proactive in-flight write, the `content`
 `[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=...`
 
 The `[procedural]` marker identifies the memory type for consolidation. The provenance tag identifies origin and trigger.
+
+## Provenance tag vocabulary (canonical)
+
+All provenance tags across hooks and skills use the format `[<origin>/<trigger>/<tier>]`:
+
+- **origin:** `proactive` (in-flight from reasoning layer) or `auto-capture` (hook-driven residual)
+- **trigger:** `in-flight`, `stop`, `pre-compact`, `curator`, `user`
+- **tier:** `tier-1`, `tier-2`, `residual`, `open-question`
+
+Examples:
+- `[proactive/in-flight/tier-1]` — memory-woven skill captured during reasoning
+- `[auto-capture/stop/residual/tier-1]` — Stop hook residual flush, high-confidence
+- `[auto-capture/stop/residual/tier-2]` — Stop hook residual flush, medium-confidence
+- `[auto-capture/pre-compact/residual/tier-1]` — pre-compact flush, high-confidence
+- `[proactive/in-flight/open-question]` — open question captured in-flight


### PR DESCRIPTION
## Summary

- Turns the Pensyve Claude Code plugin into an **ambient working-memory substrate** — memory is no longer a feature you invoke, it's the substrate the agent operates on.
- Proactive episodic captures happen **in-flight** during the session, not only at `Stop`.
- Recalls are woven into the reasoning loop via three new memory-woven skill templates + a shared memory reflex rule.
- Sessions that continue prior work resume with a relevant primer (thread-aware continuity).
- First-class support for all three memory types: semantic, episodic, procedural.

## Design + plan

- **Spec:** `pensyve-docs/specs/2026-04-18-pensyve-working-memory-substrate-design.md` (includes Task 1 implementation addendum resolving the procedural-write contract → decision (c): `pensyve_observe` with `[procedural]` content prefix, integration-layer convention, no server-side changes)
- **Plan:** `pensyve-docs/plans/2026-04-18-pensyve-claude-code-working-memory.md` (24 tasks; T1–T19 + T24 implemented in this PR; T20–T23 are manual integration scenarios scheduled post-merge)

## What changed

**Hooks (6)**
- `post-tool-write-edit.md` + `post-tool-bash.md` — score signal strength, emit `in_flight_trigger` markers when accumulated strength ≥4 with at least one strength-3 signal in the last 5 turns
- `session-start.md` — scoped recall + thread-continuity check; primer shape depends on whether session continues a prior episode; `pensyve_episode_start` with `continuation_of` when applicable
- `user-prompt-submit.md` — prompt enrichment is now **default-on** with guardrails (<1s budget, scored threshold, prompt-heuristic filter, max 5 memories)
- `stop.md` — narrowed to residual-flush role; in-flight captures handle the primary write path
- `pre-compact.md` — mirrors Stop's three-type tier-1 taxonomy; preserves episode across compaction

**Skills (7)**
- New: `memory-informed-debug`, `memory-informed-design`, `memory-informed-longitudinal-work`
- New shared refs: `skills/shared/entity-detection.md`, `skills/shared/memory-reflex.md`
- Updated: `memory-informed-refactor`, `session-memory`, `context-loader`

**Agents (1)**
- `memory-curator` narrowed to `"confirm-all"` mode / explicit invocation — in-flight captures are the primary path now

**Docs (2)**
- `README.md` — new "Memory Behavior Model" section; updated skills table; opt-out messaging
- `pensyve-plugin.local.md` — new defaults (`prompt_enrichment: true`), migration-from-v1.x section

## Provenance tags (formalized)

Canonical format: \`[<origin>/<trigger>/<tier>]\` where origin ∈ {\`proactive\`, \`auto-capture\`}, trigger ∈ {\`in-flight\`, \`stop\`, \`pre-compact\`, \`curator\`, \`user\`}, tier ∈ {\`tier-1\`, \`tier-2\`, \`residual\`, \`open-question\`}. For procedural captures, `[procedural]` precedes the provenance tag.

## Review findings addressed pre-merge

Branch-wide review surfaced **4 Important + 5 Minor** findings — all fixed in commits \`ba612f0\` (important) and \`2fddb61\` (minor). Notable: `in_flight_trigger` marker now has a documented consumer in `memory-reflex.md`; pre-compact tier-1 flush mirrors Stop's three-type taxonomy; Stop scans for `[tier-2-pending]` items from pre-compact handoff; stale `auto_capture: true` (boolean) references removed from `memory-curator`.

## Test plan

- [ ] Merge; update Pensyve plugin in Claude Code
- [ ] **T20 — thread continuity:** run 2 sessions in a project with Pensyve memories; confirm session 2 resumes with continuation primer + `continuation_of` on episode
- [ ] **T21 — in-flight capture:** debug a known failure; confirm `↳ captured:` surface + `[proactive/in-flight/tier-1]` observation in Pensyve at root-cause confirmation
- [ ] **T22 — proactive recall + silence on routine:** substantive prompt surfaces `Recalled N memories`; routine commands stay quiet
- [ ] **T23 — all three memory types:** one session produces semantic + episodic + procedural (`[procedural]` prefix) captures
- [ ] Record pass/fail per scenario at `/tmp/pensyve-validation/scenario-N.txt`
- [ ] On pass: add validation addendum to the spec + update PROGRESS.md status from `IN PROGRESS` to the final commit SHA

## Follow-ups (sibling plans)

- Automated behavioral eval harness (replay + continuity + noise + cross-integration conformance)
- Cursor adapter · Cline adapter · LangChain / Pydantic AI / CrewAI library integrations · long-tail integrations (Neovim, Kiro, Windsurf, etc.)