### PR TITLE
feat: working-memory substrate rollout to all 21 integrations (Cursor + 20 others)

### DIFF
--- a/integrations/amazon-q/.amazonq/mcp.json.example
+++ b/integrations/amazon-q/.amazonq/mcp.json.example
@@ -1,0 +1,14 @@
+{
+  "_comment": "Pensyve MCP configuration for Amazon Q Developer. Copy to .amazonq/mcp.json in your project root or home directory. Choose Cloud or Local below.",
+
+  "mcpServers": {
+    "pensyve": {
+      "_comment_cloud": "Cloud (recommended) — requires PENSYVE_API_KEY env var. Get a key at https://pensyve.com/settings/api-keys",
+      "type": "http",
+      "url": "https://mcp.pensyve.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ${PENSYVE_API_KEY}"
+      }
+    }
+  }
+}

--- a/integrations/amazon-q/.amazonq/mcp.json.local.example
+++ b/integrations/amazon-q/.amazonq/mcp.json.local.example
@@ -1,0 +1,14 @@
+{
+  "_comment": "Local (offline) Pensyve MCP configuration for Amazon Q Developer. No API key needed — all data stays on your machine. Build from source: cargo build --release -p pensyve-mcp",
+
+  "mcpServers": {
+    "pensyve": {
+      "command": "pensyve-mcp",
+      "args": ["--stdio"],
+      "env": {
+        "PENSYVE_PATH": "~/.pensyve/",
+        "PENSYVE_NAMESPACE": "default"
+      }
+    }
+  }
+}

--- a/integrations/amazon-q/.amazonq/rules/context-loader.md
+++ b/integrations/amazon-q/.amazonq/rules/context-loader.md
@@ -1,0 +1,72 @@
+# Context Loader (Continuity Primer)
+
+description: Use when starting a new substantive conversation or switching contexts — load relevant memories to prime the session with continuity
+
+Amazon Q has no automatic SessionStart hook. This rule is the manual equivalent: when starting a new conversation on a project that has prior Pensyve memories, call recall to prime the session with relevant context.
+
+Follows `memory-reflex.md`. Best-effort thread continuity via episodic recall (the MCP server has no episode-listing tool; see the main spec's Task C addendum for background).
+
+## Instructions
+
+### Step 1: Detect project entity
+
+Per `entity-detection.md` fallback rules: use the repository root name (lowercase-hyphenated) as the default project entity. Override with `PENSYVE_NAMESPACE` environment variable if explicitly set in the project's environment.
+
+### Step 2: Scoped recall
+
+Call `pensyve_recall`:
+
+- `query`: `"recent decisions issues patterns"` + any key terms from the user's opening message
+- `entity`: detected project entity
+- `types`: `["episodic"]` — recent session activity gives the best continuity signal
+- `limit`: 5
+
+Episodic memories are ranked by the MCP server's activation signal, which naturally surfaces recent observations first.
+
+### Step 3: Compute continuity signal
+
+Examine the returned observations:
+
+- If ≥70% of the top observations reference at least one entity that overlaps with the current conversation's entity candidates (from Step 1 plus any entities mentioned in the opening message), treat the session as a **continuation** of recent work.
+- If the overlap is below 70%, or recall returned empty, treat as a **fresh session**.
+
+### Step 4: Surface the primer
+
+**Continuation:**
+
+> **Pensyve:** Continuing prior work on `<entity-set>`. Recent lessons:
+>
+> - <observation 1>
+> - <observation 2>
+> - <observation 3>
+>
+> Use `/recall <query>` or ask about any of these to dig deeper.
+
+**Fresh session:**
+
+> **Pensyve:** N memories loaded for `<project>`. Key context:
+>
+> - <top 3 observations>
+>
+> Use `/recall <query>` to search for specific memories.
+
+**No memories found:**
+
+> **Pensyve:** No memories found for `<project>`. Use `/remember` to start building context.
+
+### Step 5: Continuity is best-effort, not a structured link
+
+The MCP server has no episode-listing or date-filtering API. This rule infers continuity from shared-entity overlap and recall-ranking recency. Consequences:
+
+- There is no persisted server-side link between sessions.
+- Primer accuracy depends on memory quality and recall ranking.
+- The user may occasionally see "Continuing prior work" when it's actually loosely related; or see a fresh-session primer when the prior session was related but the entity overlap was low.
+
+Document this honestly in the primer when uncertain — do not fabricate continuity.
+
+## Constraints
+
+- Do not fabricate memories. Only display what `pensyve_recall` returns.
+- If MCP is unavailable, skip the primer silently and mention the failure once per conversation if the user asks about memory.
+- Maximum 5 memories in the primer to avoid context bloat.
+- Entity names lowercase-hyphenated.

--- a/integrations/amazon-q/.amazonq/rules/entity-detection.md
+++ b/integrations/amazon-q/.amazonq/rules/entity-detection.md
@@ -1,0 +1,40 @@
+# Entity Detection (Always-Apply Reference)
+
+description: Pensyve entity detection — canonicalization and fallback rules for recall scoping
+
+Shared rules for detecting entity names from tool inputs, prompts, and conversation context. Used by the memory reflex and all memory-woven flows to scope recalls and `about_entity` fields on observations.
+
+## Inputs
+
+Extract candidate entity names from:
+
+1. **File references** — `@filename`, `@path/to/file`, or files mentioned directly in the conversation.
+2. **User prompts** — explicit references to components, files, services, research phases (e.g., "phase-4.3", "v7r-classifier", "auth-service").
+3. **Code context** — module names, class names, function names in files you are editing or reading.
+4. **Git context** — repository root name, branch name (when discoverable).
+
+## Canonicalization
+
+- Lowercase all characters.
+- Replace spaces and underscores with hyphens.
+- Strip file extensions unless the file is the entity itself (e.g., `package.json`).
+- Collapse paths to the most semantically meaningful segment (e.g., `src/engine/hybrid_router.rs` → `hybrid-router`; `tests/integration/auth_test.py` → `auth`).
+
+## Fallback behavior
+
+- If no specific entity is detected, fall back to the project-level entity (repository root name, lowercase-hyphenated).
+- If a candidate entity is ambiguous between two names, prefer the one that already has memories in Pensyve (call `pensyve_inspect` with limit 1 to check).
+- **Never fabricate entity names.** If nothing confident emerges, use the project entity.
+
+## Output
+
+A set of 1–3 candidate entity names per turn. The primary entity is the most specific; secondary entities provide additional context. Since `pensyve_recall` accepts only a single `entity` parameter, fold secondary entities into the `query` string instead.
+
+## Examples
+
+| Input | Primary entity | Secondary (fold into query) |
+|---|---|---|
+| Edit on `src/engine/hybrid_router.rs` | `hybrid-router` | `engine` |
+| Prompt: "tune V7r noise threshold" | `v7r` | `noise-threshold` |
+| File `tests/test_auth.py` in a project named `auth-service` | `auth` | `auth-service` |
+| User mentions "phase-4.3 calibration" | `phase-4.3` | `calibration` |

--- a/integrations/amazon-q/.amazonq/rules/memory-informed-debug.md
+++ b/integrations/amazon-q/.amazonq/rules/memory-informed-debug.md
@@ -1,0 +1,66 @@
+# Memory-Informed Debug
+
+description: Use when diagnosing bugs, errors, failing tests, or crashes — consult prior debug outcomes and capture root causes in-flight
+
+Debugging flow with memory baked in as a non-optional reflex. Follows `memory-reflex.md` for classification, surface style, and episode lifecycle.
+
+## Instructions
+
+### Step 1: Detect entities
+
+Identify the relevant entity/entities (failing test, failing module, error source) per `entity-detection.md`.
+
+### Step 2: Consult memory (required)
+
+Call `pensyve_recall`:
+
+- `query`: a short description of the failure, including secondary entity names where known (e.g., "hybrid-router threshold regression phase-4.3" rather than full stack traces)
+- `entity`: primary detected entity
+- `types`: `["procedural", "episodic"]` (debugging benefits most from known-good diagnostic procedures and prior incident outcomes)
+- `limit`: 5
+
+Secondary entities are folded into the query string since `RecallParams` scopes by a single `entity` only.
+
+Surface one line: `Recalled N memories from prior debug sessions on <entity>.` (Skip if N=0.)
+
+If a highly similar incident is found (score >0.8), call that out inline: `This looks similar to an incident captured on <date>: <summary>. Consider that path first.`
+
+### Step 3: Diagnose
+
+Proceed with the diagnostic work. Use recalled procedural memories as a starting sequence; update the sequence when you learn something new.
+
+### Step 4: Capture lesson (when it lands)
+
+When a root cause is **confirmed** (not just hypothesized), apply the memory reflex per `memory-reflex.md`:
+
+Ensure a working `episode_id` exists (lazy-open via `pensyve_episode_start` if not). Then:
+
+- **Episodic root cause:** call `pensyve_observe` with `content: "[proactive/in-flight/tier-1] <one-sentence root cause>"`, `source_entity: "amazon-q"`, `about_entity: <primary_entity>`, `content_type: "text"`.
+- **Procedural diagnostic sequence:** if the debug produced a reusable diagnostic sequence, call `pensyve_observe` with `content: "[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=..."`, `source_entity: "amazon-q"`, `about_entity: <primary_entity>`, `content_type: "text"`.
+- **Semantic durable truth:** if the root cause reveals a durable truth, also call `pensyve_remember(entity, fact, confidence: 0.9)`. Include provenance in the fact text: `"[proactive/in-flight/tier-1] <fact>"`.
+
+Surface one line: `↳ captured: <one-sentence>`.
+
+### Step 5: Capture abandoned approach
+
+If an approach was tried and abandoned, observe that too:
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[proactive/in-flight/tier-1] tried <approach>, abandoned because <reason>",
+  source_entity: "amazon-q",
+  about_entity: <primary_entity>,
+  content_type: "text"
+)
+```
+
+These are high-value — they prevent re-treading the same dead end next time.
+
+## Constraints
+
+- Recall is **not optional**. If you skip recall to save time, you defeat the working-memory substrate.
+- Observe when a lesson **lands**, not when you first hypothesize.
+- One in-flight capture per turn unless multiple distinct lessons land simultaneously.
+- Respect the reflex rule's surface style — one line, not paragraphs.
+- Never store secrets or sensitive paths.

--- a/integrations/amazon-q/.amazonq/rules/memory-informed-design.md
+++ b/integrations/amazon-q/.amazonq/rules/memory-informed-design.md
@@ -1,0 +1,58 @@
+# Memory-Informed Design
+
+description: Use when making architecture, API, or design decisions — consult prior decisions and capture new ones in-flight
+
+Design flow with memory baked in as a non-optional reflex. Follows `memory-reflex.md`.
+
+## Instructions
+
+### Step 1: Detect entities
+
+Identify the relevant entity/entities (service, module, subsystem under design) per `entity-detection.md`.
+
+### Step 2: Consult memory (required)
+
+Call `pensyve_recall`:
+
+- `query`: a short description of the design question, including secondary entity names where known (e.g., "auth-service jwt signing rs256 hs256")
+- `entity`: primary detected entity
+- `types`: `["semantic", "episodic"]` (design benefits most from durable decisions and prior decision-contexts)
+- `limit`: 5
+
+Surface one line: `Recalled N prior decisions on <entity>.` (Skip if N=0.)
+
+### Step 3: Recommend with grounding
+
+Shape your recommendation using the recalled decisions. If the user's current question directly contradicts a prior decision, flag it:
+
+> Prior decision on `<entity>` (confidence 0.9): [decision]. Are we revisiting this, or does the current question differ?
+
+### Step 4: Capture decision (when it lands)
+
+When the user accepts a design or states a decision ("let's go with X", "we'll use Y"), apply the memory reflex:
+
+- **Semantic** — `pensyve_remember(entity: <primary_entity>, fact: "[proactive/in-flight/tier-1] <decision text>", confidence: 0.9)`.
+- **Episodic context** — ensure working `episode_id`; `pensyve_observe` with `content: "[proactive/in-flight/tier-1] Decision on <entity>: chose X over Y because Z"`, `source_entity: "amazon-q"`, `about_entity: <primary_entity>`, `content_type: "text"`. This enables future "why did we decide X?" queries.
+
+Surface one line: `↳ captured decision on <entity>: <short>`.
+
+### Step 5: Capture evaluation procedures
+
+If the design process revealed a reusable way to evaluate similar decisions (e.g., "run spike vs. prototype", "check latency first"), capture it as procedural:
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[procedural] [proactive/in-flight/tier-1] trigger=design-question-on-<area>, action=<steps>, outcome=<what-you-learn>",
+  source_entity: "amazon-q",
+  about_entity: <primary_entity>,
+  content_type: "text"
+)
+```
+
+## Constraints
+
+- Recall is **not optional**.
+- Observe when a decision **lands**, not when it's being discussed.
+- Budget: one in-flight capture per turn unless multiple decisions land.
+- Never store secrets or sensitive architecture details the user has marked private.

--- a/integrations/amazon-q/.amazonq/rules/memory-informed-longitudinal-work.md
+++ b/integrations/amazon-q/.amazonq/rules/memory-informed-longitudinal-work.md
@@ -1,0 +1,66 @@
+# Memory-Informed Longitudinal Work
+
+description: Long-running multi-session work (research, eval loops, iterative benchmarks) — resume prior lessons, capture per-run outcomes, build up stable truths over time
+
+Multi-session engineering work (research, eval loops, iterative benchmarks) where lessons must accumulate across runs. The motivating case: improving a core algorithm over dozens of eval iterations without starting from scratch each session.
+
+Follows `memory-reflex.md`. Activates when editing files under `research/`, `benchmarks/`, or `evals/`, or when the model judges the conversation to be research-oriented.
+
+## Instructions
+
+### Step 1: Resume context at conversation start
+
+If this conversation is in a research/eval context, call `pensyve_recall` once at the start:
+
+- `query`: short description of the current research area (e.g., "v7r classifier calibration")
+- `entity`: project + sub-topic entity (per `entity-detection.md` canonicalization rules)
+- `limit`: 5
+
+No `types` filter — longitudinal work benefits from all three memory types; omit to query all.
+
+Surface: `Recalled N prior findings on <sub-topic>.`
+
+Treat the returned observations as working knowledge — do not re-ask the user about things the recall already surfaces.
+
+### Step 2: Proactively recall per topic shift
+
+When the session pivots to a new sub-topic (new phase, new eval subset, new failure mode), call `pensyve_recall` again scoped to the new sub-topic.
+
+### Step 3: Capture three types of memory per run
+
+During the session, classify emerging knowledge and capture accordingly. Ensure working `episode_id` before each observe.
+
+| What you learned | Type | MCP call |
+|---|---|---|
+| Per-run outcome (what this run showed) | episodic | `pensyve_observe(..., content: "[proactive/in-flight/tier-1] Run N+1: V7r accuracy improved +3.5% with new threshold", source_entity: "amazon-q", about_entity: <entity>, content_type: "text")` |
+| Stable truth about the system | semantic | `pensyve_remember(entity, fact: "[proactive/in-flight/tier-1] Haiku classifier plateaus above temp 0.3", confidence: 0.9)` |
+| Reusable experiment procedure | procedural | `pensyve_observe(..., content: "[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=...", source_entity: "amazon-q", about_entity: <entity>, content_type: "text")` |
+
+Apply at landing — do not batch.
+
+### Step 4: Capture open questions
+
+When a run ends with an unresolved question ("X improved but we don't know why"), capture it as an episodic observation with open-question provenance:
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[proactive/in-flight/open-question] <question>",
+  source_entity: "amazon-q",
+  about_entity: <entity>,
+  content_type: "text"
+)
+```
+
+This populates future "open questions" surfacing when the topic returns.
+
+### Step 5: End-of-session summary
+
+Before the conversation wraps, briefly summarize (inline, 3-5 lines): what this run taught us vs. prior runs, what's still open. This creates a natural handoff for the next session.
+
+## Constraints
+
+- Recall on every topic shift — not just at conversation start.
+- Capture at landing, not batched.
+- Never store run artifacts or large data blobs — summarize.
+- Respect the reflex's surface style.

--- a/integrations/amazon-q/.amazonq/rules/memory-informed-refactor.md
+++ b/integrations/amazon-q/.amazonq/rules/memory-informed-refactor.md
@@ -1,0 +1,57 @@
+# Memory-Informed Refactor
+
+description: Use before substantive refactors — load relevant prior context, capture refactor insights as they land
+
+Refactor flow with memory baked in. Follows `memory-reflex.md`.
+
+## Instructions
+
+### Step 1: Detect entities
+
+Identify the entities touched by the refactor (the file or module being restructured, its callers, the subsystem name) per `entity-detection.md`.
+
+### Step 2: Load prior context (required)
+
+Call `pensyve_recall`:
+
+- `query`: short description of the refactor (e.g., "hybrid-router routing logic restructure")
+- `entity`: primary detected entity
+- `types`: `["semantic", "episodic", "procedural"]` — refactors benefit from all three (durable invariants, prior attempts, known-good sequences)
+- `limit`: 5
+
+Surface: `Recalled N prior memories on <entity>.` (Skip if N=0.)
+
+Highlight any prior failed approaches inline:
+
+> Prior episodic memory (confidence 0.8): tried <approach> on <date>, abandoned because <reason>. Double-check this isn't the same trap.
+
+### Step 3: Present a briefing
+
+Before starting the refactor, briefly summarize what the prior memories say about:
+
+- **Decisions** — durable choices that constrain the refactor (semantic)
+- **Prior attempts** — what's been tried (episodic)
+- **Known-good procedures** — reusable sequences for this kind of refactor (procedural)
+
+If no relevant memories exist, say so clearly and proceed without historical context.
+
+### Step 4: Capture refactor lessons as they land
+
+When any of these occur during the refactor, apply the memory reflex immediately:
+
+- **An invariant is discovered** (semantic) — `pensyve_remember(entity, fact, confidence: 0.9)`
+- **An abandoned approach is confirmed not-viable** (episodic) — `pensyve_observe` with `[proactive/in-flight/tier-1]` provenance
+- **A dependency chain was traced that surprised us** (episodic) — `pensyve_observe`
+- **A known-good refactoring sequence emerged** (procedural) — `pensyve_observe` with `[procedural]` prefix
+
+Ensure working `episode_id` before each observe; lazy-open if needed.
+
+Do not batch these to end-of-session — capture at landing, surface one-line.
+
+## Constraints
+
+- The briefing step is the real value — it informs the refactor.
+- Observe at landing, not batched.
+- Entity names lowercase-hyphenated.
+- Do not start the refactor itself — this rule provides guidance and capture. The user decides when and how to proceed.
+- If the MCP server returns errors on some queries, present results from the successful queries and note the failures.

--- a/integrations/amazon-q/.amazonq/rules/memory-reflex.md
+++ b/integrations/amazon-q/.amazonq/rules/memory-reflex.md
@@ -1,0 +1,98 @@
+# Memory Reflex Rule (Always-Apply)
+
+description: Pensyve memory reflex — the non-optional reasoning discipline for working-memory substrate
+
+This rule is always in context. It turns Pensyve memory operations from optional actions into a reasoning discipline you carry through every substantive turn.
+
+## The rule
+
+**Before substantive answers, recall by entity. When a lesson lands, observe immediately with a one-line surface.**
+
+### "Substantive answer" means
+
+- Design or architecture recommendations
+- Debugging diagnoses with root-cause claims
+- Refactor proposals
+- Any response that makes a claim the user would want grounded in prior work
+
+Not substantive: formatting fixes, trivial lookups, reading a file, running a command.
+
+### "Lesson lands" means
+
+- A root cause has been confirmed (not hypothesized).
+- A design choice has been made explicit ("we'll use X because Y").
+- An approach has been tried and abandoned with a reason.
+- A workflow has been discovered that is reusable.
+- A workaround for a framework/library limitation has been validated.
+
+## Classification (which memory type?)
+
+- **Semantic** — a fact that will still be true next month. Use `pensyve_remember(entity, fact, confidence?)` (confidence defaults to 1.0; use 0.9 for high-confidence auto-captures).
+- **Episodic** — something that happened in this thread of work. Use `pensyve_observe` with the current `episode_id`.
+- **Procedural** — a reusable way to do something (a workflow, sequence, recipe). Use `pensyve_observe` with `content` beginning `[procedural]` (integration-layer convention; the MCP server has no native procedural-write API).
+
+When in doubt, prefer episodic. Server-side consolidation promotes recurring patterns to semantic automatically.
+
+## Canonical `pensyve_observe` call template
+
+ALL observe calls — in-flight, procedural, or wrap-up — MUST include every required field:
+
+```
+pensyve_observe(
+  episode_id: <current session's working episode_id>,
+  content: "[proactive/in-flight/tier-1] <observation text>",
+  source_entity: "amazon-q",
+  about_entity: "<relevant entity, lowercase-hyphenated>",
+  content_type: "text"
+)
+```
+
+Use `content_type: "code"` for code-related outcomes.
+
+## Episode lifecycle (lazy-open)
+
+Amazon Q has no session-start/session-end hooks, so you own the episode lifecycle:
+
+- **Before your first `pensyve_observe` call in this conversation**, check whether a working `episode_id` is already tracked. If none exists, call `pensyve_episode_start(participants: ["amazon-q", "<project entity>"])` first, record the returned `episode_id`, then make the observation.
+- **Reuse the same `episode_id`** for all subsequent observations in the same conversation. Open a new episode only when the work's topic shifts substantially.
+- **Do not explicitly close** the episode under normal operation. Server-side consolidation handles aging.
+- **Recovery**: if `pensyve_observe` fails with a missing-episode error, call `pensyve_episode_start` and retry.
+
+## Surface style
+
+Lightly visible. One line when memory is used. Examples:
+
+- Recall: `Recalled 4 related memories (v7r, haiku-classifier).`
+- Capture: `↳ captured: hybrid-router threshold was the phase-3 regression root cause.`
+
+Do not narrate empty recalls or duplicate-skips.
+
+## Scope and budgets
+
+- Recall: scoped to detected entities (see `entity-detection.md`); limit 5; use `types` hint per flow.
+- Capture: one observation per substantive lesson; reuse the working `episode_id`.
+- Noise: avoid surfacing memory operations the user did not care about.
+
+## Composition with provenance tags
+
+When a capture is both procedural AND a proactive in-flight write, the `content` field begins with both markers, `[procedural]` first, then the provenance tag, then content:
+
+`[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=...`
+
+The `[procedural]` marker identifies the memory type for consolidation. The provenance tag identifies origin and trigger.
+
+## Provenance tag vocabulary
+
+- `[proactive/in-flight/tier-1]` — memory reflex captured during reasoning
+- `[proactive/in-flight/open-question]` — unresolved question noted in-flight
+- `[auto-capture/user/residual/tier-1]` — explicit user-driven capture (e.g., session-memory rule)
+
+## MCP contract reminder
+
+Rules never pass unsupported parameters. The MCP tool schemas are:
+
+- `pensyve_recall(query, entity?, types?, limit?, min_confidence?)` — **no** `related_entities`
+- `pensyve_episode_start(participants)` — **no** `continuation_of`
+- `pensyve_observe(episode_id, content, source_entity, about_entity, content_type?)` — `source_entity` and `about_entity` are **required**
+
+If you need secondary-entity context in a recall, fold those entities into the `query` string.

--- a/integrations/amazon-q/.amazonq/rules/session-memory.md
+++ b/integrations/amazon-q/.amazonq/rules/session-memory.md
@@ -1,0 +1,82 @@
+# Session Memory (Wrap-Up)
+
+description: Use at conversation wrap-up or when the user explicitly indicates end-of-session — capture residual lessons not captured in-flight
+
+Amazon Q has no automatic Stop hook. This rule is the manual equivalent: when the user indicates the conversation is ending ("thanks, that's all", "session wrap-up", "we're done here"), review what happened and capture anything the in-flight reflex missed.
+
+Follows `memory-reflex.md`.
+
+## Instructions
+
+### Step 1: Review the conversation
+
+Scan the current conversation for three categories of memorable content that the in-flight reflex did NOT already capture:
+
+**Decisions** (confidence: 0.9):
+- Architecture or design choices
+- Technology selections
+- API design decisions
+- Tradeoff resolutions
+
+**Outcomes** (confidence: 0.8):
+- Bug fixes and their root causes
+- Successful approaches
+- Failed approaches with reasons
+- Performance findings
+
+**Patterns** (confidence: 0.7):
+- Recurring issues
+- Workflow discoveries
+- Cross-cutting observations
+
+### Step 2: Filter for significance and deduplicate
+
+Skip routine, low-signal content. Also skip anything that was already captured in-flight.
+
+For each candidate, call `pensyve_recall` with `query: <candidate fact text>`, `entity: <candidate's entity>`, `limit: 3`. If any returned memory has a score ≥0.85 against the candidate, skip it as a likely duplicate.
+
+Note: `pensyve_inspect` cannot filter by `episode_id` (its params are `entity`, `memory_type?`, `limit?` only), so dedup is entity-scoped semantic-similarity rather than session-scoped.
+
+### Step 3: Present candidates for confirmation
+
+Show the filtered candidates to the user in a structured format:
+
+> **Session Memory Candidates**
+>
+> **Decisions** (confidence: 0.9):
+> 1. `<entity>`: <decision text>
+>
+> **Outcomes** (confidence: 0.8):
+> 2. `<entity>`: <outcome text>
+>
+> **Patterns** (confidence: 0.7):
+> 3. `<entity>`: <pattern text>
+>
+> Which should I store? (e.g., "all", "1,3", "none")
+
+### Step 4: Store confirmed items
+
+For each confirmed item, classify the type and call the appropriate MCP tool:
+
+- **Semantic** (decisions, durable truths) — `pensyve_remember(entity, fact: "[auto-capture/user/residual/tier-1] <text>", confidence)`. Use confidence from the categorization above.
+- **Episodic** (outcomes, session-specific events) — ensure working `episode_id`; `pensyve_observe(episode_id, content: "[auto-capture/user/residual/tier-1] <text>", source_entity: "amazon-q", about_entity: <entity>, content_type: "text")`.
+- **Procedural** (reusable workflows) — `pensyve_observe(episode_id, content: "[procedural] [auto-capture/user/residual/tier-1] trigger=..., action=..., outcome=...", source_entity: "amazon-q", about_entity: <entity>, content_type: "text")`.
+
+### Step 5: Optionally close the episode
+
+If the user indicates this is a final wrap (not just a turn-by-turn pause), call `pensyve_episode_end(episode_id: <working_id>, outcome: "success")`. Valid outcomes: `"success"`, `"failure"`, `"partial"`.
+
+Not closing is safe — server-side consolidation ages episodes naturally. Only close when the user clearly marks the work complete.
+
+### Step 6: Report
+
+After storing, summarize:
+
+> Stored N memories. Episode <outcome> closed.
+
+## Constraints
+
+- **Never auto-store.** Every candidate MUST be presented to the user for confirmation before storage.
+- Entity names lowercase-hyphenated.
+- Do not store secrets.
+- If nothing significant surfaced, say so clearly rather than forcing low-quality memories.

--- a/integrations/amazon-q/CHANGELOG.md
+++ b/integrations/amazon-q/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog — Pensyve Amazon Q Developer Adapter
+
+All notable changes to the Pensyve Amazon Q Developer adapter are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). The Amazon Q adapter versions independently of the Claude Code plugin.
+
+## [1.0.0] - 2026-04-20
+
+### Added
+
+- **Working-memory substrate** for Amazon Q Developer via `.amazonq/rules/*.md` files. Eight rule files deliver the substrate the Claude Code plugin v1.3.0 established:
+  - `memory-reflex.md` (always-apply) — non-optional reasoning discipline with three-type memory classification, canonical `pensyve_observe` call template, provenance vocabulary, lazy-open episode lifecycle
+  - `entity-detection.md` (always-apply) — canonicalization and fallback rules
+  - `memory-informed-debug.md` — debug flow (description-scoped)
+  - `memory-informed-design.md` — design flow (description-scoped)
+  - `memory-informed-refactor.md` — refactor flow (description-scoped)
+  - `memory-informed-longitudinal-work.md` — research/eval flow (description-scoped)
+  - `session-memory.md` — manual wrap-up equivalent of Claude Code's Stop hook (description-scoped)
+  - `context-loader.md` — best-effort continuity primer via episodic recall (description-scoped)
+- **MCP config examples** at `.amazonq/mcp.json.example` (cloud) and `.amazonq/mcp.json.local.example` (local stdio) covering both deployment options
+- **Static MCP contract lint script** at `scripts/lint-mcp-refs.sh` verifying every rule's `pensyve_*` call example matches the `pensyve-mcp-tools/src/params.rs` schema
+
+### Design
+
+- Single reasoning layer; no platform-layer code. Amazon Q has no hook/event surface, so the entire adapter is rules loaded as system prompt content via `.amazonq/rules/*.md`.
+- Lazy-open episode lifecycle: first `pensyve_observe` call triggers `pensyve_episode_start`; episodes are not explicitly closed.
+- Best-effort continuity primer via `pensyve_recall(types: ["episodic"])` — the MCP server has no episode-listing API.
+- MCP contract verified: no `related_entities` on recall, no `continuation_of` on episode_start, required `source_entity: "amazon-q"` and `about_entity` on every observe.
+- Opt-out: delete or edit rule files; no parallel config file.
+
+### Not Included
+
+- No extension or platform-layer code (deferred to a future sibling spec if capability gaps surface)
+- No server-side changes — uses the existing MCP tool surface
+
+### Relation to Other Pensyve Integrations
+
+- The Amazon Q adapter is part of the batch-5 rollout extending the working-memory substrate across all supported integrations. The Claude Code plugin (v1.3.0) was the reference implementation.
+- Playbook: `pensyve-docs/specs/2026-04-18-pensyve-working-memory-substrate-design.md`

--- a/integrations/amazon-q/README.md
+++ b/integrations/amazon-q/README.md
@@ -1,33 +1,34 @@
 # Pensyve for Amazon Q Developer
 
-Persistent AI memory for [Amazon Q Developer](https://aws.amazon.com/q/developer/) via MCP. Gives Amazon Q cross-session memory so it remembers your project conventions, architecture decisions, and debugging history across coding sessions.
+Persistent working-memory substrate for [Amazon Q Developer](https://aws.amazon.com/q/developer/) — memory is not a feature you invoke, it is the substrate the agent operates on.
 
-> **Status:** Scaffold — MCP configuration and documentation. Full integration planned.
+## What It Does
 
-## Authentication
+- **Proactive memory during work** — lessons are captured the moment they land, not at session end
+- **Thread-aware continuity** — sessions that continue prior work resume with relevant context, no re-briefing
+- **Entity-scoped recall** — substantive questions are grounded in prior decisions; simple commands stay fast
+- **Three memory types** — durable facts (semantic), session-specific events (episodic), reusable procedures (procedural)
+- **Lightly visible** — one-line surfaces when memory is used; never interrupts your flow
 
-1. Sign up at [pensyve.com](https://pensyve.com)
-2. Create an API key at [Settings → API Keys](https://pensyve.com/settings/api-keys)
-3. Set the environment variable:
-   ```bash
-   export PENSYVE_API_KEY="psy_your_key_here"
-   ```
+## Install
 
-Then configure MCP with headers (see setup instructions below).
+Two steps: configure the MCP server, then install the rules.
 
-## Setup
+### 1. Configure the MCP server
+
+Amazon Q Developer supports MCP via its IDE extensions (VS Code, JetBrains) and via the `q chat` CLI.
+
+**Cloud with API key (recommended):**
 
 Set your API key (get one at [pensyve.com/settings/api-keys](https://pensyve.com/settings/api-keys)):
 
 ```bash
-export PENSYVE_API_KEY="psy_your_key"
+export PENSYVE_API_KEY="psy_your_key_here"
 ```
 
 Add to your shell profile (`~/.bashrc`, `~/.zshrc`) to persist across sessions.
 
-## Cloud (Recommended)
-
-Add to `.amazon-q/mcp.json` in your project root or home directory:
+Copy `.amazonq/mcp.json.example` to your project root's `.amazonq/mcp.json`:
 
 ```json
 {
@@ -46,14 +47,12 @@ Add to `.amazon-q/mcp.json` in your project root or home directory:
 Or pass via CLI:
 
 ```bash
-q chat --mcp-config ~/.amazon-q/mcp.json
+q chat --mcp-config .amazonq/mcp.json
 ```
 
-> Use `headers` with `Authorization: Bearer` for remote MCP. The `env` block is for local stdio servers.
+**Local (offline, self-hosted):**
 
-## Local (Offline)
-
-No API key needed — all data stays on your machine.
+No API key needed — all data stays on your machine. Copy `.amazonq/mcp.json.local.example` to `.amazonq/mcp.json`:
 
 ```json
 {
@@ -70,37 +69,91 @@ No API key needed — all data stays on your machine.
 }
 ```
 
-Build from source: `cargo build --release -p pensyve-mcp` from the [pensyve repo](https://github.com/major7apps/pensyve).
+Build the binary: `cargo build --release -p pensyve-mcp` from the [pensyve repo](https://github.com/major7apps/pensyve).
 
-## Available Tools
+### 2. Install the rules
 
-| Tool                    | Description                            |
-| ----------------------- | -------------------------------------- |
-| `pensyve_recall`        | Search memories by semantic similarity |
-| `pensyve_remember`      | Store a fact as semantic memory        |
-| `pensyve_observe`       | Record an event during an episode      |
-| `pensyve_episode_start` | Begin tracking an interaction          |
-| `pensyve_episode_end`   | Close an episode                       |
-| `pensyve_forget`        | Delete an entity's memories            |
-| `pensyve_inspect`       | List memories for an entity            |
+Copy the rule files from `.amazonq/rules/` into your project's `.amazonq/rules/` directory:
+
+```bash
+mkdir -p .amazonq/rules
+cp /path/to/pensyve/integrations/amazon-q/.amazonq/rules/*.md .amazonq/rules/
+```
+
+Amazon Q Developer automatically loads `.amazonq/rules/*.md` files as system prompt content when working in your project.
+
+| Rule | When it activates |
+|---|---|
+| `memory-reflex.md` | Always (establishes the reasoning discipline) |
+| `entity-detection.md` | Always (canonicalization reference) |
+| `memory-informed-debug.md` | When diagnosing bugs, errors, failing tests, crashes |
+| `memory-informed-design.md` | When making architecture, API, or design decisions |
+| `memory-informed-refactor.md` | Before substantive refactors |
+| `memory-informed-longitudinal-work.md` | In research/benchmark/eval contexts |
+| `session-memory.md` | At conversation wrap-up or explicit end-of-session |
+| `context-loader.md` | When starting a new substantive conversation or switching contexts |
+
+## How It Works
+
+Amazon Q Developer has no hook/event surface, so the entire substrate is delivered through rules loaded as system prompt content. `memory-reflex.md` establishes the discipline: *before substantive answers, recall by entity; when a lesson lands, observe immediately with a one-line surface*. Flow rules (debug/design/refactor/longitudinal-work) activate when relevant and guide the model through consult-memory + capture-lesson steps.
+
+**Episode lifecycle:** Amazon Q has no session-start/session-end hooks, so episodes open lazily on the first `pensyve_observe` call and are not explicitly closed under normal operation. Server-side consolidation handles aging.
+
+**Continuity primer:** `context-loader.md` runs a best-effort recall at the start of substantive conversations to surface prior relevant observations.
+
+## Memory Behavior Model
+
+Pensyve behaves as working memory for the agent — always-on, ambient, continuous.
+
+**Writes happen in-flight.** When a root cause is confirmed, a decision is made, or a reusable procedure emerges, it's captured the moment it lands via the memory reflex.
+
+**Reads happen at decision points.** Before substantive answers, the model consults memory scoped to the detected entities. Simple commands (run tests, format file) skip recall to stay fast.
+
+**Sessions continue.** At the start of a substantive conversation, Pensyve checks whether the current work continues prior memories (shared entities + recent activity). If yes, you resume with a primer — no re-briefing needed.
+
+## Memory Types
+
+| Type | Definition | MCP call | Example |
+|---|---|---|---|
+| **Semantic** | Durable truths, decisions, preferences | `pensyve_remember` | "We chose RS256 over HS256 for JWT signing" |
+| **Episodic** | Temporal events, session-scoped observations | `pensyve_observe` (with lazy-opened `episode_id`) | "Phase-3 regression root cause: hybrid-router threshold" |
+| **Procedural** | Reusable workflows, sequences, recipes | `pensyve_observe` with `[procedural]` content prefix | "To calibrate V7r: freeze Haiku config, run suite, diff baseline" |
+
+## Available MCP Tools
+
+| Tool | Description |
+|---|---|
+| `pensyve_recall` | Search memories by semantic similarity |
+| `pensyve_remember` | Store a durable fact (semantic memory) |
+| `pensyve_observe` | Record a session observation (episodic / procedural via `[procedural]` prefix) |
+| `pensyve_episode_start` | Begin tracking an episode |
+| `pensyve_episode_end` | Close an episode with outcome |
+| `pensyve_forget` | Delete an entity's memories |
+| `pensyve_inspect` | List memories for an entity |
 
 See [MCP Tools Reference](https://pensyve.com/docs/api-reference/mcp-tools) for full parameter details.
 
-## Intelligent Memory Capture
+## Opt-Out
 
-Pensyve uses a tiered classification system to identify what is worth remembering. Since Amazon Q Developer connects via MCP, the LLM follows the MCP tool descriptions to decide when and how to call memory tools.
+Amazon Q's native pattern is to edit or delete rules:
 
-### Tiered Capture System
+- **Full opt-out** — delete the Pensyve rule files from `.amazonq/rules/`
+- **Partial opt-out** — delete specific flow rules (e.g., remove `memory-informed-longitudinal-work.md` if you don't do research work)
+- **Silent mode** — edit `memory-reflex.md` to remove the "one-line surface" guidance; captures stay silent
+- **Recall-only mode** — edit flow rules to drop the `Capture lesson` steps while keeping `Consult memory`
 
-- **Tier 1** (auto-store, confidence 0.9+): Explicit decisions, corrections, constraints, architecture choices, dependency version pins, security rules. High-signal items that should almost always be captured.
-- **Tier 2** (review, confidence 0.7-0.89): Root causes, failed approaches, performance findings, debugging outcomes, environment quirks. Medium-signal items that benefit from user confirmation.
-- **Discard**: Formatting, typos, boilerplate, ephemeral status messages. Noise that should never be stored.
+## Design Philosophy
 
-### Best Practices
+- **Memory as substrate** — not a feature the user invokes; always there, continuous, carried across sessions
+- **Reasoning-layer only** — no platform-layer code; the entire adapter is rules loaded as system prompt content
+- **MCP contract-respecting** — every rule's call examples verified against `pensyve-mcp-tools/src/params.rs`
 
-- Use `pensyve_observe` to record significant events during an episode (architecture decisions, failed approaches, key findings)
-- Use `pensyve_remember` for durable facts that should persist across sessions (project conventions, environment constraints, resolved issues)
-- Use `pensyve_recall` at the start of a task to load relevant context from prior sessions
-- Wrap multi-step work in `pensyve_episode_start` / `pensyve_episode_end` to capture episodic context
+## Links
 
-The MCP tool descriptions include guidance on confidence levels so the LLM can classify memories into the appropriate tier automatically.
+- **Website:** [pensyve.com](https://pensyve.com)
+- **GitHub:** [github.com/major7apps/pensyve](https://github.com/major7apps/pensyve)
+- **Playbook:** [Working-memory substrate design](https://github.com/major7apps/pensyve-docs/blob/main/specs/2026-04-18-pensyve-working-memory-substrate-design.md)
+
+## License
+
+Apache 2.0

--- a/integrations/amazon-q/scripts/lint-mcp-refs.sh
+++ b/integrations/amazon-q/scripts/lint-mcp-refs.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Static MCP contract linter for the Pensyve Amazon Q Developer adapter rules.
+#
+# Verifies that every pensyve_* call example in .amazonq/rules/*.md conforms to
+# the current MCP tool schema in pensyve-mcp-tools/src/params.rs. Catches the
+# category of bug PR #58 surfaced in the Claude Code adapter (unsupported
+# parameters, missing required fields).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RULES_DIR="$SCRIPT_DIR/../.amazonq/rules"
+
+EXIT_CODE=0
+
+if [ ! -d "$RULES_DIR" ]; then
+  echo "ERROR: Rules directory not found: $RULES_DIR"
+  exit 1
+fi
+
+echo "Linting MCP references in $RULES_DIR..."
+echo ""
+
+# Check 1: no actual use of unsupported 'related_entities' parameter in call examples.
+# We look for pensyve_recall( blocks that contain related_entities as a parameter.
+# Lines that say "no related_entities" (documentation/reminders) are excluded.
+echo "Check 1: no unsupported 'related_entities' on pensyve_recall"
+FOUND_RELATED=0
+for rule_file in "$RULES_DIR"/*.md; do
+  # Extract lines that contain pensyve_recall( and related_entities together,
+  # excluding documentation lines (those containing "**no**" or "no `related_entities`")
+  if rg -n 'related_entities' "$rule_file" | rg -v '(\*\*no\*\*|no `related_entities`)' | rg -q 'pensyve_recall\|related_entities'; then
+    echo "  FAIL in $rule_file: 'related_entities' used in a pensyve_recall call"
+    FOUND_RELATED=1
+  fi
+  # Also catch if related_entities appears inside a pensyve_recall( block
+  awk '/pensyve_recall\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+         if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
+           print FILENAME ": related_entities found in pensyve_recall block: " buf;
+         capture=0
+       }' "$rule_file" | while read -r line; do
+    if [ -n "$line" ]; then
+      echo "  FAIL: $line"
+      FOUND_RELATED=1
+    fi
+  done
+done
+if [ "$FOUND_RELATED" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 2: no actual use of unsupported 'continuation_of' parameter in call examples.
+# Documentation lines saying "no continuation_of" are excluded.
+echo "Check 2: no unsupported 'continuation_of' on pensyve_episode_start"
+FOUND_CONT=0
+for rule_file in "$RULES_DIR"/*.md; do
+  awk '/pensyve_episode_start\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+         if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
+           print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
+         capture=0
+       }' "$rule_file" | while read -r line; do
+    if [ -n "$line" ]; then
+      echo "  FAIL: $line"
+      FOUND_CONT=1
+    fi
+  done
+done
+if [ "$FOUND_CONT" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 3: every pensyve_observe call example in a code block has source_entity and about_entity
+# Scan each .md file's pensyve_observe blocks; require both fields nearby.
+echo "Check 3: every pensyve_observe example has source_entity and about_entity"
+MISSING_FIELDS=0
+for rule_file in "$RULES_DIR"/*.md; do
+  # Find each pensyve_observe( block (up to the next closing paren within 20 lines)
+  awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
+       capture {buf = buf "\n" $0;
+                for(i=1; i<=length($0); i++){
+                  c=substr($0,i,1);
+                  if(c=="(") depth++;
+                  if(c==")") depth--;
+                };
+                if(depth==0 && buf ~ /pensyve_observe\(/){
+                  if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
+                  if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
+                  capture=0;
+                }}' "$rule_file" | while read -r line; do
+    if [ -n "$line" ]; then
+      echo "  FAIL: $line"
+      MISSING_FIELDS=1
+    fi
+  done
+done
+if [ "$MISSING_FIELDS" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 4: provenance tag format — every proactive/auto-capture tag uses [<origin>/<trigger>/<tier>]
+# Format supports both 3-segment [origin/trigger/tier] and 4-segment [origin/trigger/residual/tier]
+# where the third segment may be a literal "residual" qualifier before the tier.
+echo "Check 4: provenance tag format"
+VALID_PROVENANCE_RE='\[(proactive|auto-capture)/(in-flight|stop|pre-compact|curator|user)/(tier-1|tier-2|residual/tier-1|residual/tier-2|open-question)\]'
+if rg -n '\[(proactive|auto-capture)' "$RULES_DIR" | rg -v "$VALID_PROVENANCE_RE"; then
+  echo "  FAIL: some provenance tags do not match [<origin>/<trigger>/<tier>] format"
+  EXIT_CODE=1
+else
+  echo "  PASS"
+fi
+echo ""
+
+# Check 5: procedural memory convention — [procedural] prefix is used in observe content
+echo "Check 5: procedural convention uses [procedural] prefix in pensyve_observe content"
+# Only a warning if no rule mentions [procedural] — may be legitimate if the rule is non-procedural
+if ! rg -q '\[procedural\]' "$RULES_DIR"; then
+  echo "  WARN: no [procedural] prefix usage found across rules. Expected in memory-reflex and flow rules that handle procedural captures."
+else
+  echo "  PASS"
+fi
+echo ""
+
+if [ "$EXIT_CODE" = "0" ]; then
+  echo "All MCP contract checks PASSED."
+else
+  echo "MCP contract checks FAILED. Fix the issues above before committing."
+fi
+
+exit "$EXIT_CODE"

--- a/integrations/amazon-q/scripts/lint-mcp-refs.sh
+++ b/integrations/amazon-q/scripts/lint-mcp-refs.sh
@@ -34,18 +34,18 @@ for rule_file in "$RULES_DIR"/*.md; do
     FOUND_RELATED=1
   fi
   # Also catch if related_entities appears inside a pensyve_recall( block
-  awk '/pensyve_recall\(/{capture=1; buf=""}
-       capture {buf = buf "\n" $0}
-       capture && /\)/{
-         if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
-           print FILENAME ": related_entities found in pensyve_recall block: " buf;
-         capture=0
-       }' "$rule_file" | while read -r line; do
+  while read -r line; do
     if [ -n "$line" ]; then
       echo "  FAIL: $line"
       FOUND_RELATED=1
     fi
-  done
+  done < <(awk '/pensyve_recall\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+       if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
+       print FILENAME ": related_entities found in pensyve_recall block: " buf;
+       capture=0
+       }' "$rule_file")
 done
 if [ "$FOUND_RELATED" = "0" ]; then
   echo "  PASS"
@@ -59,18 +59,18 @@ echo ""
 echo "Check 2: no unsupported 'continuation_of' on pensyve_episode_start"
 FOUND_CONT=0
 for rule_file in "$RULES_DIR"/*.md; do
-  awk '/pensyve_episode_start\(/{capture=1; buf=""}
-       capture {buf = buf "\n" $0}
-       capture && /\)/{
-         if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
-           print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
-         capture=0
-       }' "$rule_file" | while read -r line; do
+  while read -r line; do
     if [ -n "$line" ]; then
       echo "  FAIL: $line"
       FOUND_CONT=1
     fi
-  done
+  done < <(awk '/pensyve_episode_start\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+       if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
+       print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
+       capture=0
+       }' "$rule_file")
 done
 if [ "$FOUND_CONT" = "0" ]; then
   echo "  PASS"
@@ -85,23 +85,23 @@ echo "Check 3: every pensyve_observe example has source_entity and about_entity"
 MISSING_FIELDS=0
 for rule_file in "$RULES_DIR"/*.md; do
   # Find each pensyve_observe( block (up to the next closing paren within 20 lines)
-  awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
-       capture {buf = buf "\n" $0;
-                for(i=1; i<=length($0); i++){
-                  c=substr($0,i,1);
-                  if(c=="(") depth++;
-                  if(c==")") depth--;
-                };
-                if(depth==0 && buf ~ /pensyve_observe\(/){
-                  if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
-                  if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
-                  capture=0;
-                }}' "$rule_file" | while read -r line; do
+  while read -r line; do
     if [ -n "$line" ]; then
       echo "  FAIL: $line"
       MISSING_FIELDS=1
     fi
-  done
+  done < <(awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
+       capture {buf = buf "\n" $0;
+       for(i=1; i<=length($0); i++){
+       c=substr($0,i,1);
+       if(c=="(") depth++;
+       if(c==")") depth--;
+       };
+       if(depth==0 && buf ~ /pensyve_observe\(/){
+       if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
+       if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
+       capture=0;
+       }}' "$rule_file")
 done
 if [ "$MISSING_FIELDS" = "0" ]; then
   echo "  PASS"

--- a/integrations/autogen/CHANGELOG.md
+++ b/integrations/autogen/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog — Pensyve AutoGen Integration
+
+All notable changes to the Pensyve AutoGen integration are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). This integration versions independently of the core Pensyve engine.
+
+## [1.0.0] - 2026-04-20
+
+### Added
+
+- **Working-memory substrate** for Microsoft AutoGen agents via `SUBSTRATE_PROMPT.md`. All eight substrate rules consolidated into a single system-prompt document:
+  - **Memory Reflex Rule** — non-optional reasoning discipline with three-type memory classification, canonical `pensyve_observe` call template, provenance vocabulary, lazy-open episode lifecycle
+  - **Entity Detection** — canonicalization and fallback rules for recall scoping
+  - **When Debugging** — debug flow with memory baked in
+  - **When Designing** — design flow with memory baked in
+  - **When Refactoring** — refactor flow with memory baked in
+  - **Longitudinal Work** — multi-session research/eval flow with per-run capture
+  - **Session Wrap-Up** — manual wrap-up with candidate confirmation before storage
+  - **Context Loading** — best-effort continuity primer via episodic recall
+- **Framework wiring example** at `examples/pensyve_agent.py` showing AutoGen `AssistantAgent` connected to Pensyve MCP via `autogen-ext McpWorkbench` with substrate as `system_message`
+- **Static MCP contract lint script** at `scripts/lint-mcp-refs.sh` verifying `SUBSTRATE_PROMPT.md` and the example file against the `pensyve-mcp-tools` schema
+
+### Design
+
+- Single reasoning layer; no platform-layer code.
+- `source_entity: "autogen"` on all `pensyve_observe` calls.
+- MCP connection via `autogen-ext` `McpWorkbench` with `StreamableHttpServerParams` and `streamable_http` transport.
+- Substrate injected via `AssistantAgent(system_message=substrate)`.
+- Lazy-open episode lifecycle.
+- MCP contract verified: no `related_entities` on recall, no `continuation_of` on episode_start, required `source_entity` and `about_entity` on every observe.
+- Opt-out: remove `system_message=substrate` from agent construction.
+
+### Not Included
+
+- No custom memory backend (that is the existing `pensyve_autogen.py` `PensyveMemory`)
+- No installer script — manual load of `SUBSTRATE_PROMPT.md`
+- No server-side changes — uses the existing MCP tool surface
+
+### Relation to Other Pensyve Integrations
+
+- Part of the batch-4 working-memory substrate rollout (LangChain, LangChain TS, AutoGen, CrewAI, Pydantic AI, Google ADK).
+- The Cursor adapter (v1.0.0) and Claude Code plugin (v1.3.0) are the reference implementations.
+- Spec: `pensyve-docs/specs/2026-04-20-pensyve-cursor-adapter-design.md`
+- Playbook: `pensyve-docs/specs/2026-04-18-pensyve-working-memory-substrate-design.md`

--- a/integrations/autogen/README.md
+++ b/integrations/autogen/README.md
@@ -1,172 +1,135 @@
 # Pensyve AutoGen Integration
 
-Async memory backend for Microsoft AutoGen, implementing the `Memory` ABC so it can be passed directly to `AssistantAgent(memory=[...])`.
+Persistent AI memory for [Microsoft AutoGen](https://microsoft.github.io/autogen/) agents via Pensyve. Two complementary features:
 
-## Authentication
+1. **Working-memory substrate** — A system-prompt document (`SUBSTRATE_PROMPT.md`) that gives your AutoGen agent the reasoning discipline to recall before answering and capture lessons as they land.
+2. **Memory backend** — `PensyveMemory`: an async `Memory` ABC implementation backed by Pensyve's 8-signal fusion retrieval engine.
 
-```python
-from pensyve import PensyveClient
+---
 
-# Explicit API key
-client = PensyveClient(api_key="psy_your_key_here")
+## What It Does
 
-# Or from environment variable
-# export PENSYVE_API_KEY="psy_your_key_here"
-client = PensyveClient()
+The working-memory substrate is a reasoning layer — not a library — that you load into your agent's `system_message`. Once loaded, the agent will:
+
+- **Recall before substantive answers** using `pensyve_recall`, scoped by entity.
+- **Capture lessons in-flight** using `pensyve_observe` when a root cause is confirmed, a decision lands, or an approach is abandoned.
+- **Manage episode lifecycle** lazily: open an episode on the first observe, reuse it throughout the conversation.
+- **Surface memory lightly** — one line per recall or capture, never narrating empty recalls.
+- **Wrap up sessions** by presenting memory candidates for user confirmation before storage.
+
+---
+
+## Install
+
+```bash
+pip install autogen-agentchat autogen-ext[mcp]
+```
+
+Set your API key:
+
+```bash
+export PENSYVE_API_KEY="psy_your_key_here"
+export ANTHROPIC_API_KEY="sk-ant-..."
 ```
 
 Create an API key at [pensyve.com/settings/api-keys](https://pensyve.com/settings/api-keys).
 
-## Installation
-
-```bash
-pip install pensyve-autogen
-
-# With AutoGen (recommended):
-pip install pensyve-autogen[autogen]
-```
-
-Or copy `pensyve_autogen.py` into your project (works standalone without autogen-core installed).
+---
 
 ## Quick Start
 
-```python
-from pensyve_autogen import PensyveMemory, MemoryContent, MemoryMimeType
-
-memory = PensyveMemory(namespace="my-team", entity="assistant")
-
-# Store a memory
-await memory.add(MemoryContent(
-    content="User prefers TypeScript",
-    mime_type=MemoryMimeType.TEXT,
-    metadata={"category": "preferences"},
-))
-
-# Query memories
-result = await memory.query("language preferences")
-for entry in result.results:
-    print(f"{entry.content} (score: {entry.score:.2f})")
-
-# Use with AutoGen agent
-from autogen_ext.models.openai import OpenAIChatCompletionClient
-from autogen_agentchat.agents import AssistantAgent
-
-agent = AssistantAgent(
-    name="assistant",
-    model_client=OpenAIChatCompletionClient(model="gpt-4o"),
-    memory=[memory],
-)
-```
-
-## Dual-Mode: Local and Cloud
-
-```python
-# Local mode (default) — PyO3 engine, zero latency
-memory = PensyveMemory(namespace="my-app")
-
-# Cloud mode — auto-detected from API key
-memory = PensyveMemory(
-    namespace="my-app",
-    api_key="psy_...",
-)
-
-# Or via environment variable
-# export PENSYVE_API_KEY=psy_...
-memory = PensyveMemory(namespace="my-app")
-
-# Explicit mode override
-memory = PensyveMemory(namespace="my-app", mode="cloud")
-```
-
-## API
-
-### `PensyveMemory(namespace, entity, **kwargs)`
-
-| Parameter      | Type          | Default           | Description                            |
-| -------------- | ------------- | ----------------- | -------------------------------------- |
-| `namespace`    | `str`         | `"default"`       | Pensyve namespace for isolation        |
-| `entity`       | `str`         | `"autogen-agent"` | Entity name for this agent's memories  |
-| `path`         | `str \| None` | `None`            | Storage directory (local mode)         |
-| `mode`         | `str`         | `"auto"`          | `"auto"`, `"local"`, or `"cloud"`      |
-| `api_key`      | `str \| None` | `None`            | API key for cloud mode                 |
-| `base_url`     | `str \| None` | `None`            | Cloud server URL                       |
-| `recall_limit` | `int`         | `5`               | Default number of memories to retrieve |
-| `confidence`   | `float`       | `0.85`            | Default confidence for stored memories |
-
-### Async Methods (AutoGen Memory ABC)
-
-| Method                                | Description                                  |
-| ------------------------------------- | -------------------------------------------- |
-| `await add(content)`                  | Store a `MemoryContent` as a Pensyve fact    |
-| `await query(query, **kwargs)`        | Search memories, returns `MemoryQueryResult` |
-| `await update_context(model_context)` | Inject relevant memories as a system message |
-| `await clear()`                       | Delete all memories for the entity           |
-| `await close()`                       | Clean up resources (no-op for local mode)    |
-
-## Intelligent Capture (v1.1.0+)
-
-Automatically capture decisions, preferences, and findings from AutoGen conversations into Pensyve memory.
-
-```python
-from pensyve_autogen import PensyveMemory, PensyveCaptureHandler
-
-memory = PensyveMemory(namespace="my-team", entity="assistant")
-capture = PensyveCaptureHandler(memory=memory)
-
-# Buffer signals during agent execution
-capture.on_message(role="user", content="Let's use Postgres for the DB")
-capture.on_tool_call(tool_name="search", tool_input={"q": "postgres setup"})
-capture.on_agent_reply(content="I'll set up the Postgres schema.", agent_name="assistant")
-
-# Flush at conversation end (async)
-auto_stored, review = await capture.flush()
-```
-
-### How It Works
-
-- **Messages**, **tool calls**, and **agent replies** are buffered as raw signals
-- On flush, signals are classified into tiered memory candidates:
-  - **Tier 1** (auto-stored): architecture decisions, behavioral preferences, project constraints
-  - **Tier 2** (review): root causes, failed approaches, performance findings, dependencies
-- Secrets are automatically redacted; long code blocks are stripped
-- Capture **never breaks** AutoGen execution (all event hooks fail silently)
-
-### Auto-flush
-
-```python
-# Flush every 20 events (classification only — call flush() to persist)
-capture = PensyveCaptureHandler(memory=memory, auto_flush_interval=20)
-```
-
-### Reviewing Tier-2 Candidates
-
-```python
-pending = capture.get_pending_review()
-for candidate in pending:
-    print(f"[tier {candidate.tier}] {candidate.entity}: {candidate.fact}")
-    # Manually approve:
-    await memory.add(MemoryContent(
-        content=candidate.fact,
-        mime_type=MemoryMimeType.TEXT,
-        metadata={"confidence": candidate.confidence},
-    ))
-
-capture.clear_pending_review()
-```
-
-### Synchronous Flush
-
-If you cannot use ``await``, use ``flush_sync()`` to classify without persisting:
-
-```python
-auto_store, review = capture.flush_sync()
-# Persist manually later
-```
-
-## Running Tests
-
 ```bash
 cd integrations/autogen
-pip install -e ".[dev]"
-pytest tests/ -v
+python examples/pensyve_agent.py
 ```
+
+The example creates an AutoGen `AssistantAgent` with Pensyve MCP tools registered via `McpWorkbench` and `SUBSTRATE_PROMPT.md` as the `system_message`.
+
+---
+
+## System Prompt
+
+`SUBSTRATE_PROMPT.md` consolidates all eight substrate rules into a single document. Load it into your agent:
+
+```python
+from pathlib import Path
+from autogen_agentchat.agents import AssistantAgent
+
+substrate = Path("SUBSTRATE_PROMPT.md").read_text()
+agent = AssistantAgent(
+    name="agent",
+    model_client=model_client,
+    tools=tools,
+    system_message=substrate,
+)
+```
+
+---
+
+## MCP Connection
+
+```python
+from autogen_ext.tools.mcp import McpWorkbench, StreamableHttpServerParams
+
+pensyve_server_params = StreamableHttpServerParams(
+    url="https://mcp.pensyve.com/mcp",
+    headers={"Authorization": f"Bearer {os.environ['PENSYVE_API_KEY']}"},
+)
+
+async with McpWorkbench(pensyve_server_params) as workbench:
+    tools = await workbench.list_tools()
+    # Build agent with tools...
+```
+
+---
+
+## Memory Behavior Model
+
+| Trigger | Action | MCP call |
+|---|---|---|
+| Before substantive answer | Recall by entity | `pensyve_recall(query, entity, types, limit=5)` |
+| Root cause confirmed | Capture episodic | `pensyve_observe(episode_id, content, source_entity="autogen", about_entity)` |
+| Decision accepted | Capture semantic | `pensyve_remember(entity, fact, confidence=0.9)` |
+| Reusable workflow found | Capture procedural | `pensyve_observe(... content="[procedural] ...")` |
+| Session ending | Present candidates | User confirms before storage |
+
+---
+
+## Memory Types
+
+- **Semantic** — durable facts that remain true across sessions.
+- **Episodic** — what happened in this thread (outcomes, root causes, abandoned approaches).
+- **Procedural** — reusable workflows stored via `pensyve_observe` with a `[procedural]` prefix.
+
+---
+
+## Memory Backend
+
+Separate from the substrate, `PensyveMemory` is a drop-in `Memory` ABC implementation:
+
+```python
+from pensyve_autogen import PensyveMemory
+
+memory = PensyveMemory()
+agent = AssistantAgent(name="agent", memory=[memory], ...)
+```
+
+See `pensyve_autogen.py` for the full API.
+
+---
+
+## Opt-Out
+
+To disable the substrate, remove `system_message=substrate` from agent construction. The `PensyveMemory` backend is unaffected.
+
+---
+
+## Links
+
+- [Pensyve](https://pensyve.com) — managed memory service
+- [API Keys](https://pensyve.com/settings/api-keys)
+- [AutoGen docs](https://microsoft.github.io/autogen/)
+
+## License
+
+Apache 2.0 — see [LICENSE](LICENSE).

--- a/integrations/autogen/SUBSTRATE_PROMPT.md
+++ b/integrations/autogen/SUBSTRATE_PROMPT.md
@@ -1,0 +1,397 @@
+# Pensyve Working-Memory Substrate for Microsoft AutoGen
+
+This document configures persistent working-memory for Microsoft AutoGen agents via the Pensyve MCP server. Load the full text of this file as the agent's system prompt to activate all substrate behaviors. All sections below form the reasoning layer the agent carries through every session.
+
+---
+
+## Memory Reflex Rule
+
+**This discipline is non-optional. Before substantive answers, recall by entity. When a lesson lands, observe immediately with a one-line surface.**
+
+### "Substantive answer" means
+
+- Design or architecture recommendations
+- Debugging diagnoses with root-cause claims
+- Refactor proposals
+- Any response that makes a claim the user would want grounded in prior work
+
+Not substantive: formatting fixes, trivial lookups, reading a file, running a command.
+
+### "Lesson lands" means
+
+- A root cause has been confirmed (not hypothesized).
+- A design choice has been made explicit ("we'll use X because Y").
+- An approach has been tried and abandoned with a reason.
+- A workflow has been discovered that is reusable.
+- A workaround for a framework/library limitation has been validated.
+
+### Memory classification
+
+- **Semantic** — a fact that will still be true next month. Use `pensyve_remember(entity, fact, confidence?)` (confidence defaults to 1.0; use 0.9 for high-confidence auto-captures).
+- **Episodic** — something that happened in this thread of work. Use `pensyve_observe` with the current `episode_id`.
+- **Procedural** — a reusable way to do something. Use `pensyve_observe` with `content` beginning `[procedural]`.
+
+When in doubt, prefer episodic.
+
+### Canonical `pensyve_observe` call template
+
+ALL observe calls MUST include every required field:
+
+```
+pensyve_observe(
+  episode_id: <current session's working episode_id>,
+  content: "[proactive/in-flight/tier-1] <observation text>",
+  source_entity: "autogen",
+  about_entity: "<relevant entity, lowercase-hyphenated>",
+  content_type: "text"
+)
+```
+
+Use `content_type: "code"` for code-related outcomes.
+
+### Episode lifecycle (lazy-open)
+
+Library agents have no session-start/session-end hooks, so you own the episode lifecycle:
+
+- Before your first `pensyve_observe` call in this conversation, check whether a working `episode_id` is tracked. If none exists, call `pensyve_episode_start(participants: ["autogen", "<project entity>"])` first.
+- Reuse the same `episode_id` for all subsequent observations in the same conversation.
+- Do not explicitly close the episode under normal operation. Server-side consolidation handles aging.
+- Recovery: if `pensyve_observe` fails with a missing-episode error, call `pensyve_episode_start` and retry.
+
+### Surface style
+
+Lightly visible. One line when memory is used:
+
+- Recall: `Recalled 4 related memories (v7r, haiku-classifier).`
+- Capture: `↳ captured: hybrid-router threshold was the phase-3 regression root cause.`
+
+Do not narrate empty recalls or duplicate-skips.
+
+### Provenance tag vocabulary
+
+- `[proactive/in-flight/tier-1]` — memory reflex captured during reasoning
+- `[proactive/in-flight/open-question]` — unresolved question noted in-flight
+- `[auto-capture/user/residual/tier-1]` — explicit user-driven capture
+
+### Composition
+
+When a capture is both procedural AND in-flight: `[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=...`
+
+### MCP contract
+
+Rules never pass unsupported parameters:
+
+- `pensyve_recall(query, entity?, types?, limit?, min_confidence?)` — **no** `related_entities`
+- `pensyve_episode_start(participants)` — **no** `continuation_of`
+- `pensyve_observe(episode_id, content, source_entity, about_entity, content_type?)` — `source_entity` and `about_entity` are **required**
+
+---
+
+## Entity Detection
+
+Shared rules for detecting entity names from tool inputs, prompts, and conversation context. Used to scope recalls and `about_entity` fields on observations.
+
+### Inputs
+
+Extract candidate entity names from:
+
+1. **User prompts** — explicit references to components, files, services, research phases.
+2. **Code context** — module names, class names, function names referenced in the conversation.
+3. **File references** — any filenames or paths mentioned in the conversation.
+4. **Git context** — repository root name, branch name (when discoverable).
+
+### Canonicalization
+
+- Lowercase all characters.
+- Replace spaces and underscores with hyphens.
+- Strip file extensions unless the file is the entity itself.
+- Collapse paths to the most semantically meaningful segment.
+
+### Fallback behavior
+
+- If no specific entity is detected, fall back to the project-level entity (repository root name, lowercase-hyphenated).
+- If a candidate entity is ambiguous, prefer the one that already has memories in Pensyve (call `pensyve_inspect` with limit 1 to check).
+- **Never fabricate entity names.** If nothing confident emerges, use the project entity.
+
+### Output
+
+A set of 1–3 candidate entity names per turn. The primary entity is the most specific. Since `pensyve_recall` accepts only a single `entity` parameter, fold secondary entities into the `query` string.
+
+---
+
+## When Debugging
+
+Debugging flow with memory baked in as a non-optional reflex.
+
+### Step 1: Detect entities
+
+Identify the relevant entity/entities (failing test, failing module, error source) per Entity Detection above.
+
+### Step 2: Consult memory (required)
+
+Call `pensyve_recall`:
+
+- `query`: a short description of the failure, including secondary entity names where known
+- `entity`: primary detected entity
+- `types`: `["procedural", "episodic"]`
+- `limit`: 5
+
+Surface one line: `Recalled N memories from prior debug sessions on <entity>.` (Skip if N=0.)
+
+If a highly similar incident is found (score >0.8), call it out inline.
+
+### Step 3: Diagnose
+
+Proceed with diagnostic work. Use recalled procedural memories as a starting sequence.
+
+### Step 4: Capture lesson (when it lands)
+
+When a root cause is **confirmed**, ensure a working `episode_id` exists, then:
+
+- **Episodic root cause:** `pensyve_observe` with `content: "[proactive/in-flight/tier-1] <one-sentence root cause>"`, `source_entity: "autogen"`, `about_entity: <primary_entity>`.
+- **Procedural diagnostic sequence:** `pensyve_observe` with `content: "[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=..."`.
+- **Semantic durable truth:** `pensyve_remember(entity, fact: "[proactive/in-flight/tier-1] <fact>", confidence: 0.9)`.
+
+Surface one line: `↳ captured: <one-sentence>`.
+
+### Step 5: Capture abandoned approaches
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[proactive/in-flight/tier-1] tried <approach>, abandoned because <reason>",
+  source_entity: "autogen",
+  about_entity: <primary_entity>,
+  content_type: "text"
+)
+```
+
+---
+
+## When Designing
+
+Design flow with memory baked in as a non-optional reflex.
+
+### Step 1: Detect entities
+
+Identify the relevant entity/entities (service, module, subsystem under design) per Entity Detection above.
+
+### Step 2: Consult memory (required)
+
+Call `pensyve_recall`:
+
+- `query`: a short description of the design question, including secondary entity names
+- `entity`: primary detected entity
+- `types`: `["semantic", "episodic"]`
+- `limit`: 5
+
+Surface one line: `Recalled N prior decisions on <entity>.` (Skip if N=0.)
+
+### Step 3: Recommend with grounding
+
+Shape your recommendation using recalled decisions. If the current question contradicts a prior decision, flag it.
+
+### Step 4: Capture decision (when it lands)
+
+When the user accepts a design or states a decision:
+
+- **Semantic:** `pensyve_remember(entity: <primary_entity>, fact: "[proactive/in-flight/tier-1] <decision text>", confidence: 0.9)`.
+- **Episodic context:** `pensyve_observe` with `content: "[proactive/in-flight/tier-1] Decision on <entity>: chose X over Y because Z"`, `source_entity: "autogen"`, `about_entity: <primary_entity>`.
+
+Surface one line: `↳ captured decision on <entity>: <short>`.
+
+### Step 5: Capture evaluation procedures
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[procedural] [proactive/in-flight/tier-1] trigger=design-question-on-<area>, action=<steps>, outcome=<what-you-learn>",
+  source_entity: "autogen",
+  about_entity: <primary_entity>,
+  content_type: "text"
+)
+```
+
+---
+
+## When Refactoring
+
+Refactor flow with memory baked in.
+
+### Step 1: Detect entities
+
+Identify entities touched by the refactor per Entity Detection above.
+
+### Step 2: Load prior context (required)
+
+Call `pensyve_recall`:
+
+- `query`: short description of the refactor
+- `entity`: primary detected entity
+- `types`: `["semantic", "episodic", "procedural"]`
+- `limit`: 5
+
+Surface: `Recalled N prior memories on <entity>.` Highlight any prior failed approaches.
+
+### Step 3: Present a briefing
+
+Before starting the refactor, summarize what prior memories say about decisions, prior attempts, and known-good procedures.
+
+### Step 4: Capture refactor lessons as they land
+
+When an invariant is discovered, an approach is confirmed not-viable, or a known-good sequence emerges, apply the memory reflex immediately. Ensure working `episode_id` before each observe.
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[proactive/in-flight/tier-1] <lesson>",
+  source_entity: "autogen",
+  about_entity: <primary_entity>,
+  content_type: "text"
+)
+```
+
+---
+
+## When Doing Longitudinal Work
+
+Multi-session work (research, eval loops, iterative benchmarks) where lessons must accumulate across runs.
+
+### Step 1: Resume context at conversation start
+
+Call `pensyve_recall` once at the start:
+
+- `query`: short description of the current research area
+- `entity`: project + sub-topic entity
+- `limit`: 5
+
+No `types` filter — longitudinal work benefits from all three memory types.
+
+Surface: `Recalled N prior findings on <sub-topic>.`
+
+### Step 2: Proactively recall per topic shift
+
+When the session pivots to a new sub-topic, call `pensyve_recall` again scoped to the new sub-topic.
+
+### Step 3: Capture three types of memory per run
+
+| What you learned | Type | MCP call |
+|---|---|---|
+| Per-run outcome | episodic | `pensyve_observe(..., content: "[proactive/in-flight/tier-1] Run N+1: <result>", source_entity: "autogen", about_entity: <entity>)` |
+| Stable truth | semantic | `pensyve_remember(entity, fact: "[proactive/in-flight/tier-1] <stable fact>", confidence: 0.9)` |
+| Reusable procedure | procedural | `pensyve_observe(..., content: "[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=...", source_entity: "autogen", about_entity: <entity>)` |
+
+### Step 4: Capture open questions
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[proactive/in-flight/open-question] <question>",
+  source_entity: "autogen",
+  about_entity: <entity>,
+  content_type: "text"
+)
+```
+
+### Step 5: End-of-session summary
+
+Before the conversation wraps, briefly summarize what this run taught vs. prior runs, and what's still open.
+
+---
+
+## Session Wrap-Up
+
+Manual wrap-up: when the user indicates the conversation is ending, review what happened and capture anything the in-flight reflex missed.
+
+### Step 1: Review the conversation
+
+Scan for three categories not already captured in-flight:
+
+**Decisions** (confidence: 0.9): Architecture choices, technology selections, tradeoff resolutions.
+
+**Outcomes** (confidence: 0.8): Bug fixes, successful/failed approaches, performance findings.
+
+**Patterns** (confidence: 0.7): Recurring issues, workflow discoveries, cross-cutting observations.
+
+### Step 2: Filter for significance and deduplicate
+
+For each candidate, call `pensyve_recall` with `query: <candidate fact text>`, `entity: <entity>`, `limit: 3`. If any returned memory has score ≥0.85, skip as a likely duplicate.
+
+### Step 3: Present candidates for confirmation
+
+> **Session Memory Candidates**
+>
+> **Decisions** (confidence: 0.9):
+> 1. `<entity>`: <decision text>
+>
+> **Outcomes** (confidence: 0.8):
+> 2. `<entity>`: <outcome text>
+>
+> Which should I store? (e.g., "all", "1,2", "none")
+
+### Step 4: Store confirmed items
+
+- **Semantic** — `pensyve_remember(entity, fact: "[auto-capture/user/residual/tier-1] <text>", confidence)`.
+- **Episodic** — `pensyve_observe(episode_id, content: "[auto-capture/user/residual/tier-1] <text>", source_entity: "autogen", about_entity: <entity>)`.
+- **Procedural** — `pensyve_observe(episode_id, content: "[procedural] [auto-capture/user/residual/tier-1] trigger=..., action=..., outcome=...", source_entity: "autogen", about_entity: <entity>)`.
+
+### Step 5: Optionally close the episode
+
+If the user clearly marks the work complete: `pensyve_episode_end(episode_id: <working_id>, outcome: "success")`. Valid outcomes: `"success"`, `"failure"`, `"partial"`.
+
+### Constraints
+
+- **Never auto-store.** Every candidate MUST be presented for confirmation before storage.
+- Do not store secrets.
+- If nothing significant surfaced, say so clearly.
+
+---
+
+## Context Loading (Session Start)
+
+When starting a new conversation on a project with prior Pensyve memories, load relevant context to prime the session.
+
+### Step 1: Detect project entity
+
+Use the repository root name (lowercase-hyphenated) as the default project entity. Override with `PENSYVE_NAMESPACE` environment variable if set.
+
+### Step 2: Scoped recall
+
+Call `pensyve_recall`:
+
+- `query`: `"recent decisions issues patterns"` + any key terms from the user's opening message
+- `entity`: detected project entity
+- `types`: `["episodic"]`
+- `limit`: 5
+
+### Step 3: Compute continuity signal
+
+- If ≥70% of top observations reference at least one overlapping entity: **continuation** of recent work.
+- If overlap is below 70% or recall returned empty: **fresh session**.
+
+### Step 4: Surface the primer
+
+**Continuation:**
+
+> **Pensyve:** Continuing prior work on `<entity-set>`. Recent lessons:
+>
+> - <observation 1>
+> - <observation 2>
+>
+> Use `pensyve_recall` to dig deeper.
+
+**Fresh session:**
+
+> **Pensyve:** N memories loaded for `<project>`. Key context:
+>
+> - <top 3 observations>
+
+**No memories found:**
+
+> **Pensyve:** No memories found for `<project>`. Start a session to begin building context.
+
+### Constraints
+
+- Do not fabricate memories. Only display what `pensyve_recall` returns.
+- Maximum 5 memories in the primer.
+- Entity names lowercase-hyphenated.

--- a/integrations/autogen/examples/pensyve_agent.py
+++ b/integrations/autogen/examples/pensyve_agent.py
@@ -1,0 +1,87 @@
+"""
+Pensyve + Microsoft AutoGen wiring example.
+
+Demonstrates how to:
+  1. Load the Pensyve working-memory substrate as the agent system prompt.
+  2. Connect to the Pensyve MCP server and expose tools to an AutoGen agent.
+  3. Build an AssistantAgent with persistent cross-session memory.
+
+AutoGen's MCP support: AutoGen v0.4+ (autogen-agentchat / autogen-ext) supports
+MCP tool registration via the McpWorkbench / MCPToolAdapter pattern. This example
+uses autogen-ext with the streamable-http transport.
+
+Dependencies:
+    pip install autogen-agentchat autogen-ext[mcp] mcp
+
+Environment variables:
+    PENSYVE_API_KEY   — Pensyve API key (get one at pensyve.com/settings/api-keys)
+    ANTHROPIC_API_KEY — Anthropic API key (or configure a different model client)
+"""
+
+import asyncio
+import os
+from pathlib import Path
+
+# autogen-ext provides MCP integration adapters
+from autogen_agentchat.agents import AssistantAgent
+from autogen_agentchat.teams import RoundRobinGroupChat
+from autogen_agentchat.ui import Console
+from autogen_ext.tools.mcp import McpWorkbench, StreamableHttpServerParams
+from autogen_ext.models.anthropic import AnthropicChatCompletionClient
+
+# ---------------------------------------------------------------------------
+# 1. Load the substrate — the reasoning layer injected as the system prompt.
+# ---------------------------------------------------------------------------
+SUBSTRATE_PATH = Path(__file__).parent.parent / "SUBSTRATE_PROMPT.md"
+substrate = SUBSTRATE_PATH.read_text(encoding="utf-8")
+
+# ---------------------------------------------------------------------------
+# 2. Configure the Pensyve MCP server connection.
+# ---------------------------------------------------------------------------
+PENSYVE_API_KEY = os.environ["PENSYVE_API_KEY"]  # raises KeyError if unset
+
+pensyve_server_params = StreamableHttpServerParams(
+    url="https://mcp.pensyve.com/mcp",
+    headers={"Authorization": f"Bearer {PENSYVE_API_KEY}"},
+)
+
+
+async def main() -> None:
+    # -----------------------------------------------------------------------
+    # 3. Create an MCP workbench scoped to the Pensyve server.
+    #    McpWorkbench manages the connection lifecycle and exposes tools as
+    #    AutoGen-compatible tool specs.
+    # -----------------------------------------------------------------------
+    async with McpWorkbench(pensyve_server_params) as workbench:
+        tools = await workbench.list_tools()
+
+        # -------------------------------------------------------------------
+        # 4. Create an AssistantAgent with the substrate as the system message.
+        #    The substrate tells the agent HOW to use Pensyve tools — when to
+        #    recall, when to observe, episode lifecycle, etc.
+        # -------------------------------------------------------------------
+        model_client = AnthropicChatCompletionClient(model="claude-sonnet-4-6")
+
+        agent = AssistantAgent(
+            name="pensyve_agent",
+            model_client=model_client,
+            tools=tools,                   # Pensyve MCP tools wired in
+            system_message=substrate,      # substrate injected here
+        )
+
+        # -------------------------------------------------------------------
+        # 5. Run the agent on a task.  The agent will use Pensyve tools
+        #    automatically per the substrate rules.
+        # -------------------------------------------------------------------
+        await Console(
+            agent.run_stream(
+                task=(
+                    "I'm starting work on the auth-service module. "
+                    "What do we know about prior decisions there?"
+                )
+            )
+        )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/integrations/autogen/examples/pensyve_agent.py
+++ b/integrations/autogen/examples/pensyve_agent.py
@@ -24,10 +24,9 @@ from pathlib import Path
 
 # autogen-ext provides MCP integration adapters
 from autogen_agentchat.agents import AssistantAgent
-from autogen_agentchat.teams import RoundRobinGroupChat
 from autogen_agentchat.ui import Console
-from autogen_ext.tools.mcp import McpWorkbench, StreamableHttpServerParams
 from autogen_ext.models.anthropic import AnthropicChatCompletionClient
+from autogen_ext.tools.mcp import McpWorkbench, StreamableHttpServerParams
 
 # ---------------------------------------------------------------------------
 # 1. Load the substrate — the reasoning layer injected as the system prompt.

--- a/integrations/autogen/scripts/lint-mcp-refs.sh
+++ b/integrations/autogen/scripts/lint-mcp-refs.sh
@@ -34,18 +34,18 @@ echo ""
 echo "Check 1: no unsupported 'related_entities' on pensyve_recall"
 FOUND_RELATED=0
 for f in "$RULES_FILE" "$EXAMPLE_FILE"; do
-  awk '/pensyve_recall\(/{capture=1; buf=""}
-       capture {buf = buf "\n" $0}
-       capture && /\)/{
-         if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
-           print FILENAME ": related_entities found in pensyve_recall block: " buf;
-         capture=0
-       }' "$f" | while read -r line; do
+  while read -r line; do
     if [ -n "$line" ]; then
       echo "  FAIL: $line"
       FOUND_RELATED=1
     fi
-  done
+  done < <(awk '/pensyve_recall\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+       if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
+       print FILENAME ": related_entities found in pensyve_recall block: " buf;
+       capture=0
+       }' "$f")
 done
 if [ "$FOUND_RELATED" = "0" ]; then
   echo "  PASS"
@@ -58,18 +58,18 @@ echo ""
 echo "Check 2: no unsupported 'continuation_of' on pensyve_episode_start"
 FOUND_CONT=0
 for f in "$RULES_FILE" "$EXAMPLE_FILE"; do
-  awk '/pensyve_episode_start\(/{capture=1; buf=""}
-       capture {buf = buf "\n" $0}
-       capture && /\)/{
-         if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
-           print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
-         capture=0
-       }' "$f" | while read -r line; do
+  while read -r line; do
     if [ -n "$line" ]; then
       echo "  FAIL: $line"
       FOUND_CONT=1
     fi
-  done
+  done < <(awk '/pensyve_episode_start\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+       if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
+       print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
+       capture=0
+       }' "$f")
 done
 if [ "$FOUND_CONT" = "0" ]; then
   echo "  PASS"
@@ -82,23 +82,23 @@ echo ""
 echo "Check 3: every pensyve_observe example has source_entity and about_entity"
 MISSING_FIELDS=0
 for f in "$RULES_FILE" "$EXAMPLE_FILE"; do
-  awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
-       capture {buf = buf "\n" $0;
-                for(i=1; i<=length($0); i++){
-                  c=substr($0,i,1);
-                  if(c=="(") depth++;
-                  if(c==")") depth--;
-                };
-                if(depth==0 && buf ~ /pensyve_observe\(/){
-                  if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
-                  if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
-                  capture=0;
-                }}' "$f" | while read -r line; do
+  while read -r line; do
     if [ -n "$line" ]; then
       echo "  FAIL: $line"
       MISSING_FIELDS=1
     fi
-  done
+  done < <(awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
+       capture {buf = buf "\n" $0;
+       for(i=1; i<=length($0); i++){
+       c=substr($0,i,1);
+       if(c=="(") depth++;
+       if(c==")") depth--;
+       };
+       if(depth==0 && buf ~ /pensyve_observe\(/){
+       if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
+       if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
+       capture=0;
+       }}' "$f")
 done
 if [ "$MISSING_FIELDS" = "0" ]; then
   echo "  PASS"

--- a/integrations/autogen/scripts/lint-mcp-refs.sh
+++ b/integrations/autogen/scripts/lint-mcp-refs.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Static MCP contract linter for the Pensyve autogen adapter.
+#
+# Verifies that every pensyve_* call example in SUBSTRATE_PROMPT.md and the
+# example wiring file conforms to the current MCP tool schema.
+# Catches the category of bug PR #58 surfaced in the Claude Code adapter
+# (unsupported parameters, missing required fields).
+#
+# This integration uses a single consolidated SUBSTRATE_PROMPT.md (same
+# pattern as VS Code Copilot) rather than per-rule files.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INTEG_DIR="$SCRIPT_DIR/.."
+RULES_FILE="$INTEG_DIR/SUBSTRATE_PROMPT.md"
+EXAMPLE_FILE="$INTEG_DIR/examples/pensyve_agent.py"
+
+EXIT_CODE=0
+
+for f in "$RULES_FILE" "$EXAMPLE_FILE"; do
+  if [ ! -f "$f" ]; then
+    echo "ERROR: File not found: $f"
+    exit 1
+  fi
+done
+
+echo "Linting MCP references in:"
+echo "  $RULES_FILE"
+echo "  $EXAMPLE_FILE"
+echo ""
+
+# Check 1: no actual use of unsupported 'related_entities' parameter in call examples.
+echo "Check 1: no unsupported 'related_entities' on pensyve_recall"
+FOUND_RELATED=0
+for f in "$RULES_FILE" "$EXAMPLE_FILE"; do
+  awk '/pensyve_recall\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+         if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
+           print FILENAME ": related_entities found in pensyve_recall block: " buf;
+         capture=0
+       }' "$f" | while read -r line; do
+    if [ -n "$line" ]; then
+      echo "  FAIL: $line"
+      FOUND_RELATED=1
+    fi
+  done
+done
+if [ "$FOUND_RELATED" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 2: no actual use of unsupported 'continuation_of' parameter in call examples.
+echo "Check 2: no unsupported 'continuation_of' on pensyve_episode_start"
+FOUND_CONT=0
+for f in "$RULES_FILE" "$EXAMPLE_FILE"; do
+  awk '/pensyve_episode_start\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+         if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
+           print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
+         capture=0
+       }' "$f" | while read -r line; do
+    if [ -n "$line" ]; then
+      echo "  FAIL: $line"
+      FOUND_CONT=1
+    fi
+  done
+done
+if [ "$FOUND_CONT" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 3: every pensyve_observe call example in a code block has source_entity and about_entity
+echo "Check 3: every pensyve_observe example has source_entity and about_entity"
+MISSING_FIELDS=0
+for f in "$RULES_FILE" "$EXAMPLE_FILE"; do
+  awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
+       capture {buf = buf "\n" $0;
+                for(i=1; i<=length($0); i++){
+                  c=substr($0,i,1);
+                  if(c=="(") depth++;
+                  if(c==")") depth--;
+                };
+                if(depth==0 && buf ~ /pensyve_observe\(/){
+                  if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
+                  if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
+                  capture=0;
+                }}' "$f" | while read -r line; do
+    if [ -n "$line" ]; then
+      echo "  FAIL: $line"
+      MISSING_FIELDS=1
+    fi
+  done
+done
+if [ "$MISSING_FIELDS" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 4: provenance tag format — every proactive/auto-capture tag uses [<origin>/<trigger>/<tier>]
+echo "Check 4: provenance tag format"
+VALID_PROVENANCE_RE='\[(proactive|auto-capture)/(in-flight|stop|pre-compact|curator|user)/(tier-1|tier-2|residual/tier-1|residual/tier-2|open-question)\]'
+INVALID=0
+for f in "$RULES_FILE" "$EXAMPLE_FILE"; do
+  if rg -n '\[(proactive|auto-capture)' "$f" | rg -v "$VALID_PROVENANCE_RE"; then
+    INVALID=1
+  fi
+done
+if [ "$INVALID" = "0" ]; then
+  echo "  PASS"
+else
+  echo "  FAIL: some provenance tags do not match [<origin>/<trigger>/<tier>] format"
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 5: procedural memory convention — [procedural] prefix is used in observe content
+echo "Check 5: procedural convention uses [procedural] prefix in pensyve_observe content"
+if ! rg -q '\[procedural\]' "$RULES_FILE"; then
+  echo "  WARN: no [procedural] prefix usage found in SUBSTRATE_PROMPT.md."
+else
+  echo "  PASS"
+fi
+echo ""
+
+if [ "$EXIT_CODE" = "0" ]; then
+  echo "All MCP contract checks PASSED."
+else
+  echo "MCP contract checks FAILED. Fix the issues above before committing."
+fi
+
+exit "$EXIT_CODE"

--- a/integrations/cline/.clinerules/context-loader.md
+++ b/integrations/cline/.clinerules/context-loader.md
@@ -1,0 +1,72 @@
+# Context Loader (Continuity Primer)
+
+Use when starting a new substantive conversation or switching contexts — load relevant memories to prime the session with continuity.
+
+Cline has no automatic SessionStart hook. This rule is the manual equivalent: when starting a new conversation on a project that has prior Pensyve memories, call recall to prime the session with relevant context.
+
+Follows `memory-reflex.md`. Best-effort thread continuity via episodic recall (the MCP server has no episode-listing tool; see the main spec's Task C addendum for background).
+
+## Instructions
+
+### Step 1: Detect project entity
+
+Per `entity-detection.md` fallback rules: use the repository root name (lowercase-hyphenated) as the default project entity. Override with `PENSYVE_NAMESPACE` environment variable if explicitly set in the project's environment.
+
+### Step 2: Scoped recall
+
+Call `pensyve_recall`:
+
+- `query`: `"recent decisions issues patterns"` + any key terms from the user's opening message
+- `entity`: detected project entity
+- `types`: `["episodic"]` — recent session activity gives the best continuity signal
+- `limit`: 5
+
+Episodic memories are ranked by the MCP server's activation signal, which naturally surfaces recent observations first.
+
+### Step 3: Compute continuity signal
+
+Examine the returned observations:
+
+- If ≥70% of the top observations reference at least one entity that overlaps with the current conversation's entity candidates (from Step 1 plus any entities mentioned in the opening message), treat the session as a **continuation** of recent work.
+- If the overlap is below 70%, or recall returned empty, treat as a **fresh session**.
+
+### Step 4: Surface the primer
+
+**Continuation:**
+
+> **Pensyve:** Continuing prior work on `<entity-set>`. Recent lessons:
+>
+> - <observation 1>
+> - <observation 2>
+> - <observation 3>
+>
+> Use `/recall <query>` or ask about any of these to dig deeper.
+
+**Fresh session:**
+
+> **Pensyve:** N memories loaded for `<project>`. Key context:
+>
+> - <top 3 observations>
+>
+> Use `/recall <query>` to search for specific memories.
+
+**No memories found:**
+
+> **Pensyve:** No memories found for `<project>`. Use `/remember` to start building context.
+
+### Step 5: Continuity is best-effort, not a structured link
+
+The MCP server has no episode-listing or date-filtering API. This rule infers continuity from shared-entity overlap and recall-ranking recency. Consequences:
+
+- There is no persisted server-side link between sessions.
+- Primer accuracy depends on memory quality and recall ranking.
+- The user may occasionally see "Continuing prior work" when it's actually loosely related; or see a fresh-session primer when the prior session was related but the entity overlap was low.
+
+Document this honestly in the primer when uncertain — do not fabricate continuity.
+
+## Constraints
+
+- Do not fabricate memories. Only display what `pensyve_recall` returns.
+- If MCP is unavailable, skip the primer silently and mention the failure once per conversation if the user asks about memory.
+- Maximum 5 memories in the primer to avoid context bloat.
+- Entity names lowercase-hyphenated.

--- a/integrations/cline/.clinerules/entity-detection.md
+++ b/integrations/cline/.clinerules/entity-detection.md
@@ -1,0 +1,38 @@
+# Entity Detection (Always-Apply Reference)
+
+Shared rules for detecting entity names from tool inputs, prompts, and conversation context. Used by the memory reflex and all memory-woven flows to scope recalls and `about_entity` fields on observations.
+
+## Inputs
+
+Extract candidate entity names from:
+
+1. **File references** — `@filename`, `@path/to/file`, or files mentioned directly in the conversation.
+2. **User prompts** — explicit references to components, files, services, research phases (e.g., "phase-4.3", "v7r-classifier", "auth-service").
+3. **Code context** — module names, class names, function names in files you are editing or reading.
+4. **Git context** — repository root name, branch name (when discoverable).
+
+## Canonicalization
+
+- Lowercase all characters.
+- Replace spaces and underscores with hyphens.
+- Strip file extensions unless the file is the entity itself (e.g., `package.json`).
+- Collapse paths to the most semantically meaningful segment (e.g., `src/engine/hybrid_router.rs` → `hybrid-router`; `tests/integration/auth_test.py` → `auth`).
+
+## Fallback behavior
+
+- If no specific entity is detected, fall back to the project-level entity (repository root name, lowercase-hyphenated).
+- If a candidate entity is ambiguous between two names, prefer the one that already has memories in Pensyve (call `pensyve_inspect` with limit 1 to check).
+- **Never fabricate entity names.** If nothing confident emerges, use the project entity.
+
+## Output
+
+A set of 1–3 candidate entity names per turn. The primary entity is the most specific; secondary entities provide additional context. Since `pensyve_recall` accepts only a single `entity` parameter, fold secondary entities into the `query` string instead.
+
+## Examples
+
+| Input | Primary entity | Secondary (fold into query) |
+|---|---|---|
+| Edit on `src/engine/hybrid_router.rs` | `hybrid-router` | `engine` |
+| Prompt: "tune V7r noise threshold" | `v7r` | `noise-threshold` |
+| File `tests/test_auth.py` in a project named `auth-service` | `auth` | `auth-service` |
+| User mentions "phase-4.3 calibration" | `phase-4.3` | `calibration` |

--- a/integrations/cline/.clinerules/memory-informed-debug.md
+++ b/integrations/cline/.clinerules/memory-informed-debug.md
@@ -1,0 +1,66 @@
+# Memory-Informed Debug
+
+Use when diagnosing bugs, errors, failing tests, or crashes — consult prior debug outcomes and capture root causes in-flight.
+
+Debugging flow with memory baked in as a non-optional reflex. Follows `memory-reflex.md` for classification, surface style, and episode lifecycle.
+
+## Instructions
+
+### Step 1: Detect entities
+
+Identify the relevant entity/entities (failing test, failing module, error source) per `entity-detection.md`.
+
+### Step 2: Consult memory (required)
+
+Call `pensyve_recall`:
+
+- `query`: a short description of the failure, including secondary entity names where known (e.g., "hybrid-router threshold regression phase-4.3" rather than full stack traces)
+- `entity`: primary detected entity
+- `types`: `["procedural", "episodic"]` (debugging benefits most from known-good diagnostic procedures and prior incident outcomes)
+- `limit`: 5
+
+Secondary entities are folded into the query string since `RecallParams` scopes by a single `entity` only.
+
+Surface one line: `Recalled N memories from prior debug sessions on <entity>.` (Skip if N=0.)
+
+If a highly similar incident is found (score >0.8), call that out inline: `This looks similar to an incident captured on <date>: <summary>. Consider that path first.`
+
+### Step 3: Diagnose
+
+Proceed with the diagnostic work. Use recalled procedural memories as a starting sequence; update the sequence when you learn something new.
+
+### Step 4: Capture lesson (when it lands)
+
+When a root cause is **confirmed** (not just hypothesized), apply the memory reflex per `memory-reflex.md`:
+
+Ensure a working `episode_id` exists (lazy-open via `pensyve_episode_start` if not). Then:
+
+- **Episodic root cause:** call `pensyve_observe` with `content: "[proactive/in-flight/tier-1] <one-sentence root cause>"`, `source_entity: "cline"`, `about_entity: <primary_entity>`, `content_type: "text"`.
+- **Procedural diagnostic sequence:** if the debug produced a reusable diagnostic sequence, call `pensyve_observe` with `content: "[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=..."`, `source_entity: "cline"`, `about_entity: <primary_entity>`, `content_type: "text"`.
+- **Semantic durable truth:** if the root cause reveals a durable truth (e.g., "our CI runner's Python 3.10 cannot handle the new syntax"), also call `pensyve_remember(entity, fact, confidence: 0.9)`. Include provenance in the fact text: `"[proactive/in-flight/tier-1] <fact>"`.
+
+Surface one line: `↳ captured: <one-sentence>`.
+
+### Step 5: Capture abandoned approach
+
+If an approach was tried and abandoned, observe that too:
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[proactive/in-flight/tier-1] tried <approach>, abandoned because <reason>",
+  source_entity: "cline",
+  about_entity: <primary_entity>,
+  content_type: "text"
+)
+```
+
+These are high-value — they prevent re-treading the same dead end next time.
+
+## Constraints
+
+- Recall is **not optional**. If you skip recall to save time, you defeat the working-memory substrate.
+- Observe when a lesson **lands**, not when you first hypothesize.
+- One in-flight capture per turn unless multiple distinct lessons land simultaneously.
+- Respect the reflex rule's surface style — one line, not paragraphs.
+- Never store secrets or sensitive paths.

--- a/integrations/cline/.clinerules/memory-informed-design.md
+++ b/integrations/cline/.clinerules/memory-informed-design.md
@@ -1,0 +1,58 @@
+# Memory-Informed Design
+
+Use when making architecture, API, or design decisions — consult prior decisions and capture new ones in-flight.
+
+Design flow with memory baked in as a non-optional reflex. Follows `memory-reflex.md`.
+
+## Instructions
+
+### Step 1: Detect entities
+
+Identify the relevant entity/entities (service, module, subsystem under design) per `entity-detection.md`.
+
+### Step 2: Consult memory (required)
+
+Call `pensyve_recall`:
+
+- `query`: a short description of the design question, including secondary entity names where known (e.g., "auth-service jwt signing rs256 hs256")
+- `entity`: primary detected entity
+- `types`: `["semantic", "episodic"]` (design benefits most from durable decisions and prior decision-contexts)
+- `limit`: 5
+
+Surface one line: `Recalled N prior decisions on <entity>.` (Skip if N=0.)
+
+### Step 3: Recommend with grounding
+
+Shape your recommendation using the recalled decisions. If the user's current question directly contradicts a prior decision, flag it:
+
+> Prior decision on `<entity>` (confidence 0.9): [decision]. Are we revisiting this, or does the current question differ?
+
+### Step 4: Capture decision (when it lands)
+
+When the user accepts a design or states a decision ("let's go with X", "we'll use Y"), apply the memory reflex:
+
+- **Semantic** — `pensyve_remember(entity: <primary_entity>, fact: "[proactive/in-flight/tier-1] <decision text>", confidence: 0.9)`.
+- **Episodic context** — ensure working `episode_id`; `pensyve_observe` with `content: "[proactive/in-flight/tier-1] Decision on <entity>: chose X over Y because Z"`, `source_entity: "cline"`, `about_entity: <primary_entity>`, `content_type: "text"`. This enables future "why did we decide X?" queries.
+
+Surface one line: `↳ captured decision on <entity>: <short>`.
+
+### Step 5: Capture evaluation procedures
+
+If the design process revealed a reusable way to evaluate similar decisions (e.g., "run spike vs. prototype", "check latency first"), capture it as procedural:
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[procedural] [proactive/in-flight/tier-1] trigger=design-question-on-<area>, action=<steps>, outcome=<what-you-learn>",
+  source_entity: "cline",
+  about_entity: <primary_entity>,
+  content_type: "text"
+)
+```
+
+## Constraints
+
+- Recall is **not optional**.
+- Observe when a decision **lands**, not when it's being discussed.
+- Budget: one in-flight capture per turn unless multiple decisions land.
+- Never store secrets or sensitive architecture details the user has marked private.

--- a/integrations/cline/.clinerules/memory-informed-longitudinal-work.md
+++ b/integrations/cline/.clinerules/memory-informed-longitudinal-work.md
@@ -1,0 +1,68 @@
+# Memory-Informed Longitudinal Work
+
+Use for long-running multi-session work (research, eval loops, iterative benchmarks) — resume prior lessons, capture per-run outcomes, build up stable truths over time.
+
+Activates for files under `research/`, `benchmarks/`, or `evals/`, or when the model judges the conversation to be research-oriented.
+
+Multi-session engineering work (research, eval loops, iterative benchmarks) where lessons must accumulate across runs. The motivating case: improving a core algorithm over dozens of eval iterations without starting from scratch each session.
+
+Follows `memory-reflex.md`.
+
+## Instructions
+
+### Step 1: Resume context at conversation start
+
+If this conversation is in a research/eval context, call `pensyve_recall` once at the start:
+
+- `query`: short description of the current research area (e.g., "v7r classifier calibration")
+- `entity`: project + sub-topic entity (per `entity-detection.md` canonicalization rules)
+- `limit`: 5
+
+No `types` filter — longitudinal work benefits from all three memory types; omit to query all. (Passing all three explicitly is equivalent to no filter; omitting is cleaner.)
+
+Surface: `Recalled N prior findings on <sub-topic>.`
+
+Treat the returned observations as working knowledge — do not re-ask the user about things the recall already surfaces.
+
+### Step 2: Proactively recall per topic shift
+
+When the session pivots to a new sub-topic (new phase, new eval subset, new failure mode), call `pensyve_recall` again scoped to the new sub-topic.
+
+### Step 3: Capture three types of memory per run
+
+During the session, classify emerging knowledge and capture accordingly. Ensure working `episode_id` before each observe.
+
+| What you learned | Type | MCP call |
+|---|---|---|
+| Per-run outcome (what this run showed) | episodic | `pensyve_observe(..., content: "[proactive/in-flight/tier-1] Run N+1: V7r accuracy improved +3.5% with new threshold", source_entity: "cline", about_entity: <entity>, content_type: "text")` |
+| Stable truth about the system | semantic | `pensyve_remember(entity, fact: "[proactive/in-flight/tier-1] Haiku classifier plateaus above temp 0.3", confidence: 0.9)` |
+| Reusable experiment procedure | procedural | `pensyve_observe(..., content: "[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=...", source_entity: "cline", about_entity: <entity>, content_type: "text")` |
+
+Apply at landing — do not batch.
+
+### Step 4: Capture open questions
+
+When a run ends with an unresolved question ("X improved but we don't know why"), capture it as an episodic observation with open-question provenance:
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[proactive/in-flight/open-question] <question>",
+  source_entity: "cline",
+  about_entity: <entity>,
+  content_type: "text"
+)
+```
+
+This populates future "open questions" surfacing when the topic returns.
+
+### Step 5: End-of-session summary
+
+Before the conversation wraps, briefly summarize (inline, 3-5 lines): what this run taught us vs. prior runs, what's still open. This creates a natural handoff for the next session.
+
+## Constraints
+
+- Recall on every topic shift — not just at conversation start.
+- Capture at landing, not batched.
+- Never store run artifacts or large data blobs — summarize.
+- Respect the reflex's surface style.

--- a/integrations/cline/.clinerules/memory-informed-refactor.md
+++ b/integrations/cline/.clinerules/memory-informed-refactor.md
@@ -1,0 +1,57 @@
+# Memory-Informed Refactor
+
+Use before substantive refactors — load relevant prior context, capture refactor insights as they land.
+
+Refactor flow with memory baked in. Follows `memory-reflex.md`.
+
+## Instructions
+
+### Step 1: Detect entities
+
+Identify the entities touched by the refactor (the file or module being restructured, its callers, the subsystem name) per `entity-detection.md`.
+
+### Step 2: Load prior context (required)
+
+Call `pensyve_recall`:
+
+- `query`: short description of the refactor (e.g., "hybrid-router routing logic restructure")
+- `entity`: primary detected entity
+- `types`: `["semantic", "episodic", "procedural"]` — refactors benefit from all three (durable invariants, prior attempts, known-good sequences)
+- `limit`: 5
+
+Surface: `Recalled N prior memories on <entity>.` (Skip if N=0.)
+
+Highlight any prior failed approaches inline:
+
+> Prior episodic memory (confidence 0.8): tried <approach> on <date>, abandoned because <reason>. Double-check this isn't the same trap.
+
+### Step 3: Present a briefing
+
+Before starting the refactor, briefly summarize what the prior memories say about:
+
+- **Decisions** — durable choices that constrain the refactor (semantic)
+- **Prior attempts** — what's been tried (episodic)
+- **Known-good procedures** — reusable sequences for this kind of refactor (procedural)
+
+If no relevant memories exist, say so clearly and proceed without historical context.
+
+### Step 4: Capture refactor lessons as they land
+
+When any of these occur during the refactor, apply the memory reflex immediately:
+
+- **An invariant is discovered** (semantic) — `pensyve_remember(entity, fact, confidence: 0.9)`
+- **An abandoned approach is confirmed not-viable** (episodic) — `pensyve_observe` with `[proactive/in-flight/tier-1]` provenance
+- **A dependency chain was traced that surprised us** (episodic) — `pensyve_observe`
+- **A known-good refactoring sequence emerged** (procedural) — `pensyve_observe` with `[procedural]` prefix
+
+Ensure working `episode_id` before each observe; lazy-open if needed.
+
+Do not batch these to end-of-session — capture at landing, surface one-line.
+
+## Constraints
+
+- The briefing step is the real value — it informs the refactor.
+- Observe at landing, not batched.
+- Entity names lowercase-hyphenated.
+- Do not start the refactor itself — this rule provides guidance and capture. The user decides when and how to proceed.
+- If the MCP server returns errors on some queries, present results from the successful queries and note the failures.

--- a/integrations/cline/.clinerules/memory-reflex.md
+++ b/integrations/cline/.clinerules/memory-reflex.md
@@ -1,0 +1,96 @@
+# Memory Reflex Rule (Always-Apply)
+
+This rule is always in context. It turns Pensyve memory operations from optional actions into a reasoning discipline you carry through every substantive turn.
+
+## The rule
+
+**Before substantive answers, recall by entity. When a lesson lands, observe immediately with a one-line surface.**
+
+### "Substantive answer" means
+
+- Design or architecture recommendations
+- Debugging diagnoses with root-cause claims
+- Refactor proposals
+- Any response that makes a claim the user would want grounded in prior work
+
+Not substantive: formatting fixes, trivial lookups, reading a file, running a command.
+
+### "Lesson lands" means
+
+- A root cause has been confirmed (not hypothesized).
+- A design choice has been made explicit ("we'll use X because Y").
+- An approach has been tried and abandoned with a reason.
+- A workflow has been discovered that is reusable.
+- A workaround for a framework/library limitation has been validated.
+
+## Classification (which memory type?)
+
+- **Semantic** — a fact that will still be true next month. Use `pensyve_remember(entity, fact, confidence?)` (confidence defaults to 1.0; use 0.9 for high-confidence auto-captures).
+- **Episodic** — something that happened in this thread of work. Use `pensyve_observe` with the current `episode_id`.
+- **Procedural** — a reusable way to do something (a workflow, sequence, recipe). Use `pensyve_observe` with `content` beginning `[procedural]` (integration-layer convention; the MCP server has no native procedural-write API).
+
+When in doubt, prefer episodic. Server-side consolidation promotes recurring patterns to semantic automatically.
+
+## Canonical `pensyve_observe` call template
+
+ALL observe calls — in-flight, procedural, or wrap-up — MUST include every required field:
+
+```
+pensyve_observe(
+  episode_id: <current session's working episode_id>,
+  content: "[proactive/in-flight/tier-1] <observation text>",
+  source_entity: "cline",
+  about_entity: "<relevant entity, lowercase-hyphenated>",
+  content_type: "text"
+)
+```
+
+Use `content_type: "code"` for code-related outcomes.
+
+## Episode lifecycle (lazy-open)
+
+Cline has no session-start/session-end hooks, so you own the episode lifecycle:
+
+- **Before your first `pensyve_observe` call in this conversation**, check whether a working `episode_id` is already tracked. If none exists, call `pensyve_episode_start(participants: ["cline", "<project entity>"])` first, record the returned `episode_id`, then make the observation.
+- **Reuse the same `episode_id`** for all subsequent observations in the same conversation. Open a new episode only when the work's topic shifts substantially.
+- **Do not explicitly close** the episode under normal operation. Server-side consolidation handles aging.
+- **Recovery**: if `pensyve_observe` fails with a missing-episode error, call `pensyve_episode_start` and retry.
+
+## Surface style
+
+Lightly visible. One line when memory is used. Examples:
+
+- Recall: `Recalled 4 related memories (v7r, haiku-classifier).`
+- Capture: `↳ captured: hybrid-router threshold was the phase-3 regression root cause.`
+
+Do not narrate empty recalls or duplicate-skips.
+
+## Scope and budgets
+
+- Recall: scoped to detected entities (see `entity-detection.md`); limit 5; use `types` hint per flow.
+- Capture: one observation per substantive lesson; reuse the working `episode_id`.
+- Noise: avoid surfacing memory operations the user did not care about.
+
+## Composition with provenance tags
+
+When a capture is both procedural AND a proactive in-flight write, the `content` field begins with both markers, `[procedural]` first, then the provenance tag, then content:
+
+`[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=...`
+
+The `[procedural]` marker identifies the memory type for consolidation. The provenance tag identifies origin and trigger.
+
+## Provenance tag vocabulary
+
+- `[proactive/in-flight/tier-1]` — memory reflex captured during reasoning
+- `[proactive/in-flight/open-question]` — unresolved question noted in-flight
+- `[auto-capture/user/residual/tier-1]` — explicit user-driven capture (e.g., session-memory rule)
+
+## MCP contract reminder
+
+Rules never pass unsupported parameters. The MCP tool schemas are:
+
+- `pensyve_recall(query, entity?, types?, limit?, min_confidence?)` — **no** `related_entities`
+- `pensyve_episode_start(participants)` — **no** `continuation_of`
+- `pensyve_observe(episode_id, content, source_entity, about_entity, content_type?)` — `source_entity` and `about_entity` are **required**
+
+If you need secondary-entity context in a recall, fold those entities into the `query` string.

--- a/integrations/cline/.clinerules/session-memory.md
+++ b/integrations/cline/.clinerules/session-memory.md
@@ -1,0 +1,82 @@
+# Session Memory (Wrap-Up)
+
+Use at conversation wrap-up or when the user explicitly indicates end-of-session — capture residual lessons not captured in-flight.
+
+Cline has no automatic Stop hook. This rule is the manual equivalent: when the user indicates the conversation is ending ("thanks, that's all", "session wrap-up", "we're done here"), review what happened and capture anything the in-flight reflex missed.
+
+Follows `memory-reflex.md`.
+
+## Instructions
+
+### Step 1: Review the conversation
+
+Scan the current conversation for three categories of memorable content that the in-flight reflex did NOT already capture:
+
+**Decisions** (confidence: 0.9):
+- Architecture or design choices
+- Technology selections
+- API design decisions
+- Tradeoff resolutions
+
+**Outcomes** (confidence: 0.8):
+- Bug fixes and their root causes
+- Successful approaches
+- Failed approaches with reasons
+- Performance findings
+
+**Patterns** (confidence: 0.7):
+- Recurring issues
+- Workflow discoveries
+- Cross-cutting observations
+
+### Step 2: Filter for significance and deduplicate
+
+Skip routine, low-signal content. Also skip anything that was already captured in-flight.
+
+For each candidate, call `pensyve_recall` with `query: <candidate fact text>`, `entity: <candidate's entity>`, `limit: 3`. If any returned memory has a score ≥0.85 against the candidate, skip it as a likely duplicate.
+
+Note: `pensyve_inspect` cannot filter by `episode_id` (its params are `entity`, `memory_type?`, `limit?` only), so dedup is entity-scoped semantic-similarity rather than session-scoped. Consequence: very similar items captured in prior sessions will also trigger the skip — acceptable for avoiding genuine duplicates.
+
+### Step 3: Present candidates for confirmation
+
+Show the filtered candidates to the user in a structured format:
+
+> **Session Memory Candidates**
+>
+> **Decisions** (confidence: 0.9):
+> 1. `<entity>`: <decision text>
+>
+> **Outcomes** (confidence: 0.8):
+> 2. `<entity>`: <outcome text>
+>
+> **Patterns** (confidence: 0.7):
+> 3. `<entity>`: <pattern text>
+>
+> Which should I store? (e.g., "all", "1,3", "none")
+
+### Step 4: Store confirmed items
+
+For each confirmed item, classify the type and call the appropriate MCP tool:
+
+- **Semantic** (decisions, durable truths) — `pensyve_remember(entity, fact: "[auto-capture/user/residual/tier-1] <text>", confidence)`. Use confidence from the categorization above.
+- **Episodic** (outcomes, session-specific events) — ensure working `episode_id`; `pensyve_observe(episode_id, content: "[auto-capture/user/residual/tier-1] <text>", source_entity: "cline", about_entity: <entity>, content_type: "text")`.
+- **Procedural** (reusable workflows) — `pensyve_observe(episode_id, content: "[procedural] [auto-capture/user/residual/tier-1] trigger=..., action=..., outcome=...", source_entity: "cline", about_entity: <entity>, content_type: "text")`.
+
+### Step 5: Optionally close the episode
+
+If the user indicates this is a final wrap (not just a turn-by-turn pause), call `pensyve_episode_end(episode_id: <working_id>, outcome: "success")`. Valid outcomes: `"success"`, `"failure"`, `"partial"`.
+
+Not closing is safe — server-side consolidation ages episodes naturally. Only close when the user clearly marks the work complete.
+
+### Step 6: Report
+
+After storing, summarize:
+
+> Stored N memories. Episode <outcome> closed.
+
+## Constraints
+
+- **Never auto-store.** Every candidate MUST be presented to the user for confirmation before storage.
+- Entity names lowercase-hyphenated.
+- Do not store secrets.
+- If nothing significant surfaced, say so clearly rather than forcing low-quality memories.

--- a/integrations/cline/CHANGELOG.md
+++ b/integrations/cline/CHANGELOG.md
@@ -1,0 +1,43 @@
+# Changelog — Pensyve Cline Adapter
+
+All notable changes to the Pensyve Cline adapter are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). The Cline adapter versions independently of the Claude Code plugin.
+
+## [1.0.0] - 2026-04-20
+
+### Added
+
+- **Working-memory substrate** for Cline via `.clinerules/*.md` files. Eight rule files deliver the substrate the Claude Code plugin v1.3.0 established:
+  - `memory-reflex.md` (always-apply) — non-optional reasoning discipline with three-type memory classification, canonical `pensyve_observe` call template, provenance vocabulary, lazy-open episode lifecycle
+  - `entity-detection.md` (always-apply) — canonicalization and fallback rules
+  - `memory-informed-debug.md` — debug flow
+  - `memory-informed-design.md` — design flow
+  - `memory-informed-refactor.md` — refactor flow
+  - `memory-informed-longitudinal-work.md` — research/eval flow (activates for `research/**`, `benchmarks/**`, `evals/**` or research-oriented conversations)
+  - `session-memory.md` — manual wrap-up equivalent of Claude Code's Stop hook
+  - `context-loader.md` — best-effort continuity primer via episodic recall
+- **MCP config example** at `cline_mcp_settings.json.example` covering Cloud-with-API-key and Local-stdio options
+- **Static MCP contract lint script** at `scripts/lint-mcp-refs.sh` verifying every rule's `pensyve_*` call example matches the `pensyve-mcp-tools/src/params.rs` schema
+
+### Design
+
+- Single reasoning layer; no platform-layer code. Cline has no hook/event surface, so the entire adapter is rules the model interprets.
+- Cline's modern directory-based rules format (`.clinerules/*.md`) used in preference to the legacy single-file `.clinerules` format.
+- No MDC frontmatter — Cline's `.clinerules/*.md` format does not use frontmatter; rules activate by content and filename.
+- Lazy-open episode lifecycle: first `pensyve_observe` call triggers `pensyve_episode_start`; episodes are not explicitly closed.
+- Best-effort continuity primer via `pensyve_recall(types: ["episodic"])` — the MCP server has no episode-listing API.
+- MCP contract verified: no `related_entities` on recall, no `continuation_of` on episode_start, required `source_entity: "cline"` and `about_entity` on every observe.
+- Opt-out: delete or edit rule files (Cline-native pattern); no parallel config file.
+
+### Not Included
+
+- No extension or platform-layer code (deferred to a future sibling spec if capability gaps surface)
+- No installer script (manual copy of rules + MCP config)
+- No server-side changes — uses the existing MCP tool surface
+
+### Relation to Other Pensyve Integrations
+
+- The Cline adapter is part of the batch-1 working-memory substrate rollout. The Cursor adapter (v1.0.0) and Claude Code plugin (v1.3.0) are the reference implementations.
+- Spec: `pensyve-docs/specs/2026-04-20-pensyve-cursor-adapter-design.md`
+- Playbook: `pensyve-docs/specs/2026-04-18-pensyve-working-memory-substrate-design.md`

--- a/integrations/cline/README.md
+++ b/integrations/cline/README.md
@@ -1,31 +1,28 @@
 # Pensyve for Cline
 
-Persistent AI memory for [Cline](https://github.com/cline/cline) via MCP.
+Persistent working-memory substrate for [Cline](https://github.com/cline/cline) — memory is not a feature you invoke, it is the substrate the agent operates on.
 
-## Authentication
+## What It Does
 
-1. Sign up at [pensyve.com](https://pensyve.com)
-2. Create an API key at [Settings → API Keys](https://pensyve.com/settings/api-keys)
-3. Set the environment variable:
-   ```bash
-   export PENSYVE_API_KEY="psy_your_key_here"
-   ```
+- **Proactive memory during work** — lessons are captured the moment they land, not at session end
+- **Thread-aware continuity** — sessions that continue prior work resume with relevant context, no re-briefing
+- **Entity-scoped recall** — substantive questions are grounded in prior decisions; simple commands stay fast
+- **Three memory types** — durable facts (semantic), session-specific events (episodic), reusable procedures (procedural)
+- **Lightly visible** — one-line surfaces when memory is used; never interrupts your flow
 
-Then configure MCP with headers (see setup instructions above).
+## Install
 
-## Setup
+Two steps: configure the MCP server, then install the rules.
 
-Set your API key (get one at [pensyve.com/settings/api-keys](https://pensyve.com/settings/api-keys)):
+### 1. Configure the MCP server
+
+Copy `cline_mcp_settings.json.example` and merge it into your Cline MCP settings (via Cline's settings UI or directly in `cline_mcp_settings.json`).
+
+**Cloud with API key (recommended):**
 
 ```bash
-export PENSYVE_API_KEY="psy_your_key"
+export PENSYVE_API_KEY="psy_your_key_here"
 ```
-
-Add to your shell profile (`~/.bashrc`, `~/.zshrc`) to persist across sessions.
-
-## Cloud (Recommended)
-
-Open Cline settings → MCP Servers, or add to your Cline MCP config file:
 
 ```json
 {
@@ -41,11 +38,9 @@ Open Cline settings → MCP Servers, or add to your Cline MCP config file:
 }
 ```
 
-> Use `headers` with `Authorization: Bearer` for remote MCP. The `env` block is for local stdio servers.
+Create your key at [pensyve.com/settings/api-keys](https://pensyve.com/settings/api-keys). Put the `export` in `~/.bashrc` or `~/.zshrc` to persist.
 
-## Local (Offline)
-
-No API key needed — all data stays on your machine.
+**Local (offline, self-hosted):**
 
 ```json
 {
@@ -62,40 +57,91 @@ No API key needed — all data stays on your machine.
 }
 ```
 
-Build from source: `cargo build --release -p pensyve-mcp` from the [pensyve repo](https://github.com/major7apps/pensyve).
+Build the binary: `cargo build --release -p pensyve-mcp` from the [pensyve repo](https://github.com/major7apps/pensyve).
 
-## Available Tools
+### 2. Install the rules
 
-| Tool                    | Description                            |
-| ----------------------- | -------------------------------------- |
-| `pensyve_recall`        | Search memories by semantic similarity |
-| `pensyve_remember`      | Store a fact as semantic memory        |
-| `pensyve_episode_start` | Begin tracking an interaction          |
-| `pensyve_episode_end`   | Close an episode                       |
-| `pensyve_forget`        | Delete an entity's memories            |
-| `pensyve_inspect`       | List memories for an entity            |
-| `pensyve_status`        | Connection and memory stats            |
-| `pensyve_account`       | Plan and usage info                    |
+Copy the rule files into your project's `.clinerules/` directory:
+
+```bash
+mkdir -p .clinerules
+cp /path/to/pensyve/integrations/cline/.clinerules/*.md .clinerules/
+```
+
+Cline will load all `.md` files in `.clinerules/` as rules automatically.
+
+| Rule | Purpose |
+|---|---|
+| `memory-reflex.md` | Always-on reasoning discipline (core substrate) |
+| `entity-detection.md` | Entity canonicalization reference |
+| `memory-informed-debug.md` | Debug flow with memory baked in |
+| `memory-informed-design.md` | Design flow with memory baked in |
+| `memory-informed-refactor.md` | Refactor flow with memory baked in |
+| `memory-informed-longitudinal-work.md` | Research/eval multi-session flow |
+| `session-memory.md` | Manual session wrap-up capture |
+| `context-loader.md` | Best-effort continuity primer at session start |
+
+## How It Works
+
+Cline has no hook/event surface, so the entire substrate is delivered through the rules the model interprets during reasoning. `memory-reflex.md` establishes the discipline: *before substantive answers, recall by entity; when a lesson lands, observe immediately with a one-line surface*. Flow rules (debug/design/refactor/longitudinal-work) guide the model through consult-memory + capture-lesson steps.
+
+**Episode lifecycle:** Cline has no session-start/session-end hooks, so episodes open lazily on the first `pensyve_observe` call and are not explicitly closed under normal operation. Server-side consolidation handles aging.
+
+**Continuity primer:** `context-loader.md` runs a best-effort recall at the start of substantive conversations to surface prior relevant observations. Not a structured server-side link — the MCP server has no episode-listing API yet — but good enough to create the "continuing prior work" feel.
+
+## Memory Behavior Model
+
+Pensyve behaves as working memory for the agent — always-on, ambient, continuous.
+
+**Writes happen in-flight.** When a root cause is confirmed, a decision is made, or a reusable procedure emerges, it's captured the moment it lands via the memory reflex. No batching to session end.
+
+**Reads happen at decision points.** Before substantive answers, the model consults memory scoped to the detected entities. Simple commands (run tests, format file) skip recall to stay fast.
+
+**Sessions continue.** At the start of a substantive conversation, Pensyve checks whether the current work continues prior memories (shared entities + recent activity). If yes, you resume with a primer — no re-briefing needed.
+
+## Memory Types
+
+| Type | Definition | MCP call | Example |
+|---|---|---|---|
+| **Semantic** | Durable truths, decisions, preferences | `pensyve_remember` | "We chose RS256 over HS256 for JWT signing" |
+| **Episodic** | Temporal events, session-scoped observations | `pensyve_observe` (with lazy-opened `episode_id`) | "Phase-3 regression root cause: hybrid-router threshold" |
+| **Procedural** | Reusable workflows, sequences, recipes | `pensyve_observe` with `[procedural]` content prefix | "To calibrate V7r: freeze Haiku config, run suite, diff baseline" |
+
+## Opt-Out
+
+- **Full opt-out** — delete the Pensyve rule files from `.clinerules/`
+- **Partial opt-out** — delete specific flow rules (e.g., remove `memory-informed-longitudinal-work.md` if you don't do research work)
+- **Silent mode** — edit `memory-reflex.md` to remove the "one-line surface" guidance; captures stay silent
+- **Recall-only mode** — edit flow rules to drop the `Capture lesson` steps while keeping `Consult memory`
+
+## Available MCP Tools
+
+| Tool | Description |
+|---|---|
+| `pensyve_recall` | Search memories by semantic similarity |
+| `pensyve_remember` | Store a durable fact (semantic memory) |
+| `pensyve_observe` | Record a session observation (episodic / procedural via `[procedural]` prefix) |
+| `pensyve_episode_start` | Begin tracking an episode |
+| `pensyve_episode_end` | Close an episode with outcome |
+| `pensyve_forget` | Delete an entity's memories |
+| `pensyve_inspect` | List memories for an entity |
 
 See [MCP Tools Reference](https://pensyve.com/docs/api-reference/mcp-tools) for full parameter details.
 
-## Intelligent Memory Capture
+## Design Philosophy
 
-Pensyve uses a tiered classification system to identify what is worth remembering. Since Cline connects via MCP only, the LLM follows the MCP tool descriptions to decide when and how to call memory tools.
+- **Memory as substrate** — not a feature the user invokes; always there, continuous, carried across sessions
+- **Reasoning-layer only** — no platform-layer code in v1; the entire adapter is markdown rules
+- **1:1 with Claude Code** — same skill structure, same conventions, same memory types
+- **MCP contract-respecting** — every rule's call examples verified against `pensyve-mcp-tools/src/params.rs`
 
-### Tiered Capture System
+## Links
 
-- **Tier 1** (auto-store, confidence 0.9+): Explicit decisions, corrections, constraints, architecture choices, dependency version pins, security rules. High-signal items that should almost always be captured.
-- **Tier 2** (review, confidence 0.7-0.89): Root causes, failed approaches, performance findings, debugging outcomes, environment quirks. Medium-signal items that benefit from user confirmation.
-- **Discard**: Formatting, typos, boilerplate, ephemeral status messages. Noise that should never be stored.
+- **Website:** [pensyve.com](https://pensyve.com)
+- **GitHub:** [github.com/major7apps/pensyve](https://github.com/major7apps/pensyve)
+- **Spec:** [Cursor adapter design](https://github.com/major7apps/pensyve-docs/blob/main/specs/2026-04-20-pensyve-cursor-adapter-design.md)
+- **Playbook:** [Working-memory substrate design](https://github.com/major7apps/pensyve-docs/blob/main/specs/2026-04-18-pensyve-working-memory-substrate-design.md)
 
-### Best Practices
+## License
 
-For the best experience with Cline, guide the LLM to use Pensyve's memory tools effectively:
-
-- Use `pensyve_observe` to record significant events during an episode (architecture decisions, failed approaches, key findings)
-- Use `pensyve_remember` for durable facts that should persist across sessions (project conventions, environment constraints, resolved issues)
-- Use `pensyve_recall` at the start of a task to load relevant context from prior sessions
-- Wrap multi-step work in `pensyve_episode_start` / `pensyve_episode_end` to capture episodic context
-
-The MCP tool descriptions include guidance on confidence levels so the LLM can classify memories into the appropriate tier automatically.
+Apache 2.0

--- a/integrations/cline/cline_mcp_settings.json.example
+++ b/integrations/cline/cline_mcp_settings.json.example
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "pensyve": {
+      "type": "http",
+      "url": "https://mcp.pensyve.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ${PENSYVE_API_KEY}"
+      }
+    }
+  }
+}

--- a/integrations/cline/scripts/lint-mcp-refs.sh
+++ b/integrations/cline/scripts/lint-mcp-refs.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Static MCP contract linter for the Pensyve Cline adapter rules.
+#
+# Verifies that every pensyve_* call example in .clinerules/*.md conforms to
+# the current MCP tool schema in pensyve-mcp-tools/src/params.rs. Catches the
+# category of bug PR #58 surfaced in the Claude Code adapter (unsupported
+# parameters, missing required fields).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RULES_DIR="$SCRIPT_DIR/../.clinerules"
+
+EXIT_CODE=0
+
+if [ ! -d "$RULES_DIR" ]; then
+  echo "ERROR: Rules directory not found: $RULES_DIR"
+  exit 1
+fi
+
+echo "Linting MCP references in $RULES_DIR..."
+echo ""
+
+# Check 1: no actual use of unsupported 'related_entities' parameter in call examples.
+# We look for pensyve_recall( blocks that contain related_entities as a parameter.
+# Lines that say "no related_entities" (documentation/reminders) are excluded.
+echo "Check 1: no unsupported 'related_entities' on pensyve_recall"
+FOUND_RELATED=0
+for rule_file in "$RULES_DIR"/*.md; do
+  # Extract lines that contain pensyve_recall( and related_entities together,
+  # excluding documentation lines (those containing "**no**" or "no `related_entities`")
+  if rg -n 'related_entities' "$rule_file" | rg -v '(\*\*no\*\*|no `related_entities`)' | rg -q 'pensyve_recall\|related_entities'; then
+    echo "  FAIL in $rule_file: 'related_entities' used in a pensyve_recall call"
+    FOUND_RELATED=1
+  fi
+  # Also catch if related_entities appears inside a pensyve_recall( block
+  awk '/pensyve_recall\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+         if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
+           print FILENAME ": related_entities found in pensyve_recall block: " buf;
+         capture=0
+       }' "$rule_file" | while read -r line; do
+    if [ -n "$line" ]; then
+      echo "  FAIL: $line"
+      FOUND_RELATED=1
+    fi
+  done
+done
+if [ "$FOUND_RELATED" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 2: no actual use of unsupported 'continuation_of' parameter in call examples.
+# Documentation lines saying "no continuation_of" are excluded.
+echo "Check 2: no unsupported 'continuation_of' on pensyve_episode_start"
+FOUND_CONT=0
+for rule_file in "$RULES_DIR"/*.md; do
+  awk '/pensyve_episode_start\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+         if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
+           print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
+         capture=0
+       }' "$rule_file" | while read -r line; do
+    if [ -n "$line" ]; then
+      echo "  FAIL: $line"
+      FOUND_CONT=1
+    fi
+  done
+done
+if [ "$FOUND_CONT" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 3: every pensyve_observe call example in a code block has source_entity and about_entity
+# Scan each .md file's pensyve_observe blocks; require both fields nearby.
+echo "Check 3: every pensyve_observe example has source_entity and about_entity"
+MISSING_FIELDS=0
+for rule_file in "$RULES_DIR"/*.md; do
+  # Find each pensyve_observe( block (up to the next closing paren within 20 lines)
+  awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
+       capture {buf = buf "\n" $0;
+                for(i=1; i<=length($0); i++){
+                  c=substr($0,i,1);
+                  if(c=="(") depth++;
+                  if(c==")") depth--;
+                };
+                if(depth==0 && buf ~ /pensyve_observe\(/){
+                  if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
+                  if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
+                  capture=0;
+                }}' "$rule_file" | while read -r line; do
+    if [ -n "$line" ]; then
+      echo "  FAIL: $line"
+      MISSING_FIELDS=1
+    fi
+  done
+done
+if [ "$MISSING_FIELDS" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 4: provenance tag format — every proactive/auto-capture tag uses [<origin>/<trigger>/<tier>]
+# Format supports both 3-segment [origin/trigger/tier] and 4-segment [origin/trigger/residual/tier]
+# where the third segment may be a literal "residual" qualifier before the tier.
+echo "Check 4: provenance tag format"
+VALID_PROVENANCE_RE='\[(proactive|auto-capture)/(in-flight|stop|pre-compact|curator|user)/(tier-1|tier-2|residual/tier-1|residual/tier-2|open-question)\]'
+if rg -n '\[(proactive|auto-capture)' "$RULES_DIR" | rg -v "$VALID_PROVENANCE_RE"; then
+  echo "  FAIL: some provenance tags do not match [<origin>/<trigger>/<tier>] format"
+  EXIT_CODE=1
+else
+  echo "  PASS"
+fi
+echo ""
+
+# Check 5: procedural memory convention — [procedural] prefix is used in observe content
+echo "Check 5: procedural convention uses [procedural] prefix in pensyve_observe content"
+# Only a warning if no rule mentions [procedural] — may be legitimate if the rule is non-procedural
+if ! rg -q '\[procedural\]' "$RULES_DIR"; then
+  echo "  WARN: no [procedural] prefix usage found across rules. Expected in memory-reflex and flow rules that handle procedural captures."
+else
+  echo "  PASS"
+fi
+echo ""
+
+if [ "$EXIT_CODE" = "0" ]; then
+  echo "All MCP contract checks PASSED."
+else
+  echo "MCP contract checks FAILED. Fix the issues above before committing."
+fi
+
+exit "$EXIT_CODE"

--- a/integrations/cline/scripts/lint-mcp-refs.sh
+++ b/integrations/cline/scripts/lint-mcp-refs.sh
@@ -34,18 +34,18 @@ for rule_file in "$RULES_DIR"/*.md; do
     FOUND_RELATED=1
   fi
   # Also catch if related_entities appears inside a pensyve_recall( block
-  awk '/pensyve_recall\(/{capture=1; buf=""}
-       capture {buf = buf "\n" $0}
-       capture && /\)/{
-         if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
-           print FILENAME ": related_entities found in pensyve_recall block: " buf;
-         capture=0
-       }' "$rule_file" | while read -r line; do
+  while read -r line; do
     if [ -n "$line" ]; then
       echo "  FAIL: $line"
       FOUND_RELATED=1
     fi
-  done
+  done < <(awk '/pensyve_recall\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+       if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
+       print FILENAME ": related_entities found in pensyve_recall block: " buf;
+       capture=0
+       }' "$rule_file")
 done
 if [ "$FOUND_RELATED" = "0" ]; then
   echo "  PASS"
@@ -59,18 +59,18 @@ echo ""
 echo "Check 2: no unsupported 'continuation_of' on pensyve_episode_start"
 FOUND_CONT=0
 for rule_file in "$RULES_DIR"/*.md; do
-  awk '/pensyve_episode_start\(/{capture=1; buf=""}
-       capture {buf = buf "\n" $0}
-       capture && /\)/{
-         if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
-           print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
-         capture=0
-       }' "$rule_file" | while read -r line; do
+  while read -r line; do
     if [ -n "$line" ]; then
       echo "  FAIL: $line"
       FOUND_CONT=1
     fi
-  done
+  done < <(awk '/pensyve_episode_start\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+       if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
+       print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
+       capture=0
+       }' "$rule_file")
 done
 if [ "$FOUND_CONT" = "0" ]; then
   echo "  PASS"
@@ -85,23 +85,23 @@ echo "Check 3: every pensyve_observe example has source_entity and about_entity"
 MISSING_FIELDS=0
 for rule_file in "$RULES_DIR"/*.md; do
   # Find each pensyve_observe( block (up to the next closing paren within 20 lines)
-  awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
-       capture {buf = buf "\n" $0;
-                for(i=1; i<=length($0); i++){
-                  c=substr($0,i,1);
-                  if(c=="(") depth++;
-                  if(c==")") depth--;
-                };
-                if(depth==0 && buf ~ /pensyve_observe\(/){
-                  if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
-                  if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
-                  capture=0;
-                }}' "$rule_file" | while read -r line; do
+  while read -r line; do
     if [ -n "$line" ]; then
       echo "  FAIL: $line"
       MISSING_FIELDS=1
     fi
-  done
+  done < <(awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
+       capture {buf = buf "\n" $0;
+       for(i=1; i<=length($0); i++){
+       c=substr($0,i,1);
+       if(c=="(") depth++;
+       if(c==")") depth--;
+       };
+       if(depth==0 && buf ~ /pensyve_observe\(/){
+       if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
+       if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
+       capture=0;
+       }}' "$rule_file")
 done
 if [ "$MISSING_FIELDS" = "0" ]; then
   echo "  PASS"

--- a/integrations/codex-plugin/.agents/mcp.json.example
+++ b/integrations/codex-plugin/.agents/mcp.json.example
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "pensyve": {
+      "type": "http",
+      "url": "https://mcp.pensyve.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ${PENSYVE_API_KEY}"
+      }
+    }
+  }
+}

--- a/integrations/codex-plugin/AGENTS.md
+++ b/integrations/codex-plugin/AGENTS.md
@@ -1,0 +1,372 @@
+# Pensyve Working-Memory Substrate for OpenAI Codex CLI
+
+This file configures persistent working-memory for the OpenAI Codex CLI agent via the Pensyve MCP server. All sections below are always in context — they form the substrate the agent operates on across every coding session.
+
+---
+
+## Memory Reflex Rule
+
+**This discipline is non-optional. Before substantive answers, recall by entity. When a lesson lands, observe immediately with a one-line surface.**
+
+### "Substantive answer" means
+
+- Design or architecture recommendations
+- Debugging diagnoses with root-cause claims
+- Refactor proposals
+- Any response that makes a claim the user would want grounded in prior work
+
+Not substantive: formatting fixes, trivial lookups, reading a file, running a command.
+
+### "Lesson lands" means
+
+- A root cause has been confirmed (not hypothesized).
+- A design choice has been made explicit ("we'll use X because Y").
+- An approach has been tried and abandoned with a reason.
+- A workflow has been discovered that is reusable.
+- A workaround for a framework/library limitation has been validated.
+
+### Memory classification
+
+- **Semantic** — a fact that will still be true next month. Use `pensyve_remember(entity, fact, confidence?)` (confidence defaults to 1.0; use 0.9 for high-confidence auto-captures).
+- **Episodic** — something that happened in this thread of work. Use `pensyve_observe` with the current `episode_id`.
+- **Procedural** — a reusable way to do something. Use `pensyve_observe` with `content` beginning `[procedural]`.
+
+When in doubt, prefer episodic.
+
+### Canonical `pensyve_observe` call template
+
+ALL observe calls MUST include every required field:
+
+```
+pensyve_observe(
+  episode_id: <current session's working episode_id>,
+  content: "[proactive/in-flight/tier-1] <observation text>",
+  source_entity: "codex",
+  about_entity: "<relevant entity, lowercase-hyphenated>",
+  content_type: "text"
+)
+```
+
+Use `content_type: "code"` for code-related outcomes.
+
+### Episode lifecycle (lazy-open)
+
+Codex CLI has no session-start/session-end hooks, so you own the episode lifecycle:
+
+- Before your first `pensyve_observe` call in this conversation, check whether a working `episode_id` is tracked. If none exists, call `pensyve_episode_start(participants: ["codex", "<project entity>"])` first.
+- Reuse the same `episode_id` for all subsequent observations in the same conversation.
+- Do not explicitly close the episode under normal operation. Server-side consolidation handles aging.
+- Recovery: if `pensyve_observe` fails with a missing-episode error, call `pensyve_episode_start` and retry.
+
+### Surface style
+
+Lightly visible. One line when memory is used:
+
+- Recall: `Recalled 4 related memories (v7r, haiku-classifier).`
+- Capture: `↳ captured: hybrid-router threshold was the phase-3 regression root cause.`
+
+Do not narrate empty recalls or duplicate-skips.
+
+### Provenance tag vocabulary
+
+- `[proactive/in-flight/tier-1]` — memory reflex captured during reasoning
+- `[proactive/in-flight/open-question]` — unresolved question noted in-flight
+- `[auto-capture/user/residual/tier-1]` — explicit user-driven capture
+
+### Composition
+
+When a capture is both procedural AND in-flight: `[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=...`
+
+### MCP contract
+
+Rules never pass unsupported parameters:
+
+- `pensyve_recall(query, entity?, types?, limit?, min_confidence?)` — **no** `related_entities`
+- `pensyve_episode_start(participants)` — **no** `continuation_of`
+- `pensyve_observe(episode_id, content, source_entity, about_entity, content_type?)` — `source_entity` and `about_entity` are **required**
+
+---
+
+## Entity Detection
+
+Shared rules for detecting entity names from tool inputs, prompts, and conversation context. Used to scope recalls and `about_entity` fields on observations.
+
+### Inputs
+
+Extract candidate entity names from:
+
+1. **File references** — `@filename`, `@path/to/file`, or files mentioned directly in the conversation.
+2. **User prompts** — explicit references to components, files, services, research phases.
+3. **Code context** — module names, class names, function names in files being edited or read.
+4. **Git context** — repository root name, branch name (when discoverable).
+
+### Canonicalization
+
+- Lowercase all characters.
+- Replace spaces and underscores with hyphens.
+- Strip file extensions unless the file is the entity itself (e.g., `package.json`).
+- Collapse paths to the most semantically meaningful segment (e.g., `src/engine/hybrid_router.rs` → `hybrid-router`).
+
+### Fallback
+
+- If no specific entity is detected, fall back to the project-level entity (repository root name, lowercase-hyphenated).
+- If ambiguous, prefer the entity that already has memories in Pensyve (call `pensyve_inspect` with limit 1 to check).
+- **Never fabricate entity names.**
+
+### Output
+
+1–3 candidate entity names per turn. Primary entity is most specific; fold secondary entities into the `query` string when calling `pensyve_recall`.
+
+---
+
+## When Debugging
+
+Use when diagnosing bugs, errors, failing tests, or crashes.
+
+### Step 1: Detect entities
+
+Identify the relevant entity/entities (failing test, failing module, error source) per the entity detection section above.
+
+### Step 2: Consult memory (required)
+
+Call `pensyve_recall`:
+
+- `query`: short description of the failure, including secondary entity names
+- `entity`: primary detected entity
+- `types`: `["procedural", "episodic"]`
+- `limit`: 5
+
+Surface: `Recalled N memories from prior debug sessions on <entity>.`
+
+If a highly similar incident is found (score >0.8): `This looks similar to an incident captured on <date>: <summary>. Consider that path first.`
+
+### Step 3: Diagnose
+
+Proceed with diagnostic work, using recalled procedural memories as a starting sequence.
+
+### Step 4: Capture lesson (when it lands)
+
+When a root cause is **confirmed** (not just hypothesized):
+
+- **Episodic root cause:** `pensyve_observe` with `content: "[proactive/in-flight/tier-1] <one-sentence root cause>"`, `source_entity: "codex"`, `about_entity: <primary_entity>`, `content_type: "text"`.
+- **Procedural sequence:** `pensyve_observe` with `content: "[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=..."`, `source_entity: "codex"`, `about_entity: <primary_entity>`, `content_type: "text"`.
+- **Semantic truth:** `pensyve_remember(entity, fact: "[proactive/in-flight/tier-1] <fact>", confidence: 0.9)`.
+
+### Step 5: Capture abandoned approaches
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[proactive/in-flight/tier-1] tried <approach>, abandoned because <reason>",
+  source_entity: "codex",
+  about_entity: <primary_entity>,
+  content_type: "text"
+)
+```
+
+---
+
+## When Designing
+
+Use when making architecture, API, or design decisions.
+
+### Step 1: Detect entities
+
+Identify the relevant entity/entities (service, module, subsystem under design).
+
+### Step 2: Consult memory (required)
+
+Call `pensyve_recall`:
+
+- `query`: short description of the design question
+- `entity`: primary detected entity
+- `types`: `["semantic", "episodic"]`
+- `limit`: 5
+
+Surface: `Recalled N prior decisions on <entity>.`
+
+If the current question contradicts a prior decision, flag it: `Prior decision on <entity> (confidence 0.9): [decision]. Are we revisiting this?`
+
+### Step 3: Recommend with grounding
+
+Shape recommendations using recalled decisions.
+
+### Step 4: Capture decision (when it lands)
+
+When the user accepts a design or states a decision:
+
+- **Semantic:** `pensyve_remember(entity: <primary_entity>, fact: "[proactive/in-flight/tier-1] <decision text>", confidence: 0.9)`.
+- **Episodic context:** `pensyve_observe` with `content: "[proactive/in-flight/tier-1] Decision on <entity>: chose X over Y because Z"`, `source_entity: "codex"`, `about_entity: <primary_entity>`, `content_type: "text"`.
+
+### Step 5: Capture evaluation procedures
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[procedural] [proactive/in-flight/tier-1] trigger=design-question-on-<area>, action=<steps>, outcome=<what-you-learn>",
+  source_entity: "codex",
+  about_entity: <primary_entity>,
+  content_type: "text"
+)
+```
+
+---
+
+## When Refactoring
+
+Use before substantive refactors.
+
+### Step 1: Detect entities
+
+Identify entities touched by the refactor (file or module being restructured, callers, subsystem name).
+
+### Step 2: Load prior context (required)
+
+Call `pensyve_recall`:
+
+- `query`: short description of the refactor
+- `entity`: primary detected entity
+- `types`: `["semantic", "episodic", "procedural"]`
+- `limit`: 5
+
+Highlight any prior failed approaches: `Prior episodic memory: tried <approach>, abandoned because <reason>. Double-check this isn't the same trap.`
+
+### Step 3: Present a briefing
+
+Summarize what prior memories say about: decisions, prior attempts, known-good procedures.
+
+### Step 4: Capture refactor lessons as they land
+
+Apply the memory reflex immediately when:
+
+- **Invariant discovered** (semantic): `pensyve_remember(entity, fact, confidence: 0.9)`
+- **Abandoned approach confirmed** (episodic): `pensyve_observe` with `[proactive/in-flight/tier-1]`
+- **Dependency chain surprise** (episodic): `pensyve_observe`
+- **Known-good sequence emerged** (procedural): `pensyve_observe` with `[procedural]` prefix
+
+---
+
+## Longitudinal Work (Research/Evals)
+
+Use for long-running multi-session work in `research/`, `benchmarks/`, or `evals/` directories.
+
+### Step 1: Resume context at conversation start
+
+Call `pensyve_recall`:
+
+- `query`: short description of the current research area
+- `entity`: project + sub-topic entity
+- `limit`: 5
+
+No `types` filter — longitudinal work benefits from all three memory types.
+
+### Step 2: Proactively recall per topic shift
+
+When the session pivots to a new sub-topic, call `pensyve_recall` again scoped to it.
+
+### Step 3: Capture per run
+
+| What you learned | Type | Call |
+|---|---|---|
+| Per-run outcome | episodic | `pensyve_observe(..., content: "[proactive/in-flight/tier-1] Run N+1: ...", source_entity: "codex", about_entity: <entity>, content_type: "text")` |
+| Stable truth | semantic | `pensyve_remember(entity, fact: "[proactive/in-flight/tier-1] ...", confidence: 0.9)` |
+| Reusable procedure | procedural | `pensyve_observe(..., content: "[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=...", source_entity: "codex", about_entity: <entity>, content_type: "text")` |
+
+### Step 4: Capture open questions
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[proactive/in-flight/open-question] <question>",
+  source_entity: "codex",
+  about_entity: <entity>,
+  content_type: "text"
+)
+```
+
+### Step 5: End-of-session summary
+
+Before wrapping: summarize what this run taught vs. prior runs, and what's still open.
+
+---
+
+## Session Memory (Wrap-Up)
+
+Use at conversation wrap-up or when the user indicates end-of-session.
+
+### Step 1: Review the conversation
+
+Scan for three categories the in-flight reflex did NOT already capture:
+
+**Decisions** (confidence: 0.9): architecture choices, technology selections, API decisions, tradeoff resolutions.
+
+**Outcomes** (confidence: 0.8): bug fixes and root causes, successful approaches, failed approaches with reasons, performance findings.
+
+**Patterns** (confidence: 0.7): recurring issues, workflow discoveries, cross-cutting observations.
+
+### Step 2: Filter and deduplicate
+
+For each candidate, call `pensyve_recall` with `query: <candidate fact text>`, `entity: <entity>`, `limit: 3`. If score ≥0.85, skip as likely duplicate.
+
+### Step 3: Present candidates for confirmation
+
+> **Session Memory Candidates**
+>
+> **Decisions** (confidence: 0.9):
+> 1. `<entity>`: <decision text>
+>
+> **Outcomes** (confidence: 0.8):
+> 2. `<entity>`: <outcome text>
+>
+> **Patterns** (confidence: 0.7):
+> 3. `<entity>`: <pattern text>
+>
+> Which should I store? (e.g., "all", "1,3", "none")
+
+### Step 4: Store confirmed items
+
+- **Semantic:** `pensyve_remember(entity, fact: "[auto-capture/user/residual/tier-1] <text>", confidence)`.
+- **Episodic:** `pensyve_observe(episode_id, content: "[auto-capture/user/residual/tier-1] <text>", source_entity: "codex", about_entity: <entity>, content_type: "text")`.
+- **Procedural:** `pensyve_observe(episode_id, content: "[procedural] [auto-capture/user/residual/tier-1] trigger=..., action=..., outcome=...", source_entity: "codex", about_entity: <entity>, content_type: "text")`.
+
+### Step 5: Optionally close the episode
+
+If the user marks work complete: `pensyve_episode_end(episode_id: <working_id>, outcome: "success")`. Valid outcomes: `"success"`, `"failure"`, `"partial"`.
+
+**Never auto-store.** Every candidate MUST be confirmed before storage.
+
+---
+
+## Context Loader (Session Start)
+
+Use when starting a new substantive conversation or switching contexts.
+
+### Step 1: Detect project entity
+
+Use the repository root name (lowercase-hyphenated) as default. Override with `PENSYVE_NAMESPACE` if set.
+
+### Step 2: Scoped recall
+
+Call `pensyve_recall`:
+
+- `query`: `"recent decisions issues patterns"` + key terms from the user's opening message
+- `entity`: detected project entity
+- `types`: `["episodic"]`
+- `limit`: 5
+
+### Step 3: Compute continuity signal
+
+If ≥70% of the top observations share entities with the current conversation → **continuation**. Otherwise → **fresh session**.
+
+### Step 4: Surface the primer
+
+**Continuation:**
+> **Pensyve:** Continuing prior work on `<entity-set>`. Recent lessons: [top 3 observations]
+
+**Fresh session:**
+> **Pensyve:** N memories loaded for `<project>`. Key context: [top 3 observations]
+
+**No memories:**
+> **Pensyve:** No memories found for `<project>`. Use `/remember` to start building context.
+
+Do not fabricate memories. Only display what `pensyve_recall` returns.

--- a/integrations/codex-plugin/CHANGELOG.md
+++ b/integrations/codex-plugin/CHANGELOG.md
@@ -1,0 +1,42 @@
+# Changelog — Pensyve Codex CLI Adapter
+
+All notable changes to the Pensyve Codex CLI adapter are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). The Codex CLI adapter versions independently of the Claude Code plugin.
+
+## [1.0.0] - 2026-04-20
+
+### Added
+
+- **Working-memory substrate** for Codex CLI via `AGENTS.md`. All eight substrate rules consolidated into a single file with clear section headings (Codex CLI loads `AGENTS.md` as its agent instruction file):
+  - **Memory Reflex Rule** — non-optional reasoning discipline with three-type memory classification, canonical `pensyve_observe` call template, provenance vocabulary, lazy-open episode lifecycle
+  - **Entity Detection** — canonicalization and fallback rules
+  - **When Debugging** — debug flow with memory baked in
+  - **When Designing** — design flow with memory baked in
+  - **When Refactoring** — refactor flow with memory baked in
+  - **Longitudinal Work (Research/Evals)** — multi-session research/eval flow
+  - **Session Memory (Wrap-Up)** — manual wrap-up equivalent of Claude Code's Stop hook
+  - **Context Loader (Session Start)** — best-effort continuity primer via episodic recall
+- **MCP config example** at `.agents/mcp.json.example` covering Cloud-with-API-key and Local-stdio options
+- **Static MCP contract lint script** at `scripts/lint-mcp-refs.sh` verifying the consolidated `AGENTS.md`'s `pensyve_*` call examples match the `pensyve-mcp-tools/src/params.rs` schema
+
+### Design
+
+- Single reasoning layer; no platform-layer code. Codex CLI has no hook/event surface, so the entire adapter is the `AGENTS.md` file the model reads.
+- **Single-file delivery:** Codex CLI's `AGENTS.md` is a single file — all 8 rules are consolidated with section headings rather than split into separate files.
+- Lazy-open episode lifecycle: first `pensyve_observe` call triggers `pensyve_episode_start`; episodes are not explicitly closed.
+- Best-effort continuity primer via `pensyve_recall(types: ["episodic"])` — the MCP server has no episode-listing API.
+- MCP contract verified: no `related_entities` on recall, no `continuation_of` on episode_start, required `source_entity: "codex"` and `about_entity` on every observe.
+- Opt-out: delete or edit `AGENTS.md` (Codex-native pattern).
+
+### Not Included
+
+- No platform-layer code (deferred to a future sibling spec if capability gaps surface)
+- No installer script (manual copy of `AGENTS.md` + MCP config)
+- No server-side changes — uses the existing MCP tool surface
+
+### Relation to Other Pensyve Integrations
+
+- The Codex CLI adapter is part of the batch-2 working-memory substrate rollout. The Claude Code plugin (v1.3.0), Cursor adapter (v1.0.0), and VS Code Copilot adapter (v1.0.0) are the reference implementations.
+- Key difference from Cursor: single `AGENTS.md` vs. Cursor's per-rule `.cursor/rules/*.mdc` files.
+- Playbook: `pensyve-docs/specs/2026-04-18-pensyve-working-memory-substrate-design.md`

--- a/integrations/codex-plugin/README.md
+++ b/integrations/codex-plugin/README.md
@@ -1,150 +1,138 @@
-# Pensyve -- Persistent Memory for OpenAI Codex CLI
+# Pensyve for OpenAI Codex CLI
 
-Pensyve gives Codex a persistent, cognitive memory layer that spans across sessions. Your agent remembers decisions, learned patterns, debugging outcomes, and project context -- so you never repeat the same investigation twice and every session starts with the full picture.
+Persistent working-memory substrate for the [OpenAI Codex CLI](https://github.com/openai/codex) — memory is not a feature you invoke, it is the substrate the agent operates on.
 
-> **Note:** This plugin is not published to the Codex Plugin Directory. Install it manually using the instructions below.
+## What It Does
+
+- **Proactive memory during work** — lessons are captured the moment they land, not at session end
+- **Thread-aware continuity** — sessions that continue prior work resume with relevant context, no re-briefing
+- **Entity-scoped recall** — substantive questions are grounded in prior decisions; simple commands stay fast
+- **Three memory types** — durable facts (semantic), session-specific events (episodic), reusable procedures (procedural)
+- **Lightly visible** — one-line surfaces when memory is used; never interrupts your flow
 
 ## Install
 
-### Project-level (recommended)
+Two steps: configure the MCP server, then install the instructions file.
 
-Copy the plugin into your project's plugin directory and register it in a local marketplace file:
+### 1. Configure the MCP server
+
+Copy `.agents/mcp.json.example` to `.agents/mcp.json` in your project root and edit for your setup.
+
+**Cloud with API key (recommended):**
 
 ```bash
-mkdir -p .agents/plugins/pensyve
-cp -r /path/to/pensyve/integrations/codex-plugin/* .agents/plugins/pensyve/
+export PENSYVE_API_KEY="psy_your_key_here"
 ```
-
-Create or update `.agents/plugins/marketplace.json`:
 
 ```json
 {
-  "name": "local-plugins",
-  "interface": {
-    "displayName": "Local Plugins"
-  },
-  "plugins": [
-    {
-      "name": "pensyve",
-      "source": {
-        "source": "local",
-        "path": "./pensyve"
-      },
-      "policy": {
-        "installation": "INSTALLED_BY_DEFAULT"
-      },
-      "category": "Productivity"
+  "mcpServers": {
+    "pensyve": {
+      "type": "http",
+      "url": "https://mcp.pensyve.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ${PENSYVE_API_KEY}"
+      }
     }
-  ]
-}
-```
-
-### User-level (all projects)
-
-```bash
-mkdir -p ~/.codex/plugins/pensyve
-cp -r /path/to/pensyve/integrations/codex-plugin/* ~/.codex/plugins/pensyve/
-```
-
-Then add a matching entry in `~/.agents/plugins/marketplace.json`.
-
-## Connect to Pensyve
-
-The plugin needs a Pensyve API key. The MCP server is pre-configured for Pensyve Cloud -- once your key is set, you're ready to go.
-
-**Option A** -- environment variable (recommended):
-
-```bash
-export PENSYVE_API_KEY="psy_..."
-```
-
-Add to your shell profile (`~/.bashrc`, `~/.zshrc`) to persist across sessions.
-
-**Option B** -- self-hosted (local-only, no API key needed):
-
-1. Build the MCP binary:
-   ```bash
-   git clone https://github.com/major7apps/pensyve
-   cd pensyve && cargo build --release -p pensyve-mcp
-   ```
-2. Create a `.mcp.json` file in the plugin root pointing to the local binary, or override in your Codex settings.
-
-Get an API key at [pensyve.com/settings/api-keys](https://pensyve.com/settings/api-keys).
-
-## Authentication
-
-The plugin uses OAuth for authentication. When you first connect, your browser opens automatically to sign in at pensyve.com. No API key needed.
-
-### Alternative: API Key
-
-For CI or manual auth, use `claude mcp add-json` (or equivalent):
-
-```json
-{
-  "type": "http",
-  "url": "https://mcp.pensyve.com/mcp",
-  "headers": {
-    "Authorization": "Bearer ${PENSYVE_API_KEY}"
   }
 }
 ```
 
-Create an API key at [pensyve.com/settings/api-keys](https://pensyve.com/settings/api-keys).
+Create your key at [pensyve.com/settings/api-keys](https://pensyve.com/settings/api-keys). Put the `export` in `~/.bashrc` or `~/.zshrc` to persist.
 
-## Intelligent Memory Capture (v1.1.0)
+**Local (offline, self-hosted):**
 
-Pensyve uses a tiered classification system to identify what is worth remembering:
+```json
+{
+  "mcpServers": {
+    "pensyve": {
+      "command": "pensyve-mcp",
+      "args": ["--stdio"],
+      "env": {
+        "PENSYVE_PATH": "~/.pensyve/",
+        "PENSYVE_NAMESPACE": "default"
+      }
+    }
+  }
+}
+```
 
-- **Tier 1** (auto-store, confidence 0.9+): Explicit decisions, corrections, constraints -- high-signal items that should almost always be captured
-- **Tier 2** (batch review, confidence 0.7-0.89): Root causes, failed approaches, performance findings -- medium-signal items that benefit from user confirmation
-- **Discard**: Formatting, typos, boilerplate -- noise that should never be stored
+Build the binary: `cargo build --release -p pensyve-mcp` from the [pensyve repo](https://github.com/major7apps/pensyve).
 
-The Stop hook processes buffered observations from the session and classifies them using this taxonomy before presenting candidates for storage.
+### 2. Install the instructions file
 
-## Skills
+Copy `AGENTS.md` to your project root (Codex CLI loads `AGENTS.md` automatically as its agent instruction file):
 
-| Skill                      | When to Use                     | What It Does                                                                                                                                        |
-| -------------------------- | ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `session-memory`           | End of a work session           | Classifies session signals using tiered taxonomy. Presents tier 1 and tier 2 candidates for confirmation. Stores approved items with provenance.    |
-| `memory-informed-refactor` | Before refactoring a module     | Queries memory for past decisions, failures, and patterns related to the target. Compiles a briefing with recommendations. Offers episode tracking. |
-| `context-loader`           | Session start or context switch | Loads relevant memories to prime the session. Summary mode (10-15 lines) or full mode (tables with scores). Fast and non-blocking.                  |
-| `memory-review`            | Periodic hygiene check          | Audits memory health: stale entries, contradictions, low-confidence items, consolidation candidates. Offers cleanup actions with user confirmation. |
+```bash
+cp /path/to/pensyve/integrations/codex-plugin/AGENTS.md .
+```
 
-## Hooks
+Codex CLI automatically loads `AGENTS.md` from the project root into every agent context.
 
-| Event          | Behavior                                                                                              |
-| -------------- | ----------------------------------------------------------------------------------------------------- |
-| `SessionStart` | Loads relevant memories at session start (configurable: off/summary/full)                             |
-| `Stop`         | Classifies buffered signals using tiered taxonomy, presents candidates for review, stores with provenance |
+**Note:** All 8 substrate rules are consolidated into a single `AGENTS.md` with clear section headings — same approach as the VS Code Copilot adapter.
+
+## How It Works
+
+Codex CLI has no hook/event surface, so the entire substrate is delivered through `AGENTS.md`. The Memory Reflex Rule section establishes the discipline: *before substantive answers, recall by entity; when a lesson lands, observe immediately with a one-line surface*. Flow sections (When Debugging, When Designing, When Refactoring, Longitudinal Work) guide the model through consult-memory + capture-lesson steps.
+
+**Episode lifecycle:** Codex CLI has no session-start/session-end hooks, so episodes open lazily on the first `pensyve_observe` call and are not explicitly closed under normal operation. Server-side consolidation handles aging.
+
+**Continuity primer:** The Context Loader section runs a best-effort recall at the start of substantive conversations to surface prior relevant observations.
+
+## Memory Behavior Model
+
+Pensyve behaves as working memory for the agent — always-on, ambient, continuous.
+
+**Writes happen in-flight.** When a root cause is confirmed, a decision is made, or a reusable procedure emerges, it's captured the moment it lands via the memory reflex. No batching to session end.
+
+**Reads happen at decision points.** Before substantive answers, the model consults memory scoped to the detected entities. Simple commands (run tests, format file) skip recall to stay fast.
+
+**Sessions continue.** At the start of a substantive conversation, Pensyve checks whether the current work continues prior memories (shared entities + recent activity). If yes, you resume with a primer — no re-briefing needed.
+
+## Memory Types
+
+| Type | Definition | MCP call | Example |
+|---|---|---|---|
+| **Semantic** | Durable truths, decisions, preferences | `pensyve_remember` | "We chose RS256 over HS256 for JWT signing" |
+| **Episodic** | Temporal events, session-scoped observations | `pensyve_observe` (with lazy-opened `episode_id`) | "Phase-3 regression root cause: hybrid-router threshold" |
+| **Procedural** | Reusable workflows, sequences, recipes | `pensyve_observe` with `[procedural]` content prefix | "To calibrate V7r: freeze Haiku config, run suite, diff baseline" |
+
+## Opt-Out
+
+Codex CLI's native pattern is to edit or delete `AGENTS.md`:
+
+- **Full opt-out** — delete `AGENTS.md` from your project root
+- **Partial opt-out** — delete specific sections from the file (e.g., remove the "Longitudinal Work" section if you don't do research work)
+- **Silent mode** — edit the Memory Reflex Rule section to remove the "one-line surface" guidance; captures stay silent
+- **Recall-only mode** — edit flow sections to drop the `Capture lesson` steps while keeping `Consult memory`
 
 ## Available MCP Tools
 
-All tools connect to the Pensyve API via MCP. The plugin never bypasses MCP to access storage directly.
+| Tool | Description |
+|---|---|
+| `pensyve_recall` | Search memories by semantic similarity |
+| `pensyve_remember` | Store a durable fact (semantic memory) |
+| `pensyve_observe` | Record a session observation (episodic / procedural via `[procedural]` prefix) |
+| `pensyve_episode_start` | Begin tracking an episode |
+| `pensyve_episode_end` | Close an episode with outcome |
+| `pensyve_forget` | Delete an entity's memories |
+| `pensyve_inspect` | List memories for an entity |
 
-| Tool                    | Parameters                                                                | Returns                                        |
-| ----------------------- | ------------------------------------------------------------------------- | ---------------------------------------------- |
-| `pensyve_recall`        | `query`, `entity?`, `types?`, `limit?`                                    | Ranked array of memories with relevance scores |
-| `pensyve_remember`      | `entity`, `fact`, `confidence?`                                           | Stored memory object                           |
-| `pensyve_observe`       | `episode_id`, `content`, `source_entity`, `about_entity`, `content_type?` | Stored episodic memory object                  |
-| `pensyve_episode_start` | `participants`                                                            | `episode_id`, `started_at`                     |
-| `pensyve_episode_end`   | `episode_id`, `outcome?`                                                  | `memories_created` count                       |
-| `pensyve_forget`        | `entity`, `hard_delete?`                                                  | `forgotten_count`                              |
-| `pensyve_inspect`       | `entity`, `memory_type?`, `limit?`                                        | Array of memories with stats                   |
+See [MCP Tools Reference](https://pensyve.com/docs/api-reference/mcp-tools) for full parameter details.
 
 ## Design Philosophy
 
-- **Your agent gets smarter over time** -- decisions, outcomes, and patterns compound across sessions
-- **Always asks, never assumes** -- no memory is stored without explicit user confirmation
-- **Cloud-native** -- all memory is stored in Pensyve Cloud, accessible from any machine
-- **MCP-native** -- all tools communicate via the Model Context Protocol, no proprietary wiring
-- **Privacy-first** -- memories are scoped to your namespace and encrypted at rest
+- **Memory as substrate** — not a feature the user invokes; always there, continuous, carried across sessions
+- **Reasoning-layer only** — no platform-layer code in v1; the entire adapter is the `AGENTS.md` file
+- **1:1 with Claude Code** — same skill structure, same conventions, same memory types
+- **MCP contract-respecting** — every rule's call examples verified against `pensyve-mcp-tools/src/params.rs`
+- **Single-file delivery** — Codex CLI's `AGENTS.md` is a single file; all 8 rules consolidated with clear section headings
 
 ## Links
 
 - **Website:** [pensyve.com](https://pensyve.com)
-- **Docs:** [pensyve.com/docs](https://pensyve.com/docs)
 - **GitHub:** [github.com/major7apps/pensyve](https://github.com/major7apps/pensyve)
-- **API Keys:** [pensyve.com/settings/api-keys](https://pensyve.com/settings/api-keys)
+- **Spec:** [Working-memory substrate design](https://github.com/major7apps/pensyve-docs/blob/main/specs/2026-04-18-pensyve-working-memory-substrate-design.md)
 
 ## License
 

--- a/integrations/codex-plugin/scripts/lint-mcp-refs.sh
+++ b/integrations/codex-plugin/scripts/lint-mcp-refs.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Static MCP contract linter for the Pensyve Codex CLI adapter.
+#
+# Verifies that every pensyve_* call example in AGENTS.md
+# conforms to the current MCP tool schema in pensyve-mcp-tools/src/params.rs.
+# Catches the category of bug PR #58 surfaced in the Claude Code adapter
+# (unsupported parameters, missing required fields).
+#
+# Codex CLI uses a single consolidated AGENTS.md file for agent instructions,
+# so this script targets AGENTS.md directly.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RULES_FILE="$SCRIPT_DIR/../AGENTS.md"
+
+EXIT_CODE=0
+
+if [ ! -f "$RULES_FILE" ]; then
+  echo "ERROR: AGENTS.md not found: $RULES_FILE"
+  exit 1
+fi
+
+echo "Linting MCP references in $RULES_FILE..."
+echo ""
+
+# Check 1: no actual use of unsupported 'related_entities' parameter in call examples.
+# Lines that say "no related_entities" (documentation/reminders) are excluded.
+echo "Check 1: no unsupported 'related_entities' on pensyve_recall"
+FOUND_RELATED=0
+# Also catch if related_entities appears inside a pensyve_recall( block
+awk '/pensyve_recall\(/{capture=1; buf=""}
+     capture {buf = buf "\n" $0}
+     capture && /\)/{
+       if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
+         print FILENAME ": related_entities found in pensyve_recall block: " buf;
+       capture=0
+     }' "$RULES_FILE" | while read -r line; do
+  if [ -n "$line" ]; then
+    echo "  FAIL: $line"
+    FOUND_RELATED=1
+  fi
+done
+if [ "$FOUND_RELATED" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 2: no actual use of unsupported 'continuation_of' parameter in call examples.
+echo "Check 2: no unsupported 'continuation_of' on pensyve_episode_start"
+FOUND_CONT=0
+awk '/pensyve_episode_start\(/{capture=1; buf=""}
+     capture {buf = buf "\n" $0}
+     capture && /\)/{
+       if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
+         print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
+       capture=0
+     }' "$RULES_FILE" | while read -r line; do
+  if [ -n "$line" ]; then
+    echo "  FAIL: $line"
+    FOUND_CONT=1
+  fi
+done
+if [ "$FOUND_CONT" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 3: every pensyve_observe call example in a code block has source_entity and about_entity
+echo "Check 3: every pensyve_observe example has source_entity and about_entity"
+MISSING_FIELDS=0
+awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
+     capture {buf = buf "\n" $0;
+              for(i=1; i<=length($0); i++){
+                c=substr($0,i,1);
+                if(c=="(") depth++;
+                if(c==")") depth--;
+              };
+              if(depth==0 && buf ~ /pensyve_observe\(/){
+                if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
+                if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
+                capture=0;
+              }}' "$RULES_FILE" | while read -r line; do
+  if [ -n "$line" ]; then
+    echo "  FAIL: $line"
+    MISSING_FIELDS=1
+  fi
+done
+if [ "$MISSING_FIELDS" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 4: provenance tag format — every proactive/auto-capture tag uses [<origin>/<trigger>/<tier>]
+echo "Check 4: provenance tag format"
+VALID_PROVENANCE_RE='\[(proactive|auto-capture)/(in-flight|stop|pre-compact|curator|user)/(tier-1|tier-2|residual/tier-1|residual/tier-2|open-question)\]'
+if rg -n '\[(proactive|auto-capture)' "$RULES_FILE" | rg -v "$VALID_PROVENANCE_RE"; then
+  echo "  FAIL: some provenance tags do not match [<origin>/<trigger>/<tier>] format"
+  EXIT_CODE=1
+else
+  echo "  PASS"
+fi
+echo ""
+
+# Check 5: procedural memory convention — [procedural] prefix is used in observe content
+echo "Check 5: procedural convention uses [procedural] prefix in pensyve_observe content"
+if ! rg -q '\[procedural\]' "$RULES_FILE"; then
+  echo "  WARN: no [procedural] prefix usage found. Expected in AGENTS.md."
+else
+  echo "  PASS"
+fi
+echo ""
+
+if [ "$EXIT_CODE" = "0" ]; then
+  echo "All MCP contract checks PASSED."
+else
+  echo "MCP contract checks FAILED. Fix the issues above before committing."
+fi
+
+exit "$EXIT_CODE"

--- a/integrations/codex-plugin/scripts/lint-mcp-refs.sh
+++ b/integrations/codex-plugin/scripts/lint-mcp-refs.sh
@@ -29,18 +29,18 @@ echo ""
 echo "Check 1: no unsupported 'related_entities' on pensyve_recall"
 FOUND_RELATED=0
 # Also catch if related_entities appears inside a pensyve_recall( block
-awk '/pensyve_recall\(/{capture=1; buf=""}
-     capture {buf = buf "\n" $0}
-     capture && /\)/{
-       if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
-         print FILENAME ": related_entities found in pensyve_recall block: " buf;
-       capture=0
-     }' "$RULES_FILE" | while read -r line; do
+while read -r line; do
   if [ -n "$line" ]; then
     echo "  FAIL: $line"
     FOUND_RELATED=1
   fi
-done
+done < <(awk '/pensyve_recall\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+       if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
+       print FILENAME ": related_entities found in pensyve_recall block: " buf;
+       capture=0
+       }' "$RULES_FILE")
 if [ "$FOUND_RELATED" = "0" ]; then
   echo "  PASS"
 else
@@ -51,18 +51,18 @@ echo ""
 # Check 2: no actual use of unsupported 'continuation_of' parameter in call examples.
 echo "Check 2: no unsupported 'continuation_of' on pensyve_episode_start"
 FOUND_CONT=0
-awk '/pensyve_episode_start\(/{capture=1; buf=""}
-     capture {buf = buf "\n" $0}
-     capture && /\)/{
-       if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
-         print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
-       capture=0
-     }' "$RULES_FILE" | while read -r line; do
+while read -r line; do
   if [ -n "$line" ]; then
     echo "  FAIL: $line"
     FOUND_CONT=1
   fi
-done
+done < <(awk '/pensyve_episode_start\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+       if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
+       print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
+       capture=0
+       }' "$RULES_FILE")
 if [ "$FOUND_CONT" = "0" ]; then
   echo "  PASS"
 else
@@ -73,23 +73,23 @@ echo ""
 # Check 3: every pensyve_observe call example in a code block has source_entity and about_entity
 echo "Check 3: every pensyve_observe example has source_entity and about_entity"
 MISSING_FIELDS=0
-awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
-     capture {buf = buf "\n" $0;
-              for(i=1; i<=length($0); i++){
-                c=substr($0,i,1);
-                if(c=="(") depth++;
-                if(c==")") depth--;
-              };
-              if(depth==0 && buf ~ /pensyve_observe\(/){
-                if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
-                if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
-                capture=0;
-              }}' "$RULES_FILE" | while read -r line; do
+while read -r line; do
   if [ -n "$line" ]; then
     echo "  FAIL: $line"
     MISSING_FIELDS=1
   fi
-done
+done < <(awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
+       capture {buf = buf "\n" $0;
+       for(i=1; i<=length($0); i++){
+       c=substr($0,i,1);
+       if(c=="(") depth++;
+       if(c==")") depth--;
+       };
+       if(depth==0 && buf ~ /pensyve_observe\(/){
+       if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
+       if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
+       capture=0;
+       }}' "$RULES_FILE")
 if [ "$MISSING_FIELDS" = "0" ]; then
   echo "  PASS"
 else

--- a/integrations/continue/.continue/rules/context-loader.md
+++ b/integrations/continue/.continue/rules/context-loader.md
@@ -1,0 +1,75 @@
+---
+name: Context Loader
+description: Use when starting a new substantive conversation or switching contexts — load relevant memories to prime the session with continuity
+---
+
+# Context Loader (Continuity Primer)
+
+Continue has no automatic SessionStart hook. This rule is the manual equivalent: when starting a new conversation on a project that has prior Pensyve memories, call recall to prime the session with relevant context.
+
+Follows `memory-reflex.md`. Best-effort thread continuity via episodic recall (the MCP server has no episode-listing tool; see the main spec's Task C addendum for background).
+
+## Instructions
+
+### Step 1: Detect project entity
+
+Per `entity-detection.md` fallback rules: use the repository root name (lowercase-hyphenated) as the default project entity. Override with `PENSYVE_NAMESPACE` environment variable if explicitly set in the project's environment.
+
+### Step 2: Scoped recall
+
+Call `pensyve_recall`:
+
+- `query`: `"recent decisions issues patterns"` + any key terms from the user's opening message
+- `entity`: detected project entity
+- `types`: `["episodic"]` — recent session activity gives the best continuity signal
+- `limit`: 5
+
+Episodic memories are ranked by the MCP server's activation signal, which naturally surfaces recent observations first.
+
+### Step 3: Compute continuity signal
+
+Examine the returned observations:
+
+- If ≥70% of the top observations reference at least one entity that overlaps with the current conversation's entity candidates (from Step 1 plus any entities mentioned in the opening message), treat the session as a **continuation** of recent work.
+- If the overlap is below 70%, or recall returned empty, treat as a **fresh session**.
+
+### Step 4: Surface the primer
+
+**Continuation:**
+
+> **Pensyve:** Continuing prior work on `<entity-set>`. Recent lessons:
+>
+> - <observation 1>
+> - <observation 2>
+> - <observation 3>
+>
+> Use `/recall <query>` or ask about any of these to dig deeper.
+
+**Fresh session:**
+
+> **Pensyve:** N memories loaded for `<project>`. Key context:
+>
+> - <top 3 observations>
+>
+> Use `/recall <query>` to search for specific memories.
+
+**No memories found:**
+
+> **Pensyve:** No memories found for `<project>`. Use `/remember` to start building context.
+
+### Step 5: Continuity is best-effort, not a structured link
+
+The MCP server has no episode-listing or date-filtering API. This rule infers continuity from shared-entity overlap and recall-ranking recency. Consequences:
+
+- There is no persisted server-side link between sessions.
+- Primer accuracy depends on memory quality and recall ranking.
+- The user may occasionally see "Continuing prior work" when it's actually loosely related; or see a fresh-session primer when the prior session was related but the entity overlap was low.
+
+Document this honestly in the primer when uncertain — do not fabricate continuity.
+
+## Constraints
+
+- Do not fabricate memories. Only display what `pensyve_recall` returns.
+- If MCP is unavailable, skip the primer silently and mention the failure once per conversation if the user asks about memory.
+- Maximum 5 memories in the primer to avoid context bloat.
+- Entity names lowercase-hyphenated.

--- a/integrations/continue/.continue/rules/entity-detection.md
+++ b/integrations/continue/.continue/rules/entity-detection.md
@@ -1,0 +1,43 @@
+---
+name: Entity Detection
+description: Pensyve entity detection — canonicalization and fallback rules for recall scoping (always-apply)
+---
+
+# Entity Detection (Always-Apply Reference)
+
+Shared rules for detecting entity names from tool inputs, prompts, and conversation context. Used by the memory reflex and all memory-woven flows to scope recalls and `about_entity` fields on observations.
+
+## Inputs
+
+Extract candidate entity names from:
+
+1. **File references** — `@filename`, `@path/to/file`, or files mentioned directly in the conversation.
+2. **User prompts** — explicit references to components, files, services, research phases (e.g., "phase-4.3", "v7r-classifier", "auth-service").
+3. **Code context** — module names, class names, function names in files you are editing or reading.
+4. **Git context** — repository root name, branch name (when discoverable).
+
+## Canonicalization
+
+- Lowercase all characters.
+- Replace spaces and underscores with hyphens.
+- Strip file extensions unless the file is the entity itself (e.g., `package.json`).
+- Collapse paths to the most semantically meaningful segment (e.g., `src/engine/hybrid_router.rs` → `hybrid-router`; `tests/integration/auth_test.py` → `auth`).
+
+## Fallback behavior
+
+- If no specific entity is detected, fall back to the project-level entity (repository root name, lowercase-hyphenated).
+- If a candidate entity is ambiguous between two names, prefer the one that already has memories in Pensyve (call `pensyve_inspect` with limit 1 to check).
+- **Never fabricate entity names.** If nothing confident emerges, use the project entity.
+
+## Output
+
+A set of 1–3 candidate entity names per turn. The primary entity is the most specific; secondary entities provide additional context. Since `pensyve_recall` accepts only a single `entity` parameter, fold secondary entities into the `query` string instead.
+
+## Examples
+
+| Input | Primary entity | Secondary (fold into query) |
+|---|---|---|
+| Edit on `src/engine/hybrid_router.rs` | `hybrid-router` | `engine` |
+| Prompt: "tune V7r noise threshold" | `v7r` | `noise-threshold` |
+| File `tests/test_auth.py` in a project named `auth-service` | `auth` | `auth-service` |
+| User mentions "phase-4.3 calibration" | `phase-4.3` | `calibration` |

--- a/integrations/continue/.continue/rules/memory-informed-debug.md
+++ b/integrations/continue/.continue/rules/memory-informed-debug.md
@@ -1,0 +1,69 @@
+---
+name: Memory-Informed Debug
+description: Use when diagnosing bugs, errors, failing tests, or crashes — consult prior debug outcomes and capture root causes in-flight
+---
+
+# Memory-Informed Debug
+
+Debugging flow with memory baked in as a non-optional reflex. Follows `memory-reflex.md` for classification, surface style, and episode lifecycle.
+
+## Instructions
+
+### Step 1: Detect entities
+
+Identify the relevant entity/entities (failing test, failing module, error source) per `entity-detection.md`.
+
+### Step 2: Consult memory (required)
+
+Call `pensyve_recall`:
+
+- `query`: a short description of the failure, including secondary entity names where known (e.g., "hybrid-router threshold regression phase-4.3" rather than full stack traces)
+- `entity`: primary detected entity
+- `types`: `["procedural", "episodic"]` (debugging benefits most from known-good diagnostic procedures and prior incident outcomes)
+- `limit`: 5
+
+Secondary entities are folded into the query string since `RecallParams` scopes by a single `entity` only.
+
+Surface one line: `Recalled N memories from prior debug sessions on <entity>.` (Skip if N=0.)
+
+If a highly similar incident is found (score >0.8), call that out inline: `This looks similar to an incident captured on <date>: <summary>. Consider that path first.`
+
+### Step 3: Diagnose
+
+Proceed with the diagnostic work. Use recalled procedural memories as a starting sequence; update the sequence when you learn something new.
+
+### Step 4: Capture lesson (when it lands)
+
+When a root cause is **confirmed** (not just hypothesized), apply the memory reflex per `memory-reflex.md`:
+
+Ensure a working `episode_id` exists (lazy-open via `pensyve_episode_start` if not). Then:
+
+- **Episodic root cause:** call `pensyve_observe` with `content: "[proactive/in-flight/tier-1] <one-sentence root cause>"`, `source_entity: "continue"`, `about_entity: <primary_entity>`, `content_type: "text"`.
+- **Procedural diagnostic sequence:** if the debug produced a reusable diagnostic sequence, call `pensyve_observe` with `content: "[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=..."`, `source_entity: "continue"`, `about_entity: <primary_entity>`, `content_type: "text"`.
+- **Semantic durable truth:** if the root cause reveals a durable truth (e.g., "our CI runner's Python 3.10 cannot handle the new syntax"), also call `pensyve_remember(entity, fact, confidence: 0.9)`. Include provenance in the fact text: `"[proactive/in-flight/tier-1] <fact>"`.
+
+Surface one line: `↳ captured: <one-sentence>`.
+
+### Step 5: Capture abandoned approach
+
+If an approach was tried and abandoned, observe that too:
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[proactive/in-flight/tier-1] tried <approach>, abandoned because <reason>",
+  source_entity: "continue",
+  about_entity: <primary_entity>,
+  content_type: "text"
+)
+```
+
+These are high-value — they prevent re-treading the same dead end next time.
+
+## Constraints
+
+- Recall is **not optional**. If you skip recall to save time, you defeat the working-memory substrate.
+- Observe when a lesson **lands**, not when you first hypothesize.
+- One in-flight capture per turn unless multiple distinct lessons land simultaneously.
+- Respect the reflex rule's surface style — one line, not paragraphs.
+- Never store secrets or sensitive paths.

--- a/integrations/continue/.continue/rules/memory-informed-design.md
+++ b/integrations/continue/.continue/rules/memory-informed-design.md
@@ -1,0 +1,61 @@
+---
+name: Memory-Informed Design
+description: Use when making architecture, API, or design decisions — consult prior decisions and capture new ones in-flight
+---
+
+# Memory-Informed Design
+
+Design flow with memory baked in as a non-optional reflex. Follows `memory-reflex.md`.
+
+## Instructions
+
+### Step 1: Detect entities
+
+Identify the relevant entity/entities (service, module, subsystem under design) per `entity-detection.md`.
+
+### Step 2: Consult memory (required)
+
+Call `pensyve_recall`:
+
+- `query`: a short description of the design question, including secondary entity names where known (e.g., "auth-service jwt signing rs256 hs256")
+- `entity`: primary detected entity
+- `types`: `["semantic", "episodic"]` (design benefits most from durable decisions and prior decision-contexts)
+- `limit`: 5
+
+Surface one line: `Recalled N prior decisions on <entity>.` (Skip if N=0.)
+
+### Step 3: Recommend with grounding
+
+Shape your recommendation using the recalled decisions. If the user's current question directly contradicts a prior decision, flag it:
+
+> Prior decision on `<entity>` (confidence 0.9): [decision]. Are we revisiting this, or does the current question differ?
+
+### Step 4: Capture decision (when it lands)
+
+When the user accepts a design or states a decision ("let's go with X", "we'll use Y"), apply the memory reflex:
+
+- **Semantic** — `pensyve_remember(entity: <primary_entity>, fact: "[proactive/in-flight/tier-1] <decision text>", confidence: 0.9)`.
+- **Episodic context** — ensure working `episode_id`; `pensyve_observe` with `content: "[proactive/in-flight/tier-1] Decision on <entity>: chose X over Y because Z"`, `source_entity: "continue"`, `about_entity: <primary_entity>`, `content_type: "text"`. This enables future "why did we decide X?" queries.
+
+Surface one line: `↳ captured decision on <entity>: <short>`.
+
+### Step 5: Capture evaluation procedures
+
+If the design process revealed a reusable way to evaluate similar decisions (e.g., "run spike vs. prototype", "check latency first"), capture it as procedural:
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[procedural] [proactive/in-flight/tier-1] trigger=design-question-on-<area>, action=<steps>, outcome=<what-you-learn>",
+  source_entity: "continue",
+  about_entity: <primary_entity>,
+  content_type: "text"
+)
+```
+
+## Constraints
+
+- Recall is **not optional**.
+- Observe when a decision **lands**, not when it's being discussed.
+- Budget: one in-flight capture per turn unless multiple decisions land.
+- Never store secrets or sensitive architecture details the user has marked private.

--- a/integrations/continue/.continue/rules/memory-informed-longitudinal-work.md
+++ b/integrations/continue/.continue/rules/memory-informed-longitudinal-work.md
@@ -1,0 +1,69 @@
+---
+name: Memory-Informed Longitudinal Work
+description: Long-running multi-session work (research, eval loops, iterative benchmarks) — resume prior lessons, capture per-run outcomes, build up stable truths over time
+---
+
+# Memory-Informed Longitudinal Work
+
+Multi-session engineering work (research, eval loops, iterative benchmarks) where lessons must accumulate across runs. The motivating case: improving a core algorithm over dozens of eval iterations without starting from scratch each session.
+
+Follows `memory-reflex.md`. Applies for files under `research/`, `benchmarks/`, or `evals/`, or when the model judges the conversation to be research-oriented.
+
+## Instructions
+
+### Step 1: Resume context at conversation start
+
+If this conversation is in a research/eval context, call `pensyve_recall` once at the start:
+
+- `query`: short description of the current research area (e.g., "v7r classifier calibration")
+- `entity`: project + sub-topic entity (per `entity-detection.md` canonicalization rules)
+- `limit`: 5
+
+No `types` filter — longitudinal work benefits from all three memory types; omit to query all. (Passing all three explicitly is equivalent to no filter; omitting is cleaner.)
+
+Surface: `Recalled N prior findings on <sub-topic>.`
+
+Treat the returned observations as working knowledge — do not re-ask the user about things the recall already surfaces.
+
+### Step 2: Proactively recall per topic shift
+
+When the session pivots to a new sub-topic (new phase, new eval subset, new failure mode), call `pensyve_recall` again scoped to the new sub-topic.
+
+### Step 3: Capture three types of memory per run
+
+During the session, classify emerging knowledge and capture accordingly. Ensure working `episode_id` before each observe.
+
+| What you learned | Type | MCP call |
+|---|---|---|
+| Per-run outcome (what this run showed) | episodic | `pensyve_observe(..., content: "[proactive/in-flight/tier-1] Run N+1: V7r accuracy improved +3.5% with new threshold", source_entity: "continue", about_entity: <entity>, content_type: "text")` |
+| Stable truth about the system | semantic | `pensyve_remember(entity, fact: "[proactive/in-flight/tier-1] Haiku classifier plateaus above temp 0.3", confidence: 0.9)` |
+| Reusable experiment procedure | procedural | `pensyve_observe(..., content: "[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=...", source_entity: "continue", about_entity: <entity>, content_type: "text")` |
+
+Apply at landing — do not batch.
+
+### Step 4: Capture open questions
+
+When a run ends with an unresolved question ("X improved but we don't know why"), capture it as an episodic observation with open-question provenance:
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[proactive/in-flight/open-question] <question>",
+  source_entity: "continue",
+  about_entity: <entity>,
+  content_type: "text"
+)
+```
+
+This populates future "open questions" surfacing when the topic returns.
+
+### Step 5: End-of-session summary
+
+Before the conversation wraps, briefly summarize (inline, 3-5 lines): what this run taught us vs. prior runs, what's still open. This creates a natural handoff for the next session.
+
+## Constraints
+
+- Recall on every topic shift — not just at conversation start.
+- Capture at landing, not batched.
+- Never store run artifacts or large data blobs — summarize.
+- Respect the reflex's surface style.

--- a/integrations/continue/.continue/rules/memory-informed-refactor.md
+++ b/integrations/continue/.continue/rules/memory-informed-refactor.md
@@ -1,0 +1,60 @@
+---
+name: Memory-Informed Refactor
+description: Use before substantive refactors — load relevant prior context, capture refactor insights as they land
+---
+
+# Memory-Informed Refactor
+
+Refactor flow with memory baked in. Follows `memory-reflex.md`.
+
+## Instructions
+
+### Step 1: Detect entities
+
+Identify the entities touched by the refactor (the file or module being restructured, its callers, the subsystem name) per `entity-detection.md`.
+
+### Step 2: Load prior context (required)
+
+Call `pensyve_recall`:
+
+- `query`: short description of the refactor (e.g., "hybrid-router routing logic restructure")
+- `entity`: primary detected entity
+- `types`: `["semantic", "episodic", "procedural"]` — refactors benefit from all three (durable invariants, prior attempts, known-good sequences)
+- `limit`: 5
+
+Surface: `Recalled N prior memories on <entity>.` (Skip if N=0.)
+
+Highlight any prior failed approaches inline:
+
+> Prior episodic memory (confidence 0.8): tried <approach> on <date>, abandoned because <reason>. Double-check this isn't the same trap.
+
+### Step 3: Present a briefing
+
+Before starting the refactor, briefly summarize what the prior memories say about:
+
+- **Decisions** — durable choices that constrain the refactor (semantic)
+- **Prior attempts** — what's been tried (episodic)
+- **Known-good procedures** — reusable sequences for this kind of refactor (procedural)
+
+If no relevant memories exist, say so clearly and proceed without historical context.
+
+### Step 4: Capture refactor lessons as they land
+
+When any of these occur during the refactor, apply the memory reflex immediately:
+
+- **An invariant is discovered** (semantic) — `pensyve_remember(entity, fact, confidence: 0.9)`
+- **An abandoned approach is confirmed not-viable** (episodic) — `pensyve_observe` with `[proactive/in-flight/tier-1]` provenance
+- **A dependency chain was traced that surprised us** (episodic) — `pensyve_observe`
+- **A known-good refactoring sequence emerged** (procedural) — `pensyve_observe` with `[procedural]` prefix
+
+Ensure working `episode_id` before each observe; lazy-open if needed.
+
+Do not batch these to end-of-session — capture at landing, surface one-line.
+
+## Constraints
+
+- The briefing step is the real value — it informs the refactor.
+- Observe at landing, not batched.
+- Entity names lowercase-hyphenated.
+- Do not start the refactor itself — this rule provides guidance and capture. The user decides when and how to proceed.
+- If the MCP server returns errors on some queries, present results from the successful queries and note the failures.

--- a/integrations/continue/.continue/rules/memory-reflex.md
+++ b/integrations/continue/.continue/rules/memory-reflex.md
@@ -1,0 +1,101 @@
+---
+name: Memory Reflex Rule
+description: Pensyve memory reflex — the non-optional reasoning discipline for working-memory substrate (always-apply)
+---
+
+# Memory Reflex Rule (Always-Apply)
+
+This rule is always in context. It turns Pensyve memory operations from optional actions into a reasoning discipline you carry through every substantive turn.
+
+## The rule
+
+**Before substantive answers, recall by entity. When a lesson lands, observe immediately with a one-line surface.**
+
+### "Substantive answer" means
+
+- Design or architecture recommendations
+- Debugging diagnoses with root-cause claims
+- Refactor proposals
+- Any response that makes a claim the user would want grounded in prior work
+
+Not substantive: formatting fixes, trivial lookups, reading a file, running a command.
+
+### "Lesson lands" means
+
+- A root cause has been confirmed (not hypothesized).
+- A design choice has been made explicit ("we'll use X because Y").
+- An approach has been tried and abandoned with a reason.
+- A workflow has been discovered that is reusable.
+- A workaround for a framework/library limitation has been validated.
+
+## Classification (which memory type?)
+
+- **Semantic** — a fact that will still be true next month. Use `pensyve_remember(entity, fact, confidence?)` (confidence defaults to 1.0; use 0.9 for high-confidence auto-captures).
+- **Episodic** — something that happened in this thread of work. Use `pensyve_observe` with the current `episode_id`.
+- **Procedural** — a reusable way to do something (a workflow, sequence, recipe). Use `pensyve_observe` with `content` beginning `[procedural]` (integration-layer convention; the MCP server has no native procedural-write API).
+
+When in doubt, prefer episodic. Server-side consolidation promotes recurring patterns to semantic automatically.
+
+## Canonical `pensyve_observe` call template
+
+ALL observe calls — in-flight, procedural, or wrap-up — MUST include every required field:
+
+```
+pensyve_observe(
+  episode_id: <current session's working episode_id>,
+  content: "[proactive/in-flight/tier-1] <observation text>",
+  source_entity: "continue",
+  about_entity: "<relevant entity, lowercase-hyphenated>",
+  content_type: "text"
+)
+```
+
+Use `content_type: "code"` for code-related outcomes.
+
+## Episode lifecycle (lazy-open)
+
+Continue has no session-start/session-end hooks, so you own the episode lifecycle:
+
+- **Before your first `pensyve_observe` call in this conversation**, check whether a working `episode_id` is already tracked. If none exists, call `pensyve_episode_start(participants: ["continue", "<project entity>"])` first, record the returned `episode_id`, then make the observation.
+- **Reuse the same `episode_id`** for all subsequent observations in the same conversation. Open a new episode only when the work's topic shifts substantially.
+- **Do not explicitly close** the episode under normal operation. Server-side consolidation handles aging.
+- **Recovery**: if `pensyve_observe` fails with a missing-episode error, call `pensyve_episode_start` and retry.
+
+## Surface style
+
+Lightly visible. One line when memory is used. Examples:
+
+- Recall: `Recalled 4 related memories (v7r, haiku-classifier).`
+- Capture: `↳ captured: hybrid-router threshold was the phase-3 regression root cause.`
+
+Do not narrate empty recalls or duplicate-skips.
+
+## Scope and budgets
+
+- Recall: scoped to detected entities (see `entity-detection.md`); limit 5; use `types` hint per flow.
+- Capture: one observation per substantive lesson; reuse the working `episode_id`.
+- Noise: avoid surfacing memory operations the user did not care about.
+
+## Composition with provenance tags
+
+When a capture is both procedural AND a proactive in-flight write, the `content` field begins with both markers, `[procedural]` first, then the provenance tag, then content:
+
+`[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=...`
+
+The `[procedural]` marker identifies the memory type for consolidation. The provenance tag identifies origin and trigger.
+
+## Provenance tag vocabulary
+
+- `[proactive/in-flight/tier-1]` — memory reflex captured during reasoning
+- `[proactive/in-flight/open-question]` — unresolved question noted in-flight
+- `[auto-capture/user/residual/tier-1]` — explicit user-driven capture (e.g., session-memory rule)
+
+## MCP contract reminder
+
+Rules never pass unsupported parameters. The MCP tool schemas are:
+
+- `pensyve_recall(query, entity?, types?, limit?, min_confidence?)` — **no** `related_entities`
+- `pensyve_episode_start(participants)` — **no** `continuation_of`
+- `pensyve_observe(episode_id, content, source_entity, about_entity, content_type?)` — `source_entity` and `about_entity` are **required**
+
+If you need secondary-entity context in a recall, fold those entities into the `query` string.

--- a/integrations/continue/.continue/rules/session-memory.md
+++ b/integrations/continue/.continue/rules/session-memory.md
@@ -1,0 +1,85 @@
+---
+name: Session Memory
+description: Use at conversation wrap-up or when the user explicitly indicates end-of-session — capture residual lessons not captured in-flight
+---
+
+# Session Memory (Wrap-Up)
+
+Continue has no automatic Stop hook. This rule is the manual equivalent: when the user indicates the conversation is ending ("thanks, that's all", "session wrap-up", "we're done here"), review what happened and capture anything the in-flight reflex missed.
+
+Follows `memory-reflex.md`.
+
+## Instructions
+
+### Step 1: Review the conversation
+
+Scan the current conversation for three categories of memorable content that the in-flight reflex did NOT already capture:
+
+**Decisions** (confidence: 0.9):
+- Architecture or design choices
+- Technology selections
+- API design decisions
+- Tradeoff resolutions
+
+**Outcomes** (confidence: 0.8):
+- Bug fixes and their root causes
+- Successful approaches
+- Failed approaches with reasons
+- Performance findings
+
+**Patterns** (confidence: 0.7):
+- Recurring issues
+- Workflow discoveries
+- Cross-cutting observations
+
+### Step 2: Filter for significance and deduplicate
+
+Skip routine, low-signal content. Also skip anything that was already captured in-flight.
+
+For each candidate, call `pensyve_recall` with `query: <candidate fact text>`, `entity: <candidate's entity>`, `limit: 3`. If any returned memory has a score ≥0.85 against the candidate, skip it as a likely duplicate.
+
+Note: `pensyve_inspect` cannot filter by `episode_id` (its params are `entity`, `memory_type?`, `limit?` only), so dedup is entity-scoped semantic-similarity rather than session-scoped. Consequence: very similar items captured in prior sessions will also trigger the skip — acceptable for avoiding genuine duplicates.
+
+### Step 3: Present candidates for confirmation
+
+Show the filtered candidates to the user in a structured format:
+
+> **Session Memory Candidates**
+>
+> **Decisions** (confidence: 0.9):
+> 1. `<entity>`: <decision text>
+>
+> **Outcomes** (confidence: 0.8):
+> 2. `<entity>`: <outcome text>
+>
+> **Patterns** (confidence: 0.7):
+> 3. `<entity>`: <pattern text>
+>
+> Which should I store? (e.g., "all", "1,3", "none")
+
+### Step 4: Store confirmed items
+
+For each confirmed item, classify the type and call the appropriate MCP tool:
+
+- **Semantic** (decisions, durable truths) — `pensyve_remember(entity, fact: "[auto-capture/user/residual/tier-1] <text>", confidence)`. Use confidence from the categorization above.
+- **Episodic** (outcomes, session-specific events) — ensure working `episode_id`; `pensyve_observe(episode_id, content: "[auto-capture/user/residual/tier-1] <text>", source_entity: "continue", about_entity: <entity>, content_type: "text")`.
+- **Procedural** (reusable workflows) — `pensyve_observe(episode_id, content: "[procedural] [auto-capture/user/residual/tier-1] trigger=..., action=..., outcome=...", source_entity: "continue", about_entity: <entity>, content_type: "text")`.
+
+### Step 5: Optionally close the episode
+
+If the user indicates this is a final wrap (not just a turn-by-turn pause), call `pensyve_episode_end(episode_id: <working_id>, outcome: "success")`. Valid outcomes: `"success"`, `"failure"`, `"partial"`.
+
+Not closing is safe — server-side consolidation ages episodes naturally. Only close when the user clearly marks the work complete.
+
+### Step 6: Report
+
+After storing, summarize:
+
+> Stored N memories. Episode <outcome> closed.
+
+## Constraints
+
+- **Never auto-store.** Every candidate MUST be presented to the user for confirmation before storage.
+- Entity names lowercase-hyphenated.
+- Do not store secrets.
+- If nothing significant surfaced, say so clearly rather than forcing low-quality memories.

--- a/integrations/continue/CHANGELOG.md
+++ b/integrations/continue/CHANGELOG.md
@@ -1,0 +1,43 @@
+# Changelog — Pensyve Continue Adapter
+
+All notable changes to the Pensyve Continue adapter are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). The Continue adapter versions independently of the Claude Code plugin.
+
+## [1.0.0] - 2026-04-20
+
+### Added
+
+- **Working-memory substrate** for Continue via `.continue/rules/*.md` files. Eight rule files deliver the substrate the Claude Code plugin v1.3.0 established:
+  - `memory-reflex.md` (always-apply) — non-optional reasoning discipline with three-type memory classification, canonical `pensyve_observe` call template, provenance vocabulary, lazy-open episode lifecycle
+  - `entity-detection.md` (always-apply) — canonicalization and fallback rules
+  - `memory-informed-debug.md` — debug flow
+  - `memory-informed-design.md` — design flow
+  - `memory-informed-refactor.md` — refactor flow
+  - `memory-informed-longitudinal-work.md` — research/eval flow
+  - `session-memory.md` — manual wrap-up equivalent of Claude Code's Stop hook
+  - `context-loader.md` — best-effort continuity primer via episodic recall
+- **MCP config example** at `config.yaml.example` covering Cloud-with-API-key and Local-stdio options in Continue's YAML config format
+- **Static MCP contract lint script** at `scripts/lint-mcp-refs.sh` verifying every rule's `pensyve_*` call example matches the `pensyve-mcp-tools/src/params.rs` schema
+
+### Design
+
+- Single reasoning layer; no platform-layer code. Continue has no hook/event surface, so the entire adapter is rules the model interprets.
+- Continue's `.continue/rules/*.md` format used with optional YAML frontmatter (`name:`, `description:`).
+- MCP config uses Continue's `mcpServers` YAML format with `streamable-http` transport for cloud and `stdio` for local.
+- Lazy-open episode lifecycle: first `pensyve_observe` call triggers `pensyve_episode_start`; episodes are not explicitly closed.
+- Best-effort continuity primer via `pensyve_recall(types: ["episodic"])` — the MCP server has no episode-listing API.
+- MCP contract verified: no `related_entities` on recall, no `continuation_of` on episode_start, required `source_entity: "continue"` and `about_entity` on every observe.
+- Opt-out: delete or edit rule files (Continue-native pattern); no parallel config file.
+
+### Not Included
+
+- No extension or platform-layer code (deferred to a future sibling spec if capability gaps surface)
+- No installer script (manual copy of rules + config merge)
+- No server-side changes — uses the existing MCP tool surface
+
+### Relation to Other Pensyve Integrations
+
+- The Continue adapter is part of the batch-1 working-memory substrate rollout. The Cursor adapter (v1.0.0) and Claude Code plugin (v1.3.0) are the reference implementations.
+- Spec: `pensyve-docs/specs/2026-04-20-pensyve-cursor-adapter-design.md`
+- Playbook: `pensyve-docs/specs/2026-04-18-pensyve-working-memory-substrate-design.md`

--- a/integrations/continue/README.md
+++ b/integrations/continue/README.md
@@ -1,110 +1,141 @@
 # Pensyve for Continue
 
-Persistent AI memory for [Continue](https://continue.dev) via MCP.
+Persistent working-memory substrate for [Continue](https://continue.dev) — memory is not a feature you invoke, it is the substrate the agent operates on.
 
-## Authentication
+## What It Does
 
-1. Sign up at [pensyve.com](https://pensyve.com)
-2. Create an API key at [Settings → API Keys](https://pensyve.com/settings/api-keys)
-3. Set the environment variable:
-   ```bash
-   export PENSYVE_API_KEY="psy_your_key_here"
-   ```
+- **Proactive memory during work** — lessons are captured the moment they land, not at session end
+- **Thread-aware continuity** — sessions that continue prior work resume with relevant context, no re-briefing
+- **Entity-scoped recall** — substantive questions are grounded in prior decisions; simple commands stay fast
+- **Three memory types** — durable facts (semantic), session-specific events (episodic), reusable procedures (procedural)
+- **Lightly visible** — one-line surfaces when memory is used; never interrupts your flow
 
-Then configure MCP with headers (see setup instructions above).
+## Install
 
-## Setup
+Two steps: configure the MCP server, then install the rules.
 
-Set your API key (get one at [pensyve.com/settings/api-keys](https://pensyve.com/settings/api-keys)):
+### 1. Configure the MCP server
+
+Merge the `config.yaml.example` fragment into your Continue config at `~/.continue/config.yaml`.
+
+**Cloud with API key (recommended):**
 
 ```bash
-export PENSYVE_API_KEY="psy_your_key"
+export PENSYVE_API_KEY="psy_your_key_here"
 ```
 
-Add to your shell profile (`~/.bashrc`, `~/.zshrc`) to persist across sessions.
-
-## Cloud (Recommended)
-
-Add to your Continue config (`~/.continue/config.json`):
-
-```json
-{
-  "experimental": {
-    "modelContextProtocolServers": [
-      {
-        "name": "pensyve",
-        "transport": {
-          "type": "streamable-http",
-          "url": "https://mcp.pensyve.com/mcp",
-          "headers": {
-            "Authorization": "Bearer ${PENSYVE_API_KEY}"
-          }
-        }
-      }
-    ]
-  }
-}
+```yaml
+mcpServers:
+  - name: pensyve
+    transport:
+      type: streamable-http
+      url: https://mcp.pensyve.com/mcp
+      headers:
+        Authorization: "Bearer ${PENSYVE_API_KEY}"
 ```
 
-## Local (Offline)
+Create your key at [pensyve.com/settings/api-keys](https://pensyve.com/settings/api-keys). Put the `export` in `~/.bashrc` or `~/.zshrc` to persist.
 
-No API key needed — all data stays on your machine.
+**Local (offline, self-hosted):**
 
-```json
-{
-  "experimental": {
-    "modelContextProtocolServers": [
-      {
-        "name": "pensyve",
-        "transport": {
-          "type": "stdio",
-          "command": "pensyve-mcp",
-          "args": ["--stdio"],
-          "env": {
-            "PENSYVE_PATH": "~/.pensyve/",
-            "PENSYVE_NAMESPACE": "default"
-          }
-        }
-      }
-    ]
-  }
-}
+```yaml
+mcpServers:
+  - name: pensyve
+    transport:
+      type: stdio
+      command: pensyve-mcp
+      args:
+        - --stdio
+      env:
+        PENSYVE_PATH: ~/.pensyve/
+        PENSYVE_NAMESPACE: default
 ```
 
-Build from source: `cargo build --release -p pensyve-mcp` from the [pensyve repo](https://github.com/major7apps/pensyve).
+Build the binary: `cargo build --release -p pensyve-mcp` from the [pensyve repo](https://github.com/major7apps/pensyve).
 
-## Available Tools
+### 2. Install the rules
 
-| Tool                    | Description                            |
-| ----------------------- | -------------------------------------- |
-| `pensyve_recall`        | Search memories by semantic similarity |
-| `pensyve_remember`      | Store a fact as semantic memory        |
-| `pensyve_episode_start` | Begin tracking an interaction          |
-| `pensyve_episode_end`   | Close an episode                       |
-| `pensyve_forget`        | Delete an entity's memories            |
-| `pensyve_inspect`       | List memories for an entity            |
-| `pensyve_status`        | Connection and memory stats            |
-| `pensyve_account`       | Plan and usage info                    |
+Copy the rule files into your project's `.continue/rules/` directory:
+
+```bash
+mkdir -p .continue/rules
+cp /path/to/pensyve/integrations/continue/.continue/rules/*.md .continue/rules/
+```
+
+Continue loads rules from `.continue/rules/` automatically. Each rule file has optional YAML frontmatter with `name` and `description` fields.
+
+| Rule | Purpose |
+|---|---|
+| `memory-reflex.md` | Always-on reasoning discipline (core substrate) |
+| `entity-detection.md` | Entity canonicalization reference |
+| `memory-informed-debug.md` | Debug flow with memory baked in |
+| `memory-informed-design.md` | Design flow with memory baked in |
+| `memory-informed-refactor.md` | Refactor flow with memory baked in |
+| `memory-informed-longitudinal-work.md` | Research/eval multi-session flow |
+| `session-memory.md` | Manual session wrap-up capture |
+| `context-loader.md` | Best-effort continuity primer at session start |
+
+## How It Works
+
+Continue has no hook/event surface, so the entire substrate is delivered through the rules the model interprets during reasoning. `memory-reflex.md` establishes the discipline: *before substantive answers, recall by entity; when a lesson lands, observe immediately with a one-line surface*. Flow rules (debug/design/refactor/longitudinal-work) guide the model through consult-memory + capture-lesson steps.
+
+**Episode lifecycle:** Continue has no session-start/session-end hooks, so episodes open lazily on the first `pensyve_observe` call and are not explicitly closed under normal operation. Server-side consolidation handles aging.
+
+**Continuity primer:** `context-loader.md` runs a best-effort recall at the start of substantive conversations to surface prior relevant observations. Not a structured server-side link — the MCP server has no episode-listing API yet — but good enough to create the "continuing prior work" feel.
+
+## Memory Behavior Model
+
+Pensyve behaves as working memory for the agent — always-on, ambient, continuous.
+
+**Writes happen in-flight.** When a root cause is confirmed, a decision is made, or a reusable procedure emerges, it's captured the moment it lands via the memory reflex. No batching to session end.
+
+**Reads happen at decision points.** Before substantive answers, the model consults memory scoped to the detected entities. Simple commands (run tests, format file) skip recall to stay fast.
+
+**Sessions continue.** At the start of a substantive conversation, Pensyve checks whether the current work continues prior memories (shared entities + recent activity). If yes, you resume with a primer — no re-briefing needed.
+
+## Memory Types
+
+| Type | Definition | MCP call | Example |
+|---|---|---|---|
+| **Semantic** | Durable truths, decisions, preferences | `pensyve_remember` | "We chose RS256 over HS256 for JWT signing" |
+| **Episodic** | Temporal events, session-scoped observations | `pensyve_observe` (with lazy-opened `episode_id`) | "Phase-3 regression root cause: hybrid-router threshold" |
+| **Procedural** | Reusable workflows, sequences, recipes | `pensyve_observe` with `[procedural]` content prefix | "To calibrate V7r: freeze Haiku config, run suite, diff baseline" |
+
+## Opt-Out
+
+- **Full opt-out** — delete the Pensyve rule files from `.continue/rules/`
+- **Partial opt-out** — delete specific flow rules (e.g., remove `memory-informed-longitudinal-work.md` if you don't do research work)
+- **Silent mode** — edit `memory-reflex.md` to remove the "one-line surface" guidance; captures stay silent
+- **Recall-only mode** — edit flow rules to drop the `Capture lesson` steps while keeping `Consult memory`
+
+## Available MCP Tools
+
+| Tool | Description |
+|---|---|
+| `pensyve_recall` | Search memories by semantic similarity |
+| `pensyve_remember` | Store a durable fact (semantic memory) |
+| `pensyve_observe` | Record a session observation (episodic / procedural via `[procedural]` prefix) |
+| `pensyve_episode_start` | Begin tracking an episode |
+| `pensyve_episode_end` | Close an episode with outcome |
+| `pensyve_forget` | Delete an entity's memories |
+| `pensyve_inspect` | List memories for an entity |
 
 See [MCP Tools Reference](https://pensyve.com/docs/api-reference/mcp-tools) for full parameter details.
 
-## Intelligent Memory Capture
+## Design Philosophy
 
-Pensyve uses a tiered classification system to identify what is worth remembering. Since Continue connects via MCP only, the LLM follows the MCP tool descriptions to decide when and how to call memory tools.
+- **Memory as substrate** — not a feature the user invokes; always there, continuous, carried across sessions
+- **Reasoning-layer only** — no platform-layer code in v1; the entire adapter is markdown rules
+- **1:1 with Claude Code** — same skill structure, same conventions, same memory types
+- **MCP contract-respecting** — every rule's call examples verified against `pensyve-mcp-tools/src/params.rs`
 
-### Tiered Capture System
+## Links
 
-- **Tier 1** (auto-store, confidence 0.9+): Explicit decisions, corrections, constraints, architecture choices, dependency version pins, security rules. High-signal items that should almost always be captured.
-- **Tier 2** (review, confidence 0.7-0.89): Root causes, failed approaches, performance findings, debugging outcomes, environment quirks. Medium-signal items that benefit from user confirmation.
-- **Discard**: Formatting, typos, boilerplate, ephemeral status messages. Noise that should never be stored.
+- **Website:** [pensyve.com](https://pensyve.com)
+- **GitHub:** [github.com/major7apps/pensyve](https://github.com/major7apps/pensyve)
+- **Spec:** [Cursor adapter design](https://github.com/major7apps/pensyve-docs/blob/main/specs/2026-04-20-pensyve-cursor-adapter-design.md)
+- **Playbook:** [Working-memory substrate design](https://github.com/major7apps/pensyve-docs/blob/main/specs/2026-04-18-pensyve-working-memory-substrate-design.md)
 
-### Best Practices
+## License
 
-For the best experience with Continue, guide the LLM to use Pensyve's memory tools effectively:
-
-- Use `pensyve_observe` to record significant events during an episode (architecture decisions, failed approaches, key findings)
-- Use `pensyve_remember` for durable facts that should persist across sessions (project conventions, environment constraints, resolved issues)
-- Use `pensyve_recall` at the start of a task to load relevant context from prior sessions
-- Wrap multi-step work in `pensyve_episode_start` / `pensyve_episode_end` to capture episodic context
-
-The MCP tool descriptions include guidance on confidence levels so the LLM can classify memories into the appropriate tier automatically.
+Apache 2.0

--- a/integrations/continue/config.yaml.example
+++ b/integrations/continue/config.yaml.example
@@ -1,0 +1,23 @@
+# Continue config.yaml — Pensyve MCP server configuration
+# Merge this fragment into your ~/.continue/config.yaml
+
+# Cloud (recommended) — requires PENSYVE_API_KEY env var
+mcpServers:
+  - name: pensyve
+    transport:
+      type: streamable-http
+      url: https://mcp.pensyve.com/mcp
+      headers:
+        Authorization: "Bearer ${PENSYVE_API_KEY}"
+
+# Local (offline) — uncomment to use local stdio server instead
+# mcpServers:
+#   - name: pensyve
+#     transport:
+#       type: stdio
+#       command: pensyve-mcp
+#       args:
+#         - --stdio
+#       env:
+#         PENSYVE_PATH: ~/.pensyve/
+#         PENSYVE_NAMESPACE: default

--- a/integrations/continue/scripts/lint-mcp-refs.sh
+++ b/integrations/continue/scripts/lint-mcp-refs.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Static MCP contract linter for the Pensyve Continue adapter rules.
+#
+# Verifies that every pensyve_* call example in .continue/rules/*.md conforms to
+# the current MCP tool schema in pensyve-mcp-tools/src/params.rs. Catches the
+# category of bug PR #58 surfaced in the Claude Code adapter (unsupported
+# parameters, missing required fields).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RULES_DIR="$SCRIPT_DIR/../.continue/rules"
+
+EXIT_CODE=0
+
+if [ ! -d "$RULES_DIR" ]; then
+  echo "ERROR: Rules directory not found: $RULES_DIR"
+  exit 1
+fi
+
+echo "Linting MCP references in $RULES_DIR..."
+echo ""
+
+# Check 1: no actual use of unsupported 'related_entities' parameter in call examples.
+# We look for pensyve_recall( blocks that contain related_entities as a parameter.
+# Lines that say "no related_entities" (documentation/reminders) are excluded.
+echo "Check 1: no unsupported 'related_entities' on pensyve_recall"
+FOUND_RELATED=0
+for rule_file in "$RULES_DIR"/*.md; do
+  # Extract lines that contain pensyve_recall( and related_entities together,
+  # excluding documentation lines (those containing "**no**" or "no `related_entities`")
+  if rg -n 'related_entities' "$rule_file" | rg -v '(\*\*no\*\*|no `related_entities`)' | rg -q 'pensyve_recall\|related_entities'; then
+    echo "  FAIL in $rule_file: 'related_entities' used in a pensyve_recall call"
+    FOUND_RELATED=1
+  fi
+  # Also catch if related_entities appears inside a pensyve_recall( block
+  awk '/pensyve_recall\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+         if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
+           print FILENAME ": related_entities found in pensyve_recall block: " buf;
+         capture=0
+       }' "$rule_file" | while read -r line; do
+    if [ -n "$line" ]; then
+      echo "  FAIL: $line"
+      FOUND_RELATED=1
+    fi
+  done
+done
+if [ "$FOUND_RELATED" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 2: no actual use of unsupported 'continuation_of' parameter in call examples.
+# Documentation lines saying "no continuation_of" are excluded.
+echo "Check 2: no unsupported 'continuation_of' on pensyve_episode_start"
+FOUND_CONT=0
+for rule_file in "$RULES_DIR"/*.md; do
+  awk '/pensyve_episode_start\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+         if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
+           print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
+         capture=0
+       }' "$rule_file" | while read -r line; do
+    if [ -n "$line" ]; then
+      echo "  FAIL: $line"
+      FOUND_CONT=1
+    fi
+  done
+done
+if [ "$FOUND_CONT" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 3: every pensyve_observe call example in a code block has source_entity and about_entity
+# Scan each .md file's pensyve_observe blocks; require both fields nearby.
+echo "Check 3: every pensyve_observe example has source_entity and about_entity"
+MISSING_FIELDS=0
+for rule_file in "$RULES_DIR"/*.md; do
+  # Find each pensyve_observe( block (up to the next closing paren within 20 lines)
+  awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
+       capture {buf = buf "\n" $0;
+                for(i=1; i<=length($0); i++){
+                  c=substr($0,i,1);
+                  if(c=="(") depth++;
+                  if(c==")") depth--;
+                };
+                if(depth==0 && buf ~ /pensyve_observe\(/){
+                  if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
+                  if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
+                  capture=0;
+                }}' "$rule_file" | while read -r line; do
+    if [ -n "$line" ]; then
+      echo "  FAIL: $line"
+      MISSING_FIELDS=1
+    fi
+  done
+done
+if [ "$MISSING_FIELDS" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 4: provenance tag format — every proactive/auto-capture tag uses [<origin>/<trigger>/<tier>]
+# Format supports both 3-segment [origin/trigger/tier] and 4-segment [origin/trigger/residual/tier]
+# where the third segment may be a literal "residual" qualifier before the tier.
+echo "Check 4: provenance tag format"
+VALID_PROVENANCE_RE='\[(proactive|auto-capture)/(in-flight|stop|pre-compact|curator|user)/(tier-1|tier-2|residual/tier-1|residual/tier-2|open-question)\]'
+if rg -n '\[(proactive|auto-capture)' "$RULES_DIR" | rg -v "$VALID_PROVENANCE_RE"; then
+  echo "  FAIL: some provenance tags do not match [<origin>/<trigger>/<tier>] format"
+  EXIT_CODE=1
+else
+  echo "  PASS"
+fi
+echo ""
+
+# Check 5: procedural memory convention — [procedural] prefix is used in observe content
+echo "Check 5: procedural convention uses [procedural] prefix in pensyve_observe content"
+# Only a warning if no rule mentions [procedural] — may be legitimate if the rule is non-procedural
+if ! rg -q '\[procedural\]' "$RULES_DIR"; then
+  echo "  WARN: no [procedural] prefix usage found across rules. Expected in memory-reflex and flow rules that handle procedural captures."
+else
+  echo "  PASS"
+fi
+echo ""
+
+if [ "$EXIT_CODE" = "0" ]; then
+  echo "All MCP contract checks PASSED."
+else
+  echo "MCP contract checks FAILED. Fix the issues above before committing."
+fi
+
+exit "$EXIT_CODE"

--- a/integrations/continue/scripts/lint-mcp-refs.sh
+++ b/integrations/continue/scripts/lint-mcp-refs.sh
@@ -34,18 +34,18 @@ for rule_file in "$RULES_DIR"/*.md; do
     FOUND_RELATED=1
   fi
   # Also catch if related_entities appears inside a pensyve_recall( block
-  awk '/pensyve_recall\(/{capture=1; buf=""}
-       capture {buf = buf "\n" $0}
-       capture && /\)/{
-         if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
-           print FILENAME ": related_entities found in pensyve_recall block: " buf;
-         capture=0
-       }' "$rule_file" | while read -r line; do
+  while read -r line; do
     if [ -n "$line" ]; then
       echo "  FAIL: $line"
       FOUND_RELATED=1
     fi
-  done
+  done < <(awk '/pensyve_recall\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+       if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
+       print FILENAME ": related_entities found in pensyve_recall block: " buf;
+       capture=0
+       }' "$rule_file")
 done
 if [ "$FOUND_RELATED" = "0" ]; then
   echo "  PASS"
@@ -59,18 +59,18 @@ echo ""
 echo "Check 2: no unsupported 'continuation_of' on pensyve_episode_start"
 FOUND_CONT=0
 for rule_file in "$RULES_DIR"/*.md; do
-  awk '/pensyve_episode_start\(/{capture=1; buf=""}
-       capture {buf = buf "\n" $0}
-       capture && /\)/{
-         if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
-           print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
-         capture=0
-       }' "$rule_file" | while read -r line; do
+  while read -r line; do
     if [ -n "$line" ]; then
       echo "  FAIL: $line"
       FOUND_CONT=1
     fi
-  done
+  done < <(awk '/pensyve_episode_start\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+       if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
+       print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
+       capture=0
+       }' "$rule_file")
 done
 if [ "$FOUND_CONT" = "0" ]; then
   echo "  PASS"
@@ -85,23 +85,23 @@ echo "Check 3: every pensyve_observe example has source_entity and about_entity"
 MISSING_FIELDS=0
 for rule_file in "$RULES_DIR"/*.md; do
   # Find each pensyve_observe( block (up to the next closing paren within 20 lines)
-  awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
-       capture {buf = buf "\n" $0;
-                for(i=1; i<=length($0); i++){
-                  c=substr($0,i,1);
-                  if(c=="(") depth++;
-                  if(c==")") depth--;
-                };
-                if(depth==0 && buf ~ /pensyve_observe\(/){
-                  if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
-                  if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
-                  capture=0;
-                }}' "$rule_file" | while read -r line; do
+  while read -r line; do
     if [ -n "$line" ]; then
       echo "  FAIL: $line"
       MISSING_FIELDS=1
     fi
-  done
+  done < <(awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
+       capture {buf = buf "\n" $0;
+       for(i=1; i<=length($0); i++){
+       c=substr($0,i,1);
+       if(c=="(") depth++;
+       if(c==")") depth--;
+       };
+       if(depth==0 && buf ~ /pensyve_observe\(/){
+       if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
+       if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
+       capture=0;
+       }}' "$rule_file")
 done
 if [ "$MISSING_FIELDS" = "0" ]; then
   echo "  PASS"

--- a/integrations/crewai/CHANGELOG.md
+++ b/integrations/crewai/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog — Pensyve CrewAI Integration
+
+All notable changes to the Pensyve CrewAI integration are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). This integration versions independently of the core Pensyve engine.
+
+## [1.0.0] - 2026-04-20
+
+### Added
+
+- **Working-memory substrate** for CrewAI agents via `SUBSTRATE_PROMPT.md`. All eight substrate rules consolidated into a single system-prompt document:
+  - **Memory Reflex Rule** — non-optional reasoning discipline with three-type memory classification, canonical `pensyve_observe` call template, provenance vocabulary, lazy-open episode lifecycle
+  - **Entity Detection** — canonicalization and fallback rules for recall scoping
+  - **When Debugging** — debug flow with memory baked in
+  - **When Designing** — design flow with memory baked in
+  - **When Refactoring** — refactor flow with memory baked in
+  - **Longitudinal Work** — multi-session research/eval flow with per-run capture
+  - **Session Wrap-Up** — manual wrap-up with candidate confirmation before storage
+  - **Context Loading** — best-effort continuity primer via episodic recall
+- **Framework wiring example** at `examples/pensyve_crew.py` showing CrewAI `Agent` with Pensyve MCP tools from `crewai-tools MCPServerAdapter` and substrate injected as the agent `backstory`
+- **Static MCP contract lint script** at `scripts/lint-mcp-refs.sh` verifying `SUBSTRATE_PROMPT.md` and the example file against the `pensyve-mcp-tools` schema
+
+### Design
+
+- Single reasoning layer; no platform-layer code.
+- `source_entity: "crewai"` on all `pensyve_observe` calls.
+- MCP connection via `crewai-tools` `MCPServerAdapter` context manager.
+- Substrate injected via `Agent(backstory=substrate)` — CrewAI's closest equivalent to a system prompt for individual agents.
+- Lazy-open episode lifecycle.
+- MCP contract verified: no `related_entities` on recall, no `continuation_of` on episode_start, required `source_entity` and `about_entity` on every observe.
+- Opt-out: remove substrate from agent `backstory`.
+
+### Not Included
+
+- No custom memory backend (that is the existing `pensyve_crewai.py`)
+- No installer script — manual load of `SUBSTRATE_PROMPT.md`
+- No server-side changes — uses the existing MCP tool surface
+
+### Relation to Other Pensyve Integrations
+
+- Part of the batch-4 working-memory substrate rollout (LangChain, LangChain TS, AutoGen, CrewAI, Pydantic AI, Google ADK).
+- The Cursor adapter (v1.0.0) and Claude Code plugin (v1.3.0) are the reference implementations.
+- Spec: `pensyve-docs/specs/2026-04-20-pensyve-cursor-adapter-design.md`
+- Playbook: `pensyve-docs/specs/2026-04-18-pensyve-working-memory-substrate-design.md`

--- a/integrations/crewai/README.md
+++ b/integrations/crewai/README.md
@@ -1,173 +1,136 @@
 # Pensyve CrewAI Integration
 
-Pensyve memory backend for CrewAI, providing persistent memory with 8-signal fusion retrieval.
+Persistent AI memory for [CrewAI](https://docs.crewai.com/) agents via Pensyve. Two complementary features:
 
-## Authentication
+1. **Working-memory substrate** — A system-prompt document (`SUBSTRATE_PROMPT.md`) that gives your CrewAI agents the reasoning discipline to recall before answering and capture lessons as they land.
+2. **Memory backend** — `PensyveCrewAIMemory`: a persistent memory provider backed by Pensyve's 8-signal fusion retrieval engine.
 
-```python
-from pensyve import PensyveClient
+---
 
-# Explicit API key
-client = PensyveClient(api_key="psy_your_key_here")
+## What It Does
 
-# Or from environment variable
-# export PENSYVE_API_KEY="psy_your_key_here"
-client = PensyveClient()
+The working-memory substrate is a reasoning layer — not a library — that you load into a CrewAI agent's `backstory`. Once loaded, the agent will:
+
+- **Recall before substantive answers** using `pensyve_recall`, scoped by entity.
+- **Capture lessons in-flight** using `pensyve_observe` when a root cause is confirmed, a decision lands, or an approach is abandoned.
+- **Manage episode lifecycle** lazily: open an episode on the first observe, reuse it throughout the conversation.
+- **Surface memory lightly** — one line per recall or capture, never narrating empty recalls.
+- **Wrap up sessions** by presenting memory candidates for user confirmation before storage.
+
+---
+
+## Install
+
+```bash
+pip install crewai crewai-tools langchain-anthropic
+```
+
+Set your API key:
+
+```bash
+export PENSYVE_API_KEY="psy_your_key_here"
+export ANTHROPIC_API_KEY="sk-ant-..."
 ```
 
 Create an API key at [pensyve.com/settings/api-keys](https://pensyve.com/settings/api-keys).
 
-## Installation
-
-```bash
-pip install pensyve
-```
-
-Copy this directory into your project, or add it to your Python path.
+---
 
 ## Quick Start
 
-```python
-from pensyve_crewai import PensyveMemory
-
-memory = PensyveMemory(namespace="my-crew")
-
-# Store memories
-memory.remember("The API rate limit is 1000 requests per minute.")
-memory.remember("Authentication uses Bearer tokens.", metadata={"confidence": 0.95})
-
-# Search memories
-matches = memory.recall("What are our API limits?", limit=5)
-for m in matches:
-    print(f"[{m.score:.2f}] {m.record.content}")
-
-# Extract facts from unstructured text
-facts = memory.extract_memories("Meeting notes: We decided to migrate to Postgres. Deadline is Friday.")
-for fact in facts:
-    memory.remember(fact)
-```
-
-## Usage with CrewAI
-
-```python
-from pensyve_crewai import PensyveMemory
-from crewai import Crew
-
-memory = PensyveMemory(namespace="my-crew")
-crew = Crew(
-    agents=[...],
-    tasks=[...],
-    memory=True,
-    memory_config={"provider": "custom", "config": {"instance": memory}},
-)
-```
-
-## Local vs. Cloud Mode
-
-The integration auto-detects which backend to use:
-
-| Mode  | Trigger                                       | Backend                     |
-| ----- | --------------------------------------------- | --------------------------- |
-| Local | No API key set                                | Pensyve SDK (PyO3 + SQLite) |
-| Cloud | `PENSYVE_API_KEY` env var or `api_key=` param | Pensyve REST API            |
-
-```python
-# Local mode (default)
-memory = PensyveMemory(namespace="my-crew")
-
-# Cloud mode (explicit key)
-memory = PensyveMemory(namespace="my-crew", api_key="psy_...")
-
-# Cloud mode (env var)
-# export PENSYVE_API_KEY=psy_...
-memory = PensyveMemory(namespace="my-crew")
-
-# Check active mode
-print(memory.mode)  # "local" or "cloud"
-```
-
-## API
-
-### `PensyveMemory(namespace, entity_name, *, path, api_key, base_url)`
-
-| Parameter     | Type          | Default                     | Description                          |
-| ------------- | ------------- | --------------------------- | ------------------------------------ |
-| `namespace`   | `str`         | `"default"`                 | Pensyve namespace for isolation      |
-| `entity_name` | `str`         | `"crew-agent"`              | Entity name to scope memories to     |
-| `path`        | `str \| None` | `None`                      | Local storage path (local mode only) |
-| `api_key`     | `str \| None` | `None`                      | Cloud API key (overrides env var)    |
-| `base_url`    | `str`         | `"https://api.pensyve.com"` | Cloud API URL                        |
-
-### Methods
-
-| Method                          | Description                                  |
-| ------------------------------- | -------------------------------------------- |
-| `remember(text, metadata=None)` | Store a memory with optional metadata        |
-| `recall(query, limit=5)`        | Search memories, returns `list[MemoryMatch]` |
-| `extract_memories(text)`        | Split text into individual facts (no LLM)    |
-| `reset()`                       | Clear all memories for this entity           |
-
-### Result Types
-
-```python
-@dataclass
-class MemoryMatch:
-    score: float          # Relevance score (0.0 - 1.0)
-    record: MemoryRecord  # The stored memory
-
-@dataclass
-class MemoryRecord:
-    content: str                    # Memory text
-    metadata: dict[str, Any] = {}   # Additional metadata
-```
-
-## Intelligent Capture (v1.1.0+)
-
-Automatically capture decisions, preferences, and findings from CrewAI task execution into Pensyve memory.
-
-```python
-from pensyve_crewai import PensyveMemory, PensyveCaptureCallbacks
-
-memory = PensyveMemory(namespace="my-crew")
-capture = PensyveCaptureCallbacks(memory=memory)
-
-# Wire into CrewAI
-from crewai import Crew
-crew = Crew(
-    agents=[...],
-    tasks=[...],
-    memory=True,
-    memory_config={"provider": "custom", "config": {"instance": memory}},
-    callbacks=[capture],
-)
-```
-
-### How It Works
-
-- **Task start/end** and **tool use** events are buffered as raw signals
-- At each task end, signals are classified into tiered memory candidates:
-  - **Tier 1** (auto-stored): architecture decisions, behavioral preferences, project constraints
-  - **Tier 2** (review): root causes, failed approaches, performance findings, dependencies
-- Secrets are automatically redacted; long code blocks are stripped
-- Capture **never breaks** CrewAI execution (all callbacks fail silently)
-
-### Reviewing Tier-2 Candidates
-
-```python
-# After crew execution
-pending = capture.get_pending_review()
-for candidate in pending:
-    print(f"[tier {candidate.tier}] {candidate.entity}: {candidate.fact}")
-    # Manually approve:
-    memory.remember(candidate.fact, metadata={"confidence": candidate.confidence})
-
-capture.clear_pending_review()
-```
-
-## Running Tests
-
 ```bash
 cd integrations/crewai
-pip install pytest
-pytest tests/ -v
+python examples/pensyve_crew.py
 ```
+
+The example creates a CrewAI `Agent` with Pensyve MCP tools from `MCPServerAdapter` and `SUBSTRATE_PROMPT.md` as the `backstory`.
+
+---
+
+## System Prompt
+
+`SUBSTRATE_PROMPT.md` consolidates all eight substrate rules into a single document. In CrewAI, the `backstory` field is the closest equivalent to a per-agent system prompt:
+
+```python
+from pathlib import Path
+from crewai import Agent
+
+substrate = Path("SUBSTRATE_PROMPT.md").read_text()
+agent = Agent(
+    role="Memory-Augmented Developer",
+    goal="Answer questions grounded in prior project knowledge.",
+    backstory=substrate,
+    tools=pensyve_tools,
+    llm=llm,
+)
+```
+
+---
+
+## MCP Connection
+
+```python
+from crewai_tools import MCPServerAdapter
+
+pensyve_server_config = {
+    "url": "https://mcp.pensyve.com/mcp",
+    "transport": "streamable_http",
+    "headers": {"Authorization": f"Bearer {os.environ['PENSYVE_API_KEY']}"},
+}
+
+with MCPServerAdapter(pensyve_server_config) as mcp_adapter:
+    pensyve_tools = mcp_adapter.tools
+    # Build agents and crew...
+```
+
+---
+
+## Memory Behavior Model
+
+| Trigger | Action | MCP call |
+|---|---|---|
+| Before substantive answer | Recall by entity | `pensyve_recall(query, entity, types, limit=5)` |
+| Root cause confirmed | Capture episodic | `pensyve_observe(episode_id, content, source_entity="crewai", about_entity)` |
+| Decision accepted | Capture semantic | `pensyve_remember(entity, fact, confidence=0.9)` |
+| Reusable workflow found | Capture procedural | `pensyve_observe(... content="[procedural] ...")` |
+| Session ending | Present candidates | User confirms before storage |
+
+---
+
+## Memory Types
+
+- **Semantic** — durable facts that remain true across sessions.
+- **Episodic** — what happened in this thread (outcomes, root causes, abandoned approaches).
+- **Procedural** — reusable workflows stored via `pensyve_observe` with a `[procedural]` prefix.
+
+---
+
+## Memory Backend
+
+Separate from the substrate, `PensyveCrewAIMemory` provides persistent memory storage:
+
+```python
+from pensyve_crewai import PensyveCrewAIMemory
+
+memory = PensyveCrewAIMemory()
+```
+
+See `pensyve_crewai.py` for the full API.
+
+---
+
+## Opt-Out
+
+To disable the substrate, remove the substrate content from the agent's `backstory`. The memory backend is unaffected.
+
+---
+
+## Links
+
+- [Pensyve](https://pensyve.com) — managed memory service
+- [API Keys](https://pensyve.com/settings/api-keys)
+- [CrewAI docs](https://docs.crewai.com/)
+
+## License
+
+Apache 2.0 — see [LICENSE](LICENSE).

--- a/integrations/crewai/SUBSTRATE_PROMPT.md
+++ b/integrations/crewai/SUBSTRATE_PROMPT.md
@@ -1,0 +1,397 @@
+# Pensyve Working-Memory Substrate for CrewAI
+
+This document configures persistent working-memory for CrewAI agents via the Pensyve MCP server. Load the full text of this file as the agent's system prompt to activate all substrate behaviors. All sections below form the reasoning layer the agent carries through every session.
+
+---
+
+## Memory Reflex Rule
+
+**This discipline is non-optional. Before substantive answers, recall by entity. When a lesson lands, observe immediately with a one-line surface.**
+
+### "Substantive answer" means
+
+- Design or architecture recommendations
+- Debugging diagnoses with root-cause claims
+- Refactor proposals
+- Any response that makes a claim the user would want grounded in prior work
+
+Not substantive: formatting fixes, trivial lookups, reading a file, running a command.
+
+### "Lesson lands" means
+
+- A root cause has been confirmed (not hypothesized).
+- A design choice has been made explicit ("we'll use X because Y").
+- An approach has been tried and abandoned with a reason.
+- A workflow has been discovered that is reusable.
+- A workaround for a framework/library limitation has been validated.
+
+### Memory classification
+
+- **Semantic** — a fact that will still be true next month. Use `pensyve_remember(entity, fact, confidence?)` (confidence defaults to 1.0; use 0.9 for high-confidence auto-captures).
+- **Episodic** — something that happened in this thread of work. Use `pensyve_observe` with the current `episode_id`.
+- **Procedural** — a reusable way to do something. Use `pensyve_observe` with `content` beginning `[procedural]`.
+
+When in doubt, prefer episodic.
+
+### Canonical `pensyve_observe` call template
+
+ALL observe calls MUST include every required field:
+
+```
+pensyve_observe(
+  episode_id: <current session's working episode_id>,
+  content: "[proactive/in-flight/tier-1] <observation text>",
+  source_entity: "crewai",
+  about_entity: "<relevant entity, lowercase-hyphenated>",
+  content_type: "text"
+)
+```
+
+Use `content_type: "code"` for code-related outcomes.
+
+### Episode lifecycle (lazy-open)
+
+Library agents have no session-start/session-end hooks, so you own the episode lifecycle:
+
+- Before your first `pensyve_observe` call in this conversation, check whether a working `episode_id` is tracked. If none exists, call `pensyve_episode_start(participants: ["crewai", "<project entity>"])` first.
+- Reuse the same `episode_id` for all subsequent observations in the same conversation.
+- Do not explicitly close the episode under normal operation. Server-side consolidation handles aging.
+- Recovery: if `pensyve_observe` fails with a missing-episode error, call `pensyve_episode_start` and retry.
+
+### Surface style
+
+Lightly visible. One line when memory is used:
+
+- Recall: `Recalled 4 related memories (v7r, haiku-classifier).`
+- Capture: `↳ captured: hybrid-router threshold was the phase-3 regression root cause.`
+
+Do not narrate empty recalls or duplicate-skips.
+
+### Provenance tag vocabulary
+
+- `[proactive/in-flight/tier-1]` — memory reflex captured during reasoning
+- `[proactive/in-flight/open-question]` — unresolved question noted in-flight
+- `[auto-capture/user/residual/tier-1]` — explicit user-driven capture
+
+### Composition
+
+When a capture is both procedural AND in-flight: `[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=...`
+
+### MCP contract
+
+Rules never pass unsupported parameters:
+
+- `pensyve_recall(query, entity?, types?, limit?, min_confidence?)` — **no** `related_entities`
+- `pensyve_episode_start(participants)` — **no** `continuation_of`
+- `pensyve_observe(episode_id, content, source_entity, about_entity, content_type?)` — `source_entity` and `about_entity` are **required**
+
+---
+
+## Entity Detection
+
+Shared rules for detecting entity names from tool inputs, prompts, and conversation context. Used to scope recalls and `about_entity` fields on observations.
+
+### Inputs
+
+Extract candidate entity names from:
+
+1. **User prompts** — explicit references to components, files, services, research phases.
+2. **Code context** — module names, class names, function names referenced in the conversation.
+3. **File references** — any filenames or paths mentioned in the conversation.
+4. **Git context** — repository root name, branch name (when discoverable).
+
+### Canonicalization
+
+- Lowercase all characters.
+- Replace spaces and underscores with hyphens.
+- Strip file extensions unless the file is the entity itself.
+- Collapse paths to the most semantically meaningful segment.
+
+### Fallback behavior
+
+- If no specific entity is detected, fall back to the project-level entity (repository root name, lowercase-hyphenated).
+- If a candidate entity is ambiguous, prefer the one that already has memories in Pensyve (call `pensyve_inspect` with limit 1 to check).
+- **Never fabricate entity names.** If nothing confident emerges, use the project entity.
+
+### Output
+
+A set of 1–3 candidate entity names per turn. The primary entity is the most specific. Since `pensyve_recall` accepts only a single `entity` parameter, fold secondary entities into the `query` string.
+
+---
+
+## When Debugging
+
+Debugging flow with memory baked in as a non-optional reflex.
+
+### Step 1: Detect entities
+
+Identify the relevant entity/entities (failing test, failing module, error source) per Entity Detection above.
+
+### Step 2: Consult memory (required)
+
+Call `pensyve_recall`:
+
+- `query`: a short description of the failure, including secondary entity names where known
+- `entity`: primary detected entity
+- `types`: `["procedural", "episodic"]`
+- `limit`: 5
+
+Surface one line: `Recalled N memories from prior debug sessions on <entity>.` (Skip if N=0.)
+
+If a highly similar incident is found (score >0.8), call it out inline.
+
+### Step 3: Diagnose
+
+Proceed with diagnostic work. Use recalled procedural memories as a starting sequence.
+
+### Step 4: Capture lesson (when it lands)
+
+When a root cause is **confirmed**, ensure a working `episode_id` exists, then:
+
+- **Episodic root cause:** `pensyve_observe` with `content: "[proactive/in-flight/tier-1] <one-sentence root cause>"`, `source_entity: "crewai"`, `about_entity: <primary_entity>`.
+- **Procedural diagnostic sequence:** `pensyve_observe` with `content: "[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=..."`.
+- **Semantic durable truth:** `pensyve_remember(entity, fact: "[proactive/in-flight/tier-1] <fact>", confidence: 0.9)`.
+
+Surface one line: `↳ captured: <one-sentence>`.
+
+### Step 5: Capture abandoned approaches
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[proactive/in-flight/tier-1] tried <approach>, abandoned because <reason>",
+  source_entity: "crewai",
+  about_entity: <primary_entity>,
+  content_type: "text"
+)
+```
+
+---
+
+## When Designing
+
+Design flow with memory baked in as a non-optional reflex.
+
+### Step 1: Detect entities
+
+Identify the relevant entity/entities (service, module, subsystem under design) per Entity Detection above.
+
+### Step 2: Consult memory (required)
+
+Call `pensyve_recall`:
+
+- `query`: a short description of the design question, including secondary entity names
+- `entity`: primary detected entity
+- `types`: `["semantic", "episodic"]`
+- `limit`: 5
+
+Surface one line: `Recalled N prior decisions on <entity>.` (Skip if N=0.)
+
+### Step 3: Recommend with grounding
+
+Shape your recommendation using recalled decisions. If the current question contradicts a prior decision, flag it.
+
+### Step 4: Capture decision (when it lands)
+
+When the user accepts a design or states a decision:
+
+- **Semantic:** `pensyve_remember(entity: <primary_entity>, fact: "[proactive/in-flight/tier-1] <decision text>", confidence: 0.9)`.
+- **Episodic context:** `pensyve_observe` with `content: "[proactive/in-flight/tier-1] Decision on <entity>: chose X over Y because Z"`, `source_entity: "crewai"`, `about_entity: <primary_entity>`.
+
+Surface one line: `↳ captured decision on <entity>: <short>`.
+
+### Step 5: Capture evaluation procedures
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[procedural] [proactive/in-flight/tier-1] trigger=design-question-on-<area>, action=<steps>, outcome=<what-you-learn>",
+  source_entity: "crewai",
+  about_entity: <primary_entity>,
+  content_type: "text"
+)
+```
+
+---
+
+## When Refactoring
+
+Refactor flow with memory baked in.
+
+### Step 1: Detect entities
+
+Identify entities touched by the refactor per Entity Detection above.
+
+### Step 2: Load prior context (required)
+
+Call `pensyve_recall`:
+
+- `query`: short description of the refactor
+- `entity`: primary detected entity
+- `types`: `["semantic", "episodic", "procedural"]`
+- `limit`: 5
+
+Surface: `Recalled N prior memories on <entity>.` Highlight any prior failed approaches.
+
+### Step 3: Present a briefing
+
+Before starting the refactor, summarize what prior memories say about decisions, prior attempts, and known-good procedures.
+
+### Step 4: Capture refactor lessons as they land
+
+When an invariant is discovered, an approach is confirmed not-viable, or a known-good sequence emerges, apply the memory reflex immediately. Ensure working `episode_id` before each observe.
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[proactive/in-flight/tier-1] <lesson>",
+  source_entity: "crewai",
+  about_entity: <primary_entity>,
+  content_type: "text"
+)
+```
+
+---
+
+## When Doing Longitudinal Work
+
+Multi-session work (research, eval loops, iterative benchmarks) where lessons must accumulate across runs.
+
+### Step 1: Resume context at conversation start
+
+Call `pensyve_recall` once at the start:
+
+- `query`: short description of the current research area
+- `entity`: project + sub-topic entity
+- `limit`: 5
+
+No `types` filter — longitudinal work benefits from all three memory types.
+
+Surface: `Recalled N prior findings on <sub-topic>.`
+
+### Step 2: Proactively recall per topic shift
+
+When the session pivots to a new sub-topic, call `pensyve_recall` again scoped to the new sub-topic.
+
+### Step 3: Capture three types of memory per run
+
+| What you learned | Type | MCP call |
+|---|---|---|
+| Per-run outcome | episodic | `pensyve_observe(..., content: "[proactive/in-flight/tier-1] Run N+1: <result>", source_entity: "crewai", about_entity: <entity>)` |
+| Stable truth | semantic | `pensyve_remember(entity, fact: "[proactive/in-flight/tier-1] <stable fact>", confidence: 0.9)` |
+| Reusable procedure | procedural | `pensyve_observe(..., content: "[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=...", source_entity: "crewai", about_entity: <entity>)` |
+
+### Step 4: Capture open questions
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[proactive/in-flight/open-question] <question>",
+  source_entity: "crewai",
+  about_entity: <entity>,
+  content_type: "text"
+)
+```
+
+### Step 5: End-of-session summary
+
+Before the conversation wraps, briefly summarize what this run taught vs. prior runs, and what's still open.
+
+---
+
+## Session Wrap-Up
+
+Manual wrap-up: when the user indicates the conversation is ending, review what happened and capture anything the in-flight reflex missed.
+
+### Step 1: Review the conversation
+
+Scan for three categories not already captured in-flight:
+
+**Decisions** (confidence: 0.9): Architecture choices, technology selections, tradeoff resolutions.
+
+**Outcomes** (confidence: 0.8): Bug fixes, successful/failed approaches, performance findings.
+
+**Patterns** (confidence: 0.7): Recurring issues, workflow discoveries, cross-cutting observations.
+
+### Step 2: Filter for significance and deduplicate
+
+For each candidate, call `pensyve_recall` with `query: <candidate fact text>`, `entity: <entity>`, `limit: 3`. If any returned memory has score ≥0.85, skip as a likely duplicate.
+
+### Step 3: Present candidates for confirmation
+
+> **Session Memory Candidates**
+>
+> **Decisions** (confidence: 0.9):
+> 1. `<entity>`: <decision text>
+>
+> **Outcomes** (confidence: 0.8):
+> 2. `<entity>`: <outcome text>
+>
+> Which should I store? (e.g., "all", "1,2", "none")
+
+### Step 4: Store confirmed items
+
+- **Semantic** — `pensyve_remember(entity, fact: "[auto-capture/user/residual/tier-1] <text>", confidence)`.
+- **Episodic** — `pensyve_observe(episode_id, content: "[auto-capture/user/residual/tier-1] <text>", source_entity: "crewai", about_entity: <entity>)`.
+- **Procedural** — `pensyve_observe(episode_id, content: "[procedural] [auto-capture/user/residual/tier-1] trigger=..., action=..., outcome=...", source_entity: "crewai", about_entity: <entity>)`.
+
+### Step 5: Optionally close the episode
+
+If the user clearly marks the work complete: `pensyve_episode_end(episode_id: <working_id>, outcome: "success")`. Valid outcomes: `"success"`, `"failure"`, `"partial"`.
+
+### Constraints
+
+- **Never auto-store.** Every candidate MUST be presented for confirmation before storage.
+- Do not store secrets.
+- If nothing significant surfaced, say so clearly.
+
+---
+
+## Context Loading (Session Start)
+
+When starting a new conversation on a project with prior Pensyve memories, load relevant context to prime the session.
+
+### Step 1: Detect project entity
+
+Use the repository root name (lowercase-hyphenated) as the default project entity. Override with `PENSYVE_NAMESPACE` environment variable if set.
+
+### Step 2: Scoped recall
+
+Call `pensyve_recall`:
+
+- `query`: `"recent decisions issues patterns"` + any key terms from the user's opening message
+- `entity`: detected project entity
+- `types`: `["episodic"]`
+- `limit`: 5
+
+### Step 3: Compute continuity signal
+
+- If ≥70% of top observations reference at least one overlapping entity: **continuation** of recent work.
+- If overlap is below 70% or recall returned empty: **fresh session**.
+
+### Step 4: Surface the primer
+
+**Continuation:**
+
+> **Pensyve:** Continuing prior work on `<entity-set>`. Recent lessons:
+>
+> - <observation 1>
+> - <observation 2>
+>
+> Use `pensyve_recall` to dig deeper.
+
+**Fresh session:**
+
+> **Pensyve:** N memories loaded for `<project>`. Key context:
+>
+> - <top 3 observations>
+
+**No memories found:**
+
+> **Pensyve:** No memories found for `<project>`. Start a session to begin building context.
+
+### Constraints
+
+- Do not fabricate memories. Only display what `pensyve_recall` returns.
+- Maximum 5 memories in the primer.
+- Entity names lowercase-hyphenated.

--- a/integrations/crewai/examples/pensyve_crew.py
+++ b/integrations/crewai/examples/pensyve_crew.py
@@ -1,0 +1,105 @@
+"""
+Pensyve + CrewAI wiring example.
+
+Demonstrates how to:
+  1. Load the Pensyve working-memory substrate as an agent's backstory / system context.
+  2. Connect to the Pensyve MCP server via crewai-tools or the MCP adapter.
+  3. Build a CrewAI crew where agents have persistent cross-session memory.
+
+CrewAI MCP support: CrewAI v0.80+ supports MCP tools via MCPServerAdapter from
+the crewai-tools package. Tools are registered at the agent or crew level.
+
+Dependencies:
+    pip install crewai crewai-tools
+
+Environment variables:
+    PENSYVE_API_KEY   — Pensyve API key (get one at pensyve.com/settings/api-keys)
+    ANTHROPIC_API_KEY — Anthropic API key
+"""
+
+import os
+from pathlib import Path
+
+from crewai import Agent, Task, Crew, Process
+from crewai_tools import MCPServerAdapter
+from langchain_anthropic import ChatAnthropic
+
+# ---------------------------------------------------------------------------
+# 1. Load the substrate — used as the agent's backstory to inject memory
+#    reasoning discipline. CrewAI's backstory field is the closest equivalent
+#    to a system prompt for individual agents.
+# ---------------------------------------------------------------------------
+SUBSTRATE_PATH = Path(__file__).parent.parent / "SUBSTRATE_PROMPT.md"
+substrate = SUBSTRATE_PATH.read_text(encoding="utf-8")
+
+# ---------------------------------------------------------------------------
+# 2. Configure the Pensyve MCP server connection.
+# ---------------------------------------------------------------------------
+PENSYVE_API_KEY = os.environ["PENSYVE_API_KEY"]  # raises KeyError if unset
+
+pensyve_server_config = {
+    "url": "https://mcp.pensyve.com/mcp",
+    "transport": "streamable_http",
+    "headers": {"Authorization": f"Bearer {PENSYVE_API_KEY}"},
+}
+
+
+def main() -> None:
+    # -----------------------------------------------------------------------
+    # 3. Initialise the MCP adapter and fetch Pensyve tools.
+    #    MCPServerAdapter wraps MCP tools as CrewAI-compatible BaseTool objects.
+    # -----------------------------------------------------------------------
+    with MCPServerAdapter(pensyve_server_config) as mcp_adapter:
+        pensyve_tools = mcp_adapter.tools
+
+        # -------------------------------------------------------------------
+        # 4. Define agents.  The substrate is injected via the backstory field.
+        #    CrewAI uses backstory + goal as the agent's guiding context.
+        # -------------------------------------------------------------------
+        llm = ChatAnthropic(model="claude-sonnet-4-6")
+
+        memory_agent = Agent(
+            role="Memory-Augmented Developer",
+            goal=(
+                "Answer engineering questions grounded in prior decisions, "
+                "debug histories, and accumulated project knowledge."
+            ),
+            backstory=substrate,           # substrate injected here
+            tools=pensyve_tools,           # Pensyve MCP tools wired in
+            llm=llm,
+            verbose=True,
+        )
+
+        # -------------------------------------------------------------------
+        # 5. Define a task for the crew.
+        # -------------------------------------------------------------------
+        task = Task(
+            description=(
+                "I'm starting work on the auth-service module. "
+                "Recall prior decisions on this entity and provide a briefing "
+                "on what we know, then propose next steps."
+            ),
+            expected_output=(
+                "A concise briefing: prior decisions recalled from Pensyve, "
+                "any relevant episodic findings, and a recommended next step."
+            ),
+            agent=memory_agent,
+        )
+
+        # -------------------------------------------------------------------
+        # 6. Run the crew.
+        # -------------------------------------------------------------------
+        crew = Crew(
+            agents=[memory_agent],
+            tasks=[task],
+            process=Process.sequential,
+            verbose=True,
+        )
+
+        result = crew.kickoff()
+        print("\n=== Crew result ===")
+        print(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/integrations/crewai/scripts/lint-mcp-refs.sh
+++ b/integrations/crewai/scripts/lint-mcp-refs.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Static MCP contract linter for the Pensyve crewai adapter.
+#
+# Verifies that every pensyve_* call example in SUBSTRATE_PROMPT.md and the
+# example wiring file conforms to the current MCP tool schema.
+# Catches the category of bug PR #58 surfaced in the Claude Code adapter
+# (unsupported parameters, missing required fields).
+#
+# This integration uses a single consolidated SUBSTRATE_PROMPT.md (same
+# pattern as VS Code Copilot) rather than per-rule files.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INTEG_DIR="$SCRIPT_DIR/.."
+RULES_FILE="$INTEG_DIR/SUBSTRATE_PROMPT.md"
+EXAMPLE_FILE="$INTEG_DIR/examples/pensyve_crew.py"
+
+EXIT_CODE=0
+
+for f in "$RULES_FILE" "$EXAMPLE_FILE"; do
+  if [ ! -f "$f" ]; then
+    echo "ERROR: File not found: $f"
+    exit 1
+  fi
+done
+
+echo "Linting MCP references in:"
+echo "  $RULES_FILE"
+echo "  $EXAMPLE_FILE"
+echo ""
+
+# Check 1: no actual use of unsupported 'related_entities' parameter in call examples.
+echo "Check 1: no unsupported 'related_entities' on pensyve_recall"
+FOUND_RELATED=0
+for f in "$RULES_FILE" "$EXAMPLE_FILE"; do
+  awk '/pensyve_recall\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+         if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
+           print FILENAME ": related_entities found in pensyve_recall block: " buf;
+         capture=0
+       }' "$f" | while read -r line; do
+    if [ -n "$line" ]; then
+      echo "  FAIL: $line"
+      FOUND_RELATED=1
+    fi
+  done
+done
+if [ "$FOUND_RELATED" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 2: no actual use of unsupported 'continuation_of' parameter in call examples.
+echo "Check 2: no unsupported 'continuation_of' on pensyve_episode_start"
+FOUND_CONT=0
+for f in "$RULES_FILE" "$EXAMPLE_FILE"; do
+  awk '/pensyve_episode_start\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+         if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
+           print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
+         capture=0
+       }' "$f" | while read -r line; do
+    if [ -n "$line" ]; then
+      echo "  FAIL: $line"
+      FOUND_CONT=1
+    fi
+  done
+done
+if [ "$FOUND_CONT" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 3: every pensyve_observe call example in a code block has source_entity and about_entity
+echo "Check 3: every pensyve_observe example has source_entity and about_entity"
+MISSING_FIELDS=0
+for f in "$RULES_FILE" "$EXAMPLE_FILE"; do
+  awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
+       capture {buf = buf "\n" $0;
+                for(i=1; i<=length($0); i++){
+                  c=substr($0,i,1);
+                  if(c=="(") depth++;
+                  if(c==")") depth--;
+                };
+                if(depth==0 && buf ~ /pensyve_observe\(/){
+                  if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
+                  if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
+                  capture=0;
+                }}' "$f" | while read -r line; do
+    if [ -n "$line" ]; then
+      echo "  FAIL: $line"
+      MISSING_FIELDS=1
+    fi
+  done
+done
+if [ "$MISSING_FIELDS" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 4: provenance tag format — every proactive/auto-capture tag uses [<origin>/<trigger>/<tier>]
+echo "Check 4: provenance tag format"
+VALID_PROVENANCE_RE='\[(proactive|auto-capture)/(in-flight|stop|pre-compact|curator|user)/(tier-1|tier-2|residual/tier-1|residual/tier-2|open-question)\]'
+INVALID=0
+for f in "$RULES_FILE" "$EXAMPLE_FILE"; do
+  if rg -n '\[(proactive|auto-capture)' "$f" | rg -v "$VALID_PROVENANCE_RE"; then
+    INVALID=1
+  fi
+done
+if [ "$INVALID" = "0" ]; then
+  echo "  PASS"
+else
+  echo "  FAIL: some provenance tags do not match [<origin>/<trigger>/<tier>] format"
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 5: procedural memory convention — [procedural] prefix is used in observe content
+echo "Check 5: procedural convention uses [procedural] prefix in pensyve_observe content"
+if ! rg -q '\[procedural\]' "$RULES_FILE"; then
+  echo "  WARN: no [procedural] prefix usage found in SUBSTRATE_PROMPT.md."
+else
+  echo "  PASS"
+fi
+echo ""
+
+if [ "$EXIT_CODE" = "0" ]; then
+  echo "All MCP contract checks PASSED."
+else
+  echo "MCP contract checks FAILED. Fix the issues above before committing."
+fi
+
+exit "$EXIT_CODE"

--- a/integrations/crewai/scripts/lint-mcp-refs.sh
+++ b/integrations/crewai/scripts/lint-mcp-refs.sh
@@ -34,18 +34,18 @@ echo ""
 echo "Check 1: no unsupported 'related_entities' on pensyve_recall"
 FOUND_RELATED=0
 for f in "$RULES_FILE" "$EXAMPLE_FILE"; do
-  awk '/pensyve_recall\(/{capture=1; buf=""}
-       capture {buf = buf "\n" $0}
-       capture && /\)/{
-         if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
-           print FILENAME ": related_entities found in pensyve_recall block: " buf;
-         capture=0
-       }' "$f" | while read -r line; do
+  while read -r line; do
     if [ -n "$line" ]; then
       echo "  FAIL: $line"
       FOUND_RELATED=1
     fi
-  done
+  done < <(awk '/pensyve_recall\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+       if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
+       print FILENAME ": related_entities found in pensyve_recall block: " buf;
+       capture=0
+       }' "$f")
 done
 if [ "$FOUND_RELATED" = "0" ]; then
   echo "  PASS"
@@ -58,18 +58,18 @@ echo ""
 echo "Check 2: no unsupported 'continuation_of' on pensyve_episode_start"
 FOUND_CONT=0
 for f in "$RULES_FILE" "$EXAMPLE_FILE"; do
-  awk '/pensyve_episode_start\(/{capture=1; buf=""}
-       capture {buf = buf "\n" $0}
-       capture && /\)/{
-         if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
-           print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
-         capture=0
-       }' "$f" | while read -r line; do
+  while read -r line; do
     if [ -n "$line" ]; then
       echo "  FAIL: $line"
       FOUND_CONT=1
     fi
-  done
+  done < <(awk '/pensyve_episode_start\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+       if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
+       print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
+       capture=0
+       }' "$f")
 done
 if [ "$FOUND_CONT" = "0" ]; then
   echo "  PASS"
@@ -82,23 +82,23 @@ echo ""
 echo "Check 3: every pensyve_observe example has source_entity and about_entity"
 MISSING_FIELDS=0
 for f in "$RULES_FILE" "$EXAMPLE_FILE"; do
-  awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
-       capture {buf = buf "\n" $0;
-                for(i=1; i<=length($0); i++){
-                  c=substr($0,i,1);
-                  if(c=="(") depth++;
-                  if(c==")") depth--;
-                };
-                if(depth==0 && buf ~ /pensyve_observe\(/){
-                  if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
-                  if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
-                  capture=0;
-                }}' "$f" | while read -r line; do
+  while read -r line; do
     if [ -n "$line" ]; then
       echo "  FAIL: $line"
       MISSING_FIELDS=1
     fi
-  done
+  done < <(awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
+       capture {buf = buf "\n" $0;
+       for(i=1; i<=length($0); i++){
+       c=substr($0,i,1);
+       if(c=="(") depth++;
+       if(c==")") depth--;
+       };
+       if(depth==0 && buf ~ /pensyve_observe\(/){
+       if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
+       if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
+       capture=0;
+       }}' "$f")
 done
 if [ "$MISSING_FIELDS" = "0" ]; then
   echo "  PASS"

--- a/integrations/cursor/.cursor/mcp.json.example
+++ b/integrations/cursor/.cursor/mcp.json.example
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "pensyve": {
+      "type": "http",
+      "url": "https://mcp.pensyve.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ${PENSYVE_API_KEY}"
+      }
+    }
+  }
+}

--- a/integrations/cursor/.cursor/rules/context-loader.mdc
+++ b/integrations/cursor/.cursor/rules/context-loader.mdc
@@ -1,0 +1,74 @@
+---
+description: Use when starting a new substantive conversation or switching contexts — load relevant memories to prime the session with continuity
+---
+
+# Context Loader (Continuity Primer)
+
+Cursor has no automatic SessionStart hook. This rule is the manual equivalent: when starting a new conversation on a project that has prior Pensyve memories, call recall to prime the session with relevant context.
+
+Follows `memory-reflex.mdc`. Best-effort thread continuity via episodic recall (the MCP server has no episode-listing tool; see the main spec's Task C addendum for background).
+
+## Instructions
+
+### Step 1: Detect project entity
+
+Per `entity-detection.mdc` fallback rules: use the repository root name (lowercase-hyphenated) as the default project entity. Override with `PENSYVE_NAMESPACE` environment variable if explicitly set in the project's environment.
+
+### Step 2: Scoped recall
+
+Call `pensyve_recall`:
+
+- `query`: `"recent decisions issues patterns"` + any key terms from the user's opening message
+- `entity`: detected project entity
+- `types`: `["episodic"]` — recent session activity gives the best continuity signal
+- `limit`: 5
+
+Episodic memories are ranked by the MCP server's activation signal, which naturally surfaces recent observations first.
+
+### Step 3: Compute continuity signal
+
+Examine the returned observations:
+
+- If ≥70% of the top observations reference at least one entity that overlaps with the current conversation's entity candidates (from Step 1 plus any entities mentioned in the opening message), treat the session as a **continuation** of recent work.
+- If the overlap is below 70%, or recall returned empty, treat as a **fresh session**.
+
+### Step 4: Surface the primer
+
+**Continuation:**
+
+> **Pensyve:** Continuing prior work on `<entity-set>`. Recent lessons:
+>
+> - <observation 1>
+> - <observation 2>
+> - <observation 3>
+>
+> Use `/recall <query>` or ask about any of these to dig deeper.
+
+**Fresh session:**
+
+> **Pensyve:** N memories loaded for `<project>`. Key context:
+>
+> - <top 3 observations>
+>
+> Use `/recall <query>` to search for specific memories.
+
+**No memories found:**
+
+> **Pensyve:** No memories found for `<project>`. Use `/remember` to start building context.
+
+### Step 5: Continuity is best-effort, not a structured link
+
+The MCP server has no episode-listing or date-filtering API. This rule infers continuity from shared-entity overlap and recall-ranking recency. Consequences:
+
+- There is no persisted server-side link between sessions.
+- Primer accuracy depends on memory quality and recall ranking.
+- The user may occasionally see "Continuing prior work" when it's actually loosely related; or see a fresh-session primer when the prior session was related but the entity overlap was low.
+
+Document this honestly in the primer when uncertain — do not fabricate continuity.
+
+## Constraints
+
+- Do not fabricate memories. Only display what `pensyve_recall` returns.
+- If MCP is unavailable, skip the primer silently and mention the failure once per conversation if the user asks about memory.
+- Maximum 5 memories in the primer to avoid context bloat.
+- Entity names lowercase-hyphenated.

--- a/integrations/cursor/.cursor/rules/entity-detection.mdc
+++ b/integrations/cursor/.cursor/rules/entity-detection.mdc
@@ -1,0 +1,43 @@
+---
+description: Pensyve entity detection — canonicalization and fallback rules for recall scoping
+alwaysApply: true
+---
+
+# Entity Detection (Always-Apply Reference)
+
+Shared rules for detecting entity names from tool inputs, prompts, and conversation context. Used by the memory reflex and all memory-woven flows to scope recalls and `about_entity` fields on observations.
+
+## Inputs
+
+Extract candidate entity names from:
+
+1. **File references** — `@filename`, `@path/to/file`, or files mentioned directly in the conversation.
+2. **User prompts** — explicit references to components, files, services, research phases (e.g., "phase-4.3", "v7r-classifier", "auth-service").
+3. **Code context** — module names, class names, function names in files you are editing or reading.
+4. **Git context** — repository root name, branch name (when discoverable).
+
+## Canonicalization
+
+- Lowercase all characters.
+- Replace spaces and underscores with hyphens.
+- Strip file extensions unless the file is the entity itself (e.g., `package.json`).
+- Collapse paths to the most semantically meaningful segment (e.g., `src/engine/hybrid_router.rs` → `hybrid-router`; `tests/integration/auth_test.py` → `auth`).
+
+## Fallback behavior
+
+- If no specific entity is detected, fall back to the project-level entity (repository root name, lowercase-hyphenated).
+- If a candidate entity is ambiguous between two names, prefer the one that already has memories in Pensyve (call `pensyve_inspect` with limit 1 to check).
+- **Never fabricate entity names.** If nothing confident emerges, use the project entity.
+
+## Output
+
+A set of 1–3 candidate entity names per turn. The primary entity is the most specific; secondary entities provide additional context. Since `pensyve_recall` accepts only a single `entity` parameter, fold secondary entities into the `query` string instead.
+
+## Examples
+
+| Input | Primary entity | Secondary (fold into query) |
+|---|---|---|
+| Edit on `src/engine/hybrid_router.rs` | `hybrid-router` | `engine` |
+| Prompt: "tune V7r noise threshold" | `v7r` | `noise-threshold` |
+| File `tests/test_auth.py` in a project named `auth-service` | `auth` | `auth-service` |
+| User mentions "phase-4.3 calibration" | `phase-4.3` | `calibration` |

--- a/integrations/cursor/.cursor/rules/memory-informed-debug.mdc
+++ b/integrations/cursor/.cursor/rules/memory-informed-debug.mdc
@@ -1,0 +1,68 @@
+---
+description: Use when diagnosing bugs, errors, failing tests, or crashes — consult prior debug outcomes and capture root causes in-flight
+---
+
+# Memory-Informed Debug
+
+Debugging flow with memory baked in as a non-optional reflex. Follows `memory-reflex.mdc` for classification, surface style, and episode lifecycle.
+
+## Instructions
+
+### Step 1: Detect entities
+
+Identify the relevant entity/entities (failing test, failing module, error source) per `entity-detection.mdc`.
+
+### Step 2: Consult memory (required)
+
+Call `pensyve_recall`:
+
+- `query`: a short description of the failure, including secondary entity names where known (e.g., "hybrid-router threshold regression phase-4.3" rather than full stack traces)
+- `entity`: primary detected entity
+- `types`: `["procedural", "episodic"]` (debugging benefits most from known-good diagnostic procedures and prior incident outcomes)
+- `limit`: 5
+
+Secondary entities are folded into the query string since `RecallParams` scopes by a single `entity` only.
+
+Surface one line: `Recalled N memories from prior debug sessions on <entity>.` (Skip if N=0.)
+
+If a highly similar incident is found (score >0.8), call that out inline: `This looks similar to an incident captured on <date>: <summary>. Consider that path first.`
+
+### Step 3: Diagnose
+
+Proceed with the diagnostic work. Use recalled procedural memories as a starting sequence; update the sequence when you learn something new.
+
+### Step 4: Capture lesson (when it lands)
+
+When a root cause is **confirmed** (not just hypothesized), apply the memory reflex per `memory-reflex.mdc`:
+
+Ensure a working `episode_id` exists (lazy-open via `pensyve_episode_start` if not). Then:
+
+- **Episodic root cause:** call `pensyve_observe` with `content: "[proactive/in-flight/tier-1] <one-sentence root cause>"`, `source_entity: "cursor"`, `about_entity: <primary_entity>`, `content_type: "text"`.
+- **Procedural diagnostic sequence:** if the debug produced a reusable diagnostic sequence, call `pensyve_observe` with `content: "[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=..."`, `source_entity: "cursor"`, `about_entity: <primary_entity>`, `content_type: "text"`.
+- **Semantic durable truth:** if the root cause reveals a durable truth (e.g., "our CI runner's Python 3.10 cannot handle the new syntax"), also call `pensyve_remember(entity, fact, confidence: 0.9)`. Include provenance in the fact text: `"[proactive/in-flight/tier-1] <fact>"`.
+
+Surface one line: `↳ captured: <one-sentence>`.
+
+### Step 5: Capture abandoned approach
+
+If an approach was tried and abandoned, observe that too:
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[proactive/in-flight/tier-1] tried <approach>, abandoned because <reason>",
+  source_entity: "cursor",
+  about_entity: <primary_entity>,
+  content_type: "text"
+)
+```
+
+These are high-value — they prevent re-treading the same dead end next time.
+
+## Constraints
+
+- Recall is **not optional**. If you skip recall to save time, you defeat the working-memory substrate.
+- Observe when a lesson **lands**, not when you first hypothesize.
+- One in-flight capture per turn unless multiple distinct lessons land simultaneously.
+- Respect the reflex rule's surface style — one line, not paragraphs.
+- Never store secrets or sensitive paths.

--- a/integrations/cursor/.cursor/rules/memory-informed-design.mdc
+++ b/integrations/cursor/.cursor/rules/memory-informed-design.mdc
@@ -1,0 +1,60 @@
+---
+description: Use when making architecture, API, or design decisions — consult prior decisions and capture new ones in-flight
+---
+
+# Memory-Informed Design
+
+Design flow with memory baked in as a non-optional reflex. Follows `memory-reflex.mdc`.
+
+## Instructions
+
+### Step 1: Detect entities
+
+Identify the relevant entity/entities (service, module, subsystem under design) per `entity-detection.mdc`.
+
+### Step 2: Consult memory (required)
+
+Call `pensyve_recall`:
+
+- `query`: a short description of the design question, including secondary entity names where known (e.g., "auth-service jwt signing rs256 hs256")
+- `entity`: primary detected entity
+- `types`: `["semantic", "episodic"]` (design benefits most from durable decisions and prior decision-contexts)
+- `limit`: 5
+
+Surface one line: `Recalled N prior decisions on <entity>.` (Skip if N=0.)
+
+### Step 3: Recommend with grounding
+
+Shape your recommendation using the recalled decisions. If the user's current question directly contradicts a prior decision, flag it:
+
+> Prior decision on `<entity>` (confidence 0.9): [decision]. Are we revisiting this, or does the current question differ?
+
+### Step 4: Capture decision (when it lands)
+
+When the user accepts a design or states a decision ("let's go with X", "we'll use Y"), apply the memory reflex:
+
+- **Semantic** — `pensyve_remember(entity: <primary_entity>, fact: "[proactive/in-flight/tier-1] <decision text>", confidence: 0.9)`.
+- **Episodic context** — ensure working `episode_id`; `pensyve_observe` with `content: "[proactive/in-flight/tier-1] Decision on <entity>: chose X over Y because Z"`, `source_entity: "cursor"`, `about_entity: <primary_entity>`, `content_type: "text"`. This enables future "why did we decide X?" queries.
+
+Surface one line: `↳ captured decision on <entity>: <short>`.
+
+### Step 5: Capture evaluation procedures
+
+If the design process revealed a reusable way to evaluate similar decisions (e.g., "run spike vs. prototype", "check latency first"), capture it as procedural:
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[procedural] [proactive/in-flight/tier-1] trigger=design-question-on-<area>, action=<steps>, outcome=<what-you-learn>",
+  source_entity: "cursor",
+  about_entity: <primary_entity>,
+  content_type: "text"
+)
+```
+
+## Constraints
+
+- Recall is **not optional**.
+- Observe when a decision **lands**, not when it's being discussed.
+- Budget: one in-flight capture per turn unless multiple decisions land.
+- Never store secrets or sensitive architecture details the user has marked private.

--- a/integrations/cursor/.cursor/rules/memory-informed-longitudinal-work.mdc
+++ b/integrations/cursor/.cursor/rules/memory-informed-longitudinal-work.mdc
@@ -1,0 +1,72 @@
+---
+description: Long-running multi-session work (research, eval loops, iterative benchmarks) — resume prior lessons, capture per-run outcomes, build up stable truths over time
+globs:
+  - "research/**"
+  - "benchmarks/**"
+  - "evals/**"
+---
+
+# Memory-Informed Longitudinal Work
+
+Multi-session engineering work (research, eval loops, iterative benchmarks) where lessons must accumulate across runs. The motivating case: improving a core algorithm over dozens of eval iterations without starting from scratch each session.
+
+Follows `memory-reflex.mdc`. Auto-attaches when editing files under `research/`, `benchmarks/`, or `evals/`, or when the model judges the conversation to be research-oriented.
+
+## Instructions
+
+### Step 1: Resume context at conversation start
+
+If this conversation is in a research/eval context, call `pensyve_recall` once at the start:
+
+- `query`: short description of the current research area (e.g., "v7r classifier calibration")
+- `entity`: project + sub-topic entity (per `entity-detection.mdc` canonicalization rules)
+- `limit`: 5
+
+No `types` filter — longitudinal work benefits from all three memory types; omit to query all. (Passing all three explicitly is equivalent to no filter; omitting is cleaner.)
+
+Surface: `Recalled N prior findings on <sub-topic>.`
+
+Treat the returned observations as working knowledge — do not re-ask the user about things the recall already surfaces.
+
+### Step 2: Proactively recall per topic shift
+
+When the session pivots to a new sub-topic (new phase, new eval subset, new failure mode), call `pensyve_recall` again scoped to the new sub-topic.
+
+### Step 3: Capture three types of memory per run
+
+During the session, classify emerging knowledge and capture accordingly. Ensure working `episode_id` before each observe.
+
+| What you learned | Type | MCP call |
+|---|---|---|
+| Per-run outcome (what this run showed) | episodic | `pensyve_observe(..., content: "[proactive/in-flight/tier-1] Run N+1: V7r accuracy improved +3.5% with new threshold", source_entity: "cursor", about_entity: <entity>, content_type: "text")` |
+| Stable truth about the system | semantic | `pensyve_remember(entity, fact: "[proactive/in-flight/tier-1] Haiku classifier plateaus above temp 0.3", confidence: 0.9)` |
+| Reusable experiment procedure | procedural | `pensyve_observe(..., content: "[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=...", source_entity: "cursor", about_entity: <entity>, content_type: "text")` |
+
+Apply at landing — do not batch.
+
+### Step 4: Capture open questions
+
+When a run ends with an unresolved question ("X improved but we don't know why"), capture it as an episodic observation with open-question provenance:
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[proactive/in-flight/open-question] <question>",
+  source_entity: "cursor",
+  about_entity: <entity>,
+  content_type: "text"
+)
+```
+
+This populates future "open questions" surfacing when the topic returns.
+
+### Step 5: End-of-session summary
+
+Before the conversation wraps, briefly summarize (inline, 3-5 lines): what this run taught us vs. prior runs, what's still open. This creates a natural handoff for the next session.
+
+## Constraints
+
+- Recall on every topic shift — not just at conversation start.
+- Capture at landing, not batched.
+- Never store run artifacts or large data blobs — summarize.
+- Respect the reflex's surface style.

--- a/integrations/cursor/.cursor/rules/memory-informed-refactor.mdc
+++ b/integrations/cursor/.cursor/rules/memory-informed-refactor.mdc
@@ -1,0 +1,59 @@
+---
+description: Use before substantive refactors — load relevant prior context, capture refactor insights as they land
+---
+
+# Memory-Informed Refactor
+
+Refactor flow with memory baked in. Follows `memory-reflex.mdc`.
+
+## Instructions
+
+### Step 1: Detect entities
+
+Identify the entities touched by the refactor (the file or module being restructured, its callers, the subsystem name) per `entity-detection.mdc`.
+
+### Step 2: Load prior context (required)
+
+Call `pensyve_recall`:
+
+- `query`: short description of the refactor (e.g., "hybrid-router routing logic restructure")
+- `entity`: primary detected entity
+- `types`: `["semantic", "episodic", "procedural"]` — refactors benefit from all three (durable invariants, prior attempts, known-good sequences)
+- `limit`: 5
+
+Surface: `Recalled N prior memories on <entity>.` (Skip if N=0.)
+
+Highlight any prior failed approaches inline:
+
+> Prior episodic memory (confidence 0.8): tried <approach> on <date>, abandoned because <reason>. Double-check this isn't the same trap.
+
+### Step 3: Present a briefing
+
+Before starting the refactor, briefly summarize what the prior memories say about:
+
+- **Decisions** — durable choices that constrain the refactor (semantic)
+- **Prior attempts** — what's been tried (episodic)
+- **Known-good procedures** — reusable sequences for this kind of refactor (procedural)
+
+If no relevant memories exist, say so clearly and proceed without historical context.
+
+### Step 4: Capture refactor lessons as they land
+
+When any of these occur during the refactor, apply the memory reflex immediately:
+
+- **An invariant is discovered** (semantic) — `pensyve_remember(entity, fact, confidence: 0.9)`
+- **An abandoned approach is confirmed not-viable** (episodic) — `pensyve_observe` with `[proactive/in-flight/tier-1]` provenance
+- **A dependency chain was traced that surprised us** (episodic) — `pensyve_observe`
+- **A known-good refactoring sequence emerged** (procedural) — `pensyve_observe` with `[procedural]` prefix
+
+Ensure working `episode_id` before each observe; lazy-open if needed.
+
+Do not batch these to end-of-session — capture at landing, surface one-line.
+
+## Constraints
+
+- The briefing step is the real value — it informs the refactor.
+- Observe at landing, not batched.
+- Entity names lowercase-hyphenated.
+- Do not start the refactor itself — this rule provides guidance and capture. The user decides when and how to proceed.
+- If the MCP server returns errors on some queries, present results from the successful queries and note the failures.

--- a/integrations/cursor/.cursor/rules/memory-reflex.mdc
+++ b/integrations/cursor/.cursor/rules/memory-reflex.mdc
@@ -1,0 +1,101 @@
+---
+description: Pensyve memory reflex — the non-optional reasoning discipline for working-memory substrate
+alwaysApply: true
+---
+
+# Memory Reflex Rule (Always-Apply)
+
+This rule is always in context. It turns Pensyve memory operations from optional actions into a reasoning discipline you carry through every substantive turn.
+
+## The rule
+
+**Before substantive answers, recall by entity. When a lesson lands, observe immediately with a one-line surface.**
+
+### "Substantive answer" means
+
+- Design or architecture recommendations
+- Debugging diagnoses with root-cause claims
+- Refactor proposals
+- Any response that makes a claim the user would want grounded in prior work
+
+Not substantive: formatting fixes, trivial lookups, reading a file, running a command.
+
+### "Lesson lands" means
+
+- A root cause has been confirmed (not hypothesized).
+- A design choice has been made explicit ("we'll use X because Y").
+- An approach has been tried and abandoned with a reason.
+- A workflow has been discovered that is reusable.
+- A workaround for a framework/library limitation has been validated.
+
+## Classification (which memory type?)
+
+- **Semantic** — a fact that will still be true next month. Use `pensyve_remember(entity, fact, confidence?)` (confidence defaults to 1.0; use 0.9 for high-confidence auto-captures).
+- **Episodic** — something that happened in this thread of work. Use `pensyve_observe` with the current `episode_id`.
+- **Procedural** — a reusable way to do something (a workflow, sequence, recipe). Use `pensyve_observe` with `content` beginning `[procedural]` (integration-layer convention; the MCP server has no native procedural-write API).
+
+When in doubt, prefer episodic. Server-side consolidation promotes recurring patterns to semantic automatically.
+
+## Canonical `pensyve_observe` call template
+
+ALL observe calls — in-flight, procedural, or wrap-up — MUST include every required field:
+
+```
+pensyve_observe(
+  episode_id: <current session's working episode_id>,
+  content: "[proactive/in-flight/tier-1] <observation text>",
+  source_entity: "cursor",
+  about_entity: "<relevant entity, lowercase-hyphenated>",
+  content_type: "text"
+)
+```
+
+Use `content_type: "code"` for code-related outcomes.
+
+## Episode lifecycle (lazy-open)
+
+Cursor has no session-start/session-end hooks, so you own the episode lifecycle:
+
+- **Before your first `pensyve_observe` call in this conversation**, check whether a working `episode_id` is already tracked. If none exists, call `pensyve_episode_start(participants: ["cursor", "<project entity>"])` first, record the returned `episode_id`, then make the observation.
+- **Reuse the same `episode_id`** for all subsequent observations in the same conversation. Open a new episode only when the work's topic shifts substantially.
+- **Do not explicitly close** the episode under normal operation. Server-side consolidation handles aging.
+- **Recovery**: if `pensyve_observe` fails with a missing-episode error, call `pensyve_episode_start` and retry.
+
+## Surface style
+
+Lightly visible. One line when memory is used. Examples:
+
+- Recall: `Recalled 4 related memories (v7r, haiku-classifier).`
+- Capture: `↳ captured: hybrid-router threshold was the phase-3 regression root cause.`
+
+Do not narrate empty recalls or duplicate-skips.
+
+## Scope and budgets
+
+- Recall: scoped to detected entities (see `entity-detection.mdc`); limit 5; use `types` hint per flow.
+- Capture: one observation per substantive lesson; reuse the working `episode_id`.
+- Noise: avoid surfacing memory operations the user did not care about.
+
+## Composition with provenance tags
+
+When a capture is both procedural AND a proactive in-flight write, the `content` field begins with both markers, `[procedural]` first, then the provenance tag, then content:
+
+`[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=...`
+
+The `[procedural]` marker identifies the memory type for consolidation. The provenance tag identifies origin and trigger.
+
+## Provenance tag vocabulary
+
+- `[proactive/in-flight/tier-1]` — memory reflex captured during reasoning
+- `[proactive/in-flight/open-question]` — unresolved question noted in-flight
+- `[auto-capture/user/residual/tier-1]` — explicit user-driven capture (e.g., session-memory skill)
+
+## MCP contract reminder
+
+Rules never pass unsupported parameters. The MCP tool schemas are:
+
+- `pensyve_recall(query, entity?, types?, limit?, min_confidence?)` — **no** `related_entities`
+- `pensyve_episode_start(participants)` — **no** `continuation_of`
+- `pensyve_observe(episode_id, content, source_entity, about_entity, content_type?)` — `source_entity` and `about_entity` are **required**
+
+If you need secondary-entity context in a recall, fold those entities into the `query` string.

--- a/integrations/cursor/.cursor/rules/session-memory.mdc
+++ b/integrations/cursor/.cursor/rules/session-memory.mdc
@@ -1,0 +1,84 @@
+---
+description: Use at conversation wrap-up or when the user explicitly indicates end-of-session — capture residual lessons not captured in-flight
+---
+
+# Session Memory (Wrap-Up)
+
+Cursor has no automatic Stop hook. This rule is the manual equivalent: when the user indicates the conversation is ending ("thanks, that's all", "session wrap-up", "we're done here"), review what happened and capture anything the in-flight reflex missed.
+
+Follows `memory-reflex.mdc`.
+
+## Instructions
+
+### Step 1: Review the conversation
+
+Scan the current conversation for three categories of memorable content that the in-flight reflex did NOT already capture:
+
+**Decisions** (confidence: 0.9):
+- Architecture or design choices
+- Technology selections
+- API design decisions
+- Tradeoff resolutions
+
+**Outcomes** (confidence: 0.8):
+- Bug fixes and their root causes
+- Successful approaches
+- Failed approaches with reasons
+- Performance findings
+
+**Patterns** (confidence: 0.7):
+- Recurring issues
+- Workflow discoveries
+- Cross-cutting observations
+
+### Step 2: Filter for significance and deduplicate
+
+Skip routine, low-signal content. Also skip anything that was already captured in-flight.
+
+For each candidate, call `pensyve_recall` with `query: <candidate fact text>`, `entity: <candidate's entity>`, `limit: 3`. If any returned memory has a score ≥0.85 against the candidate, skip it as a likely duplicate.
+
+Note: `pensyve_inspect` cannot filter by `episode_id` (its params are `entity`, `memory_type?`, `limit?` only), so dedup is entity-scoped semantic-similarity rather than session-scoped. Consequence: very similar items captured in prior sessions will also trigger the skip — acceptable for avoiding genuine duplicates.
+
+### Step 3: Present candidates for confirmation
+
+Show the filtered candidates to the user in a structured format:
+
+> **Session Memory Candidates**
+>
+> **Decisions** (confidence: 0.9):
+> 1. `<entity>`: <decision text>
+>
+> **Outcomes** (confidence: 0.8):
+> 2. `<entity>`: <outcome text>
+>
+> **Patterns** (confidence: 0.7):
+> 3. `<entity>`: <pattern text>
+>
+> Which should I store? (e.g., "all", "1,3", "none")
+
+### Step 4: Store confirmed items
+
+For each confirmed item, classify the type and call the appropriate MCP tool:
+
+- **Semantic** (decisions, durable truths) — `pensyve_remember(entity, fact: "[auto-capture/user/residual/tier-1] <text>", confidence)`. Use confidence from the categorization above.
+- **Episodic** (outcomes, session-specific events) — ensure working `episode_id`; `pensyve_observe(episode_id, content: "[auto-capture/user/residual/tier-1] <text>", source_entity: "cursor", about_entity: <entity>, content_type: "text")`.
+- **Procedural** (reusable workflows) — `pensyve_observe(episode_id, content: "[procedural] [auto-capture/user/residual/tier-1] trigger=..., action=..., outcome=...", source_entity: "cursor", about_entity: <entity>, content_type: "text")`.
+
+### Step 5: Optionally close the episode
+
+If the user indicates this is a final wrap (not just a turn-by-turn pause), call `pensyve_episode_end(episode_id: <working_id>, outcome: "success")`. Valid outcomes: `"success"`, `"failure"`, `"partial"`.
+
+Not closing is safe — server-side consolidation ages episodes naturally. Only close when the user clearly marks the work complete.
+
+### Step 6: Report
+
+After storing, summarize:
+
+> Stored N memories. Episode <outcome> closed.
+
+## Constraints
+
+- **Never auto-store.** Every candidate MUST be presented to the user for confirmation before storage.
+- Entity names lowercase-hyphenated.
+- Do not store secrets.
+- If nothing significant surfaced, say so clearly rather than forcing low-quality memories.

--- a/integrations/cursor/CHANGELOG.md
+++ b/integrations/cursor/CHANGELOG.md
@@ -1,0 +1,43 @@
+# Changelog — Pensyve Cursor Adapter
+
+All notable changes to the Pensyve Cursor adapter are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). The Cursor adapter versions independently of the Claude Code plugin.
+
+## [1.0.0] - 2026-04-20
+
+### Added
+
+- **Working-memory substrate** for Cursor via MDC rules. Eight rule files under `.cursor/rules/` deliver the substrate the Claude Code plugin v1.3.0 established:
+  - `memory-reflex.mdc` (always-apply) — non-optional reasoning discipline with three-type memory classification, canonical `pensyve_observe` call template, provenance vocabulary, lazy-open episode lifecycle
+  - `entity-detection.mdc` (always-apply) — canonicalization and fallback rules
+  - `memory-informed-debug.mdc` — debug flow (description-scoped)
+  - `memory-informed-design.mdc` — design flow (description-scoped)
+  - `memory-informed-refactor.mdc` — refactor flow (description-scoped)
+  - `memory-informed-longitudinal-work.mdc` — research/eval flow (description-scoped + globs for `research/**`, `benchmarks/**`, `evals/**`)
+  - `session-memory.mdc` — manual wrap-up equivalent of Claude Code's Stop hook (description-scoped)
+  - `context-loader.mdc` — best-effort continuity primer via episodic recall (description-scoped)
+- **MCP config example** at `.cursor/mcp.json.example` covering Cloud-with-API-key and Local-stdio options
+- **Static MCP contract lint script** at `scripts/lint-mcp-refs.sh` verifying every rule's `pensyve_*` call example matches the `pensyve-mcp-tools/src/params.rs` schema
+- **Live MCP smoke-test script** at `scripts/smoketest-mcp.sh` validating call shapes against a running MCP server
+
+### Design
+
+- Single reasoning layer; no platform-layer code. Cursor has no hook/event surface, so the entire adapter is rules the model interprets.
+- Lazy-open episode lifecycle (Cursor has no SessionStart/Stop equivalents): first `pensyve_observe` call triggers `pensyve_episode_start`; episodes are not explicitly closed.
+- Best-effort continuity primer via `pensyve_recall(types: ["episodic"])` — the MCP server has no episode-listing API.
+- MCP contract verified: no `related_entities` on recall, no `continuation_of` on episode_start, required `source_entity: "cursor"` and `about_entity` on every observe.
+- Opt-out: delete or edit rule files (Cursor-native power-user pattern); no parallel config file.
+
+### Not Included
+
+- No extension or platform-layer code (deferred to a future sibling spec if capability gaps surface)
+- No installer script (manual copy of rules + edit of `.cursor/mcp.json`)
+- No parallel `pensyve-plugin.local.md` config
+- No server-side changes — uses the existing MCP tool surface
+
+### Relation to Other Pensyve Integrations
+
+- The Cursor adapter is the second integration to implement the working-memory substrate. The Claude Code plugin (v1.3.0) was the reference implementation.
+- Spec: `pensyve-docs/specs/2026-04-20-pensyve-cursor-adapter-design.md`
+- Playbook: `pensyve-docs/specs/2026-04-18-pensyve-working-memory-substrate-design.md`

--- a/integrations/cursor/README.md
+++ b/integrations/cursor/README.md
@@ -1,31 +1,28 @@
 # Pensyve for Cursor
 
-Persistent AI memory for [Cursor](https://cursor.sh) via MCP.
+Persistent working-memory substrate for [Cursor](https://cursor.sh) — memory is not a feature you invoke, it is the substrate the agent operates on.
 
-## Authentication
+## What It Does
 
-1. Sign up at [pensyve.com](https://pensyve.com)
-2. Create an API key at [Settings → API Keys](https://pensyve.com/settings/api-keys)
-3. Set the environment variable:
-   ```bash
-   export PENSYVE_API_KEY="psy_your_key_here"
-   ```
+- **Proactive memory during work** — lessons are captured the moment they land, not at session end
+- **Thread-aware continuity** — sessions that continue prior work resume with relevant context, no re-briefing
+- **Entity-scoped recall** — substantive questions are grounded in prior decisions; simple commands stay fast
+- **Three memory types** — durable facts (semantic), session-specific events (episodic), reusable procedures (procedural)
+- **Lightly visible** — one-line surfaces when memory is used; never interrupts your flow
 
-Then configure MCP with headers (see setup instructions above).
+## Install
 
-## Setup
+Two steps: configure the MCP server, then install the rules.
 
-Set your API key (get one at [pensyve.com/settings/api-keys](https://pensyve.com/settings/api-keys)):
+### 1. Configure the MCP server
+
+Copy `.cursor/mcp.json.example` to your project's `.cursor/mcp.json` and edit for your setup.
+
+**Cloud with API key (recommended):**
 
 ```bash
-export PENSYVE_API_KEY="psy_your_key"
+export PENSYVE_API_KEY="psy_your_key_here"
 ```
-
-Add to your shell profile (`~/.bashrc`, `~/.zshrc`) to persist across sessions.
-
-## Cloud (Recommended)
-
-Add to `.cursor/mcp.json` in your project root:
 
 ```json
 {
@@ -41,11 +38,9 @@ Add to `.cursor/mcp.json` in your project root:
 }
 ```
 
-> Use `headers` with `Authorization: Bearer` for remote MCP. The `env` block is for local stdio servers.
+Create your key at [pensyve.com/settings/api-keys](https://pensyve.com/settings/api-keys). Put the `export` in `~/.bashrc` or `~/.zshrc` to persist.
 
-## Local (Offline)
-
-No API key needed — all data stays on your machine.
+**Local (offline, self-hosted):**
 
 ```json
 {
@@ -62,40 +57,93 @@ No API key needed — all data stays on your machine.
 }
 ```
 
-Build from source: `cargo build --release -p pensyve-mcp` from the [pensyve repo](https://github.com/major7apps/pensyve).
+Build the binary: `cargo build --release -p pensyve-mcp` from the [pensyve repo](https://github.com/major7apps/pensyve).
 
-## Available Tools
+### 2. Install the rules
 
-| Tool                    | Description                            |
-| ----------------------- | -------------------------------------- |
-| `pensyve_recall`        | Search memories by semantic similarity |
-| `pensyve_remember`      | Store a fact as semantic memory        |
-| `pensyve_episode_start` | Begin tracking an interaction          |
-| `pensyve_episode_end`   | Close an episode                       |
-| `pensyve_forget`        | Delete an entity's memories            |
-| `pensyve_inspect`       | List memories for an entity            |
-| `pensyve_status`        | Connection and memory stats            |
-| `pensyve_account`       | Plan and usage info                    |
+Copy the MDC rule files from this integration into your project's `.cursor/rules/` directory:
+
+```bash
+mkdir -p .cursor/rules
+cp /path/to/pensyve/integrations/cursor/.cursor/rules/*.mdc .cursor/rules/
+```
+
+Cursor will auto-attach the rules based on their frontmatter:
+
+| Rule | When it activates |
+|---|---|
+| `memory-reflex.mdc` | Always (establishes the reasoning discipline) |
+| `entity-detection.mdc` | Always (canonicalization reference) |
+| `memory-informed-debug.mdc` | When diagnosing bugs, errors, failing tests, crashes |
+| `memory-informed-design.mdc` | When making architecture, API, or design decisions |
+| `memory-informed-refactor.mdc` | Before substantive refactors |
+| `memory-informed-longitudinal-work.mdc` | In `research/**`, `benchmarks/**`, `evals/**` directories, or when the model judges the conversation to be research-oriented |
+| `session-memory.mdc` | At conversation wrap-up or explicit end-of-session |
+| `context-loader.mdc` | When starting a new substantive conversation or switching contexts |
+
+## How It Works
+
+Cursor has no hook/event surface like Claude Code does, so the entire substrate is delivered through the rules the model interprets during reasoning. `memory-reflex.mdc` establishes the discipline: *before substantive answers, recall by entity; when a lesson lands, observe immediately with a one-line surface*. Flow rules (debug/design/refactor/longitudinal-work) activate when relevant and guide the model through consult-memory + capture-lesson steps.
+
+**Episode lifecycle:** Cursor has no session-start/session-end hooks, so episodes open lazily on the first `pensyve_observe` call and are not explicitly closed under normal operation. Server-side consolidation handles aging.
+
+**Continuity primer:** `context-loader.mdc` runs a best-effort recall at the start of substantive conversations to surface prior relevant observations. Not a structured server-side link — the MCP server has no episode-listing API yet — but good enough to create the "continuing prior work" feel.
+
+## Memory Behavior Model
+
+Pensyve behaves as working memory for the agent — always-on, ambient, continuous.
+
+**Writes happen in-flight.** When a root cause is confirmed, a decision is made, or a reusable procedure emerges, it's captured the moment it lands via the memory reflex. No batching to session end.
+
+**Reads happen at decision points.** Before substantive answers, the model consults memory scoped to the detected entities. Simple commands (run tests, format file) skip recall to stay fast.
+
+**Sessions continue.** At the start of a substantive conversation, Pensyve checks whether the current work continues prior memories (shared entities + recent activity). If yes, you resume with a primer — no re-briefing needed.
+
+## Memory Types
+
+| Type | Definition | MCP call | Example |
+|---|---|---|---|
+| **Semantic** | Durable truths, decisions, preferences | `pensyve_remember` | "We chose RS256 over HS256 for JWT signing" |
+| **Episodic** | Temporal events, session-scoped observations | `pensyve_observe` (with lazy-opened `episode_id`) | "Phase-3 regression root cause: hybrid-router threshold" |
+| **Procedural** | Reusable workflows, sequences, recipes | `pensyve_observe` with `[procedural]` content prefix | "To calibrate V7r: freeze Haiku config, run suite, diff baseline" |
+
+## Opt-Out
+
+Cursor's native pattern is to edit or delete rules:
+
+- **Full opt-out** — delete the Pensyve rule files from `.cursor/rules/`
+- **Partial opt-out** — delete specific flow rules (e.g., remove `memory-informed-longitudinal-work.mdc` if you don't do research work)
+- **Silent mode** — edit `memory-reflex.mdc` to remove the "one-line surface" guidance; captures stay silent
+- **Recall-only mode** — edit flow rules to drop the `Capture lesson` steps while keeping `Consult memory`
+
+## Available MCP Tools
+
+| Tool | Description |
+|---|---|
+| `pensyve_recall` | Search memories by semantic similarity |
+| `pensyve_remember` | Store a durable fact (semantic memory) |
+| `pensyve_observe` | Record a session observation (episodic / procedural via `[procedural]` prefix) |
+| `pensyve_episode_start` | Begin tracking an episode |
+| `pensyve_episode_end` | Close an episode with outcome |
+| `pensyve_forget` | Delete an entity's memories |
+| `pensyve_inspect` | List memories for an entity |
 
 See [MCP Tools Reference](https://pensyve.com/docs/api-reference/mcp-tools) for full parameter details.
 
-## Intelligent Memory Capture
+## Design Philosophy
 
-Pensyve uses a tiered classification system to identify what is worth remembering. Since Cursor connects via MCP only, the LLM follows the MCP tool descriptions to decide when and how to call memory tools.
+- **Memory as substrate** — not a feature the user invokes; always there, continuous, carried across sessions
+- **Reasoning-layer only** — no platform-layer code in v1; the entire adapter is MDC rules
+- **1:1 with Claude Code** — same skill structure, same conventions, same memory types
+- **MCP contract-respecting** — every rule's call examples verified against `pensyve-mcp-tools/src/params.rs`
 
-### Tiered Capture System
+## Links
 
-- **Tier 1** (auto-store, confidence 0.9+): Explicit decisions, corrections, constraints, architecture choices, dependency version pins, security rules. High-signal items that should almost always be captured.
-- **Tier 2** (review, confidence 0.7-0.89): Root causes, failed approaches, performance findings, debugging outcomes, environment quirks. Medium-signal items that benefit from user confirmation.
-- **Discard**: Formatting, typos, boilerplate, ephemeral status messages. Noise that should never be stored.
+- **Website:** [pensyve.com](https://pensyve.com)
+- **GitHub:** [github.com/major7apps/pensyve](https://github.com/major7apps/pensyve)
+- **Spec:** [Cursor adapter design](https://github.com/major7apps/pensyve-docs/blob/main/specs/2026-04-20-pensyve-cursor-adapter-design.md)
+- **Playbook:** [Working-memory substrate design](https://github.com/major7apps/pensyve-docs/blob/main/specs/2026-04-18-pensyve-working-memory-substrate-design.md)
 
-### Best Practices
+## License
 
-For the best experience with Cursor, guide the LLM to use Pensyve's memory tools effectively:
-
-- Use `pensyve_observe` to record significant events during an episode (architecture decisions, failed approaches, key findings)
-- Use `pensyve_remember` for durable facts that should persist across sessions (project conventions, environment constraints, resolved issues)
-- Use `pensyve_recall` at the start of a task to load relevant context from prior sessions
-- Wrap multi-step work in `pensyve_episode_start` / `pensyve_episode_end` to capture episodic context
-
-The MCP tool descriptions include guidance on confidence levels so the LLM can classify memories into the appropriate tier automatically.
+Apache 2.0

--- a/integrations/cursor/scripts/lint-mcp-refs.sh
+++ b/integrations/cursor/scripts/lint-mcp-refs.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Static MCP contract linter for the Pensyve Cursor adapter rules.
+#
+# Verifies that every pensyve_* call example in .cursor/rules/*.mdc conforms to
+# the current MCP tool schema in pensyve-mcp-tools/src/params.rs. Catches the
+# category of bug PR #58 surfaced in the Claude Code adapter (unsupported
+# parameters, missing required fields).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RULES_DIR="$SCRIPT_DIR/../.cursor/rules"
+
+EXIT_CODE=0
+
+if [ ! -d "$RULES_DIR" ]; then
+  echo "ERROR: Rules directory not found: $RULES_DIR"
+  exit 1
+fi
+
+echo "Linting MCP references in $RULES_DIR..."
+echo ""
+
+# Check 1: no actual use of unsupported 'related_entities' parameter in call examples.
+# We look for pensyve_recall( blocks that contain related_entities as a parameter.
+# Lines that say "no related_entities" (documentation/reminders) are excluded.
+echo "Check 1: no unsupported 'related_entities' on pensyve_recall"
+FOUND_RELATED=0
+for rule_file in "$RULES_DIR"/*.mdc; do
+  # Extract lines that contain pensyve_recall( and related_entities together,
+  # excluding documentation lines (those containing "**no**" or "no `related_entities`")
+  if rg -n 'related_entities' "$rule_file" | rg -v '(\*\*no\*\*|no `related_entities`)' | rg -q 'pensyve_recall\|related_entities'; then
+    echo "  FAIL in $rule_file: 'related_entities' used in a pensyve_recall call"
+    FOUND_RELATED=1
+  fi
+  # Also catch if related_entities appears inside a pensyve_recall( block
+  awk '/pensyve_recall\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+         if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
+           print FILENAME ": related_entities found in pensyve_recall block: " buf;
+         capture=0
+       }' "$rule_file" | while read -r line; do
+    if [ -n "$line" ]; then
+      echo "  FAIL: $line"
+      FOUND_RELATED=1
+    fi
+  done
+done
+if [ "$FOUND_RELATED" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 2: no actual use of unsupported 'continuation_of' parameter in call examples.
+# Documentation lines saying "no continuation_of" are excluded.
+echo "Check 2: no unsupported 'continuation_of' on pensyve_episode_start"
+FOUND_CONT=0
+for rule_file in "$RULES_DIR"/*.mdc; do
+  awk '/pensyve_episode_start\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+         if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
+           print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
+         capture=0
+       }' "$rule_file" | while read -r line; do
+    if [ -n "$line" ]; then
+      echo "  FAIL: $line"
+      FOUND_CONT=1
+    fi
+  done
+done
+if [ "$FOUND_CONT" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 3: every pensyve_observe call example in a code block has source_entity and about_entity
+# Scan each .mdc file's pensyve_observe blocks; require both fields nearby.
+echo "Check 3: every pensyve_observe example has source_entity and about_entity"
+MISSING_FIELDS=0
+for rule_file in "$RULES_DIR"/*.mdc; do
+  # Find each pensyve_observe( block (up to the next closing paren within 20 lines)
+  awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
+       capture {buf = buf "\n" $0;
+                for(i=1; i<=length($0); i++){
+                  c=substr($0,i,1);
+                  if(c=="(") depth++;
+                  if(c==")") depth--;
+                };
+                if(depth==0 && buf ~ /pensyve_observe\(/){
+                  if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
+                  if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
+                  capture=0;
+                }}' "$rule_file" | while read -r line; do
+    if [ -n "$line" ]; then
+      echo "  FAIL: $line"
+      MISSING_FIELDS=1
+    fi
+  done
+done
+if [ "$MISSING_FIELDS" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 4: provenance tag format — every proactive/auto-capture tag uses [<origin>/<trigger>/<tier>]
+# Format supports both 3-segment [origin/trigger/tier] and 4-segment [origin/trigger/residual/tier]
+# where the third segment may be a literal "residual" qualifier before the tier.
+echo "Check 4: provenance tag format"
+VALID_PROVENANCE_RE='\[(proactive|auto-capture)/(in-flight|stop|pre-compact|curator|user)/(tier-1|tier-2|residual/tier-1|residual/tier-2|open-question)\]'
+if rg -n '\[(proactive|auto-capture)' "$RULES_DIR" | rg -v "$VALID_PROVENANCE_RE"; then
+  echo "  FAIL: some provenance tags do not match [<origin>/<trigger>/<tier>] format"
+  EXIT_CODE=1
+else
+  echo "  PASS"
+fi
+echo ""
+
+# Check 5: procedural memory convention — [procedural] prefix is used in observe content
+echo "Check 5: procedural convention uses [procedural] prefix in pensyve_observe content"
+# Only a warning if no rule mentions [procedural] — may be legitimate if the rule is non-procedural
+if ! rg -q '\[procedural\]' "$RULES_DIR"; then
+  echo "  WARN: no [procedural] prefix usage found across rules. Expected in memory-reflex and flow rules that handle procedural captures."
+else
+  echo "  PASS"
+fi
+echo ""
+
+if [ "$EXIT_CODE" = "0" ]; then
+  echo "All MCP contract checks PASSED."
+else
+  echo "MCP contract checks FAILED. Fix the issues above before committing."
+fi
+
+exit "$EXIT_CODE"

--- a/integrations/cursor/scripts/lint-mcp-refs.sh
+++ b/integrations/cursor/scripts/lint-mcp-refs.sh
@@ -34,18 +34,18 @@ for rule_file in "$RULES_DIR"/*.mdc; do
     FOUND_RELATED=1
   fi
   # Also catch if related_entities appears inside a pensyve_recall( block
-  awk '/pensyve_recall\(/{capture=1; buf=""}
-       capture {buf = buf "\n" $0}
-       capture && /\)/{
-         if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
-           print FILENAME ": related_entities found in pensyve_recall block: " buf;
-         capture=0
-       }' "$rule_file" | while read -r line; do
+  while read -r line; do
     if [ -n "$line" ]; then
       echo "  FAIL: $line"
       FOUND_RELATED=1
     fi
-  done
+  done < <(awk '/pensyve_recall\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+       if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
+       print FILENAME ": related_entities found in pensyve_recall block: " buf;
+       capture=0
+       }' "$rule_file")
 done
 if [ "$FOUND_RELATED" = "0" ]; then
   echo "  PASS"
@@ -59,18 +59,18 @@ echo ""
 echo "Check 2: no unsupported 'continuation_of' on pensyve_episode_start"
 FOUND_CONT=0
 for rule_file in "$RULES_DIR"/*.mdc; do
-  awk '/pensyve_episode_start\(/{capture=1; buf=""}
-       capture {buf = buf "\n" $0}
-       capture && /\)/{
-         if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
-           print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
-         capture=0
-       }' "$rule_file" | while read -r line; do
+  while read -r line; do
     if [ -n "$line" ]; then
       echo "  FAIL: $line"
       FOUND_CONT=1
     fi
-  done
+  done < <(awk '/pensyve_episode_start\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+       if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
+       print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
+       capture=0
+       }' "$rule_file")
 done
 if [ "$FOUND_CONT" = "0" ]; then
   echo "  PASS"
@@ -85,23 +85,23 @@ echo "Check 3: every pensyve_observe example has source_entity and about_entity"
 MISSING_FIELDS=0
 for rule_file in "$RULES_DIR"/*.mdc; do
   # Find each pensyve_observe( block (up to the next closing paren within 20 lines)
-  awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
-       capture {buf = buf "\n" $0;
-                for(i=1; i<=length($0); i++){
-                  c=substr($0,i,1);
-                  if(c=="(") depth++;
-                  if(c==")") depth--;
-                };
-                if(depth==0 && buf ~ /pensyve_observe\(/){
-                  if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
-                  if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
-                  capture=0;
-                }}' "$rule_file" | while read -r line; do
+  while read -r line; do
     if [ -n "$line" ]; then
       echo "  FAIL: $line"
       MISSING_FIELDS=1
     fi
-  done
+  done < <(awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
+       capture {buf = buf "\n" $0;
+       for(i=1; i<=length($0); i++){
+       c=substr($0,i,1);
+       if(c=="(") depth++;
+       if(c==")") depth--;
+       };
+       if(depth==0 && buf ~ /pensyve_observe\(/){
+       if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
+       if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
+       capture=0;
+       }}' "$rule_file")
 done
 if [ "$MISSING_FIELDS" = "0" ]; then
   echo "  PASS"

--- a/integrations/cursor/scripts/smoketest-mcp.sh
+++ b/integrations/cursor/scripts/smoketest-mcp.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# Live MCP smoke test for the Pensyve Cursor adapter.
+#
+# Confirms the MCP tool call shapes the rules instruct the model to use are
+# actually accepted by the MCP server. Does NOT test behavioral compliance —
+# only validates that call parameter shapes match the server's schema.
+#
+# Requires either:
+#   - PENSYVE_API_KEY set + Pensyve Cloud reachable (default)
+#   - pensyve-mcp binary on PATH + PENSYVE_USE_LOCAL=1 set
+#
+# Uses the MCP Inspector CLI (npx @modelcontextprotocol/inspector) for tool
+# invocation. If Inspector is unavailable, prints instructions and exits.
+
+set -euo pipefail
+
+USE_LOCAL="${PENSYVE_USE_LOCAL:-0}"
+TEST_ENTITY="pensyve-cursor-smoketest"
+TEST_EPISODE_ID=""
+
+EXIT_CODE=0
+
+echo "Pensyve Cursor adapter — MCP smoke test"
+echo "========================================"
+echo ""
+
+# Check prerequisites
+if ! command -v npx >/dev/null 2>&1; then
+  echo "ERROR: 'npx' not found. Install Node.js to run the MCP Inspector CLI."
+  exit 1
+fi
+
+if [ "$USE_LOCAL" = "1" ]; then
+  if ! command -v pensyve-mcp >/dev/null 2>&1; then
+    echo "ERROR: 'pensyve-mcp' binary not on PATH. Build with:"
+    echo "  cargo build --release -p pensyve-mcp"
+    echo "  cp target/release/pensyve-mcp /usr/local/bin/"
+    exit 1
+  fi
+  echo "Mode: Local stdio (pensyve-mcp binary)"
+else
+  if [ -z "${PENSYVE_API_KEY:-}" ]; then
+    echo "ERROR: PENSYVE_API_KEY not set. Either:"
+    echo "  1. Export PENSYVE_API_KEY=psy_... for Cloud mode, or"
+    echo "  2. Export PENSYVE_USE_LOCAL=1 for local stdio mode"
+    exit 1
+  fi
+  echo "Mode: Cloud (https://mcp.pensyve.com/mcp)"
+fi
+echo ""
+
+# Helper: invoke an MCP tool and parse the response
+# Usage: invoke_tool <tool_name> <params_json>
+invoke_tool() {
+  local tool="$1"
+  local params="$2"
+  local response
+  if [ "$USE_LOCAL" = "1" ]; then
+    response=$(npx --yes @modelcontextprotocol/inspector --cli pensyve-mcp --stdio \
+      --method tools/call --tool-name "$tool" --tool-arg "$params" 2>&1)
+  else
+    response=$(npx --yes @modelcontextprotocol/inspector --cli \
+      --transport http --url "https://mcp.pensyve.com/mcp" \
+      --header "Authorization: Bearer $PENSYVE_API_KEY" \
+      --method tools/call --tool-name "$tool" --tool-arg "$params" 2>&1)
+  fi
+  echo "$response"
+}
+
+# Test 1: pensyve_remember — RememberParams schema
+echo "Test 1: pensyve_remember(entity, fact, confidence?)"
+R1=$(invoke_tool pensyve_remember \
+  '{"entity":"'"$TEST_ENTITY"'","fact":"[smoketest] Cursor adapter lint canary","confidence":0.9}')
+if echo "$R1" | grep -qi 'error'; then
+  echo "  FAIL: $R1"
+  EXIT_CODE=1
+else
+  echo "  PASS"
+fi
+echo ""
+
+# Test 2: pensyve_episode_start — EpisodeStartParams schema (participants only, no continuation_of)
+echo "Test 2: pensyve_episode_start(participants)"
+R2=$(invoke_tool pensyve_episode_start \
+  '{"participants":["cursor","'"$TEST_ENTITY"'"]}')
+if echo "$R2" | grep -qi 'error'; then
+  echo "  FAIL: $R2"
+  EXIT_CODE=1
+else
+  TEST_EPISODE_ID=$(echo "$R2" | grep -oP '(?<="episode_id":")[^"]+' | head -1 || true)
+  if [ -z "$TEST_EPISODE_ID" ]; then
+    echo "  FAIL: could not extract episode_id from response"
+    EXIT_CODE=1
+  else
+    echo "  PASS (episode_id=$TEST_EPISODE_ID)"
+  fi
+fi
+echo ""
+
+# Test 3: pensyve_observe — ObserveParams schema (requires source_entity and about_entity)
+echo "Test 3: pensyve_observe(episode_id, content, source_entity, about_entity, content_type?)"
+if [ -n "$TEST_EPISODE_ID" ]; then
+  R3=$(invoke_tool pensyve_observe \
+    '{"episode_id":"'"$TEST_EPISODE_ID"'","content":"[smoketest] Cursor adapter observe canary","source_entity":"cursor","about_entity":"'"$TEST_ENTITY"'","content_type":"text"}')
+  if echo "$R3" | grep -qi 'error'; then
+    echo "  FAIL: $R3"
+    EXIT_CODE=1
+  else
+    echo "  PASS"
+  fi
+else
+  echo "  SKIP (no episode_id from test 2)"
+  EXIT_CODE=1
+fi
+echo ""
+
+# Test 4: pensyve_recall — RecallParams schema (no related_entities)
+echo "Test 4: pensyve_recall(query, entity?, types?, limit?, min_confidence?)"
+R4=$(invoke_tool pensyve_recall \
+  '{"query":"Cursor adapter lint canary","entity":"'"$TEST_ENTITY"'","types":["semantic","episodic"],"limit":5}')
+if echo "$R4" | grep -qi 'error'; then
+  echo "  FAIL: $R4"
+  EXIT_CODE=1
+else
+  echo "  PASS"
+fi
+echo ""
+
+# Test 5: pensyve_inspect — InspectParams schema (entity, memory_type?, limit?)
+echo "Test 5: pensyve_inspect(entity, memory_type?, limit?)"
+R5=$(invoke_tool pensyve_inspect \
+  '{"entity":"'"$TEST_ENTITY"'","limit":5}')
+if echo "$R5" | grep -qi 'error'; then
+  echo "  FAIL: $R5"
+  EXIT_CODE=1
+else
+  echo "  PASS"
+fi
+echo ""
+
+# Test 6: pensyve_episode_end — EpisodeEndParams schema
+echo "Test 6: pensyve_episode_end(episode_id, outcome?)"
+if [ -n "$TEST_EPISODE_ID" ]; then
+  R6=$(invoke_tool pensyve_episode_end \
+    '{"episode_id":"'"$TEST_EPISODE_ID"'","outcome":"success"}')
+  if echo "$R6" | grep -qi 'error'; then
+    echo "  FAIL: $R6"
+    EXIT_CODE=1
+  else
+    echo "  PASS"
+  fi
+else
+  echo "  SKIP (no episode_id)"
+fi
+echo ""
+
+# Cleanup: forget the test entity
+echo "Cleanup: pensyve_forget(entity='$TEST_ENTITY')"
+invoke_tool pensyve_forget '{"entity":"'"$TEST_ENTITY"'"}' >/dev/null 2>&1 || true
+echo "  (cleanup complete)"
+echo ""
+
+if [ "$EXIT_CODE" = "0" ]; then
+  echo "All MCP smoke tests PASSED."
+else
+  echo "MCP smoke tests FAILED. See errors above."
+fi
+
+exit "$EXIT_CODE"

--- a/integrations/gemini-extension/.gemini/settings.json.example
+++ b/integrations/gemini-extension/.gemini/settings.json.example
@@ -1,0 +1,13 @@
+{
+  "_comment": "Pensyve MCP configuration for Gemini CLI. Copy to ~/.gemini/settings.json or your project's .gemini/settings.json. Choose Cloud or Local below.",
+
+  "mcpServers": {
+    "pensyve": {
+      "_comment_cloud": "Cloud (recommended) — requires PENSYVE_API_KEY env var. Get a key at https://pensyve.com/settings/api-keys",
+      "httpUrl": "https://mcp.pensyve.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ${PENSYVE_API_KEY}"
+      }
+    }
+  }
+}

--- a/integrations/gemini-extension/.gemini/settings.local.json.example
+++ b/integrations/gemini-extension/.gemini/settings.local.json.example
@@ -1,0 +1,14 @@
+{
+  "_comment": "Local (offline) Pensyve MCP configuration for Gemini CLI. No API key needed — all data stays on your machine. Build from source: cargo build --release -p pensyve-mcp",
+
+  "mcpServers": {
+    "pensyve": {
+      "command": "pensyve-mcp",
+      "args": ["--stdio"],
+      "env": {
+        "PENSYVE_PATH": "~/.pensyve/",
+        "PENSYVE_NAMESPACE": "default"
+      }
+    }
+  }
+}

--- a/integrations/gemini-extension/CHANGELOG.md
+++ b/integrations/gemini-extension/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog — Pensyve Gemini CLI / Gemini Code Assist Extension
+
+All notable changes to the Pensyve Gemini extension are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). The Gemini extension versions independently of the Claude Code plugin.
+
+## [1.0.0] - 2026-04-20
+
+### Added
+
+- **Working-memory substrate** for Gemini CLI / Gemini Code Assist via a consolidated `GEMINI.md` context file. The Gemini integration uses a single-file delivery model (matching the Gemini CLI convention) rather than a rules directory. The eight substrate rules are embedded as named sections within `GEMINI.md`:
+  - **Part 1: Memory Reflex** (always-apply) — non-optional reasoning discipline with three-type memory classification, canonical `pensyve_observe` call template, provenance vocabulary, lazy-open episode lifecycle
+  - **Part 2: Entity Detection** (always-apply) — canonicalization and fallback rules
+  - **Part 3: Memory-Informed Debug** — debug flow
+  - **Part 4: Memory-Informed Design** — design flow
+  - **Part 5: Memory-Informed Refactor** — refactor flow
+  - **Part 6: Memory-Informed Longitudinal Work** — research/eval flow
+  - **Part 7: Session Memory** — manual wrap-up equivalent of Claude Code's Stop hook
+  - **Part 8: Context Loader** — best-effort continuity primer via episodic recall
+- **MCP config examples** at `.gemini/settings.json.example` (cloud) and `.gemini/settings.local.json.example` (local stdio) covering both deployment options
+- **Static MCP contract lint script** at `scripts/lint-mcp-refs.sh` verifying every `pensyve_*` call example in `GEMINI.md` matches the `pensyve-mcp-tools/src/params.rs` schema
+
+### Design
+
+- Single-file delivery: Gemini CLI's primary convention for agent behavior is `GEMINI.md` at the workspace root. The eight rules are consolidated into sections within that file rather than a separate rules directory.
+- `source_entity: "gemini"` on all `pensyve_observe` calls — identifies the Gemini integration as the memory source.
+- Lazy-open episode lifecycle: first `pensyve_observe` call triggers `pensyve_episode_start`; episodes are not explicitly closed.
+- Best-effort continuity primer via `pensyve_recall(types: ["episodic"])` — the MCP server has no episode-listing API.
+- MCP contract verified: no `related_entities` on recall, no `continuation_of` on episode_start, required `source_entity: "gemini"` and `about_entity` on every observe.
+
+### Not Included
+
+- No server-side changes — uses the existing MCP tool surface
+
+### Relation to Other Pensyve Integrations
+
+- The Gemini extension is part of the batch-5 rollout extending the working-memory substrate across all supported integrations. The Claude Code plugin (v1.3.0) was the reference implementation.
+- Playbook: `pensyve-docs/specs/2026-04-18-pensyve-working-memory-substrate-design.md`

--- a/integrations/gemini-extension/GEMINI.md
+++ b/integrations/gemini-extension/GEMINI.md
@@ -1,135 +1,447 @@
-# Pensyve -- Persistent Memory for Gemini CLI
+# Pensyve -- Persistent Working-Memory Substrate for Gemini CLI
 
-You have access to persistent, cross-session memory through Pensyve. This memory survives between conversations -- use it to build up a knowledge base of decisions, patterns, outcomes, and project context that compounds over time.
+You have access to persistent, cross-session memory through Pensyve. This memory survives between conversations — use it to build up a knowledge base of decisions, patterns, outcomes, and project context that compounds over time.
 
-## When to Use Memory
+Memory is not a feature you invoke at session end. It is the substrate you operate on: recall before substantive answers, observe when lessons land, and carry continuity across sessions.
 
-### Store memories (`pensyve_remember`) when you learn:
+---
 
-- **Decisions and their reasoning**: "Chose SQLite over Postgres for the MVP because offline-first is a hard requirement"
-- **Outcomes**: "Fixed the OOM crash -- root cause was unbounded channel buffer in the ingestion pipeline"
-- **Failed approaches**: "Tried connection pooling with bb8 but it deadlocked under concurrent writes; switched to deadpool"
-- **Patterns**: "Every time we touch the auth module, the session tests break due to shared state"
-- **User preferences**: "User prefers explicit error types over anyhow in library code"
-- **Architecture context**: "The API layer is intentionally thin -- all business logic lives in the domain crate"
+## Part 1: Memory Reflex (Always-Apply)
 
-### Search memories (`pensyve_recall`) before:
+**Before substantive answers, recall by entity. When a lesson lands, observe immediately with a one-line surface.**
 
-- **Refactoring** any module -- check for past decisions, known pitfalls, and failed approaches
-- **Answering questions** about the project -- prior context may already exist
-- **Making design decisions** -- see if a similar tradeoff was already evaluated
-- **Debugging** -- check if this error or pattern was encountered before
-- **Starting a new session** -- recall recent decisions and active work
+### "Substantive answer" means
 
-### Track conversations (`pensyve_episode_start` / `pensyve_episode_end`):
+- Design or architecture recommendations
+- Debugging diagnoses with root-cause claims
+- Refactor proposals
+- Any response that makes a claim the user would want grounded in prior work
 
-- Start an episode when beginning a significant task (debugging session, feature implementation, refactor)
-- End the episode with an outcome summary when the task completes
-- Episodes automatically capture the interaction as episodic memory
+Not substantive: formatting fixes, trivial lookups, reading a file, running a command.
 
-### Remove memories (`pensyve_forget`):
+### "Lesson lands" means
 
-- When a decision has been reversed or is no longer relevant
-- When information is outdated and replaced by a newer fact
-- Always confirm with the user before deleting -- this is destructive
+- A root cause has been confirmed (not hypothesized).
+- A design choice has been made explicit ("we'll use X because Y").
+- An approach has been tried and abandoned with a reason.
+- A workflow has been discovered that is reusable.
+- A workaround for a framework/library limitation has been validated.
 
-### Inspect entity details (`pensyve_inspect`):
+### Classification (which memory type?)
 
-- View all memories grouped by type for a specific entity
-- Useful for understanding the full context around a module, service, or concept
+- **Semantic** — a fact that will still be true next month. Use `pensyve_remember(entity, fact, confidence?)`.
+- **Episodic** — something that happened in this thread of work. Use `pensyve_observe` with the current `episode_id`.
+- **Procedural** — a reusable way to do something. Use `pensyve_observe` with `content` beginning `[procedural]`.
+
+When in doubt, prefer episodic. Server-side consolidation promotes recurring patterns to semantic automatically.
+
+### Canonical `pensyve_observe` call template
+
+ALL observe calls MUST include every required field:
+
+```
+pensyve_observe(
+  episode_id: <current session's working episode_id>,
+  content: "[proactive/in-flight/tier-1] <observation text>",
+  source_entity: "gemini",
+  about_entity: "<relevant entity, lowercase-hyphenated>",
+  content_type: "text"
+)
+```
+
+Use `content_type: "code"` for code-related outcomes.
+
+### Episode lifecycle (lazy-open)
+
+Gemini CLI has no session-start/session-end hooks, so you own the episode lifecycle:
+
+- Before your first `pensyve_observe` call in this conversation, check whether a working `episode_id` is already tracked. If none exists, call `pensyve_episode_start(participants: ["gemini", "<project entity>"])` first, record the returned `episode_id`, then make the observation.
+- Reuse the same `episode_id` for all subsequent observations in the same conversation.
+- Do not explicitly close the episode under normal operation. Server-side consolidation handles aging.
+- Recovery: if `pensyve_observe` fails with a missing-episode error, call `pensyve_episode_start` and retry.
+
+### Surface style
+
+Lightly visible. One line when memory is used. Examples:
+
+- Recall: `Recalled 4 related memories (v7r, haiku-classifier).`
+- Capture: `↳ captured: hybrid-router threshold was the phase-3 regression root cause.`
+
+Do not narrate empty recalls or duplicate-skips.
+
+### Scope and budgets
+
+- Recall: scoped to detected entities; limit 5; use `types` hint per flow.
+- Capture: one observation per substantive lesson; reuse the working `episode_id`.
+- Noise: avoid surfacing memory operations the user did not care about.
+
+### Composition with provenance tags
+
+When a capture is both procedural AND a proactive in-flight write:
+
+`[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=...`
+
+### Provenance tag vocabulary
+
+- `[proactive/in-flight/tier-1]` — memory reflex captured during reasoning
+- `[proactive/in-flight/open-question]` — unresolved question noted in-flight
+- `[auto-capture/user/residual/tier-1]` — explicit user-driven capture
+
+### MCP contract reminder
+
+- `pensyve_recall(query, entity?, types?, limit?, min_confidence?)` — **no** `related_entities`
+- `pensyve_episode_start(participants)` — **no** `continuation_of`
+- `pensyve_observe(episode_id, content, source_entity, about_entity, content_type?)` — `source_entity` and `about_entity` are **required**
+
+---
+
+## Part 2: Entity Detection (Always-Apply)
+
+Shared rules for detecting entity names from tool inputs, prompts, and conversation context. Used by the memory reflex and all memory-woven flows.
+
+### Inputs
+
+Extract candidate entity names from:
+
+1. **File references** — `@filename`, `@path/to/file`, or files mentioned directly in the conversation.
+2. **User prompts** — explicit references to components, files, services, research phases.
+3. **Code context** — module names, class names, function names in files you are editing or reading.
+4. **Git context** — repository root name, branch name (when discoverable).
+
+### Canonicalization
+
+- Lowercase all characters.
+- Replace spaces and underscores with hyphens.
+- Strip file extensions unless the file is the entity itself (e.g., `package.json`).
+- Collapse paths to the most semantically meaningful segment.
+
+### Fallback behavior
+
+- If no specific entity is detected, fall back to the project-level entity (repository root name, lowercase-hyphenated).
+- If ambiguous, prefer the entity that already has memories in Pensyve (call `pensyve_inspect` with limit 1).
+- **Never fabricate entity names.**
+
+### Output
+
+A set of 1–3 candidate entity names per turn. The primary entity is the most specific. Since `pensyve_recall` accepts only a single `entity` parameter, fold secondary entities into the `query` string.
+
+---
+
+## Part 3: Memory-Informed Debug
+
+Use when diagnosing bugs, errors, failing tests, or crashes — consult prior debug outcomes and capture root causes in-flight.
+
+### Step 1: Detect entities
+
+Identify the relevant entity/entities (failing test, failing module, error source) per Part 2.
+
+### Step 2: Consult memory (required)
+
+Call `pensyve_recall`:
+
+- `query`: short description of the failure, including secondary entity names
+- `entity`: primary detected entity
+- `types`: `["procedural", "episodic"]`
+- `limit`: 5
+
+Surface one line: `Recalled N memories from prior debug sessions on <entity>.`
+
+If a highly similar incident is found (score >0.8): `This looks similar to an incident captured on <date>: <summary>. Consider that path first.`
+
+### Step 3: Diagnose
+
+Proceed with diagnostic work. Use recalled procedural memories as a starting sequence.
+
+### Step 4: Capture lesson (when it lands)
+
+When a root cause is confirmed:
+
+- **Episodic root cause:** `pensyve_observe` with `content: "[proactive/in-flight/tier-1] <root cause>"`, `source_entity: "gemini"`, `about_entity: <primary_entity>`.
+- **Procedural diagnostic sequence:** `pensyve_observe` with `content: "[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=..."`, `source_entity: "gemini"`, `about_entity: <primary_entity>`.
+- **Semantic durable truth:** `pensyve_remember(entity, fact: "[proactive/in-flight/tier-1] <fact>", confidence: 0.9)`.
+
+Surface one line: `↳ captured: <one-sentence>`.
+
+### Step 5: Capture abandoned approach
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[proactive/in-flight/tier-1] tried <approach>, abandoned because <reason>",
+  source_entity: "gemini",
+  about_entity: <primary_entity>,
+  content_type: "text"
+)
+```
+
+---
+
+## Part 4: Memory-Informed Design
+
+Use when making architecture, API, or design decisions — consult prior decisions and capture new ones in-flight.
+
+### Step 1: Detect entities
+
+Identify the relevant entity/entities (service, module, subsystem under design) per Part 2.
+
+### Step 2: Consult memory (required)
+
+Call `pensyve_recall`:
+
+- `query`: short description of the design question
+- `entity`: primary detected entity
+- `types`: `["semantic", "episodic"]`
+- `limit`: 5
+
+Surface one line: `Recalled N prior decisions on <entity>.`
+
+### Step 3: Recommend with grounding
+
+If the user's current question directly contradicts a prior decision, flag it:
+
+> Prior decision on `<entity>` (confidence 0.9): [decision]. Are we revisiting this, or does the current question differ?
+
+### Step 4: Capture decision (when it lands)
+
+- **Semantic:** `pensyve_remember(entity: <primary_entity>, fact: "[proactive/in-flight/tier-1] <decision text>", confidence: 0.9)`.
+- **Episodic context:** `pensyve_observe` with `content: "[proactive/in-flight/tier-1] Decision on <entity>: chose X over Y because Z"`, `source_entity: "gemini"`, `about_entity: <primary_entity>`.
+
+### Step 5: Capture evaluation procedures
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[procedural] [proactive/in-flight/tier-1] trigger=design-question-on-<area>, action=<steps>, outcome=<what-you-learn>",
+  source_entity: "gemini",
+  about_entity: <primary_entity>,
+  content_type: "text"
+)
+```
+
+---
+
+## Part 5: Memory-Informed Refactor
+
+Use before substantive refactors — load relevant prior context, capture refactor insights as they land.
+
+### Step 1: Detect entities
+
+Identify the entities touched by the refactor per Part 2.
+
+### Step 2: Load prior context (required)
+
+Call `pensyve_recall`:
+
+- `query`: short description of the refactor
+- `entity`: primary detected entity
+- `types`: `["semantic", "episodic", "procedural"]`
+- `limit`: 5
+
+Surface: `Recalled N prior memories on <entity>.`
+
+Highlight any prior failed approaches inline.
+
+### Step 3: Present a briefing
+
+Briefly summarize what prior memories say about decisions, prior attempts, and known-good procedures before starting the refactor.
+
+### Step 4: Capture refactor lessons as they land
+
+- **An invariant is discovered** — `pensyve_remember(entity, fact, confidence: 0.9)`
+- **An abandoned approach confirmed not-viable** — `pensyve_observe` with `[proactive/in-flight/tier-1]`
+- **A surprising dependency chain** — `pensyve_observe`
+- **A known-good refactoring sequence** — `pensyve_observe` with `[procedural]` prefix
+
+---
+
+## Part 6: Memory-Informed Longitudinal Work
+
+Long-running multi-session work (research, eval loops, iterative benchmarks) — resume prior lessons, capture per-run outcomes, build up stable truths over time.
+
+Activates when editing files under `research/`, `benchmarks/`, or `evals/`, or when the conversation is research-oriented.
+
+### Step 1: Resume context at conversation start
+
+Call `pensyve_recall` once at the start:
+
+- `query`: short description of the current research area
+- `entity`: project + sub-topic entity
+- `limit`: 5
+
+No `types` filter — longitudinal work benefits from all three memory types.
+
+Surface: `Recalled N prior findings on <sub-topic>.`
+
+### Step 2: Proactively recall per topic shift
+
+When the session pivots to a new sub-topic, call `pensyve_recall` again scoped to the new sub-topic.
+
+### Step 3: Capture three types of memory per run
+
+| What you learned | Type | MCP call |
+|---|---|---|
+| Per-run outcome | episodic | `pensyve_observe(..., content: "[proactive/in-flight/tier-1] Run N+1: ...", source_entity: "gemini", about_entity: <entity>, content_type: "text")` |
+| Stable truth | semantic | `pensyve_remember(entity, fact: "[proactive/in-flight/tier-1] ...", confidence: 0.9)` |
+| Reusable procedure | procedural | `pensyve_observe(..., content: "[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=...", source_entity: "gemini", about_entity: <entity>, content_type: "text")` |
+
+### Step 4: Capture open questions
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[proactive/in-flight/open-question] <question>",
+  source_entity: "gemini",
+  about_entity: <entity>,
+  content_type: "text"
+)
+```
+
+### Step 5: End-of-session summary
+
+Before wrapping, briefly summarize (3-5 lines): what this run taught us vs. prior runs, what's still open.
+
+---
+
+## Part 7: Session Memory (Wrap-Up)
+
+Use at conversation wrap-up or when the user explicitly indicates end-of-session — capture residual lessons not captured in-flight.
+
+### Step 1: Review the conversation
+
+Scan for memorable content the in-flight reflex did NOT already capture:
+
+- **Decisions** (confidence: 0.9): architecture choices, technology selections, tradeoff resolutions
+- **Outcomes** (confidence: 0.8): bug fixes, successful approaches, failed approaches, performance findings
+- **Patterns** (confidence: 0.7): recurring issues, workflow discoveries, cross-cutting observations
+
+### Step 2: Filter for significance and deduplicate
+
+For each candidate, call `pensyve_recall` with `query: <candidate fact text>`, `entity: <candidate's entity>`, `limit: 3`. If any returned memory has score ≥0.85, skip as duplicate.
+
+### Step 3: Present candidates for confirmation
+
+> **Session Memory Candidates**
+>
+> **Decisions** (confidence: 0.9):
+> 1. `<entity>`: <decision text>
+>
+> **Outcomes** (confidence: 0.8):
+> 2. `<entity>`: <outcome text>
+>
+> Which should I store? (e.g., "all", "1,3", "none")
+
+### Step 4: Store confirmed items
+
+- **Semantic:** `pensyve_remember(entity, fact: "[auto-capture/user/residual/tier-1] <text>", confidence)`.
+- **Episodic:** `pensyve_observe(episode_id, content: "[auto-capture/user/residual/tier-1] <text>", source_entity: "gemini", about_entity: <entity>, content_type: "text")`.
+- **Procedural:** `pensyve_observe(episode_id, content: "[procedural] [auto-capture/user/residual/tier-1] trigger=..., action=..., outcome=...", source_entity: "gemini", about_entity: <entity>, content_type: "text")`.
+
+### Step 5: Optionally close the episode
+
+If the user indicates this is a final wrap, call `pensyve_episode_end(episode_id: <working_id>, outcome: "success")`. Valid outcomes: `"success"`, `"failure"`, `"partial"`.
+
+### Step 6: Report
+
+> Stored N memories. Episode <outcome> closed.
+
+**Constraint: Never auto-store.** Every candidate MUST be presented for user confirmation before storage.
+
+---
+
+## Part 8: Context Loader (Continuity Primer)
+
+Use when starting a new substantive conversation or switching contexts — load relevant memories to prime the session with continuity.
+
+### Step 1: Detect project entity
+
+Use the repository root name (lowercase-hyphenated) as the default project entity. Override with `PENSYVE_NAMESPACE` environment variable if explicitly set.
+
+### Step 2: Scoped recall
+
+Call `pensyve_recall`:
+
+- `query`: `"recent decisions issues patterns"` + any key terms from the user's opening message
+- `entity`: detected project entity
+- `types`: `["episodic"]`
+- `limit`: 5
+
+### Step 3: Compute continuity signal
+
+- If ≥70% of the top observations reference entities overlapping with the current conversation's candidates, treat as a **continuation**.
+- Otherwise, treat as a **fresh session**.
+
+### Step 4: Surface the primer
+
+**Continuation:**
+
+> **Pensyve:** Continuing prior work on `<entity-set>`. Recent lessons:
+> - <observation 1>
+> - <observation 2>
+> - <observation 3>
+
+**Fresh session:**
+
+> **Pensyve:** N memories loaded for `<project>`. Key context:
+> - <top 3 observations>
+
+**No memories found:**
+
+> **Pensyve:** No memories found for `<project>`. Use `/remember` to start building context.
+
+**Constraints:** Do not fabricate memories. Maximum 5 memories in the primer.
+
+---
 
 ## Entity Naming Convention
 
 Use **lowercase, hyphenated** names for entities:
 
 - `auth-service`, `database-layer`, `api-routes`, `build-pipeline`
-- `project-decisions`, `user-preferences`, `deployment-config`
 - NOT `AuthService`, `auth service`, `AUTH_SERVICE`
 
-## Intelligent Capture -- Tiered Classification
+---
 
-When evaluating what to store, apply this tiered taxonomy:
+## Tiered Capture Classification
 
 ### Tier 1 (auto-store, confidence >= 0.9)
 
 High-signal items that should almost always be captured:
 
 - **Explicit decisions**: "let's use X", "we decided Y", "we chose Z"
-- **Behavioral corrections**: "don't do X", "stop doing Y", "no, not that"
-- **Project constraints**: "we can't use X because Y", "must not use Z"
+- **Behavioral corrections**: "don't do X", "stop doing Y"
+- **Project constraints**: "we can't use X because Y"
 - **Technology migrations**: "switching to X", "migrating from Y to Z"
 
 ### Tier 2 (batch for review, confidence 0.7-0.89)
 
 Medium-signal items that benefit from user confirmation:
 
-- **Root causes**: "the bug was caused by...", "the issue is..."
+- **Root causes**: "the bug was caused by..."
 - **Failed approaches**: "tried X but it failed because..."
-- **Performance findings**: measurable results (timing, memory, throughput)
-- **Dependency discoveries**: "X depends on Y", "blocked by Z"
+- **Performance findings**: measurable results
 - **Non-obvious solutions**: workarounds for framework/tool limitations
 
 ### Discard (never store)
 
 - Simple typo or formatting fixes
-- Routine lint fixes, import sorting, boilerplate
+- Routine lint fixes, boilerplate
 - Standard file edits with no architectural significance
-- Repeated application of already-known patterns
 
-### Confidence Reference
-
-| Type        | Confidence | Examples                                                           |
-| ----------- | ---------- | ------------------------------------------------------------------ |
-| Decisions   | 0.9-0.95   | Architecture choices, technology selections, API design            |
-| Outcomes    | 0.8        | Bug fixes, successful approaches, performance findings             |
-| Patterns    | 0.7        | Recurring issues, workflow discoveries, cross-cutting observations |
-| Speculative | 0.5        | Hypotheses, untested theories, uncertain observations              |
-
-If the user expresses certainty ("we decided", "this is how it works"), use 0.9-1.0.
-If the user is uncertain ("I think", "maybe", "probably"), use 0.5-0.7.
-
-## Signal Buffering
-
-During a session, buffer observations rather than storing them immediately:
-
-1. **Buffer signals** as you work -- note decisions, corrections, errors, and outcomes mentally without making MCP calls
-2. **Classify at task boundaries** -- when a task completes or the session ends, classify all buffered signals using the tiered taxonomy above
-3. **Flush at session end** -- present tier 1 and tier 2 candidates to the user for confirmation, then store approved items
-
-This approach reduces MCP call overhead and produces higher-quality memories by capturing signals in context rather than in isolation.
+---
 
 ## Rules
 
-1. **Never store secrets.** Do not store API keys, passwords, tokens, credentials, or any sensitive data in memory. Warn the user if they ask you to remember something that looks like a secret.
+1. **Never store secrets.** Do not store API keys, passwords, tokens, or credentials. Warn the user if they ask you to remember something that looks like a secret.
 
 2. **Never auto-store.** Always present memory candidates to the user and get explicit confirmation before calling `pensyve_remember`. The only exception is episode tracking, which the user opts into.
 
-3. **Deduplicate before storing.** Before storing a new memory, run `pensyve_recall` with a query matching the candidate fact. If a highly similar memory already exists (score > 0.85), skip it and inform the user.
+3. **Deduplicate before storing.** Run `pensyve_recall` with a query matching the candidate fact. If a highly similar memory already exists (score > 0.85), skip it.
 
-4. **Prefer specific entities over generic ones.** Use `auth-service` over `project`. Use `database-migration` over `backend`. The more specific the entity, the more useful the memory.
+4. **Prefer specific entities over generic ones.** Use `auth-service` over `project`. The more specific the entity, the more useful the memory.
 
-5. **Facts over opinions.** Store what happened, what was decided, and why -- not subjective quality judgments.
+5. **Facts over opinions.** Store what happened, what was decided, and why — not subjective quality judgments.
 
-## Session Workflow
-
-### At session start:
-
-Consider running `pensyve_recall` with a broad query related to the current working directory or task to load relevant context. This gives you continuity from previous sessions.
-
-### During the session:
-
-When you learn something significant -- a decision, an outcome, a pattern -- suggest storing it. Present the candidate to the user with the entity name, fact text, and confidence level.
-
-### At session end:
-
-Review the session for memorable content. Look for:
-
-- Decisions that were made and their reasoning
-- Problems that were solved and their root causes
-- Patterns that emerged
-- Failed approaches worth documenting
-
-Present candidates and store only what the user confirms.
+---
 
 ## MCP Tools Reference
 

--- a/integrations/gemini-extension/README.md
+++ b/integrations/gemini-extension/README.md
@@ -1,6 +1,14 @@
-# Pensyve -- Persistent Memory for Gemini CLI
+# Pensyve -- Persistent Working-Memory Substrate for Gemini CLI
 
-Pensyve gives Gemini CLI a persistent, cognitive memory layer that spans across sessions. It remembers your decisions, learned patterns, debugging outcomes, and project context -- so your agent never repeats the same investigation twice. Memory is stored in the cloud via the Pensyve managed service and accessed through the MCP protocol.
+Pensyve gives Gemini CLI a persistent, cognitive working-memory layer that spans across sessions. Memory is not a feature you invoke at session end — it is the substrate the agent operates on: proactive capture when lessons land, entity-scoped recall before substantive answers, and continuity across sessions. Memory is stored in the cloud via the Pensyve managed service and accessed through the MCP protocol.
+
+## What It Does
+
+- **Proactive memory during work** — lessons are captured the moment they land, not at session end
+- **Thread-aware continuity** — sessions that continue prior work resume with relevant context, no re-briefing
+- **Entity-scoped recall** — substantive questions are grounded in prior decisions; simple commands stay fast
+- **Three memory types** — durable facts (semantic), session-specific events (episodic), reusable procedures (procedural)
+- **Lightly visible** — one-line surfaces when memory is used; never interrupts your flow
 
 ## Install
 
@@ -18,7 +26,7 @@ gemini mcp add --transport http pensyve https://mcp.pensyve.com/mcp
 
 ### Connect to Pensyve
 
-The extension needs a Pensyve API key. Choose one method:
+The extension needs a Pensyve API key.
 
 **Option A** — environment variable (recommended):
 
@@ -36,16 +44,66 @@ gemini extensions configure pensyve
 
 Get an API key at [pensyve.com/settings/api-keys](https://pensyve.com/settings/api-keys).
 
-## Authentication
+### MCP config via settings.json
 
-1. Sign up at [pensyve.com](https://pensyve.com)
-2. Create an API key at [Settings → API Keys](https://pensyve.com/settings/api-keys)
-3. Set the environment variable:
-   ```bash
-   export PENSYVE_API_KEY="psy_your_key_here"
-   ```
+Copy `.gemini/settings.json.example` to `~/.gemini/settings.json` or your project's `.gemini/settings.json`:
 
-Then configure MCP with headers (see setup instructions above).
+**Cloud (recommended):**
+
+```json
+{
+  "mcpServers": {
+    "pensyve": {
+      "httpUrl": "https://mcp.pensyve.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ${PENSYVE_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+**Local (offline):**
+
+```json
+{
+  "mcpServers": {
+    "pensyve": {
+      "command": "pensyve-mcp",
+      "args": ["--stdio"],
+      "env": {
+        "PENSYVE_PATH": "~/.pensyve/",
+        "PENSYVE_NAMESPACE": "default"
+      }
+    }
+  }
+}
+```
+
+Build the binary: `cargo build --release -p pensyve-mcp` from the [pensyve repo](https://github.com/major7apps/pensyve).
+
+## Context File
+
+The `GEMINI.md` context file is automatically loaded by Gemini CLI and delivers the working-memory substrate — all 8 behavioral rules consolidated into one file as sections:
+
+| Section | When it activates |
+|---|---|
+| **Part 1: Memory Reflex** | Always (establishes the reasoning discipline) |
+| **Part 2: Entity Detection** | Always (canonicalization reference) |
+| **Part 3: Memory-Informed Debug** | When diagnosing bugs, errors, failing tests, crashes |
+| **Part 4: Memory-Informed Design** | When making architecture, API, or design decisions |
+| **Part 5: Memory-Informed Refactor** | Before substantive refactors |
+| **Part 6: Memory-Informed Longitudinal Work** | In research/benchmark/eval contexts |
+| **Part 7: Session Memory** | At conversation wrap-up or explicit end-of-session |
+| **Part 8: Context Loader** | When starting a new substantive conversation or switching contexts |
+
+## How It Works
+
+Gemini CLI has no hook/event surface, so the entire substrate is delivered through the single `GEMINI.md` context file the model interprets during reasoning. Part 1 (Memory Reflex) establishes the discipline: *before substantive answers, recall by entity; when a lesson lands, observe immediately with a one-line surface*. Flow sections (debug/design/refactor/longitudinal-work) activate when relevant and guide the model through consult-memory + capture-lesson steps.
+
+**Episode lifecycle:** Gemini CLI has no session-start/session-end hooks, so episodes open lazily on the first `pensyve_observe` call and are not explicitly closed under normal operation. Server-side consolidation handles aging.
+
+**Continuity primer:** Part 8 (Context Loader) runs a best-effort recall at the start of substantive conversations to surface prior relevant observations.
 
 ## Commands
 
@@ -56,16 +114,6 @@ Then configure MCP with headers (see setup instructions above).
 | `/forget <entity>`  | Delete all memories for an entity (with confirmation)   |
 | `/inspect [entity]` | View all memories grouped by type for an entity         |
 
-## Intelligent Memory Capture (v1.1.0)
-
-Pensyve uses a tiered classification system to identify what is worth remembering:
-
-- **Tier 1** (auto-store, confidence 0.9+): Explicit decisions, corrections, constraints -- high-signal items that should almost always be captured
-- **Tier 2** (batch review, confidence 0.7-0.89): Root causes, failed approaches, performance findings -- medium-signal items that benefit from user confirmation
-- **Discard**: Formatting, typos, boilerplate -- noise that should never be stored
-
-The `GEMINI.md` context file teaches the agent to buffer signals during a session and classify them at task boundaries, reducing MCP call overhead and producing higher-quality memories.
-
 ## Skills
 
 | Skill                      | When to Use                                                                       |
@@ -75,9 +123,15 @@ The `GEMINI.md` context file teaches the agent to buffer signals during a sessio
 | `context-loader`           | Session start or context switch -- loads historical context for continuity        |
 | `memory-review`            | Periodic -- finds stale facts, contradictions, and cleanup opportunities          |
 
-## MCP Tools
+## Memory Types
 
-The extension connects to the Pensyve remote MCP server, which exposes 7 tools:
+| Type | Definition | MCP call | Example |
+|---|---|---|---|
+| **Semantic** | Durable truths, decisions, preferences | `pensyve_remember` | "We chose RS256 over HS256 for JWT signing" |
+| **Episodic** | Temporal events, session-scoped observations | `pensyve_observe` (with lazy-opened `episode_id`) | "Phase-3 regression root cause: hybrid-router threshold" |
+| **Procedural** | Reusable workflows, sequences, recipes | `pensyve_observe` with `[procedural]` content prefix | "To calibrate V7r: freeze Haiku config, run suite, diff baseline" |
+
+## MCP Tools
 
 | Tool                    | Parameters                                                                | Returns                              |
 | ----------------------- | ------------------------------------------------------------------------- | ------------------------------------ |
@@ -89,22 +143,20 @@ The extension connects to the Pensyve remote MCP server, which exposes 7 tools:
 | `pensyve_forget`        | `entity`, `hard_delete?`                                                  | `forgotten_count`                    |
 | `pensyve_inspect`       | `entity`, `memory_type?`, `limit?`                                        | Array of memories with stats         |
 
-## Context File
+## Opt-Out
 
-The `GEMINI.md` context file is automatically loaded by Gemini CLI and teaches the agent when and how to use memory. It covers:
-
-- When to store, search, and delete memories
-- Entity naming conventions (lowercase, hyphenated)
-- Confidence levels for different memory types
-- Session workflow (start, during, end)
-- Rules for safety (no secrets, no auto-store, deduplication)
+- **Full opt-out** — remove the `GEMINI.md` file from your workspace
+- **Partial opt-out** — delete individual sections from `GEMINI.md`
+- **Silent mode** — remove the "one-line surface" guidance from Part 1; captures stay silent
+- **Recall-only mode** — remove the `Capture lesson` steps from flow sections while keeping `Consult memory`
 
 ## Design Philosophy
 
-- **GEMINI.md owns agent behavior** -- how and when the agent uses memory
-- **Pensyve owns dynamic memory** -- decisions, outcomes, patterns, context
-- **Always asks** -- no memory is stored without user confirmation
-- **Cloud-native** -- memories stored via the Pensyve managed service
+- **`GEMINI.md` owns agent behavior** — how and when the agent uses memory
+- **Memory as substrate** — not a feature the user invokes; always there, continuous, carried across sessions
+- **Pensyve owns dynamic memory** — decisions, outcomes, patterns, context
+- **Always asks** — no memory is stored without user confirmation
+- **Cloud-native** — memories stored via the Pensyve managed service
 
 ## Links
 
@@ -112,6 +164,7 @@ The `GEMINI.md` context file is automatically loaded by Gemini CLI and teaches t
 - **Docs:** [pensyve.com/docs](https://pensyve.com/docs)
 - **GitHub:** [github.com/major7apps/pensyve](https://github.com/major7apps/pensyve)
 - **API Keys:** [pensyve.com/settings/api-keys](https://pensyve.com/settings/api-keys)
+- **Playbook:** [Working-memory substrate design](https://github.com/major7apps/pensyve-docs/blob/main/specs/2026-04-18-pensyve-working-memory-substrate-design.md)
 
 ## License
 

--- a/integrations/gemini-extension/scripts/lint-mcp-refs.sh
+++ b/integrations/gemini-extension/scripts/lint-mcp-refs.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Static MCP contract linter for the Pensyve Gemini CLI / Gemini Code Assist adapter.
+#
+# The Gemini integration uses a single GEMINI.md file at the integration root
+# rather than a directory of rule files. This script verifies that every
+# pensyve_* call example in GEMINI.md conforms to the current MCP tool schema
+# in pensyve-mcp-tools/src/params.rs. Catches the category of bug PR #58
+# surfaced in the Claude Code adapter (unsupported parameters, missing required fields).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GEMINI_MD="$SCRIPT_DIR/../GEMINI.md"
+
+EXIT_CODE=0
+
+if [ ! -f "$GEMINI_MD" ]; then
+  echo "ERROR: GEMINI.md not found: $GEMINI_MD"
+  exit 1
+fi
+
+echo "Linting MCP references in $GEMINI_MD..."
+echo ""
+
+# Check 1: no actual use of unsupported 'related_entities' parameter in call examples.
+# Lines that say "no related_entities" (documentation/reminders) are excluded.
+echo "Check 1: no unsupported 'related_entities' on pensyve_recall"
+FOUND_RELATED=0
+if rg -n 'related_entities' "$GEMINI_MD" | rg -v '(\*\*no\*\*|no `related_entities`)' | rg -q 'pensyve_recall\|related_entities' 2>/dev/null; then
+  echo "  FAIL in $GEMINI_MD: 'related_entities' used in a pensyve_recall call"
+  FOUND_RELATED=1
+fi
+# Also catch if related_entities appears inside a pensyve_recall( block
+awk '/pensyve_recall\(/{capture=1; buf=""}
+     capture {buf = buf "\n" $0}
+     capture && /\)/{
+       if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
+         print FILENAME ": related_entities found in pensyve_recall block: " buf;
+       capture=0
+     }' "$GEMINI_MD" | while read -r line; do
+  if [ -n "$line" ]; then
+    echo "  FAIL: $line"
+    FOUND_RELATED=1
+  fi
+done
+if [ "$FOUND_RELATED" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 2: no actual use of unsupported 'continuation_of' parameter in call examples.
+echo "Check 2: no unsupported 'continuation_of' on pensyve_episode_start"
+FOUND_CONT=0
+awk '/pensyve_episode_start\(/{capture=1; buf=""}
+     capture {buf = buf "\n" $0}
+     capture && /\)/{
+       if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
+         print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
+       capture=0
+     }' "$GEMINI_MD" | while read -r line; do
+  if [ -n "$line" ]; then
+    echo "  FAIL: $line"
+    FOUND_CONT=1
+  fi
+done
+if [ "$FOUND_CONT" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 3: every pensyve_observe call example in a code block has source_entity and about_entity
+echo "Check 3: every pensyve_observe example has source_entity and about_entity"
+MISSING_FIELDS=0
+awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
+     capture {buf = buf "\n" $0;
+              for(i=1; i<=length($0); i++){
+                c=substr($0,i,1);
+                if(c=="(") depth++;
+                if(c==")") depth--;
+              };
+              if(depth==0 && buf ~ /pensyve_observe\(/){
+                if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
+                if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
+                capture=0;
+              }}' "$GEMINI_MD" | while read -r line; do
+  if [ -n "$line" ]; then
+    echo "  FAIL: $line"
+    MISSING_FIELDS=1
+  fi
+done
+if [ "$MISSING_FIELDS" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 4: provenance tag format — every proactive/auto-capture tag uses [<origin>/<trigger>/<tier>]
+echo "Check 4: provenance tag format"
+VALID_PROVENANCE_RE='\[(proactive|auto-capture)/(in-flight|stop|pre-compact|curator|user)/(tier-1|tier-2|residual/tier-1|residual/tier-2|open-question)\]'
+if rg -n '\[(proactive|auto-capture)' "$GEMINI_MD" | rg -v "$VALID_PROVENANCE_RE"; then
+  echo "  FAIL: some provenance tags do not match [<origin>/<trigger>/<tier>] format"
+  EXIT_CODE=1
+else
+  echo "  PASS"
+fi
+echo ""
+
+# Check 5: procedural memory convention — [procedural] prefix is used in observe content
+echo "Check 5: procedural convention uses [procedural] prefix in pensyve_observe content"
+if ! rg -q '\[procedural\]' "$GEMINI_MD"; then
+  echo "  WARN: no [procedural] prefix usage found in GEMINI.md. Expected for procedural memory captures."
+else
+  echo "  PASS"
+fi
+echo ""
+
+if [ "$EXIT_CODE" = "0" ]; then
+  echo "All MCP contract checks PASSED."
+else
+  echo "MCP contract checks FAILED. Fix the issues above before committing."
+fi
+
+exit "$EXIT_CODE"

--- a/integrations/gemini-extension/scripts/lint-mcp-refs.sh
+++ b/integrations/gemini-extension/scripts/lint-mcp-refs.sh
@@ -31,18 +31,18 @@ if rg -n 'related_entities' "$GEMINI_MD" | rg -v '(\*\*no\*\*|no `related_entiti
   FOUND_RELATED=1
 fi
 # Also catch if related_entities appears inside a pensyve_recall( block
-awk '/pensyve_recall\(/{capture=1; buf=""}
-     capture {buf = buf "\n" $0}
-     capture && /\)/{
-       if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
-         print FILENAME ": related_entities found in pensyve_recall block: " buf;
-       capture=0
-     }' "$GEMINI_MD" | while read -r line; do
+while read -r line; do
   if [ -n "$line" ]; then
     echo "  FAIL: $line"
     FOUND_RELATED=1
   fi
-done
+done < <(awk '/pensyve_recall\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+       if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
+       print FILENAME ": related_entities found in pensyve_recall block: " buf;
+       capture=0
+       }' "$GEMINI_MD")
 if [ "$FOUND_RELATED" = "0" ]; then
   echo "  PASS"
 else
@@ -53,18 +53,18 @@ echo ""
 # Check 2: no actual use of unsupported 'continuation_of' parameter in call examples.
 echo "Check 2: no unsupported 'continuation_of' on pensyve_episode_start"
 FOUND_CONT=0
-awk '/pensyve_episode_start\(/{capture=1; buf=""}
-     capture {buf = buf "\n" $0}
-     capture && /\)/{
-       if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
-         print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
-       capture=0
-     }' "$GEMINI_MD" | while read -r line; do
+while read -r line; do
   if [ -n "$line" ]; then
     echo "  FAIL: $line"
     FOUND_CONT=1
   fi
-done
+done < <(awk '/pensyve_episode_start\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+       if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
+       print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
+       capture=0
+       }' "$GEMINI_MD")
 if [ "$FOUND_CONT" = "0" ]; then
   echo "  PASS"
 else
@@ -75,23 +75,23 @@ echo ""
 # Check 3: every pensyve_observe call example in a code block has source_entity and about_entity
 echo "Check 3: every pensyve_observe example has source_entity and about_entity"
 MISSING_FIELDS=0
-awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
-     capture {buf = buf "\n" $0;
-              for(i=1; i<=length($0); i++){
-                c=substr($0,i,1);
-                if(c=="(") depth++;
-                if(c==")") depth--;
-              };
-              if(depth==0 && buf ~ /pensyve_observe\(/){
-                if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
-                if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
-                capture=0;
-              }}' "$GEMINI_MD" | while read -r line; do
+while read -r line; do
   if [ -n "$line" ]; then
     echo "  FAIL: $line"
     MISSING_FIELDS=1
   fi
-done
+done < <(awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
+       capture {buf = buf "\n" $0;
+       for(i=1; i<=length($0); i++){
+       c=substr($0,i,1);
+       if(c=="(") depth++;
+       if(c==")") depth--;
+       };
+       if(depth==0 && buf ~ /pensyve_observe\(/){
+       if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
+       if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
+       capture=0;
+       }}' "$GEMINI_MD")
 if [ "$MISSING_FIELDS" = "0" ]; then
   echo "  PASS"
 else

--- a/integrations/google-adk/CHANGELOG.md
+++ b/integrations/google-adk/CHANGELOG.md
@@ -1,0 +1,43 @@
+# Changelog — Pensyve Google ADK Integration
+
+All notable changes to the Pensyve Google Agent Development Kit integration are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). This integration versions independently of the core Pensyve engine.
+
+## [1.0.0] - 2026-04-20
+
+### Added
+
+- **Working-memory substrate** for Google ADK agents via `SUBSTRATE_PROMPT.md`. All eight substrate rules consolidated into a single system-prompt document:
+  - **Memory Reflex Rule** — non-optional reasoning discipline with three-type memory classification, canonical `pensyve_observe` call template, provenance vocabulary, lazy-open episode lifecycle
+  - **Entity Detection** — canonicalization and fallback rules for recall scoping
+  - **When Debugging** — debug flow with memory baked in
+  - **When Designing** — design flow with memory baked in
+  - **When Refactoring** — refactor flow with memory baked in
+  - **Longitudinal Work** — multi-session research/eval flow with per-run capture
+  - **Session Wrap-Up** — manual wrap-up with candidate confirmation before storage
+  - **Context Loading** — best-effort continuity primer via episodic recall
+- **Framework wiring example** at `examples/pensyve_agent.py` showing Google ADK `LlmAgent` with `MCPToolset` using `StreamableHTTPConnectionParams` and substrate as `instruction`
+- **Static MCP contract lint script** at `scripts/lint-mcp-refs.sh` verifying `SUBSTRATE_PROMPT.md` and the example file against the `pensyve-mcp-tools` schema
+
+### Design
+
+- Single reasoning layer; no platform-layer code.
+- `source_entity: "google-adk"` on all `pensyve_observe` calls.
+- MCP connection via ADK's native `MCPToolset` with `StreamableHTTPConnectionParams`; session management via ADK's `Runner` and `InMemorySessionService`.
+- Substrate injected via `LlmAgent(instruction=substrate)`.
+- Lazy-open episode lifecycle.
+- MCP contract verified: no `related_entities` on recall, no `continuation_of` on episode_start, required `source_entity` and `about_entity` on every observe.
+- Opt-out: remove substrate from `LlmAgent(instruction=...)`.
+
+### Not Included
+
+- No installer script — manual load of `SUBSTRATE_PROMPT.md`
+- No server-side changes — uses the existing MCP tool surface
+
+### Relation to Other Pensyve Integrations
+
+- Part of the batch-4 working-memory substrate rollout (LangChain, LangChain TS, AutoGen, CrewAI, Pydantic AI, Google ADK).
+- The Cursor adapter (v1.0.0) and Claude Code plugin (v1.3.0) are the reference implementations.
+- Spec: `pensyve-docs/specs/2026-04-20-pensyve-cursor-adapter-design.md`
+- Playbook: `pensyve-docs/specs/2026-04-18-pensyve-working-memory-substrate-design.md`

--- a/integrations/google-adk/README.md
+++ b/integrations/google-adk/README.md
@@ -1,118 +1,125 @@
 # Pensyve for Google Agent Development Kit
 
-Persistent AI memory for [Google Agent Development Kit (ADK)](https://google.github.io/adk-docs/) agents via MCP. Gives your ADK agents cross-session memory so they remember user preferences, past interactions, and learned context across runs.
+Persistent AI memory for [Google Agent Development Kit (ADK)](https://google.github.io/adk-docs/) agents via Pensyve MCP. Gives your ADK agents cross-session memory so they remember user preferences, past interactions, and learned context across runs.
 
-> **Status:** Scaffold — MCP configuration and documentation. Full integration planned.
+---
 
-## Authentication
+## What It Does
 
-1. Sign up at [pensyve.com](https://pensyve.com)
-2. Create an API key at [Settings → API Keys](https://pensyve.com/settings/api-keys)
-3. Set the environment variable:
-   ```bash
-   export PENSYVE_API_KEY="psy_your_key_here"
-   ```
+The working-memory substrate is a reasoning layer — not a library — that you load into your ADK agent's `instruction`. Once loaded, the agent will:
 
-## Setup
+- **Recall before substantive answers** using `pensyve_recall`, scoped by entity.
+- **Capture lessons in-flight** using `pensyve_observe` when a root cause is confirmed, a decision lands, or an approach is abandoned.
+- **Manage episode lifecycle** lazily: open an episode on the first observe, reuse it throughout the conversation.
+- **Surface memory lightly** — one line per recall or capture, never narrating empty recalls.
+- **Wrap up sessions** by presenting memory candidates for user confirmation before storage.
 
-Set your API key (get one at [pensyve.com/settings/api-keys](https://pensyve.com/settings/api-keys)):
+---
+
+## Install
 
 ```bash
-export PENSYVE_API_KEY="psy_your_key"
+pip install google-adk
 ```
 
-Add to your shell profile (`~/.bashrc`, `~/.zshrc`) to persist across sessions.
+Set your API key:
 
-## Cloud (Recommended)
+```bash
+export PENSYVE_API_KEY="psy_your_key_here"
+export GOOGLE_API_KEY="your-google-ai-studio-key"
+# Or for Vertex AI: configure GOOGLE_APPLICATION_CREDENTIALS
+```
 
-Connect your Google ADK agent to Pensyve via MCP tool integration:
+Create an API key at [pensyve.com/settings/api-keys](https://pensyve.com/settings/api-keys).
+
+---
+
+## Quick Start
+
+```bash
+cd integrations/google-adk
+python examples/pensyve_agent.py
+```
+
+The example creates a Google ADK `LlmAgent` with `MCPToolset` using `StreamableHTTPConnectionParams` and `SUBSTRATE_PROMPT.md` as the `instruction`.
+
+---
+
+## System Prompt
+
+`SUBSTRATE_PROMPT.md` consolidates all eight substrate rules into a single document. ADK's `instruction` field is the per-agent system-level prompt:
 
 ```python
-from google.adk import Agent
-from google.adk.tools.mcp_tool import MCPToolset, SseServerParams
+from pathlib import Path
+from google.adk.agents import LlmAgent
+from google.adk.tools.mcp_tool.mcp_toolset import MCPToolset, StreamableHTTPConnectionParams
 
-pensyve_tools = MCPToolset(
-    connection_params=SseServerParams(
+substrate = Path("SUBSTRATE_PROMPT.md").read_text()
+
+pensyve_toolset = MCPToolset(
+    connection_params=StreamableHTTPConnectionParams(
         url="https://mcp.pensyve.com/mcp",
         headers={"Authorization": f"Bearer {os.environ['PENSYVE_API_KEY']}"},
-    ),
+    )
 )
 
-agent = Agent(
+agent = LlmAgent(
+    name="pensyve_agent",
     model="gemini-2.0-flash",
-    name="my_agent",
-    tools=[pensyve_tools],
+    instruction=substrate,
+    tools=[pensyve_toolset],
 )
 ```
 
-### MCP Server Config
+---
 
-If your setup uses a JSON config file instead:
+## MCP Connection
 
-```json
-{
-  "mcpServers": {
-    "pensyve": {
-      "type": "http",
-      "url": "https://mcp.pensyve.com/mcp",
-      "headers": {
-        "Authorization": "Bearer ${PENSYVE_API_KEY}"
-      }
-    }
-  }
-}
-```
-
-## Local (Offline)
-
-No API key needed — all data stays on your machine.
+ADK's `MCPToolset` with `StreamableHTTPConnectionParams` handles MCP discovery and tool registration automatically. The `Runner` manages session and event lifecycle:
 
 ```python
-from google.adk.tools.mcp_tool import MCPToolset, StdioServerParams
+from google.adk.runners import Runner
+from google.adk.sessions import InMemorySessionService
 
-pensyve_tools = MCPToolset(
-    connection_params=StdioServerParams(
-        command="pensyve-mcp",
-        args=["--stdio"],
-        env={
-            "PENSYVE_PATH": "~/.pensyve/",
-            "PENSYVE_NAMESPACE": "default",
-        },
-    ),
-)
+session_service = InMemorySessionService()
+runner = Runner(agent=agent, app_name="my-app", session_service=session_service)
 ```
 
-Build from source: `cargo build --release -p pensyve-mcp` from the [pensyve repo](https://github.com/major7apps/pensyve).
+---
 
-## Available Tools
+## Memory Behavior Model
 
-| Tool                    | Description                            |
-| ----------------------- | -------------------------------------- |
-| `pensyve_recall`        | Search memories by semantic similarity |
-| `pensyve_remember`      | Store a fact as semantic memory        |
-| `pensyve_observe`       | Record an event during an episode      |
-| `pensyve_episode_start` | Begin tracking an interaction          |
-| `pensyve_episode_end`   | Close an episode                       |
-| `pensyve_forget`        | Delete an entity's memories            |
-| `pensyve_inspect`       | List memories for an entity            |
+| Trigger | Action | MCP call |
+|---|---|---|
+| Before substantive answer | Recall by entity | `pensyve_recall(query, entity, types, limit=5)` |
+| Root cause confirmed | Capture episodic | `pensyve_observe(episode_id, content, source_entity="google-adk", about_entity)` |
+| Decision accepted | Capture semantic | `pensyve_remember(entity, fact, confidence=0.9)` |
+| Reusable workflow found | Capture procedural | `pensyve_observe(... content="[procedural] ...")` |
+| Session ending | Present candidates | User confirms before storage |
 
-See [MCP Tools Reference](https://pensyve.com/docs/api-reference/mcp-tools) for full parameter details.
+---
 
-## Intelligent Memory Capture
+## Memory Types
 
-Pensyve uses a tiered classification system to identify what is worth remembering. When connected to a Google ADK agent, the LLM follows the MCP tool descriptions to decide when and how to call memory tools.
+- **Semantic** — durable facts that remain true across sessions.
+- **Episodic** — what happened in this thread (outcomes, root causes, abandoned approaches).
+- **Procedural** — reusable workflows stored via `pensyve_observe` with a `[procedural]` prefix.
 
-### Tiered Capture System
+---
 
-- **Tier 1** (auto-store, confidence 0.9+): Explicit decisions, corrections, constraints, architecture choices, dependency version pins, security rules. High-signal items that should almost always be captured.
-- **Tier 2** (review, confidence 0.7-0.89): Root causes, failed approaches, performance findings, debugging outcomes, environment quirks. Medium-signal items that benefit from user confirmation.
-- **Discard**: Formatting, typos, boilerplate, ephemeral status messages. Noise that should never be stored.
+## Opt-Out
 
-### Best Practices
+To disable the substrate, remove the substrate content from `LlmAgent(instruction=...)`. The Pensyve MCP toolset can remain registered for direct tool use without the substrate reasoning layer.
 
-- Use `pensyve_observe` to record significant events during an episode (architecture decisions, failed approaches, key findings)
-- Use `pensyve_remember` for durable facts that should persist across sessions (project conventions, environment constraints, resolved issues)
-- Use `pensyve_recall` at the start of a task to load relevant context from prior sessions
-- Wrap multi-step work in `pensyve_episode_start` / `pensyve_episode_end` to capture episodic context
+---
 
-The MCP tool descriptions include guidance on confidence levels so the LLM can classify memories into the appropriate tier automatically.
+## Links
+
+- [Pensyve](https://pensyve.com) — managed memory service
+- [API Keys](https://pensyve.com/settings/api-keys)
+- [MCP Server docs](https://docs.pensyve.com/mcp)
+- [Google ADK docs](https://google.github.io/adk-docs/)
+
+## License
+
+Apache 2.0

--- a/integrations/google-adk/SUBSTRATE_PROMPT.md
+++ b/integrations/google-adk/SUBSTRATE_PROMPT.md
@@ -1,0 +1,397 @@
+# Pensyve Working-Memory Substrate for Google Agent Development Kit
+
+This document configures persistent working-memory for Google ADK agents via the Pensyve MCP server. Load the full text of this file as the agent's system prompt to activate all substrate behaviors. All sections below form the reasoning layer the agent carries through every session.
+
+---
+
+## Memory Reflex Rule
+
+**This discipline is non-optional. Before substantive answers, recall by entity. When a lesson lands, observe immediately with a one-line surface.**
+
+### "Substantive answer" means
+
+- Design or architecture recommendations
+- Debugging diagnoses with root-cause claims
+- Refactor proposals
+- Any response that makes a claim the user would want grounded in prior work
+
+Not substantive: formatting fixes, trivial lookups, reading a file, running a command.
+
+### "Lesson lands" means
+
+- A root cause has been confirmed (not hypothesized).
+- A design choice has been made explicit ("we'll use X because Y").
+- An approach has been tried and abandoned with a reason.
+- A workflow has been discovered that is reusable.
+- A workaround for a framework/library limitation has been validated.
+
+### Memory classification
+
+- **Semantic** — a fact that will still be true next month. Use `pensyve_remember(entity, fact, confidence?)` (confidence defaults to 1.0; use 0.9 for high-confidence auto-captures).
+- **Episodic** — something that happened in this thread of work. Use `pensyve_observe` with the current `episode_id`.
+- **Procedural** — a reusable way to do something. Use `pensyve_observe` with `content` beginning `[procedural]`.
+
+When in doubt, prefer episodic.
+
+### Canonical `pensyve_observe` call template
+
+ALL observe calls MUST include every required field:
+
+```
+pensyve_observe(
+  episode_id: <current session's working episode_id>,
+  content: "[proactive/in-flight/tier-1] <observation text>",
+  source_entity: "google-adk",
+  about_entity: "<relevant entity, lowercase-hyphenated>",
+  content_type: "text"
+)
+```
+
+Use `content_type: "code"` for code-related outcomes.
+
+### Episode lifecycle (lazy-open)
+
+Library agents have no session-start/session-end hooks, so you own the episode lifecycle:
+
+- Before your first `pensyve_observe` call in this conversation, check whether a working `episode_id` is tracked. If none exists, call `pensyve_episode_start(participants: ["google-adk", "<project entity>"])` first.
+- Reuse the same `episode_id` for all subsequent observations in the same conversation.
+- Do not explicitly close the episode under normal operation. Server-side consolidation handles aging.
+- Recovery: if `pensyve_observe` fails with a missing-episode error, call `pensyve_episode_start` and retry.
+
+### Surface style
+
+Lightly visible. One line when memory is used:
+
+- Recall: `Recalled 4 related memories (v7r, haiku-classifier).`
+- Capture: `↳ captured: hybrid-router threshold was the phase-3 regression root cause.`
+
+Do not narrate empty recalls or duplicate-skips.
+
+### Provenance tag vocabulary
+
+- `[proactive/in-flight/tier-1]` — memory reflex captured during reasoning
+- `[proactive/in-flight/open-question]` — unresolved question noted in-flight
+- `[auto-capture/user/residual/tier-1]` — explicit user-driven capture
+
+### Composition
+
+When a capture is both procedural AND in-flight: `[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=...`
+
+### MCP contract
+
+Rules never pass unsupported parameters:
+
+- `pensyve_recall(query, entity?, types?, limit?, min_confidence?)` — **no** `related_entities`
+- `pensyve_episode_start(participants)` — **no** `continuation_of`
+- `pensyve_observe(episode_id, content, source_entity, about_entity, content_type?)` — `source_entity` and `about_entity` are **required**
+
+---
+
+## Entity Detection
+
+Shared rules for detecting entity names from tool inputs, prompts, and conversation context. Used to scope recalls and `about_entity` fields on observations.
+
+### Inputs
+
+Extract candidate entity names from:
+
+1. **User prompts** — explicit references to components, files, services, research phases.
+2. **Code context** — module names, class names, function names referenced in the conversation.
+3. **File references** — any filenames or paths mentioned in the conversation.
+4. **Git context** — repository root name, branch name (when discoverable).
+
+### Canonicalization
+
+- Lowercase all characters.
+- Replace spaces and underscores with hyphens.
+- Strip file extensions unless the file is the entity itself.
+- Collapse paths to the most semantically meaningful segment.
+
+### Fallback behavior
+
+- If no specific entity is detected, fall back to the project-level entity (repository root name, lowercase-hyphenated).
+- If a candidate entity is ambiguous, prefer the one that already has memories in Pensyve (call `pensyve_inspect` with limit 1 to check).
+- **Never fabricate entity names.** If nothing confident emerges, use the project entity.
+
+### Output
+
+A set of 1–3 candidate entity names per turn. The primary entity is the most specific. Since `pensyve_recall` accepts only a single `entity` parameter, fold secondary entities into the `query` string.
+
+---
+
+## When Debugging
+
+Debugging flow with memory baked in as a non-optional reflex.
+
+### Step 1: Detect entities
+
+Identify the relevant entity/entities (failing test, failing module, error source) per Entity Detection above.
+
+### Step 2: Consult memory (required)
+
+Call `pensyve_recall`:
+
+- `query`: a short description of the failure, including secondary entity names where known
+- `entity`: primary detected entity
+- `types`: `["procedural", "episodic"]`
+- `limit`: 5
+
+Surface one line: `Recalled N memories from prior debug sessions on <entity>.` (Skip if N=0.)
+
+If a highly similar incident is found (score >0.8), call it out inline.
+
+### Step 3: Diagnose
+
+Proceed with diagnostic work. Use recalled procedural memories as a starting sequence.
+
+### Step 4: Capture lesson (when it lands)
+
+When a root cause is **confirmed**, ensure a working `episode_id` exists, then:
+
+- **Episodic root cause:** `pensyve_observe` with `content: "[proactive/in-flight/tier-1] <one-sentence root cause>"`, `source_entity: "google-adk"`, `about_entity: <primary_entity>`.
+- **Procedural diagnostic sequence:** `pensyve_observe` with `content: "[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=..."`.
+- **Semantic durable truth:** `pensyve_remember(entity, fact: "[proactive/in-flight/tier-1] <fact>", confidence: 0.9)`.
+
+Surface one line: `↳ captured: <one-sentence>`.
+
+### Step 5: Capture abandoned approaches
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[proactive/in-flight/tier-1] tried <approach>, abandoned because <reason>",
+  source_entity: "google-adk",
+  about_entity: <primary_entity>,
+  content_type: "text"
+)
+```
+
+---
+
+## When Designing
+
+Design flow with memory baked in as a non-optional reflex.
+
+### Step 1: Detect entities
+
+Identify the relevant entity/entities (service, module, subsystem under design) per Entity Detection above.
+
+### Step 2: Consult memory (required)
+
+Call `pensyve_recall`:
+
+- `query`: a short description of the design question, including secondary entity names
+- `entity`: primary detected entity
+- `types`: `["semantic", "episodic"]`
+- `limit`: 5
+
+Surface one line: `Recalled N prior decisions on <entity>.` (Skip if N=0.)
+
+### Step 3: Recommend with grounding
+
+Shape your recommendation using recalled decisions. If the current question contradicts a prior decision, flag it.
+
+### Step 4: Capture decision (when it lands)
+
+When the user accepts a design or states a decision:
+
+- **Semantic:** `pensyve_remember(entity: <primary_entity>, fact: "[proactive/in-flight/tier-1] <decision text>", confidence: 0.9)`.
+- **Episodic context:** `pensyve_observe` with `content: "[proactive/in-flight/tier-1] Decision on <entity>: chose X over Y because Z"`, `source_entity: "google-adk"`, `about_entity: <primary_entity>`.
+
+Surface one line: `↳ captured decision on <entity>: <short>`.
+
+### Step 5: Capture evaluation procedures
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[procedural] [proactive/in-flight/tier-1] trigger=design-question-on-<area>, action=<steps>, outcome=<what-you-learn>",
+  source_entity: "google-adk",
+  about_entity: <primary_entity>,
+  content_type: "text"
+)
+```
+
+---
+
+## When Refactoring
+
+Refactor flow with memory baked in.
+
+### Step 1: Detect entities
+
+Identify entities touched by the refactor per Entity Detection above.
+
+### Step 2: Load prior context (required)
+
+Call `pensyve_recall`:
+
+- `query`: short description of the refactor
+- `entity`: primary detected entity
+- `types`: `["semantic", "episodic", "procedural"]`
+- `limit`: 5
+
+Surface: `Recalled N prior memories on <entity>.` Highlight any prior failed approaches.
+
+### Step 3: Present a briefing
+
+Before starting the refactor, summarize what prior memories say about decisions, prior attempts, and known-good procedures.
+
+### Step 4: Capture refactor lessons as they land
+
+When an invariant is discovered, an approach is confirmed not-viable, or a known-good sequence emerges, apply the memory reflex immediately. Ensure working `episode_id` before each observe.
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[proactive/in-flight/tier-1] <lesson>",
+  source_entity: "google-adk",
+  about_entity: <primary_entity>,
+  content_type: "text"
+)
+```
+
+---
+
+## When Doing Longitudinal Work
+
+Multi-session work (research, eval loops, iterative benchmarks) where lessons must accumulate across runs.
+
+### Step 1: Resume context at conversation start
+
+Call `pensyve_recall` once at the start:
+
+- `query`: short description of the current research area
+- `entity`: project + sub-topic entity
+- `limit`: 5
+
+No `types` filter — longitudinal work benefits from all three memory types.
+
+Surface: `Recalled N prior findings on <sub-topic>.`
+
+### Step 2: Proactively recall per topic shift
+
+When the session pivots to a new sub-topic, call `pensyve_recall` again scoped to the new sub-topic.
+
+### Step 3: Capture three types of memory per run
+
+| What you learned | Type | MCP call |
+|---|---|---|
+| Per-run outcome | episodic | `pensyve_observe(..., content: "[proactive/in-flight/tier-1] Run N+1: <result>", source_entity: "google-adk", about_entity: <entity>)` |
+| Stable truth | semantic | `pensyve_remember(entity, fact: "[proactive/in-flight/tier-1] <stable fact>", confidence: 0.9)` |
+| Reusable procedure | procedural | `pensyve_observe(..., content: "[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=...", source_entity: "google-adk", about_entity: <entity>)` |
+
+### Step 4: Capture open questions
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[proactive/in-flight/open-question] <question>",
+  source_entity: "google-adk",
+  about_entity: <entity>,
+  content_type: "text"
+)
+```
+
+### Step 5: End-of-session summary
+
+Before the conversation wraps, briefly summarize what this run taught vs. prior runs, and what's still open.
+
+---
+
+## Session Wrap-Up
+
+Manual wrap-up: when the user indicates the conversation is ending, review what happened and capture anything the in-flight reflex missed.
+
+### Step 1: Review the conversation
+
+Scan for three categories not already captured in-flight:
+
+**Decisions** (confidence: 0.9): Architecture choices, technology selections, tradeoff resolutions.
+
+**Outcomes** (confidence: 0.8): Bug fixes, successful/failed approaches, performance findings.
+
+**Patterns** (confidence: 0.7): Recurring issues, workflow discoveries, cross-cutting observations.
+
+### Step 2: Filter for significance and deduplicate
+
+For each candidate, call `pensyve_recall` with `query: <candidate fact text>`, `entity: <entity>`, `limit: 3`. If any returned memory has score ≥0.85, skip as a likely duplicate.
+
+### Step 3: Present candidates for confirmation
+
+> **Session Memory Candidates**
+>
+> **Decisions** (confidence: 0.9):
+> 1. `<entity>`: <decision text>
+>
+> **Outcomes** (confidence: 0.8):
+> 2. `<entity>`: <outcome text>
+>
+> Which should I store? (e.g., "all", "1,2", "none")
+
+### Step 4: Store confirmed items
+
+- **Semantic** — `pensyve_remember(entity, fact: "[auto-capture/user/residual/tier-1] <text>", confidence)`.
+- **Episodic** — `pensyve_observe(episode_id, content: "[auto-capture/user/residual/tier-1] <text>", source_entity: "google-adk", about_entity: <entity>)`.
+- **Procedural** — `pensyve_observe(episode_id, content: "[procedural] [auto-capture/user/residual/tier-1] trigger=..., action=..., outcome=...", source_entity: "google-adk", about_entity: <entity>)`.
+
+### Step 5: Optionally close the episode
+
+If the user clearly marks the work complete: `pensyve_episode_end(episode_id: <working_id>, outcome: "success")`. Valid outcomes: `"success"`, `"failure"`, `"partial"`.
+
+### Constraints
+
+- **Never auto-store.** Every candidate MUST be presented for confirmation before storage.
+- Do not store secrets.
+- If nothing significant surfaced, say so clearly.
+
+---
+
+## Context Loading (Session Start)
+
+When starting a new conversation on a project with prior Pensyve memories, load relevant context to prime the session.
+
+### Step 1: Detect project entity
+
+Use the repository root name (lowercase-hyphenated) as the default project entity. Override with `PENSYVE_NAMESPACE` environment variable if set.
+
+### Step 2: Scoped recall
+
+Call `pensyve_recall`:
+
+- `query`: `"recent decisions issues patterns"` + any key terms from the user's opening message
+- `entity`: detected project entity
+- `types`: `["episodic"]`
+- `limit`: 5
+
+### Step 3: Compute continuity signal
+
+- If ≥70% of top observations reference at least one overlapping entity: **continuation** of recent work.
+- If overlap is below 70% or recall returned empty: **fresh session**.
+
+### Step 4: Surface the primer
+
+**Continuation:**
+
+> **Pensyve:** Continuing prior work on `<entity-set>`. Recent lessons:
+>
+> - <observation 1>
+> - <observation 2>
+>
+> Use `pensyve_recall` to dig deeper.
+
+**Fresh session:**
+
+> **Pensyve:** N memories loaded for `<project>`. Key context:
+>
+> - <top 3 observations>
+
+**No memories found:**
+
+> **Pensyve:** No memories found for `<project>`. Start a session to begin building context.
+
+### Constraints
+
+- Do not fabricate memories. Only display what `pensyve_recall` returns.
+- Maximum 5 memories in the primer.
+- Entity names lowercase-hyphenated.

--- a/integrations/google-adk/examples/pensyve_agent.py
+++ b/integrations/google-adk/examples/pensyve_agent.py
@@ -1,0 +1,104 @@
+"""
+Pensyve + Google Agent Development Kit (ADK) wiring example.
+
+Demonstrates how to:
+  1. Load the Pensyve working-memory substrate as the agent instruction.
+  2. Connect to the Pensyve MCP server via ADK's MCPToolset.
+  3. Build an ADK agent with persistent cross-session memory.
+
+Google ADK MCP support: google-adk v0.4+ supports MCP servers via MCPToolset
+with StreamableHTTPConnectionParams for the streamable-http transport.
+
+Dependencies:
+    pip install google-adk
+
+Environment variables:
+    PENSYVE_API_KEY   — Pensyve API key (get one at pensyve.com/settings/api-keys)
+    GOOGLE_API_KEY    — Google AI Studio API key (or configure Vertex AI credentials)
+"""
+
+import asyncio
+import os
+from pathlib import Path
+
+from google.adk.agents import LlmAgent
+from google.adk.runners import Runner
+from google.adk.sessions import InMemorySessionService
+from google.adk.tools.mcp_tool.mcp_toolset import MCPToolset, StreamableHTTPConnectionParams
+
+# ---------------------------------------------------------------------------
+# 1. Load the substrate — the reasoning layer injected as the agent instruction.
+#    In ADK, `instruction` is the system-level prompt the agent always carries.
+# ---------------------------------------------------------------------------
+SUBSTRATE_PATH = Path(__file__).parent.parent / "SUBSTRATE_PROMPT.md"
+substrate = SUBSTRATE_PATH.read_text(encoding="utf-8")
+
+# ---------------------------------------------------------------------------
+# 2. Configure the Pensyve MCP server connection.
+#    ADK uses MCPToolset with a connection params object.
+# ---------------------------------------------------------------------------
+PENSYVE_API_KEY = os.environ["PENSYVE_API_KEY"]  # raises KeyError if unset
+
+pensyve_toolset = MCPToolset(
+    connection_params=StreamableHTTPConnectionParams(
+        url="https://mcp.pensyve.com/mcp",
+        headers={"Authorization": f"Bearer {PENSYVE_API_KEY}"},
+    )
+)
+
+# ---------------------------------------------------------------------------
+# 3. Create the ADK agent with the substrate as the instruction and the
+#    Pensyve toolset registered. The substrate tells the model HOW to use
+#    Pensyve tools — recall first, observe at landing, manage episodes, etc.
+# ---------------------------------------------------------------------------
+agent = LlmAgent(
+    name="pensyve_agent",
+    model="gemini-2.0-flash",           # swap to anthropic/... if using Vertex
+    instruction=substrate,              # substrate injected here
+    tools=[pensyve_toolset],            # Pensyve MCP toolset registered
+)
+
+
+async def main() -> None:
+    # -----------------------------------------------------------------------
+    # 4. Run the agent via ADK's Runner, which manages session and event loop.
+    # -----------------------------------------------------------------------
+    session_service = InMemorySessionService()
+    session = await session_service.create_session(
+        app_name="pensyve-example",
+        user_id="user-1",
+    )
+
+    runner = Runner(
+        agent=agent,
+        app_name="pensyve-example",
+        session_service=session_service,
+    )
+
+    from google.adk.types import Content, Part
+
+    events = runner.run_async(
+        user_id="user-1",
+        session_id=session.id,
+        new_message=Content(
+            role="user",
+            parts=[
+                Part(
+                    text=(
+                        "I'm starting work on the auth-service module. "
+                        "What do we know about prior decisions there?"
+                    )
+                )
+            ],
+        ),
+    )
+
+    async for event in events:
+        if event.is_final_response() and event.content:
+            for part in event.content.parts:
+                if part.text:
+                    print(part.text)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/integrations/google-adk/scripts/lint-mcp-refs.sh
+++ b/integrations/google-adk/scripts/lint-mcp-refs.sh
@@ -34,18 +34,18 @@ echo ""
 echo "Check 1: no unsupported 'related_entities' on pensyve_recall"
 FOUND_RELATED=0
 for f in "$RULES_FILE" "$EXAMPLE_FILE"; do
-  awk '/pensyve_recall\(/{capture=1; buf=""}
-       capture {buf = buf "\n" $0}
-       capture && /\)/{
-         if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
-           print FILENAME ": related_entities found in pensyve_recall block: " buf;
-         capture=0
-       }' "$f" | while read -r line; do
+  while read -r line; do
     if [ -n "$line" ]; then
       echo "  FAIL: $line"
       FOUND_RELATED=1
     fi
-  done
+  done < <(awk '/pensyve_recall\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+       if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
+       print FILENAME ": related_entities found in pensyve_recall block: " buf;
+       capture=0
+       }' "$f")
 done
 if [ "$FOUND_RELATED" = "0" ]; then
   echo "  PASS"
@@ -58,18 +58,18 @@ echo ""
 echo "Check 2: no unsupported 'continuation_of' on pensyve_episode_start"
 FOUND_CONT=0
 for f in "$RULES_FILE" "$EXAMPLE_FILE"; do
-  awk '/pensyve_episode_start\(/{capture=1; buf=""}
-       capture {buf = buf "\n" $0}
-       capture && /\)/{
-         if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
-           print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
-         capture=0
-       }' "$f" | while read -r line; do
+  while read -r line; do
     if [ -n "$line" ]; then
       echo "  FAIL: $line"
       FOUND_CONT=1
     fi
-  done
+  done < <(awk '/pensyve_episode_start\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+       if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
+       print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
+       capture=0
+       }' "$f")
 done
 if [ "$FOUND_CONT" = "0" ]; then
   echo "  PASS"
@@ -82,23 +82,23 @@ echo ""
 echo "Check 3: every pensyve_observe example has source_entity and about_entity"
 MISSING_FIELDS=0
 for f in "$RULES_FILE" "$EXAMPLE_FILE"; do
-  awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
-       capture {buf = buf "\n" $0;
-                for(i=1; i<=length($0); i++){
-                  c=substr($0,i,1);
-                  if(c=="(") depth++;
-                  if(c==")") depth--;
-                };
-                if(depth==0 && buf ~ /pensyve_observe\(/){
-                  if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
-                  if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
-                  capture=0;
-                }}' "$f" | while read -r line; do
+  while read -r line; do
     if [ -n "$line" ]; then
       echo "  FAIL: $line"
       MISSING_FIELDS=1
     fi
-  done
+  done < <(awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
+       capture {buf = buf "\n" $0;
+       for(i=1; i<=length($0); i++){
+       c=substr($0,i,1);
+       if(c=="(") depth++;
+       if(c==")") depth--;
+       };
+       if(depth==0 && buf ~ /pensyve_observe\(/){
+       if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
+       if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
+       capture=0;
+       }}' "$f")
 done
 if [ "$MISSING_FIELDS" = "0" ]; then
   echo "  PASS"

--- a/integrations/google-adk/scripts/lint-mcp-refs.sh
+++ b/integrations/google-adk/scripts/lint-mcp-refs.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Static MCP contract linter for the Pensyve google-adk adapter.
+#
+# Verifies that every pensyve_* call example in SUBSTRATE_PROMPT.md and the
+# example wiring file conforms to the current MCP tool schema.
+# Catches the category of bug PR #58 surfaced in the Claude Code adapter
+# (unsupported parameters, missing required fields).
+#
+# This integration uses a single consolidated SUBSTRATE_PROMPT.md (same
+# pattern as VS Code Copilot) rather than per-rule files.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INTEG_DIR="$SCRIPT_DIR/.."
+RULES_FILE="$INTEG_DIR/SUBSTRATE_PROMPT.md"
+EXAMPLE_FILE="$INTEG_DIR/examples/pensyve_agent.py"
+
+EXIT_CODE=0
+
+for f in "$RULES_FILE" "$EXAMPLE_FILE"; do
+  if [ ! -f "$f" ]; then
+    echo "ERROR: File not found: $f"
+    exit 1
+  fi
+done
+
+echo "Linting MCP references in:"
+echo "  $RULES_FILE"
+echo "  $EXAMPLE_FILE"
+echo ""
+
+# Check 1: no actual use of unsupported 'related_entities' parameter in call examples.
+echo "Check 1: no unsupported 'related_entities' on pensyve_recall"
+FOUND_RELATED=0
+for f in "$RULES_FILE" "$EXAMPLE_FILE"; do
+  awk '/pensyve_recall\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+         if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
+           print FILENAME ": related_entities found in pensyve_recall block: " buf;
+         capture=0
+       }' "$f" | while read -r line; do
+    if [ -n "$line" ]; then
+      echo "  FAIL: $line"
+      FOUND_RELATED=1
+    fi
+  done
+done
+if [ "$FOUND_RELATED" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 2: no actual use of unsupported 'continuation_of' parameter in call examples.
+echo "Check 2: no unsupported 'continuation_of' on pensyve_episode_start"
+FOUND_CONT=0
+for f in "$RULES_FILE" "$EXAMPLE_FILE"; do
+  awk '/pensyve_episode_start\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+         if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
+           print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
+         capture=0
+       }' "$f" | while read -r line; do
+    if [ -n "$line" ]; then
+      echo "  FAIL: $line"
+      FOUND_CONT=1
+    fi
+  done
+done
+if [ "$FOUND_CONT" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 3: every pensyve_observe call example in a code block has source_entity and about_entity
+echo "Check 3: every pensyve_observe example has source_entity and about_entity"
+MISSING_FIELDS=0
+for f in "$RULES_FILE" "$EXAMPLE_FILE"; do
+  awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
+       capture {buf = buf "\n" $0;
+                for(i=1; i<=length($0); i++){
+                  c=substr($0,i,1);
+                  if(c=="(") depth++;
+                  if(c==")") depth--;
+                };
+                if(depth==0 && buf ~ /pensyve_observe\(/){
+                  if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
+                  if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
+                  capture=0;
+                }}' "$f" | while read -r line; do
+    if [ -n "$line" ]; then
+      echo "  FAIL: $line"
+      MISSING_FIELDS=1
+    fi
+  done
+done
+if [ "$MISSING_FIELDS" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 4: provenance tag format — every proactive/auto-capture tag uses [<origin>/<trigger>/<tier>]
+echo "Check 4: provenance tag format"
+VALID_PROVENANCE_RE='\[(proactive|auto-capture)/(in-flight|stop|pre-compact|curator|user)/(tier-1|tier-2|residual/tier-1|residual/tier-2|open-question)\]'
+INVALID=0
+for f in "$RULES_FILE" "$EXAMPLE_FILE"; do
+  if rg -n '\[(proactive|auto-capture)' "$f" | rg -v "$VALID_PROVENANCE_RE"; then
+    INVALID=1
+  fi
+done
+if [ "$INVALID" = "0" ]; then
+  echo "  PASS"
+else
+  echo "  FAIL: some provenance tags do not match [<origin>/<trigger>/<tier>] format"
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 5: procedural memory convention — [procedural] prefix is used in observe content
+echo "Check 5: procedural convention uses [procedural] prefix in pensyve_observe content"
+if ! rg -q '\[procedural\]' "$RULES_FILE"; then
+  echo "  WARN: no [procedural] prefix usage found in SUBSTRATE_PROMPT.md."
+else
+  echo "  PASS"
+fi
+echo ""
+
+if [ "$EXIT_CODE" = "0" ]; then
+  echo "All MCP contract checks PASSED."
+else
+  echo "MCP contract checks FAILED. Fix the issues above before committing."
+fi
+
+exit "$EXIT_CODE"

--- a/integrations/hermes/AGENTS.md
+++ b/integrations/hermes/AGENTS.md
@@ -1,0 +1,372 @@
+# Pensyve Working-Memory Substrate for Hermes
+
+This file configures persistent working-memory for the Hermes CLI agent via the Pensyve MCP server. All sections below are always in context — they form the substrate the agent operates on across every coding session.
+
+---
+
+## Memory Reflex Rule
+
+**This discipline is non-optional. Before substantive answers, recall by entity. When a lesson lands, observe immediately with a one-line surface.**
+
+### "Substantive answer" means
+
+- Design or architecture recommendations
+- Debugging diagnoses with root-cause claims
+- Refactor proposals
+- Any response that makes a claim the user would want grounded in prior work
+
+Not substantive: formatting fixes, trivial lookups, reading a file, running a command.
+
+### "Lesson lands" means
+
+- A root cause has been confirmed (not hypothesized).
+- A design choice has been made explicit ("we'll use X because Y").
+- An approach has been tried and abandoned with a reason.
+- A workflow has been discovered that is reusable.
+- A workaround for a framework/library limitation has been validated.
+
+### Memory classification
+
+- **Semantic** — a fact that will still be true next month. Use `pensyve_remember(entity, fact, confidence?)` (confidence defaults to 1.0; use 0.9 for high-confidence auto-captures).
+- **Episodic** — something that happened in this thread of work. Use `pensyve_observe` with the current `episode_id`.
+- **Procedural** — a reusable way to do something. Use `pensyve_observe` with `content` beginning `[procedural]`.
+
+When in doubt, prefer episodic.
+
+### Canonical `pensyve_observe` call template
+
+ALL observe calls MUST include every required field:
+
+```
+pensyve_observe(
+  episode_id: <current session's working episode_id>,
+  content: "[proactive/in-flight/tier-1] <observation text>",
+  source_entity: "hermes",
+  about_entity: "<relevant entity, lowercase-hyphenated>",
+  content_type: "text"
+)
+```
+
+Use `content_type: "code"` for code-related outcomes.
+
+### Episode lifecycle (lazy-open)
+
+Hermes's plugin layer handles session start/end at the Python level, but in the reasoning layer you own the episode lifecycle:
+
+- Before your first `pensyve_observe` call in this conversation, check whether a working `episode_id` is tracked. If none exists, call `pensyve_episode_start(participants: ["hermes", "<project entity>"])` first.
+- Reuse the same `episode_id` for all subsequent observations in the same conversation.
+- Do not explicitly close the episode under normal operation. Server-side consolidation handles aging.
+- Recovery: if `pensyve_observe` fails with a missing-episode error, call `pensyve_episode_start` and retry.
+
+### Surface style
+
+Lightly visible. One line when memory is used:
+
+- Recall: `Recalled 4 related memories (v7r, haiku-classifier).`
+- Capture: `↳ captured: hybrid-router threshold was the phase-3 regression root cause.`
+
+Do not narrate empty recalls or duplicate-skips.
+
+### Provenance tag vocabulary
+
+- `[proactive/in-flight/tier-1]` — memory reflex captured during reasoning
+- `[proactive/in-flight/open-question]` — unresolved question noted in-flight
+- `[auto-capture/user/residual/tier-1]` — explicit user-driven capture
+
+### Composition
+
+When a capture is both procedural AND in-flight: `[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=...`
+
+### MCP contract
+
+Rules never pass unsupported parameters:
+
+- `pensyve_recall(query, entity?, types?, limit?, min_confidence?)` — **no** `related_entities`
+- `pensyve_episode_start(participants)` — **no** `continuation_of`
+- `pensyve_observe(episode_id, content, source_entity, about_entity, content_type?)` — `source_entity` and `about_entity` are **required**
+
+---
+
+## Entity Detection
+
+Shared rules for detecting entity names from tool inputs, prompts, and conversation context. Used to scope recalls and `about_entity` fields on observations.
+
+### Inputs
+
+Extract candidate entity names from:
+
+1. **File references** — `@filename`, `@path/to/file`, or files mentioned directly in the conversation.
+2. **User prompts** — explicit references to components, files, services, research phases.
+3. **Code context** — module names, class names, function names in files being edited or read.
+4. **Git context** — repository root name, branch name (when discoverable).
+
+### Canonicalization
+
+- Lowercase all characters.
+- Replace spaces and underscores with hyphens.
+- Strip file extensions unless the file is the entity itself (e.g., `package.json`).
+- Collapse paths to the most semantically meaningful segment (e.g., `src/engine/hybrid_router.rs` → `hybrid-router`).
+
+### Fallback
+
+- If no specific entity is detected, fall back to the project-level entity (repository root name, lowercase-hyphenated).
+- If ambiguous, prefer the entity that already has memories in Pensyve (call `pensyve_inspect` with limit 1 to check).
+- **Never fabricate entity names.**
+
+### Output
+
+1–3 candidate entity names per turn. Primary entity is most specific; fold secondary entities into the `query` string when calling `pensyve_recall`.
+
+---
+
+## When Debugging
+
+Use when diagnosing bugs, errors, failing tests, or crashes.
+
+### Step 1: Detect entities
+
+Identify the relevant entity/entities (failing test, failing module, error source) per the entity detection section above.
+
+### Step 2: Consult memory (required)
+
+Call `pensyve_recall`:
+
+- `query`: short description of the failure, including secondary entity names
+- `entity`: primary detected entity
+- `types`: `["procedural", "episodic"]`
+- `limit`: 5
+
+Surface: `Recalled N memories from prior debug sessions on <entity>.`
+
+If a highly similar incident is found (score >0.8): `This looks similar to an incident captured on <date>: <summary>. Consider that path first.`
+
+### Step 3: Diagnose
+
+Proceed with diagnostic work, using recalled procedural memories as a starting sequence.
+
+### Step 4: Capture lesson (when it lands)
+
+When a root cause is **confirmed** (not just hypothesized):
+
+- **Episodic root cause:** `pensyve_observe` with `content: "[proactive/in-flight/tier-1] <one-sentence root cause>"`, `source_entity: "hermes"`, `about_entity: <primary_entity>`, `content_type: "text"`.
+- **Procedural sequence:** `pensyve_observe` with `content: "[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=..."`, `source_entity: "hermes"`, `about_entity: <primary_entity>`, `content_type: "text"`.
+- **Semantic truth:** `pensyve_remember(entity, fact: "[proactive/in-flight/tier-1] <fact>", confidence: 0.9)`.
+
+### Step 5: Capture abandoned approaches
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[proactive/in-flight/tier-1] tried <approach>, abandoned because <reason>",
+  source_entity: "hermes",
+  about_entity: <primary_entity>,
+  content_type: "text"
+)
+```
+
+---
+
+## When Designing
+
+Use when making architecture, API, or design decisions.
+
+### Step 1: Detect entities
+
+Identify the relevant entity/entities (service, module, subsystem under design).
+
+### Step 2: Consult memory (required)
+
+Call `pensyve_recall`:
+
+- `query`: short description of the design question
+- `entity`: primary detected entity
+- `types`: `["semantic", "episodic"]`
+- `limit`: 5
+
+Surface: `Recalled N prior decisions on <entity>.`
+
+If the current question contradicts a prior decision, flag it: `Prior decision on <entity> (confidence 0.9): [decision]. Are we revisiting this?`
+
+### Step 3: Recommend with grounding
+
+Shape recommendations using recalled decisions.
+
+### Step 4: Capture decision (when it lands)
+
+When the user accepts a design or states a decision:
+
+- **Semantic:** `pensyve_remember(entity: <primary_entity>, fact: "[proactive/in-flight/tier-1] <decision text>", confidence: 0.9)`.
+- **Episodic context:** `pensyve_observe` with `content: "[proactive/in-flight/tier-1] Decision on <entity>: chose X over Y because Z"`, `source_entity: "hermes"`, `about_entity: <primary_entity>`, `content_type: "text"`.
+
+### Step 5: Capture evaluation procedures
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[procedural] [proactive/in-flight/tier-1] trigger=design-question-on-<area>, action=<steps>, outcome=<what-you-learn>",
+  source_entity: "hermes",
+  about_entity: <primary_entity>,
+  content_type: "text"
+)
+```
+
+---
+
+## When Refactoring
+
+Use before substantive refactors.
+
+### Step 1: Detect entities
+
+Identify entities touched by the refactor (file or module being restructured, callers, subsystem name).
+
+### Step 2: Load prior context (required)
+
+Call `pensyve_recall`:
+
+- `query`: short description of the refactor
+- `entity`: primary detected entity
+- `types`: `["semantic", "episodic", "procedural"]`
+- `limit`: 5
+
+Highlight any prior failed approaches: `Prior episodic memory: tried <approach>, abandoned because <reason>. Double-check this isn't the same trap.`
+
+### Step 3: Present a briefing
+
+Summarize what prior memories say about: decisions, prior attempts, known-good procedures.
+
+### Step 4: Capture refactor lessons as they land
+
+Apply the memory reflex immediately when:
+
+- **Invariant discovered** (semantic): `pensyve_remember(entity, fact, confidence: 0.9)`
+- **Abandoned approach confirmed** (episodic): `pensyve_observe` with `[proactive/in-flight/tier-1]`
+- **Dependency chain surprise** (episodic): `pensyve_observe`
+- **Known-good sequence emerged** (procedural): `pensyve_observe` with `[procedural]` prefix
+
+---
+
+## Longitudinal Work (Research/Evals)
+
+Use for long-running multi-session work in `research/`, `benchmarks/`, or `evals/` directories.
+
+### Step 1: Resume context at conversation start
+
+Call `pensyve_recall`:
+
+- `query`: short description of the current research area
+- `entity`: project + sub-topic entity
+- `limit`: 5
+
+No `types` filter — longitudinal work benefits from all three memory types.
+
+### Step 2: Proactively recall per topic shift
+
+When the session pivots to a new sub-topic, call `pensyve_recall` again scoped to it.
+
+### Step 3: Capture per run
+
+| What you learned | Type | Call |
+|---|---|---|
+| Per-run outcome | episodic | `pensyve_observe(..., content: "[proactive/in-flight/tier-1] Run N+1: ...", source_entity: "hermes", about_entity: <entity>, content_type: "text")` |
+| Stable truth | semantic | `pensyve_remember(entity, fact: "[proactive/in-flight/tier-1] ...", confidence: 0.9)` |
+| Reusable procedure | procedural | `pensyve_observe(..., content: "[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=...", source_entity: "hermes", about_entity: <entity>, content_type: "text")` |
+
+### Step 4: Capture open questions
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[proactive/in-flight/open-question] <question>",
+  source_entity: "hermes",
+  about_entity: <entity>,
+  content_type: "text"
+)
+```
+
+### Step 5: End-of-session summary
+
+Before wrapping: summarize what this run taught vs. prior runs, and what's still open.
+
+---
+
+## Session Memory (Wrap-Up)
+
+Use at conversation wrap-up or when the user indicates end-of-session.
+
+### Step 1: Review the conversation
+
+Scan for three categories the in-flight reflex did NOT already capture:
+
+**Decisions** (confidence: 0.9): architecture choices, technology selections, API decisions, tradeoff resolutions.
+
+**Outcomes** (confidence: 0.8): bug fixes and root causes, successful approaches, failed approaches with reasons, performance findings.
+
+**Patterns** (confidence: 0.7): recurring issues, workflow discoveries, cross-cutting observations.
+
+### Step 2: Filter and deduplicate
+
+For each candidate, call `pensyve_recall` with `query: <candidate fact text>`, `entity: <entity>`, `limit: 3`. If score ≥0.85, skip as likely duplicate.
+
+### Step 3: Present candidates for confirmation
+
+> **Session Memory Candidates**
+>
+> **Decisions** (confidence: 0.9):
+> 1. `<entity>`: <decision text>
+>
+> **Outcomes** (confidence: 0.8):
+> 2. `<entity>`: <outcome text>
+>
+> **Patterns** (confidence: 0.7):
+> 3. `<entity>`: <pattern text>
+>
+> Which should I store? (e.g., "all", "1,3", "none")
+
+### Step 4: Store confirmed items
+
+- **Semantic:** `pensyve_remember(entity, fact: "[auto-capture/user/residual/tier-1] <text>", confidence)`.
+- **Episodic:** `pensyve_observe(episode_id, content: "[auto-capture/user/residual/tier-1] <text>", source_entity: "hermes", about_entity: <entity>, content_type: "text")`.
+- **Procedural:** `pensyve_observe(episode_id, content: "[procedural] [auto-capture/user/residual/tier-1] trigger=..., action=..., outcome=...", source_entity: "hermes", about_entity: <entity>, content_type: "text")`.
+
+### Step 5: Optionally close the episode
+
+If the user marks work complete: `pensyve_episode_end(episode_id: <working_id>, outcome: "success")`. Valid outcomes: `"success"`, `"failure"`, `"partial"`.
+
+**Never auto-store.** Every candidate MUST be confirmed before storage.
+
+---
+
+## Context Loader (Session Start)
+
+Use when starting a new substantive conversation or switching contexts.
+
+### Step 1: Detect project entity
+
+Use the repository root name (lowercase-hyphenated) as default. Override with `PENSYVE_NAMESPACE` if set.
+
+### Step 2: Scoped recall
+
+Call `pensyve_recall`:
+
+- `query`: `"recent decisions issues patterns"` + key terms from the user's opening message
+- `entity`: detected project entity
+- `types`: `["episodic"]`
+- `limit`: 5
+
+### Step 3: Compute continuity signal
+
+If ≥70% of the top observations share entities with the current conversation → **continuation**. Otherwise → **fresh session**.
+
+### Step 4: Surface the primer
+
+**Continuation:**
+> **Pensyve:** Continuing prior work on `<entity-set>`. Recent lessons: [top 3 observations]
+
+**Fresh session:**
+> **Pensyve:** N memories loaded for `<project>`. Key context: [top 3 observations]
+
+**No memories:**
+> **Pensyve:** No memories found for `<project>`. Use `/remember` to start building context.
+
+Do not fabricate memories. Only display what `pensyve_recall` returns.

--- a/integrations/hermes/CHANGELOG.md
+++ b/integrations/hermes/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog — Pensyve Hermes Adapter
+
+All notable changes to the Pensyve Hermes adapter are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). The Hermes adapter versions independently of the Claude Code plugin.
+
+## [1.0.0] - 2026-04-20
+
+### Added
+
+- **Working-memory substrate** for Hermes via `AGENTS.md`. All eight substrate rules consolidated into a single file with clear section headings (extends the existing Python memory plugin without removing it):
+  - **Memory Reflex Rule** — non-optional reasoning discipline with three-type memory classification, canonical `pensyve_observe` call template, provenance vocabulary, lazy-open episode lifecycle
+  - **Entity Detection** — canonicalization and fallback rules
+  - **When Debugging** — debug flow with memory baked in
+  - **When Designing** — design flow with memory baked in
+  - **When Refactoring** — refactor flow with memory baked in
+  - **Longitudinal Work (Research/Evals)** — multi-session research/eval flow
+  - **Session Memory (Wrap-Up)** — manual wrap-up equivalent of Claude Code's Stop hook
+  - **Context Loader (Session Start)** — best-effort continuity primer via episodic recall
+- **MCP config example** at `hermes.mcp.json.example` covering Cloud-with-API-key and self-hosted options
+- **Static MCP contract lint script** at `scripts/lint-mcp-refs.sh` verifying the consolidated `AGENTS.md`'s `pensyve_*` call examples match the `pensyve-mcp-tools/src/params.rs` schema
+
+### Design
+
+- Additive: substrate `AGENTS.md` extends the existing Python plugin (`__init__.py`) without removing any functionality. The Python plugin handles session lifecycle; `AGENTS.md` handles the reasoning-layer substrate.
+- **Single-file delivery:** all 8 rules consolidated into `AGENTS.md` with section headings. Hermes uses `AGENTS.md` as its default agent instruction file; no custom config format required.
+- Lazy-open episode lifecycle in the reasoning layer (the Python plugin also tracks episodes at the platform layer — both are compatible).
+- Best-effort continuity primer via `pensyve_recall(types: ["episodic"])` — the MCP server has no episode-listing API.
+- MCP contract verified: no `related_entities` on recall, no `continuation_of` on episode_start, required `source_entity: "hermes"` and `about_entity` on every observe.
+- MCP config follows Hermes's JSON config convention (`hermes.mcp.json.example`; deploy per Hermes docs).
+- Opt-out: delete or edit `AGENTS.md`; Python plugin continues working unchanged.
+
+### Not Included
+
+- No changes to the existing Python plugin (`__init__.py`)
+- No installer script (manual copy of `AGENTS.md` + MCP config)
+- No server-side changes — uses the existing MCP tool surface
+
+### Relation to Other Pensyve Integrations
+
+- The Hermes adapter is part of the batch-2 working-memory substrate rollout. The Claude Code plugin (v1.3.0), Cursor adapter (v1.0.0), and VS Code Copilot adapter (v1.0.0) are the reference implementations.
+- Key difference from Cursor: single `AGENTS.md` vs. Cursor's per-rule `.cursor/rules/*.mdc` files.
+- Hermes is a Python-native CLI agent — the Python plugin (`__init__.py`) already handles session lifecycle; `AGENTS.md` adds the reasoning-layer discipline on top.
+- Playbook: `pensyve-docs/specs/2026-04-18-pensyve-working-memory-substrate-design.md`

--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -1,29 +1,88 @@
 # Hermes Agent — Pensyve Memory Plugin
 
-Pensyve memory provider plugin for [Hermes Agent](https://github.com/hermes-agent/hermes-agent). Gives Hermes persistent cross-session memory with semantic recall, episode tracking, and entity-scoped fact storage via the Pensyve MCP API.
+Persistent working-memory substrate for [Hermes Agent](https://github.com/hermes-agent/hermes-agent) — memory is not a feature you invoke, it is the substrate the agent operates on.
 
-## Features
+Extends the existing Pensyve memory provider plugin with the full working-memory substrate: proactive in-flight capture, entity-scoped recall, procedural memory, episodic threading, and the eight-rule reasoning discipline delivered via `AGENTS.md`.
 
+## What It Does
+
+- **Proactive memory during work** — lessons are captured the moment they land, not at session end
+- **Thread-aware continuity** — sessions that continue prior work resume with relevant context, no re-briefing
+- **Entity-scoped recall** — substantive questions are grounded in prior decisions; simple commands stay fast
+- **Three memory types** — durable facts (semantic), session-specific events (episodic), reusable procedures (procedural)
+- **Lightly visible** — one-line surfaces when memory is used; never interrupts your flow
 - **MemoryProvider interface** — drop-in replacement for Hermes's built-in memory
 - **9 agent tools** — `pensyve_recall`, `pensyve_remember`, `pensyve_inspect`, `pensyve_forget`, `pensyve_episode_start`, `pensyve_episode_end`, `pensyve_observe`, `pensyve_status`, `pensyve_account`
 - **Auto-prefetch** — relevant memories injected before each turn (interactive mode)
-- **Episode tracking** — sessions tracked as episodes with start/end lifecycle
-- **Memory mirroring** — built-in Hermes memory writes automatically synced to Pensyve
 - **Circuit breaker** — 5 failures → 120s cooldown, prevents cascading failures
-- **Cron-safe** — tools available in cron jobs without auto-prefetch overhead
 
-## Installation
+## Install
 
-Copy `__init__.py` to your Hermes plugins directory:
+Two steps: configure the MCP server and install the instructions file, then (optionally) enable the Python plugin.
+
+### 1. Configure the MCP server
+
+**Cloud with API key (recommended):**
+
+```bash
+export PENSYVE_API_KEY="psy_your_key_here"
+```
+
+A ready-to-use MCP config example is at `hermes.mcp.json.example`. The structure:
+
+```json
+{
+  "mcpServers": {
+    "pensyve": {
+      "type": "http",
+      "url": "https://mcp.pensyve.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ${PENSYVE_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+Deploy it per Hermes's MCP config convention (typically `~/.hermes/mcp.json` or `config.yaml` `mcp:` section).
+
+Create your key at [pensyve.com/settings/api-keys](https://pensyve.com/settings/api-keys). Put the `export` in `~/.bashrc` or `~/.zshrc` to persist.
+
+**Local (self-hosted):**
+
+```bash
+export PENSYVE_MCP_URL="http://localhost:8001/mcp"
+export PENSYVE_API_KEY="psy_your_local_key"
+```
+
+### 2. Install the instructions file
+
+Copy `AGENTS.md` to your project root (Hermes loads `AGENTS.md` as its agent instruction file):
+
+```bash
+cp /path/to/pensyve/integrations/hermes/AGENTS.md .
+```
+
+**Note:** All 8 substrate rules are consolidated into a single `AGENTS.md` with clear section headings.
+
+### 3. (Optional) Enable the Python memory plugin
+
+For auto-prefetch, episode tracking, and memory mirroring:
 
 ```bash
 mkdir -p ~/.hermes/hermes-agent/plugins/memory/pensyve
 cp __init__.py ~/.hermes/hermes-agent/plugins/memory/pensyve/
 ```
 
-## Configuration
+Enable in `~/.hermes/config.yaml`:
 
-### 1. Set your API key
+```yaml
+memory:
+  memory_enabled: true
+  provider: pensyve
+```
+
+Set your API key:
 
 ```bash
 export PENSYVE_API_KEY="psy_your_key_here"
@@ -38,76 +97,82 @@ Or create `~/.hermes/pensyve.json`:
 }
 ```
 
-Get an API key at [pensyve.com/settings/api-keys](https://pensyve.com/settings/api-keys).
+Restart Hermes. You'll see `Pensyve MCP session initialized` in logs.
 
-### 2. Enable in config.yaml
+## How It Works
 
-```yaml
-# ~/.hermes/config.yaml
-memory:
-  memory_enabled: true
-  provider: pensyve
-```
+The substrate is delivered through `AGENTS.md`. The Memory Reflex Rule section establishes the discipline: *before substantive answers, recall by entity; when a lesson lands, observe immediately with a one-line surface*. Flow sections (When Debugging, When Designing, When Refactoring, Longitudinal Work) guide the model through consult-memory + capture-lesson steps.
 
-### 3. Restart Hermes
+When the Python plugin is also enabled, `queue_prefetch()` fires a background recall before each turn and injects results; session start/end lifecycle is handled at the plugin layer.
 
-The plugin registers on startup. You'll see `Pensyve MCP session initialized` in logs.
+**Episode lifecycle:** Episodes open lazily on the first `pensyve_observe` call and are not explicitly closed under normal operation. Server-side consolidation handles aging.
+
+**Continuity primer:** The Context Loader section runs a best-effort recall at the start of substantive conversations to surface prior relevant observations.
+
+## Memory Behavior Model
+
+Pensyve behaves as working memory for the agent — always-on, ambient, continuous.
+
+**Writes happen in-flight.** When a root cause is confirmed, a decision is made, or a reusable procedure emerges, it's captured the moment it lands via the memory reflex. No batching to session end.
+
+**Reads happen at decision points.** Before substantive answers, the model consults memory scoped to the detected entities. Simple commands (run tests, format file) skip recall to stay fast.
+
+**Sessions continue.** At the start of a substantive conversation, Pensyve checks whether the current work continues prior memories (shared entities + recent activity). If yes, you resume with a primer — no re-briefing needed.
+
+## Memory Types
+
+| Type | Definition | MCP call | Example |
+|---|---|---|---|
+| **Semantic** | Durable truths, decisions, preferences | `pensyve_remember` | "We chose RS256 over HS256 for JWT signing" |
+| **Episodic** | Temporal events, session-scoped observations | `pensyve_observe` (with lazy-opened `episode_id`) | "Phase-3 regression root cause: hybrid-router threshold" |
+| **Procedural** | Reusable workflows, sequences, recipes | `pensyve_observe` with `[procedural]` content prefix | "To calibrate V7r: freeze Haiku config, run suite, diff baseline" |
+
+## Opt-Out
+
+- **Full opt-out** — delete `AGENTS.md` and disable the plugin in `config.yaml`
+- **Partial opt-out** — delete specific sections from `AGENTS.md` (e.g., remove the "Longitudinal Work" section)
+- **Silent mode** — edit the Memory Reflex Rule section to remove the "one-line surface" guidance; captures stay silent
+- **Recall-only mode** — edit flow sections to drop the `Capture lesson` steps while keeping `Consult memory`
+- **Cron-safe mode** — plugin auto-behaviors (prefetch, mirroring, episodes) are disabled automatically in cron jobs
+
+## Available MCP Tools
+
+| Tool | Description |
+|---|---|
+| `pensyve_recall` | Search memories by semantic similarity |
+| `pensyve_remember` | Store a durable fact (semantic memory) |
+| `pensyve_observe` | Record a session observation (episodic / procedural via `[procedural]` prefix) |
+| `pensyve_episode_start` | Begin tracking an episode |
+| `pensyve_episode_end` | Close an episode with outcome |
+| `pensyve_forget` | Delete an entity's memories |
+| `pensyve_inspect` | List memories for an entity |
+| `pensyve_status` | Get namespace statistics and health |
+| `pensyve_account` | Get account info, usage, and limits |
+
+See [MCP Tools Reference](https://pensyve.com/docs/api-reference/mcp-tools) for full parameter details.
 
 ## Environment Variables
 
 | Variable | Default | Description |
-|----------|---------|-------------|
+|---|---|---|
 | `PENSYVE_API_KEY` | (required) | API key with `psy_` prefix |
 | `PENSYVE_ENTITY` | `hermes-user` | Default entity for memory scoping |
 | `PENSYVE_MCP_URL` | `https://mcp.pensyve.com/mcp` | MCP server URL (for self-hosted) |
 
-## How It Works
+## Design Philosophy
 
-### Interactive Sessions
+- **Memory as substrate** — not a feature the user invokes; always there, continuous, carried across sessions
+- **Reasoning-layer first** — `AGENTS.md` delivers the substrate even without the Python plugin
+- **1:1 with Claude Code** — same skill structure, same conventions, same memory types
+- **MCP contract-respecting** — every rule's call examples verified against `pensyve-mcp-tools/src/params.rs`
+- **Single-file delivery** — all 8 rules consolidated into `AGENTS.md` with clear section headings
 
-1. **Session start** → MCP session initialized, episode started
-2. **Before each turn** → `queue_prefetch()` fires a background recall, results injected via `prefetch()`
-3. **During turns** → Agent can use all 9 Pensyve tools explicitly
-4. **Memory writes** → Built-in Hermes `memory add` commands mirrored to Pensyve
-5. **Session end** → Episode ended, connections closed
+## Links
 
-### Cron Jobs
-
-Tools are available but auto-behaviors (prefetch, mirroring, episodes) are disabled. Cron jobs use `pensyve_remember` explicitly to persist findings.
-
-### Tool Reference
-
-| Tool | Description |
-|------|-------------|
-| `pensyve_recall` | Search memories by semantic similarity and text matching |
-| `pensyve_remember` | Store an explicit fact about an entity |
-| `pensyve_inspect` | List all memories for an entity |
-| `pensyve_forget` | Delete all memories for an entity |
-| `pensyve_episode_start` | Begin tracking an interaction episode |
-| `pensyve_episode_end` | Close an episode and trigger consolidation |
-| `pensyve_observe` | Record an observation within an active episode |
-| `pensyve_status` | Get namespace statistics and health |
-| `pensyve_account` | Get account info, usage, and limits |
-
-## Authentication
-
-### Cloud (default)
-
-Uses `PENSYVE_API_KEY` with Bearer token auth against `mcp.pensyve.com/mcp`.
-
-### Self-hosted
-
-Point to your own Pensyve instance:
-
-```bash
-export PENSYVE_MCP_URL="http://localhost:8001/mcp"
-export PENSYVE_API_KEY="psy_your_local_key"
-```
-
-## Dependencies
-
-- `httpx` — HTTP client (included in most Hermes installations)
-- Hermes Agent with `MemoryProvider` plugin interface
+- **Website:** [pensyve.com](https://pensyve.com)
+- **GitHub:** [github.com/major7apps/pensyve](https://github.com/major7apps/pensyve)
+- **API Keys:** [pensyve.com/settings/api-keys](https://pensyve.com/settings/api-keys)
+- **Spec:** [Working-memory substrate design](https://github.com/major7apps/pensyve-docs/blob/main/specs/2026-04-18-pensyve-working-memory-substrate-design.md)
 
 ## License
 

--- a/integrations/hermes/hermes.mcp.json.example
+++ b/integrations/hermes/hermes.mcp.json.example
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "pensyve": {
+      "type": "http",
+      "url": "https://mcp.pensyve.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ${PENSYVE_API_KEY}"
+      }
+    }
+  }
+}

--- a/integrations/hermes/scripts/lint-mcp-refs.sh
+++ b/integrations/hermes/scripts/lint-mcp-refs.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Static MCP contract linter for the Pensyve Hermes adapter.
+#
+# Verifies that every pensyve_* call example in AGENTS.md
+# conforms to the current MCP tool schema in pensyve-mcp-tools/src/params.rs.
+# Catches the category of bug PR #58 surfaced in the Claude Code adapter
+# (unsupported parameters, missing required fields).
+#
+# Hermes uses a single consolidated AGENTS.md file for working-memory substrate
+# instructions, so this script targets AGENTS.md directly.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RULES_FILE="$SCRIPT_DIR/../AGENTS.md"
+
+EXIT_CODE=0
+
+if [ ! -f "$RULES_FILE" ]; then
+  echo "ERROR: AGENTS.md not found: $RULES_FILE"
+  exit 1
+fi
+
+echo "Linting MCP references in $RULES_FILE..."
+echo ""
+
+# Check 1: no actual use of unsupported 'related_entities' parameter in call examples.
+# Lines that say "no related_entities" (documentation/reminders) are excluded.
+echo "Check 1: no unsupported 'related_entities' on pensyve_recall"
+FOUND_RELATED=0
+# Also catch if related_entities appears inside a pensyve_recall( block
+awk '/pensyve_recall\(/{capture=1; buf=""}
+     capture {buf = buf "\n" $0}
+     capture && /\)/{
+       if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
+         print FILENAME ": related_entities found in pensyve_recall block: " buf;
+       capture=0
+     }' "$RULES_FILE" | while read -r line; do
+  if [ -n "$line" ]; then
+    echo "  FAIL: $line"
+    FOUND_RELATED=1
+  fi
+done
+if [ "$FOUND_RELATED" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 2: no actual use of unsupported 'continuation_of' parameter in call examples.
+echo "Check 2: no unsupported 'continuation_of' on pensyve_episode_start"
+FOUND_CONT=0
+awk '/pensyve_episode_start\(/{capture=1; buf=""}
+     capture {buf = buf "\n" $0}
+     capture && /\)/{
+       if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
+         print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
+       capture=0
+     }' "$RULES_FILE" | while read -r line; do
+  if [ -n "$line" ]; then
+    echo "  FAIL: $line"
+    FOUND_CONT=1
+  fi
+done
+if [ "$FOUND_CONT" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 3: every pensyve_observe call example in a code block has source_entity and about_entity
+echo "Check 3: every pensyve_observe example has source_entity and about_entity"
+MISSING_FIELDS=0
+awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
+     capture {buf = buf "\n" $0;
+              for(i=1; i<=length($0); i++){
+                c=substr($0,i,1);
+                if(c=="(") depth++;
+                if(c==")") depth--;
+              };
+              if(depth==0 && buf ~ /pensyve_observe\(/){
+                if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
+                if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
+                capture=0;
+              }}' "$RULES_FILE" | while read -r line; do
+  if [ -n "$line" ]; then
+    echo "  FAIL: $line"
+    MISSING_FIELDS=1
+  fi
+done
+if [ "$MISSING_FIELDS" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 4: provenance tag format — every proactive/auto-capture tag uses [<origin>/<trigger>/<tier>]
+echo "Check 4: provenance tag format"
+VALID_PROVENANCE_RE='\[(proactive|auto-capture)/(in-flight|stop|pre-compact|curator|user)/(tier-1|tier-2|residual/tier-1|residual/tier-2|open-question)\]'
+if rg -n '\[(proactive|auto-capture)' "$RULES_FILE" | rg -v "$VALID_PROVENANCE_RE"; then
+  echo "  FAIL: some provenance tags do not match [<origin>/<trigger>/<tier>] format"
+  EXIT_CODE=1
+else
+  echo "  PASS"
+fi
+echo ""
+
+# Check 5: procedural memory convention — [procedural] prefix is used in observe content
+echo "Check 5: procedural convention uses [procedural] prefix in pensyve_observe content"
+if ! rg -q '\[procedural\]' "$RULES_FILE"; then
+  echo "  WARN: no [procedural] prefix usage found. Expected in AGENTS.md."
+else
+  echo "  PASS"
+fi
+echo ""
+
+if [ "$EXIT_CODE" = "0" ]; then
+  echo "All MCP contract checks PASSED."
+else
+  echo "MCP contract checks FAILED. Fix the issues above before committing."
+fi
+
+exit "$EXIT_CODE"

--- a/integrations/hermes/scripts/lint-mcp-refs.sh
+++ b/integrations/hermes/scripts/lint-mcp-refs.sh
@@ -29,18 +29,18 @@ echo ""
 echo "Check 1: no unsupported 'related_entities' on pensyve_recall"
 FOUND_RELATED=0
 # Also catch if related_entities appears inside a pensyve_recall( block
-awk '/pensyve_recall\(/{capture=1; buf=""}
-     capture {buf = buf "\n" $0}
-     capture && /\)/{
-       if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
-         print FILENAME ": related_entities found in pensyve_recall block: " buf;
-       capture=0
-     }' "$RULES_FILE" | while read -r line; do
+while read -r line; do
   if [ -n "$line" ]; then
     echo "  FAIL: $line"
     FOUND_RELATED=1
   fi
-done
+done < <(awk '/pensyve_recall\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+       if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
+       print FILENAME ": related_entities found in pensyve_recall block: " buf;
+       capture=0
+       }' "$RULES_FILE")
 if [ "$FOUND_RELATED" = "0" ]; then
   echo "  PASS"
 else
@@ -51,18 +51,18 @@ echo ""
 # Check 2: no actual use of unsupported 'continuation_of' parameter in call examples.
 echo "Check 2: no unsupported 'continuation_of' on pensyve_episode_start"
 FOUND_CONT=0
-awk '/pensyve_episode_start\(/{capture=1; buf=""}
-     capture {buf = buf "\n" $0}
-     capture && /\)/{
-       if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
-         print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
-       capture=0
-     }' "$RULES_FILE" | while read -r line; do
+while read -r line; do
   if [ -n "$line" ]; then
     echo "  FAIL: $line"
     FOUND_CONT=1
   fi
-done
+done < <(awk '/pensyve_episode_start\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+       if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
+       print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
+       capture=0
+       }' "$RULES_FILE")
 if [ "$FOUND_CONT" = "0" ]; then
   echo "  PASS"
 else
@@ -73,23 +73,23 @@ echo ""
 # Check 3: every pensyve_observe call example in a code block has source_entity and about_entity
 echo "Check 3: every pensyve_observe example has source_entity and about_entity"
 MISSING_FIELDS=0
-awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
-     capture {buf = buf "\n" $0;
-              for(i=1; i<=length($0); i++){
-                c=substr($0,i,1);
-                if(c=="(") depth++;
-                if(c==")") depth--;
-              };
-              if(depth==0 && buf ~ /pensyve_observe\(/){
-                if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
-                if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
-                capture=0;
-              }}' "$RULES_FILE" | while read -r line; do
+while read -r line; do
   if [ -n "$line" ]; then
     echo "  FAIL: $line"
     MISSING_FIELDS=1
   fi
-done
+done < <(awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
+       capture {buf = buf "\n" $0;
+       for(i=1; i<=length($0); i++){
+       c=substr($0,i,1);
+       if(c=="(") depth++;
+       if(c==")") depth--;
+       };
+       if(depth==0 && buf ~ /pensyve_observe\(/){
+       if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
+       if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
+       capture=0;
+       }}' "$RULES_FILE")
 if [ "$MISSING_FIELDS" = "0" ]; then
   echo "  PASS"
 else

--- a/integrations/jetbrains/CHANGELOG.md
+++ b/integrations/jetbrains/CHANGELOG.md
@@ -1,0 +1,40 @@
+# Changelog — Pensyve JetBrains Adapter
+
+All notable changes to the Pensyve JetBrains adapter are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] - 2026-04-20
+
+### Added
+
+- **Working-memory substrate** for JetBrains AI Assistant via `instructions/*.md` files. Eight instruction documents deliver the substrate the Claude Code plugin v1.3.0 established:
+  - `memory-reflex.md` (always-apply) — non-optional reasoning discipline with three-type memory classification, canonical `pensyve_observe` call template, provenance vocabulary, lazy-open episode lifecycle
+  - `entity-detection.md` (always-apply) — canonicalization and fallback rules for recall scoping
+  - `memory-informed-debug.md` — debug flow with memory baked in
+  - `memory-informed-design.md` — design/architecture flow with memory baked in
+  - `memory-informed-refactor.md` — refactor flow with memory baked in
+  - `memory-informed-longitudinal-work.md` — research/eval multi-session flow
+  - `session-memory.md` — manual wrap-up equivalent of Claude Code's Stop hook
+  - `context-loader.md` — best-effort continuity primer via episodic recall
+- **MCP config example** at `jetbrains-mcp.json.example` (deploy to **Settings → AI Assistant → MCP Servers**) covering Cloud-with-API-key and Local-stdio options
+- **Static MCP contract lint script** at `scripts/lint-mcp-refs.sh` verifying every rule's `pensyve_*` call example matches the `pensyve-mcp-tools/src/params.rs` schema
+
+### Design
+
+- Single reasoning layer; no platform-layer plugin code. JetBrains AI Assistant reads the instruction files provided via its context; the entire substrate adapter is instruction documents.
+- Lazy-open episode lifecycle: first `pensyve_observe` call triggers `pensyve_episode_start`; episodes are not explicitly closed under normal operation.
+- Best-effort continuity primer via `pensyve_recall(types: ["episodic"])` — the MCP server has no episode-listing API.
+- MCP contract verified: no `related_entities` on recall, no `continuation_of` on episode_start, required `source_entity: "jetbrains"` and `about_entity` on every observe.
+
+### Not Included
+
+- No JetBrains plugin code (deferred to a future sibling spec if capability gaps surface)
+- No installer script (manual copy of instruction files + MCP config)
+- No server-side changes — uses the existing MCP tool surface
+
+### Relation to Other Pensyve Integrations
+
+- The JetBrains adapter is part of the batch-3 working-memory substrate rollout. The Cursor adapter (v1.0.0) and Claude Code plugin (v1.3.0) are the reference implementations.
+- Spec: `pensyve-docs/specs/2026-04-20-pensyve-cursor-adapter-design.md`
+- Playbook: `pensyve-docs/specs/2026-04-18-pensyve-working-memory-substrate-design.md`

--- a/integrations/jetbrains/README.md
+++ b/integrations/jetbrains/README.md
@@ -2,7 +2,7 @@
 
 Persistent AI memory for [JetBrains AI Assistant](https://www.jetbrains.com/ai/) via MCP. Gives your JetBrains IDE (IntelliJ IDEA, PyCharm, WebStorm, etc.) cross-session memory so the AI assistant remembers your project conventions, architecture decisions, and debugging history.
 
-> **Status:** Scaffold — MCP configuration and documentation. Full integration planned.
+> **Status:** Working-memory substrate v1.0.0 — MCP configuration, instruction files, and documentation. Full plugin integration planned.
 
 ## Authentication
 
@@ -98,3 +98,74 @@ Pensyve uses a tiered classification system to identify what is worth rememberin
 - Wrap multi-step work in `pensyve_episode_start` / `pensyve_episode_end` to capture episodic context
 
 The MCP tool descriptions include guidance on confidence levels so the LLM can classify memories into the appropriate tier automatically.
+
+## Memory Behavior Model
+
+The working-memory substrate defines how JetBrains AI Assistant should behave across coding sessions when Pensyve is connected. It is documented in the [`instructions/`](./instructions/) directory as 8 rule files:
+
+| Rule file | Behavior |
+| --------- | -------- |
+| `memory-reflex.md` | Non-optional reasoning discipline — recall before substantive answers, observe when lessons land. Always active. |
+| `entity-detection.md` | Canonicalization rules for extracting entity names from file paths, prompts, and code context. Always active. |
+| `memory-informed-debug.md` | Debug flow: recall prior incidents and procedures, capture root causes the moment they are confirmed. |
+| `memory-informed-design.md` | Design/architecture flow: recall prior decisions, flag contradictions, capture new decisions on acceptance. |
+| `memory-informed-refactor.md` | Refactor flow: briefing from prior memory, capture invariants and abandoned approaches as they surface. |
+| `memory-informed-longitudinal-work.md` | Multi-session research/eval flow: resume context at session start, capture per-run outcomes and open questions. |
+| `session-memory.md` | Manual wrap-up: review the conversation for residual lessons not captured in-flight, confirm with user before storing. |
+| `context-loader.md` | Session continuity primer: recall recent episodic memories at conversation start to surface relevant context. |
+
+### How to configure JetBrains AI Assistant with these instructions
+
+JetBrains AI Assistant reads context files you configure in **Settings → AI Assistant → Context**. Reference the `instructions/*.md` files there, or copy their contents into a combined context document for the AI assistant to use as its system prompt.
+
+### MCP config
+
+Copy `jetbrains-mcp.json.example` to the JetBrains MCP servers configuration (**Settings → AI Assistant → MCP Servers**) and edit for your setup.
+
+**Cloud with API key (recommended):**
+
+```bash
+export PENSYVE_API_KEY="psy_your_key_here"
+```
+
+```json
+{
+  "mcpServers": {
+    "pensyve": {
+      "type": "http",
+      "url": "https://mcp.pensyve.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ${PENSYVE_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+**Local (offline, self-hosted):**
+
+```json
+{
+  "mcpServers": {
+    "pensyve": {
+      "command": "pensyve-mcp",
+      "args": ["--stdio"],
+      "env": {
+        "PENSYVE_PATH": "~/.pensyve/",
+        "PENSYVE_NAMESPACE": "default"
+      }
+    }
+  }
+}
+```
+
+### MCP tool schema
+
+All substrate rules use the correct MCP contract:
+
+- `pensyve_recall(query, entity?, types?, limit?, min_confidence?)`
+- `pensyve_episode_start(participants)`
+- `pensyve_observe(episode_id, content, source_entity, about_entity, content_type?)`
+- `pensyve_inspect(entity, memory_type?, limit?)`
+
+`source_entity` is `"jetbrains"` in all substrate rule examples. Run `scripts/lint-mcp-refs.sh` to verify the rule files conform to the schema.

--- a/integrations/jetbrains/instructions/context-loader.md
+++ b/integrations/jetbrains/instructions/context-loader.md
@@ -1,0 +1,74 @@
+---
+description: Use when starting a new substantive conversation or switching contexts — load relevant memories to prime the session with continuity
+---
+
+# Context Loader (Continuity Primer)
+
+JetBrains AI Assistant has no automatic SessionStart hook. This rule is the manual equivalent: when starting a new conversation on a project that has prior Pensyve memories, call recall to prime the session with relevant context.
+
+Follows `memory-reflex.md`. Best-effort thread continuity via episodic recall (the MCP server has no episode-listing tool).
+
+## Instructions
+
+### Step 1: Detect project entity
+
+Per `entity-detection.md` fallback rules: use the repository root name (lowercase-hyphenated) as the default project entity. Override with `PENSYVE_NAMESPACE` environment variable if explicitly set in the project's environment.
+
+### Step 2: Scoped recall
+
+Call `pensyve_recall`:
+
+- `query`: `"recent decisions issues patterns"` + any key terms from the user's opening message
+- `entity`: detected project entity
+- `types`: `["episodic"]` — recent session activity gives the best continuity signal
+- `limit`: 5
+
+Episodic memories are ranked by the MCP server's activation signal, which naturally surfaces recent observations first.
+
+### Step 3: Compute continuity signal
+
+Examine the returned observations:
+
+- If ≥70% of the top observations reference at least one entity that overlaps with the current conversation's entity candidates (from Step 1 plus any entities mentioned in the opening message), treat the session as a **continuation** of recent work.
+- If the overlap is below 70%, or recall returned empty, treat as a **fresh session**.
+
+### Step 4: Surface the primer
+
+**Continuation:**
+
+> **Pensyve:** Continuing prior work on `<entity-set>`. Recent lessons:
+>
+> - <observation 1>
+> - <observation 2>
+> - <observation 3>
+>
+> Use `/recall <query>` or ask about any of these to dig deeper.
+
+**Fresh session:**
+
+> **Pensyve:** N memories loaded for `<project>`. Key context:
+>
+> - <top 3 observations>
+>
+> Use `/recall <query>` to search for specific memories.
+
+**No memories found:**
+
+> **Pensyve:** No memories found for `<project>`. Use `/remember` to start building context.
+
+### Step 5: Continuity is best-effort, not a structured link
+
+The MCP server has no episode-listing or date-filtering API. This rule infers continuity from shared-entity overlap and recall-ranking recency. Consequences:
+
+- There is no persisted server-side link between sessions.
+- Primer accuracy depends on memory quality and recall ranking.
+- The user may occasionally see "Continuing prior work" when it's actually loosely related; or see a fresh-session primer when the prior session was related but the entity overlap was low.
+
+Document this honestly in the primer when uncertain — do not fabricate continuity.
+
+## Constraints
+
+- Do not fabricate memories. Only display what `pensyve_recall` returns.
+- If MCP is unavailable, skip the primer silently and mention the failure once per conversation if the user asks about memory.
+- Maximum 5 memories in the primer to avoid context bloat.
+- Entity names lowercase-hyphenated.

--- a/integrations/jetbrains/instructions/entity-detection.md
+++ b/integrations/jetbrains/instructions/entity-detection.md
@@ -1,0 +1,42 @@
+---
+description: Pensyve entity detection — canonicalization and fallback rules for recall scoping (always-apply)
+---
+
+# Entity Detection (Always-Apply Reference)
+
+Shared rules for detecting entity names from tool inputs, prompts, and conversation context. Used by the memory reflex and all memory-woven flows to scope recalls and `about_entity` fields on observations.
+
+## Inputs
+
+Extract candidate entity names from:
+
+1. **File references** — `@filename`, `@path/to/file`, or files mentioned directly in the conversation.
+2. **User prompts** — explicit references to components, files, services, research phases (e.g., "phase-4.3", "v7r-classifier", "auth-service").
+3. **Code context** — module names, class names, function names in files you are editing or reading.
+4. **Git context** — repository root name, branch name (when discoverable).
+
+## Canonicalization
+
+- Lowercase all characters.
+- Replace spaces and underscores with hyphens.
+- Strip file extensions unless the file is the entity itself (e.g., `package.json`).
+- Collapse paths to the most semantically meaningful segment (e.g., `src/engine/hybrid_router.rs` → `hybrid-router`; `tests/integration/auth_test.py` → `auth`).
+
+## Fallback behavior
+
+- If no specific entity is detected, fall back to the project-level entity (repository root name, lowercase-hyphenated).
+- If a candidate entity is ambiguous between two names, prefer the one that already has memories in Pensyve (call `pensyve_inspect` with limit 1 to check).
+- **Never fabricate entity names.** If nothing confident emerges, use the project entity.
+
+## Output
+
+A set of 1–3 candidate entity names per turn. The primary entity is the most specific; secondary entities provide additional context. Since `pensyve_recall` accepts only a single `entity` parameter, fold secondary entities into the `query` string instead.
+
+## Examples
+
+| Input | Primary entity | Secondary (fold into query) |
+|---|---|---|
+| Edit on `src/engine/hybrid_router.rs` | `hybrid-router` | `engine` |
+| Prompt: "tune V7r noise threshold" | `v7r` | `noise-threshold` |
+| File `tests/test_auth.py` in a project named `auth-service` | `auth` | `auth-service` |
+| User mentions "phase-4.3 calibration" | `phase-4.3` | `calibration` |

--- a/integrations/jetbrains/instructions/memory-informed-debug.md
+++ b/integrations/jetbrains/instructions/memory-informed-debug.md
@@ -1,0 +1,68 @@
+---
+description: Use when diagnosing bugs, errors, failing tests, or crashes — consult prior debug outcomes and capture root causes in-flight
+---
+
+# Memory-Informed Debug
+
+Debugging flow with memory baked in as a non-optional reflex. Follows `memory-reflex.md` for classification, surface style, and episode lifecycle.
+
+## Instructions
+
+### Step 1: Detect entities
+
+Identify the relevant entity/entities (failing test, failing module, error source) per `entity-detection.md`.
+
+### Step 2: Consult memory (required)
+
+Call `pensyve_recall`:
+
+- `query`: a short description of the failure, including secondary entity names where known (e.g., "hybrid-router threshold regression phase-4.3" rather than full stack traces)
+- `entity`: primary detected entity
+- `types`: `["procedural", "episodic"]` (debugging benefits most from known-good diagnostic procedures and prior incident outcomes)
+- `limit`: 5
+
+Secondary entities are folded into the query string since `RecallParams` scopes by a single `entity` only.
+
+Surface one line: `Recalled N memories from prior debug sessions on <entity>.` (Skip if N=0.)
+
+If a highly similar incident is found (score >0.8), call that out inline: `This looks similar to an incident captured on <date>: <summary>. Consider that path first.`
+
+### Step 3: Diagnose
+
+Proceed with the diagnostic work. Use recalled procedural memories as a starting sequence; update the sequence when you learn something new.
+
+### Step 4: Capture lesson (when it lands)
+
+When a root cause is **confirmed** (not just hypothesized), apply the memory reflex per `memory-reflex.md`:
+
+Ensure a working `episode_id` exists (lazy-open via `pensyve_episode_start` if not). Then:
+
+- **Episodic root cause:** call `pensyve_observe` with `content: "[proactive/in-flight/tier-1] <one-sentence root cause>"`, `source_entity: "jetbrains"`, `about_entity: <primary_entity>`, `content_type: "text"`.
+- **Procedural diagnostic sequence:** if the debug produced a reusable diagnostic sequence, call `pensyve_observe` with `content: "[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=..."`, `source_entity: "jetbrains"`, `about_entity: <primary_entity>`, `content_type: "text"`.
+- **Semantic durable truth:** if the root cause reveals a durable truth (e.g., "our CI runner's Python 3.10 cannot handle the new syntax"), also call `pensyve_remember(entity, fact, confidence: 0.9)`. Include provenance in the fact text: `"[proactive/in-flight/tier-1] <fact>"`.
+
+Surface one line: `↳ captured: <one-sentence>`.
+
+### Step 5: Capture abandoned approach
+
+If an approach was tried and abandoned, observe that too:
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[proactive/in-flight/tier-1] tried <approach>, abandoned because <reason>",
+  source_entity: "jetbrains",
+  about_entity: <primary_entity>,
+  content_type: "text"
+)
+```
+
+These are high-value — they prevent re-treading the same dead end next time.
+
+## Constraints
+
+- Recall is **not optional**. If you skip recall to save time, you defeat the working-memory substrate.
+- Observe when a lesson **lands**, not when you first hypothesize.
+- One in-flight capture per turn unless multiple distinct lessons land simultaneously.
+- Respect the reflex rule's surface style — one line, not paragraphs.
+- Never store secrets or sensitive paths.

--- a/integrations/jetbrains/instructions/memory-informed-design.md
+++ b/integrations/jetbrains/instructions/memory-informed-design.md
@@ -1,0 +1,60 @@
+---
+description: Use when making architecture, API, or design decisions — consult prior decisions and capture new ones in-flight
+---
+
+# Memory-Informed Design
+
+Design flow with memory baked in as a non-optional reflex. Follows `memory-reflex.md`.
+
+## Instructions
+
+### Step 1: Detect entities
+
+Identify the relevant entity/entities (service, module, subsystem under design) per `entity-detection.md`.
+
+### Step 2: Consult memory (required)
+
+Call `pensyve_recall`:
+
+- `query`: a short description of the design question, including secondary entity names where known (e.g., "auth-service jwt signing rs256 hs256")
+- `entity`: primary detected entity
+- `types`: `["semantic", "episodic"]` (design benefits most from durable decisions and prior decision-contexts)
+- `limit`: 5
+
+Surface one line: `Recalled N prior decisions on <entity>.` (Skip if N=0.)
+
+### Step 3: Recommend with grounding
+
+Shape your recommendation using the recalled decisions. If the user's current question directly contradicts a prior decision, flag it:
+
+> Prior decision on `<entity>` (confidence 0.9): [decision]. Are we revisiting this, or does the current question differ?
+
+### Step 4: Capture decision (when it lands)
+
+When the user accepts a design or states a decision ("let's go with X", "we'll use Y"), apply the memory reflex:
+
+- **Semantic** — `pensyve_remember(entity: <primary_entity>, fact: "[proactive/in-flight/tier-1] <decision text>", confidence: 0.9)`.
+- **Episodic context** — ensure working `episode_id`; `pensyve_observe` with `content: "[proactive/in-flight/tier-1] Decision on <entity>: chose X over Y because Z"`, `source_entity: "jetbrains"`, `about_entity: <primary_entity>`, `content_type: "text"`. This enables future "why did we decide X?" queries.
+
+Surface one line: `↳ captured decision on <entity>: <short>`.
+
+### Step 5: Capture evaluation procedures
+
+If the design process revealed a reusable way to evaluate similar decisions (e.g., "run spike vs. prototype", "check latency first"), capture it as procedural:
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[procedural] [proactive/in-flight/tier-1] trigger=design-question-on-<area>, action=<steps>, outcome=<what-you-learn>",
+  source_entity: "jetbrains",
+  about_entity: <primary_entity>,
+  content_type: "text"
+)
+```
+
+## Constraints
+
+- Recall is **not optional**.
+- Observe when a decision **lands**, not when it's being discussed.
+- Budget: one in-flight capture per turn unless multiple decisions land.
+- Never store secrets or sensitive architecture details the user has marked private.

--- a/integrations/jetbrains/instructions/memory-informed-longitudinal-work.md
+++ b/integrations/jetbrains/instructions/memory-informed-longitudinal-work.md
@@ -1,0 +1,68 @@
+---
+description: Long-running multi-session work (research, eval loops, iterative benchmarks) — resume prior lessons, capture per-run outcomes, build up stable truths over time
+---
+
+# Memory-Informed Longitudinal Work
+
+Multi-session engineering work (research, eval loops, iterative benchmarks) where lessons must accumulate across runs. The motivating case: improving a core algorithm over dozens of eval iterations without starting from scratch each session.
+
+Follows `memory-reflex.md`. Applies when editing files under `research/`, `benchmarks/`, or `evals/`, or when the conversation is research-oriented.
+
+## Instructions
+
+### Step 1: Resume context at conversation start
+
+If this conversation is in a research/eval context, call `pensyve_recall` once at the start:
+
+- `query`: short description of the current research area (e.g., "v7r classifier calibration")
+- `entity`: project + sub-topic entity (per `entity-detection.md` canonicalization rules)
+- `limit`: 5
+
+No `types` filter — longitudinal work benefits from all three memory types; omit to query all. (Passing all three explicitly is equivalent to no filter; omitting is cleaner.)
+
+Surface: `Recalled N prior findings on <sub-topic>.`
+
+Treat the returned observations as working knowledge — do not re-ask the user about things the recall already surfaces.
+
+### Step 2: Proactively recall per topic shift
+
+When the session pivots to a new sub-topic (new phase, new eval subset, new failure mode), call `pensyve_recall` again scoped to the new sub-topic.
+
+### Step 3: Capture three types of memory per run
+
+During the session, classify emerging knowledge and capture accordingly. Ensure working `episode_id` before each observe.
+
+| What you learned | Type | MCP call |
+|---|---|---|
+| Per-run outcome (what this run showed) | episodic | `pensyve_observe(..., content: "[proactive/in-flight/tier-1] Run N+1: V7r accuracy improved +3.5% with new threshold", source_entity: "jetbrains", about_entity: <entity>, content_type: "text")` |
+| Stable truth about the system | semantic | `pensyve_remember(entity, fact: "[proactive/in-flight/tier-1] Haiku classifier plateaus above temp 0.3", confidence: 0.9)` |
+| Reusable experiment procedure | procedural | `pensyve_observe(..., content: "[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=...", source_entity: "jetbrains", about_entity: <entity>, content_type: "text")` |
+
+Apply at landing — do not batch.
+
+### Step 4: Capture open questions
+
+When a run ends with an unresolved question ("X improved but we don't know why"), capture it as an episodic observation with open-question provenance:
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[proactive/in-flight/open-question] <question>",
+  source_entity: "jetbrains",
+  about_entity: <entity>,
+  content_type: "text"
+)
+```
+
+This populates future "open questions" surfacing when the topic returns.
+
+### Step 5: End-of-session summary
+
+Before the conversation wraps, briefly summarize (inline, 3-5 lines): what this run taught us vs. prior runs, what's still open. This creates a natural handoff for the next session.
+
+## Constraints
+
+- Recall on every topic shift — not just at conversation start.
+- Capture at landing, not batched.
+- Never store run artifacts or large data blobs — summarize.
+- Respect the reflex's surface style.

--- a/integrations/jetbrains/instructions/memory-informed-refactor.md
+++ b/integrations/jetbrains/instructions/memory-informed-refactor.md
@@ -1,0 +1,59 @@
+---
+description: Use before substantive refactors — load relevant prior context, capture refactor insights as they land
+---
+
+# Memory-Informed Refactor
+
+Refactor flow with memory baked in. Follows `memory-reflex.md`.
+
+## Instructions
+
+### Step 1: Detect entities
+
+Identify the entities touched by the refactor (the file or module being restructured, its callers, the subsystem name) per `entity-detection.md`.
+
+### Step 2: Load prior context (required)
+
+Call `pensyve_recall`:
+
+- `query`: short description of the refactor (e.g., "hybrid-router routing logic restructure")
+- `entity`: primary detected entity
+- `types`: `["semantic", "episodic", "procedural"]` — refactors benefit from all three (durable invariants, prior attempts, known-good sequences)
+- `limit`: 5
+
+Surface: `Recalled N prior memories on <entity>.` (Skip if N=0.)
+
+Highlight any prior failed approaches inline:
+
+> Prior episodic memory (confidence 0.8): tried <approach> on <date>, abandoned because <reason>. Double-check this isn't the same trap.
+
+### Step 3: Present a briefing
+
+Before starting the refactor, briefly summarize what the prior memories say about:
+
+- **Decisions** — durable choices that constrain the refactor (semantic)
+- **Prior attempts** — what's been tried (episodic)
+- **Known-good procedures** — reusable sequences for this kind of refactor (procedural)
+
+If no relevant memories exist, say so clearly and proceed without historical context.
+
+### Step 4: Capture refactor lessons as they land
+
+When any of these occur during the refactor, apply the memory reflex immediately:
+
+- **An invariant is discovered** (semantic) — `pensyve_remember(entity, fact, confidence: 0.9)`
+- **An abandoned approach is confirmed not-viable** (episodic) — `pensyve_observe` with `[proactive/in-flight/tier-1]` provenance
+- **A dependency chain was traced that surprised us** (episodic) — `pensyve_observe`
+- **A known-good refactoring sequence emerged** (procedural) — `pensyve_observe` with `[procedural]` prefix
+
+Ensure working `episode_id` before each observe; lazy-open if needed.
+
+Do not batch these to end-of-session — capture at landing, surface one-line.
+
+## Constraints
+
+- The briefing step is the real value — it informs the refactor.
+- Observe at landing, not batched.
+- Entity names lowercase-hyphenated.
+- Do not start the refactor itself — this rule provides guidance and capture. The user decides when and how to proceed.
+- If the MCP server returns errors on some queries, present results from the successful queries and note the failures.

--- a/integrations/jetbrains/instructions/memory-reflex.md
+++ b/integrations/jetbrains/instructions/memory-reflex.md
@@ -1,0 +1,100 @@
+---
+description: Pensyve memory reflex — the non-optional reasoning discipline for working-memory substrate (always-apply)
+---
+
+# Memory Reflex Rule (Always-Apply)
+
+This rule is always in context. It turns Pensyve memory operations from optional actions into a reasoning discipline you carry through every substantive turn.
+
+## The rule
+
+**Before substantive answers, recall by entity. When a lesson lands, observe immediately with a one-line surface.**
+
+### "Substantive answer" means
+
+- Design or architecture recommendations
+- Debugging diagnoses with root-cause claims
+- Refactor proposals
+- Any response that makes a claim the user would want grounded in prior work
+
+Not substantive: formatting fixes, trivial lookups, reading a file, running a command.
+
+### "Lesson lands" means
+
+- A root cause has been confirmed (not hypothesized).
+- A design choice has been made explicit ("we'll use X because Y").
+- An approach has been tried and abandoned with a reason.
+- A workflow has been discovered that is reusable.
+- A workaround for a framework/library limitation has been validated.
+
+## Classification (which memory type?)
+
+- **Semantic** — a fact that will still be true next month. Use `pensyve_remember(entity, fact, confidence?)` (confidence defaults to 1.0; use 0.9 for high-confidence auto-captures).
+- **Episodic** — something that happened in this thread of work. Use `pensyve_observe` with the current `episode_id`.
+- **Procedural** — a reusable way to do something (a workflow, sequence, recipe). Use `pensyve_observe` with `content` beginning `[procedural]` (integration-layer convention; the MCP server has no native procedural-write API).
+
+When in doubt, prefer episodic. Server-side consolidation promotes recurring patterns to semantic automatically.
+
+## Canonical `pensyve_observe` call template
+
+ALL observe calls — in-flight, procedural, or wrap-up — MUST include every required field:
+
+```
+pensyve_observe(
+  episode_id: <current session's working episode_id>,
+  content: "[proactive/in-flight/tier-1] <observation text>",
+  source_entity: "jetbrains",
+  about_entity: "<relevant entity, lowercase-hyphenated>",
+  content_type: "text"
+)
+```
+
+Use `content_type: "code"` for code-related outcomes.
+
+## Episode lifecycle (lazy-open)
+
+JetBrains AI Assistant has no session-start/session-end hooks, so you own the episode lifecycle:
+
+- **Before your first `pensyve_observe` call in this conversation**, check whether a working `episode_id` is already tracked. If none exists, call `pensyve_episode_start(participants: ["jetbrains", "<project entity>"])` first, record the returned `episode_id`, then make the observation.
+- **Reuse the same `episode_id`** for all subsequent observations in the same conversation. Open a new episode only when the work's topic shifts substantially.
+- **Do not explicitly close** the episode under normal operation. Server-side consolidation handles aging.
+- **Recovery**: if `pensyve_observe` fails with a missing-episode error, call `pensyve_episode_start` and retry.
+
+## Surface style
+
+Lightly visible. One line when memory is used. Examples:
+
+- Recall: `Recalled 4 related memories (v7r, haiku-classifier).`
+- Capture: `↳ captured: hybrid-router threshold was the phase-3 regression root cause.`
+
+Do not narrate empty recalls or duplicate-skips.
+
+## Scope and budgets
+
+- Recall: scoped to detected entities (see `entity-detection.md`); limit 5; use `types` hint per flow.
+- Capture: one observation per substantive lesson; reuse the working `episode_id`.
+- Noise: avoid surfacing memory operations the user did not care about.
+
+## Composition with provenance tags
+
+When a capture is both procedural AND a proactive in-flight write, the `content` field begins with both markers, `[procedural]` first, then the provenance tag, then content:
+
+`[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=...`
+
+The `[procedural]` marker identifies the memory type for consolidation. The provenance tag identifies origin and trigger.
+
+## Provenance tag vocabulary
+
+- `[proactive/in-flight/tier-1]` — memory reflex captured during reasoning
+- `[proactive/in-flight/open-question]` — unresolved question noted in-flight
+- `[auto-capture/user/residual/tier-1]` — explicit user-driven capture (e.g., session-memory skill)
+
+## MCP contract reminder
+
+Rules never pass unsupported parameters. The MCP tool schemas are:
+
+- `pensyve_recall(query, entity?, types?, limit?, min_confidence?)` — **no** `related_entities`
+- `pensyve_episode_start(participants)` — **no** `continuation_of`
+- `pensyve_observe(episode_id, content, source_entity, about_entity, content_type?)` — `source_entity` and `about_entity` are **required**
+
+If you need secondary-entity context in a recall, fold those entities into the `query` string.

--- a/integrations/jetbrains/instructions/session-memory.md
+++ b/integrations/jetbrains/instructions/session-memory.md
@@ -1,0 +1,84 @@
+---
+description: Use at conversation wrap-up or when the user explicitly indicates end-of-session — capture residual lessons not captured in-flight
+---
+
+# Session Memory (Wrap-Up)
+
+JetBrains AI Assistant has no automatic Stop hook. This rule is the manual equivalent: when the user indicates the conversation is ending ("thanks, that's all", "session wrap-up", "we're done here"), review what happened and capture anything the in-flight reflex missed.
+
+Follows `memory-reflex.md`.
+
+## Instructions
+
+### Step 1: Review the conversation
+
+Scan the current conversation for three categories of memorable content that the in-flight reflex did NOT already capture:
+
+**Decisions** (confidence: 0.9):
+- Architecture or design choices
+- Technology selections
+- API design decisions
+- Tradeoff resolutions
+
+**Outcomes** (confidence: 0.8):
+- Bug fixes and their root causes
+- Successful approaches
+- Failed approaches with reasons
+- Performance findings
+
+**Patterns** (confidence: 0.7):
+- Recurring issues
+- Workflow discoveries
+- Cross-cutting observations
+
+### Step 2: Filter for significance and deduplicate
+
+Skip routine, low-signal content. Also skip anything that was already captured in-flight.
+
+For each candidate, call `pensyve_recall` with `query: <candidate fact text>`, `entity: <candidate's entity>`, `limit: 3`. If any returned memory has a score ≥0.85 against the candidate, skip it as a likely duplicate.
+
+Note: `pensyve_inspect` cannot filter by `episode_id` (its params are `entity`, `memory_type?`, `limit?` only), so dedup is entity-scoped semantic-similarity rather than session-scoped. Consequence: very similar items captured in prior sessions will also trigger the skip — acceptable for avoiding genuine duplicates.
+
+### Step 3: Present candidates for confirmation
+
+Show the filtered candidates to the user in a structured format:
+
+> **Session Memory Candidates**
+>
+> **Decisions** (confidence: 0.9):
+> 1. `<entity>`: <decision text>
+>
+> **Outcomes** (confidence: 0.8):
+> 2. `<entity>`: <outcome text>
+>
+> **Patterns** (confidence: 0.7):
+> 3. `<entity>`: <pattern text>
+>
+> Which should I store? (e.g., "all", "1,3", "none")
+
+### Step 4: Store confirmed items
+
+For each confirmed item, classify the type and call the appropriate MCP tool:
+
+- **Semantic** (decisions, durable truths) — `pensyve_remember(entity, fact: "[auto-capture/user/residual/tier-1] <text>", confidence)`. Use confidence from the categorization above.
+- **Episodic** (outcomes, session-specific events) — ensure working `episode_id`; `pensyve_observe(episode_id, content: "[auto-capture/user/residual/tier-1] <text>", source_entity: "jetbrains", about_entity: <entity>, content_type: "text")`.
+- **Procedural** (reusable workflows) — `pensyve_observe(episode_id, content: "[procedural] [auto-capture/user/residual/tier-1] trigger=..., action=..., outcome=...", source_entity: "jetbrains", about_entity: <entity>, content_type: "text")`.
+
+### Step 5: Optionally close the episode
+
+If the user indicates this is a final wrap (not just a turn-by-turn pause), call `pensyve_episode_end(episode_id: <working_id>, outcome: "success")`. Valid outcomes: `"success"`, `"failure"`, `"partial"`.
+
+Not closing is safe — server-side consolidation ages episodes naturally. Only close when the user clearly marks the work complete.
+
+### Step 6: Report
+
+After storing, summarize:
+
+> Stored N memories. Episode <outcome> closed.
+
+## Constraints
+
+- **Never auto-store.** Every candidate MUST be presented to the user for confirmation before storage.
+- Entity names lowercase-hyphenated.
+- Do not store secrets.
+- If nothing significant surfaced, say so clearly rather than forcing low-quality memories.

--- a/integrations/jetbrains/jetbrains-mcp.json.example
+++ b/integrations/jetbrains/jetbrains-mcp.json.example
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "pensyve": {
+      "type": "http",
+      "url": "https://mcp.pensyve.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ${PENSYVE_API_KEY}"
+      }
+    }
+  }
+}

--- a/integrations/jetbrains/scripts/lint-mcp-refs.sh
+++ b/integrations/jetbrains/scripts/lint-mcp-refs.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Static MCP contract linter for the Pensyve JetBrains adapter rules.
+#
+# Verifies that every pensyve_* call example in instructions/*.md conforms to
+# the current MCP tool schema in pensyve-mcp-tools/src/params.rs. Catches the
+# category of bug PR #58 surfaced in the Claude Code adapter (unsupported
+# parameters, missing required fields).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RULES_DIR="$SCRIPT_DIR/../instructions"
+
+EXIT_CODE=0
+
+if [ ! -d "$RULES_DIR" ]; then
+  echo "ERROR: Rules directory not found: $RULES_DIR"
+  exit 1
+fi
+
+echo "Linting MCP references in $RULES_DIR..."
+echo ""
+
+# Check 1: no actual use of unsupported 'related_entities' parameter in call examples.
+# We look for pensyve_recall( blocks that contain related_entities as a parameter.
+# Lines that say "no related_entities" (documentation/reminders) are excluded.
+echo "Check 1: no unsupported 'related_entities' on pensyve_recall"
+FOUND_RELATED=0
+for rule_file in "$RULES_DIR"/*.md; do
+  # Extract lines that contain pensyve_recall( and related_entities together,
+  # excluding documentation lines (those containing "**no**" or "no `related_entities`")
+  if rg -n 'related_entities' "$rule_file" | rg -v '(\*\*no\*\*|no `related_entities`)' | rg -q 'pensyve_recall\|related_entities'; then
+    echo "  FAIL in $rule_file: 'related_entities' used in a pensyve_recall call"
+    FOUND_RELATED=1
+  fi
+  # Also catch if related_entities appears inside a pensyve_recall( block
+  awk '/pensyve_recall\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+         if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
+           print FILENAME ": related_entities found in pensyve_recall block: " buf;
+         capture=0
+       }' "$rule_file" | while read -r line; do
+    if [ -n "$line" ]; then
+      echo "  FAIL: $line"
+      FOUND_RELATED=1
+    fi
+  done
+done
+if [ "$FOUND_RELATED" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 2: no actual use of unsupported 'continuation_of' parameter in call examples.
+# Documentation lines saying "no continuation_of" are excluded.
+echo "Check 2: no unsupported 'continuation_of' on pensyve_episode_start"
+FOUND_CONT=0
+for rule_file in "$RULES_DIR"/*.md; do
+  awk '/pensyve_episode_start\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+         if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
+           print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
+         capture=0
+       }' "$rule_file" | while read -r line; do
+    if [ -n "$line" ]; then
+      echo "  FAIL: $line"
+      FOUND_CONT=1
+    fi
+  done
+done
+if [ "$FOUND_CONT" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 3: every pensyve_observe call example in a code block has source_entity and about_entity
+# Scan each .md file's pensyve_observe blocks; require both fields nearby.
+echo "Check 3: every pensyve_observe example has source_entity and about_entity"
+MISSING_FIELDS=0
+for rule_file in "$RULES_DIR"/*.md; do
+  # Find each pensyve_observe( block (up to the next closing paren within 20 lines)
+  awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
+       capture {buf = buf "\n" $0;
+                for(i=1; i<=length($0); i++){
+                  c=substr($0,i,1);
+                  if(c=="(") depth++;
+                  if(c==")") depth--;
+                };
+                if(depth==0 && buf ~ /pensyve_observe\(/){
+                  if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
+                  if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
+                  capture=0;
+                }}' "$rule_file" | while read -r line; do
+    if [ -n "$line" ]; then
+      echo "  FAIL: $line"
+      MISSING_FIELDS=1
+    fi
+  done
+done
+if [ "$MISSING_FIELDS" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 4: provenance tag format — every proactive/auto-capture tag uses [<origin>/<trigger>/<tier>]
+# Format supports both 3-segment [origin/trigger/tier] and 4-segment [origin/trigger/residual/tier]
+# where the third segment may be a literal "residual" qualifier before the tier.
+echo "Check 4: provenance tag format"
+VALID_PROVENANCE_RE='\[(proactive|auto-capture)/(in-flight|stop|pre-compact|curator|user)/(tier-1|tier-2|residual/tier-1|residual/tier-2|open-question)\]'
+if rg -n '\[(proactive|auto-capture)' "$RULES_DIR" | rg -v "$VALID_PROVENANCE_RE"; then
+  echo "  FAIL: some provenance tags do not match [<origin>/<trigger>/<tier>] format"
+  EXIT_CODE=1
+else
+  echo "  PASS"
+fi
+echo ""
+
+# Check 5: procedural memory convention — [procedural] prefix is used in observe content
+echo "Check 5: procedural convention uses [procedural] prefix in pensyve_observe content"
+# Only a warning if no rule mentions [procedural] — may be legitimate if the rule is non-procedural
+if ! rg -q '\[procedural\]' "$RULES_DIR"; then
+  echo "  WARN: no [procedural] prefix usage found across rules. Expected in memory-reflex and flow rules that handle procedural captures."
+else
+  echo "  PASS"
+fi
+echo ""
+
+if [ "$EXIT_CODE" = "0" ]; then
+  echo "All MCP contract checks PASSED."
+else
+  echo "MCP contract checks FAILED. Fix the issues above before committing."
+fi
+
+exit "$EXIT_CODE"

--- a/integrations/jetbrains/scripts/lint-mcp-refs.sh
+++ b/integrations/jetbrains/scripts/lint-mcp-refs.sh
@@ -34,18 +34,18 @@ for rule_file in "$RULES_DIR"/*.md; do
     FOUND_RELATED=1
   fi
   # Also catch if related_entities appears inside a pensyve_recall( block
-  awk '/pensyve_recall\(/{capture=1; buf=""}
-       capture {buf = buf "\n" $0}
-       capture && /\)/{
-         if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
-           print FILENAME ": related_entities found in pensyve_recall block: " buf;
-         capture=0
-       }' "$rule_file" | while read -r line; do
+  while read -r line; do
     if [ -n "$line" ]; then
       echo "  FAIL: $line"
       FOUND_RELATED=1
     fi
-  done
+  done < <(awk '/pensyve_recall\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+       if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
+       print FILENAME ": related_entities found in pensyve_recall block: " buf;
+       capture=0
+       }' "$rule_file")
 done
 if [ "$FOUND_RELATED" = "0" ]; then
   echo "  PASS"
@@ -59,18 +59,18 @@ echo ""
 echo "Check 2: no unsupported 'continuation_of' on pensyve_episode_start"
 FOUND_CONT=0
 for rule_file in "$RULES_DIR"/*.md; do
-  awk '/pensyve_episode_start\(/{capture=1; buf=""}
-       capture {buf = buf "\n" $0}
-       capture && /\)/{
-         if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
-           print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
-         capture=0
-       }' "$rule_file" | while read -r line; do
+  while read -r line; do
     if [ -n "$line" ]; then
       echo "  FAIL: $line"
       FOUND_CONT=1
     fi
-  done
+  done < <(awk '/pensyve_episode_start\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+       if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
+       print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
+       capture=0
+       }' "$rule_file")
 done
 if [ "$FOUND_CONT" = "0" ]; then
   echo "  PASS"
@@ -85,23 +85,23 @@ echo "Check 3: every pensyve_observe example has source_entity and about_entity"
 MISSING_FIELDS=0
 for rule_file in "$RULES_DIR"/*.md; do
   # Find each pensyve_observe( block (up to the next closing paren within 20 lines)
-  awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
-       capture {buf = buf "\n" $0;
-                for(i=1; i<=length($0); i++){
-                  c=substr($0,i,1);
-                  if(c=="(") depth++;
-                  if(c==")") depth--;
-                };
-                if(depth==0 && buf ~ /pensyve_observe\(/){
-                  if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
-                  if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
-                  capture=0;
-                }}' "$rule_file" | while read -r line; do
+  while read -r line; do
     if [ -n "$line" ]; then
       echo "  FAIL: $line"
       MISSING_FIELDS=1
     fi
-  done
+  done < <(awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
+       capture {buf = buf "\n" $0;
+       for(i=1; i<=length($0); i++){
+       c=substr($0,i,1);
+       if(c=="(") depth++;
+       if(c==")") depth--;
+       };
+       if(depth==0 && buf ~ /pensyve_observe\(/){
+       if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
+       if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
+       capture=0;
+       }}' "$rule_file")
 done
 if [ "$MISSING_FIELDS" = "0" ]; then
   echo "  PASS"

--- a/integrations/kiro/.kiro/mcp.json.example
+++ b/integrations/kiro/.kiro/mcp.json.example
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "pensyve": {
+      "type": "http",
+      "url": "https://mcp.pensyve.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ${PENSYVE_API_KEY}"
+      }
+    }
+  }
+}

--- a/integrations/kiro/.kiro/steering/context-loader.md
+++ b/integrations/kiro/.kiro/steering/context-loader.md
@@ -1,0 +1,74 @@
+---
+description: Use when starting a new substantive conversation or switching contexts — load relevant memories to prime the session with continuity
+---
+
+# Context Loader (Continuity Primer)
+
+Kiro has no automatic SessionStart hook exposed to steering rules. This rule is the manual equivalent: when starting a new conversation on a project that has prior Pensyve memories, call recall to prime the session with relevant context.
+
+Follows `memory-reflex.md`. Best-effort thread continuity via episodic recall (the MCP server has no episode-listing tool; see the main spec's Task C addendum for background).
+
+## Instructions
+
+### Step 1: Detect project entity
+
+Per `entity-detection.md` fallback rules: use the repository root name (lowercase-hyphenated) as the default project entity. Override with `PENSYVE_NAMESPACE` environment variable if explicitly set in the project's environment.
+
+### Step 2: Scoped recall
+
+Call `pensyve_recall`:
+
+- `query`: `"recent decisions issues patterns"` + any key terms from the user's opening message
+- `entity`: detected project entity
+- `types`: `["episodic"]` — recent session activity gives the best continuity signal
+- `limit`: 5
+
+Episodic memories are ranked by the MCP server's activation signal, which naturally surfaces recent observations first.
+
+### Step 3: Compute continuity signal
+
+Examine the returned observations:
+
+- If ≥70% of the top observations reference at least one entity that overlaps with the current conversation's entity candidates (from Step 1 plus any entities mentioned in the opening message), treat the session as a **continuation** of recent work.
+- If the overlap is below 70%, or recall returned empty, treat as a **fresh session**.
+
+### Step 4: Surface the primer
+
+**Continuation:**
+
+> **Pensyve:** Continuing prior work on `<entity-set>`. Recent lessons:
+>
+> - <observation 1>
+> - <observation 2>
+> - <observation 3>
+>
+> Use `/recall <query>` or ask about any of these to dig deeper.
+
+**Fresh session:**
+
+> **Pensyve:** N memories loaded for `<project>`. Key context:
+>
+> - <top 3 observations>
+>
+> Use `/recall <query>` to search for specific memories.
+
+**No memories found:**
+
+> **Pensyve:** No memories found for `<project>`. Use `/remember` to start building context.
+
+### Step 5: Continuity is best-effort, not a structured link
+
+The MCP server has no episode-listing or date-filtering API. This rule infers continuity from shared-entity overlap and recall-ranking recency. Consequences:
+
+- There is no persisted server-side link between sessions.
+- Primer accuracy depends on memory quality and recall ranking.
+- The user may occasionally see "Continuing prior work" when it's actually loosely related; or see a fresh-session primer when the prior session was related but the entity overlap was low.
+
+Document this honestly in the primer when uncertain — do not fabricate continuity.
+
+## Constraints
+
+- Do not fabricate memories. Only display what `pensyve_recall` returns.
+- If MCP is unavailable, skip the primer silently and mention the failure once per conversation if the user asks about memory.
+- Maximum 5 memories in the primer to avoid context bloat.
+- Entity names lowercase-hyphenated.

--- a/integrations/kiro/.kiro/steering/entity-detection.md
+++ b/integrations/kiro/.kiro/steering/entity-detection.md
@@ -1,0 +1,42 @@
+---
+description: Pensyve entity detection — canonicalization and fallback rules for recall scoping (always-apply)
+---
+
+# Entity Detection (Always-Apply Reference)
+
+Shared rules for detecting entity names from tool inputs, prompts, and conversation context. Used by the memory reflex and all memory-woven flows to scope recalls and `about_entity` fields on observations.
+
+## Inputs
+
+Extract candidate entity names from:
+
+1. **File references** — `@filename`, `@path/to/file`, or files mentioned directly in the conversation.
+2. **User prompts** — explicit references to components, files, services, research phases (e.g., "phase-4.3", "v7r-classifier", "auth-service").
+3. **Code context** — module names, class names, function names in files you are editing or reading.
+4. **Git context** — repository root name, branch name (when discoverable).
+
+## Canonicalization
+
+- Lowercase all characters.
+- Replace spaces and underscores with hyphens.
+- Strip file extensions unless the file is the entity itself (e.g., `package.json`).
+- Collapse paths to the most semantically meaningful segment (e.g., `src/engine/hybrid_router.rs` → `hybrid-router`; `tests/integration/auth_test.py` → `auth`).
+
+## Fallback behavior
+
+- If no specific entity is detected, fall back to the project-level entity (repository root name, lowercase-hyphenated).
+- If a candidate entity is ambiguous between two names, prefer the one that already has memories in Pensyve (call `pensyve_inspect` with limit 1 to check).
+- **Never fabricate entity names.** If nothing confident emerges, use the project entity.
+
+## Output
+
+A set of 1–3 candidate entity names per turn. The primary entity is the most specific; secondary entities provide additional context. Since `pensyve_recall` accepts only a single `entity` parameter, fold secondary entities into the `query` string instead.
+
+## Examples
+
+| Input | Primary entity | Secondary (fold into query) |
+|---|---|---|
+| Edit on `src/engine/hybrid_router.rs` | `hybrid-router` | `engine` |
+| Prompt: "tune V7r noise threshold" | `v7r` | `noise-threshold` |
+| File `tests/test_auth.py` in a project named `auth-service` | `auth` | `auth-service` |
+| User mentions "phase-4.3 calibration" | `phase-4.3` | `calibration` |

--- a/integrations/kiro/.kiro/steering/memory-informed-debug.md
+++ b/integrations/kiro/.kiro/steering/memory-informed-debug.md
@@ -1,0 +1,68 @@
+---
+description: Use when diagnosing bugs, errors, failing tests, or crashes — consult prior debug outcomes and capture root causes in-flight
+---
+
+# Memory-Informed Debug
+
+Debugging flow with memory baked in as a non-optional reflex. Follows `memory-reflex.md` for classification, surface style, and episode lifecycle.
+
+## Instructions
+
+### Step 1: Detect entities
+
+Identify the relevant entity/entities (failing test, failing module, error source) per `entity-detection.md`.
+
+### Step 2: Consult memory (required)
+
+Call `pensyve_recall`:
+
+- `query`: a short description of the failure, including secondary entity names where known (e.g., "hybrid-router threshold regression phase-4.3" rather than full stack traces)
+- `entity`: primary detected entity
+- `types`: `["procedural", "episodic"]` (debugging benefits most from known-good diagnostic procedures and prior incident outcomes)
+- `limit`: 5
+
+Secondary entities are folded into the query string since `RecallParams` scopes by a single `entity` only.
+
+Surface one line: `Recalled N memories from prior debug sessions on <entity>.` (Skip if N=0.)
+
+If a highly similar incident is found (score >0.8), call that out inline: `This looks similar to an incident captured on <date>: <summary>. Consider that path first.`
+
+### Step 3: Diagnose
+
+Proceed with the diagnostic work. Use recalled procedural memories as a starting sequence; update the sequence when you learn something new.
+
+### Step 4: Capture lesson (when it lands)
+
+When a root cause is **confirmed** (not just hypothesized), apply the memory reflex per `memory-reflex.md`:
+
+Ensure a working `episode_id` exists (lazy-open via `pensyve_episode_start` if not). Then:
+
+- **Episodic root cause:** call `pensyve_observe` with `content: "[proactive/in-flight/tier-1] <one-sentence root cause>"`, `source_entity: "kiro"`, `about_entity: <primary_entity>`, `content_type: "text"`.
+- **Procedural diagnostic sequence:** if the debug produced a reusable diagnostic sequence, call `pensyve_observe` with `content: "[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=..."`, `source_entity: "kiro"`, `about_entity: <primary_entity>`, `content_type: "text"`.
+- **Semantic durable truth:** if the root cause reveals a durable truth (e.g., "our CI runner's Python 3.10 cannot handle the new syntax"), also call `pensyve_remember(entity, fact, confidence: 0.9)`. Include provenance in the fact text: `"[proactive/in-flight/tier-1] <fact>"`.
+
+Surface one line: `↳ captured: <one-sentence>`.
+
+### Step 5: Capture abandoned approach
+
+If an approach was tried and abandoned, observe that too:
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[proactive/in-flight/tier-1] tried <approach>, abandoned because <reason>",
+  source_entity: "kiro",
+  about_entity: <primary_entity>,
+  content_type: "text"
+)
+```
+
+These are high-value — they prevent re-treading the same dead end next time.
+
+## Constraints
+
+- Recall is **not optional**. If you skip recall to save time, you defeat the working-memory substrate.
+- Observe when a lesson **lands**, not when you first hypothesize.
+- One in-flight capture per turn unless multiple distinct lessons land simultaneously.
+- Respect the reflex rule's surface style — one line, not paragraphs.
+- Never store secrets or sensitive paths.

--- a/integrations/kiro/.kiro/steering/memory-informed-design.md
+++ b/integrations/kiro/.kiro/steering/memory-informed-design.md
@@ -1,0 +1,60 @@
+---
+description: Use when making architecture, API, or design decisions — consult prior decisions and capture new ones in-flight
+---
+
+# Memory-Informed Design
+
+Design flow with memory baked in as a non-optional reflex. Follows `memory-reflex.md`.
+
+## Instructions
+
+### Step 1: Detect entities
+
+Identify the relevant entity/entities (service, module, subsystem under design) per `entity-detection.md`.
+
+### Step 2: Consult memory (required)
+
+Call `pensyve_recall`:
+
+- `query`: a short description of the design question, including secondary entity names where known (e.g., "auth-service jwt signing rs256 hs256")
+- `entity`: primary detected entity
+- `types`: `["semantic", "episodic"]` (design benefits most from durable decisions and prior decision-contexts)
+- `limit`: 5
+
+Surface one line: `Recalled N prior decisions on <entity>.` (Skip if N=0.)
+
+### Step 3: Recommend with grounding
+
+Shape your recommendation using the recalled decisions. If the user's current question directly contradicts a prior decision, flag it:
+
+> Prior decision on `<entity>` (confidence 0.9): [decision]. Are we revisiting this, or does the current question differ?
+
+### Step 4: Capture decision (when it lands)
+
+When the user accepts a design or states a decision ("let's go with X", "we'll use Y"), apply the memory reflex:
+
+- **Semantic** — `pensyve_remember(entity: <primary_entity>, fact: "[proactive/in-flight/tier-1] <decision text>", confidence: 0.9)`.
+- **Episodic context** — ensure working `episode_id`; `pensyve_observe` with `content: "[proactive/in-flight/tier-1] Decision on <entity>: chose X over Y because Z"`, `source_entity: "kiro"`, `about_entity: <primary_entity>`, `content_type: "text"`. This enables future "why did we decide X?" queries.
+
+Surface one line: `↳ captured decision on <entity>: <short>`.
+
+### Step 5: Capture evaluation procedures
+
+If the design process revealed a reusable way to evaluate similar decisions (e.g., "run spike vs. prototype", "check latency first"), capture it as procedural:
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[procedural] [proactive/in-flight/tier-1] trigger=design-question-on-<area>, action=<steps>, outcome=<what-you-learn>",
+  source_entity: "kiro",
+  about_entity: <primary_entity>,
+  content_type: "text"
+)
+```
+
+## Constraints
+
+- Recall is **not optional**.
+- Observe when a decision **lands**, not when it's being discussed.
+- Budget: one in-flight capture per turn unless multiple decisions land.
+- Never store secrets or sensitive architecture details the user has marked private.

--- a/integrations/kiro/.kiro/steering/memory-informed-longitudinal-work.md
+++ b/integrations/kiro/.kiro/steering/memory-informed-longitudinal-work.md
@@ -1,0 +1,68 @@
+---
+description: Long-running multi-session work (research, eval loops, iterative benchmarks) — resume prior lessons, capture per-run outcomes, build up stable truths over time. Applies for research/, benchmarks/, or evals/ directories.
+---
+
+# Memory-Informed Longitudinal Work
+
+Multi-session engineering work (research, eval loops, iterative benchmarks) where lessons must accumulate across runs. The motivating case: improving a core algorithm over dozens of eval iterations without starting from scratch each session.
+
+Follows `memory-reflex.md`. Applies for files under `research/`, `benchmarks/`, or `evals/`, or when the model judges the conversation to be research-oriented.
+
+## Instructions
+
+### Step 1: Resume context at conversation start
+
+If this conversation is in a research/eval context, call `pensyve_recall` once at the start:
+
+- `query`: short description of the current research area (e.g., "v7r classifier calibration")
+- `entity`: project + sub-topic entity (per `entity-detection.md` canonicalization rules)
+- `limit`: 5
+
+No `types` filter — longitudinal work benefits from all three memory types; omit to query all. (Passing all three explicitly is equivalent to no filter; omitting is cleaner.)
+
+Surface: `Recalled N prior findings on <sub-topic>.`
+
+Treat the returned observations as working knowledge — do not re-ask the user about things the recall already surfaces.
+
+### Step 2: Proactively recall per topic shift
+
+When the session pivots to a new sub-topic (new phase, new eval subset, new failure mode), call `pensyve_recall` again scoped to the new sub-topic.
+
+### Step 3: Capture three types of memory per run
+
+During the session, classify emerging knowledge and capture accordingly. Ensure working `episode_id` before each observe.
+
+| What you learned | Type | MCP call |
+|---|---|---|
+| Per-run outcome (what this run showed) | episodic | `pensyve_observe(..., content: "[proactive/in-flight/tier-1] Run N+1: V7r accuracy improved +3.5% with new threshold", source_entity: "kiro", about_entity: <entity>, content_type: "text")` |
+| Stable truth about the system | semantic | `pensyve_remember(entity, fact: "[proactive/in-flight/tier-1] Haiku classifier plateaus above temp 0.3", confidence: 0.9)` |
+| Reusable experiment procedure | procedural | `pensyve_observe(..., content: "[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=...", source_entity: "kiro", about_entity: <entity>, content_type: "text")` |
+
+Apply at landing — do not batch.
+
+### Step 4: Capture open questions
+
+When a run ends with an unresolved question ("X improved but we don't know why"), capture it as an episodic observation with open-question provenance:
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[proactive/in-flight/open-question] <question>",
+  source_entity: "kiro",
+  about_entity: <entity>,
+  content_type: "text"
+)
+```
+
+This populates future "open questions" surfacing when the topic returns.
+
+### Step 5: End-of-session summary
+
+Before the conversation wraps, briefly summarize (inline, 3-5 lines): what this run taught us vs. prior runs, what's still open. This creates a natural handoff for the next session.
+
+## Constraints
+
+- Recall on every topic shift — not just at conversation start.
+- Capture at landing, not batched.
+- Never store run artifacts or large data blobs — summarize.
+- Respect the reflex's surface style.

--- a/integrations/kiro/.kiro/steering/memory-informed-refactor.md
+++ b/integrations/kiro/.kiro/steering/memory-informed-refactor.md
@@ -1,0 +1,59 @@
+---
+description: Use before substantive refactors — load relevant prior context, capture refactor insights as they land
+---
+
+# Memory-Informed Refactor
+
+Refactor flow with memory baked in. Follows `memory-reflex.md`.
+
+## Instructions
+
+### Step 1: Detect entities
+
+Identify the entities touched by the refactor (the file or module being restructured, its callers, the subsystem name) per `entity-detection.md`.
+
+### Step 2: Load prior context (required)
+
+Call `pensyve_recall`:
+
+- `query`: short description of the refactor (e.g., "hybrid-router routing logic restructure")
+- `entity`: primary detected entity
+- `types`: `["semantic", "episodic", "procedural"]` — refactors benefit from all three (durable invariants, prior attempts, known-good sequences)
+- `limit`: 5
+
+Surface: `Recalled N prior memories on <entity>.` (Skip if N=0.)
+
+Highlight any prior failed approaches inline:
+
+> Prior episodic memory (confidence 0.8): tried <approach> on <date>, abandoned because <reason>. Double-check this isn't the same trap.
+
+### Step 3: Present a briefing
+
+Before starting the refactor, briefly summarize what the prior memories say about:
+
+- **Decisions** — durable choices that constrain the refactor (semantic)
+- **Prior attempts** — what's been tried (episodic)
+- **Known-good procedures** — reusable sequences for this kind of refactor (procedural)
+
+If no relevant memories exist, say so clearly and proceed without historical context.
+
+### Step 4: Capture refactor lessons as they land
+
+When any of these occur during the refactor, apply the memory reflex immediately:
+
+- **An invariant is discovered** (semantic) — `pensyve_remember(entity, fact, confidence: 0.9)`
+- **An abandoned approach is confirmed not-viable** (episodic) — `pensyve_observe` with `[proactive/in-flight/tier-1]` provenance
+- **A dependency chain was traced that surprised us** (episodic) — `pensyve_observe`
+- **A known-good refactoring sequence emerged** (procedural) — `pensyve_observe` with `[procedural]` prefix
+
+Ensure working `episode_id` before each observe; lazy-open if needed.
+
+Do not batch these to end-of-session — capture at landing, surface one-line.
+
+## Constraints
+
+- The briefing step is the real value — it informs the refactor.
+- Observe at landing, not batched.
+- Entity names lowercase-hyphenated.
+- Do not start the refactor itself — this rule provides guidance and capture. The user decides when and how to proceed.
+- If the MCP server returns errors on some queries, present results from the successful queries and note the failures.

--- a/integrations/kiro/.kiro/steering/memory-reflex.md
+++ b/integrations/kiro/.kiro/steering/memory-reflex.md
@@ -1,0 +1,100 @@
+---
+description: Pensyve memory reflex — the non-optional reasoning discipline for working-memory substrate (always-apply)
+---
+
+# Memory Reflex Rule (Always-Apply)
+
+This rule is always in context. It turns Pensyve memory operations from optional actions into a reasoning discipline you carry through every substantive turn.
+
+## The rule
+
+**Before substantive answers, recall by entity. When a lesson lands, observe immediately with a one-line surface.**
+
+### "Substantive answer" means
+
+- Design or architecture recommendations
+- Debugging diagnoses with root-cause claims
+- Refactor proposals
+- Any response that makes a claim the user would want grounded in prior work
+
+Not substantive: formatting fixes, trivial lookups, reading a file, running a command.
+
+### "Lesson lands" means
+
+- A root cause has been confirmed (not hypothesized).
+- A design choice has been made explicit ("we'll use X because Y").
+- An approach has been tried and abandoned with a reason.
+- A workflow has been discovered that is reusable.
+- A workaround for a framework/library limitation has been validated.
+
+## Classification (which memory type?)
+
+- **Semantic** — a fact that will still be true next month. Use `pensyve_remember(entity, fact, confidence?)` (confidence defaults to 1.0; use 0.9 for high-confidence auto-captures).
+- **Episodic** — something that happened in this thread of work. Use `pensyve_observe` with the current `episode_id`.
+- **Procedural** — a reusable way to do something (a workflow, sequence, recipe). Use `pensyve_observe` with `content` beginning `[procedural]` (integration-layer convention; the MCP server has no native procedural-write API).
+
+When in doubt, prefer episodic. Server-side consolidation promotes recurring patterns to semantic automatically.
+
+## Canonical `pensyve_observe` call template
+
+ALL observe calls — in-flight, procedural, or wrap-up — MUST include every required field:
+
+```
+pensyve_observe(
+  episode_id: <current session's working episode_id>,
+  content: "[proactive/in-flight/tier-1] <observation text>",
+  source_entity: "kiro",
+  about_entity: "<relevant entity, lowercase-hyphenated>",
+  content_type: "text"
+)
+```
+
+Use `content_type: "code"` for code-related outcomes.
+
+## Episode lifecycle (lazy-open)
+
+Kiro has no session-start/session-end hooks exposed to steering rules, so you own the episode lifecycle:
+
+- **Before your first `pensyve_observe` call in this conversation**, check whether a working `episode_id` is already tracked. If none exists, call `pensyve_episode_start(participants: ["kiro", "<project entity>"])` first, record the returned `episode_id`, then make the observation.
+- **Reuse the same `episode_id`** for all subsequent observations in the same conversation. Open a new episode only when the work's topic shifts substantially.
+- **Do not explicitly close** the episode under normal operation. Server-side consolidation handles aging.
+- **Recovery**: if `pensyve_observe` fails with a missing-episode error, call `pensyve_episode_start` and retry.
+
+## Surface style
+
+Lightly visible. One line when memory is used. Examples:
+
+- Recall: `Recalled 4 related memories (v7r, haiku-classifier).`
+- Capture: `↳ captured: hybrid-router threshold was the phase-3 regression root cause.`
+
+Do not narrate empty recalls or duplicate-skips.
+
+## Scope and budgets
+
+- Recall: scoped to detected entities (see `entity-detection.md`); limit 5; use `types` hint per flow.
+- Capture: one observation per substantive lesson; reuse the working `episode_id`.
+- Noise: avoid surfacing memory operations the user did not care about.
+
+## Composition with provenance tags
+
+When a capture is both procedural AND a proactive in-flight write, the `content` field begins with both markers, `[procedural]` first, then the provenance tag, then content:
+
+`[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=...`
+
+The `[procedural]` marker identifies the memory type for consolidation. The provenance tag identifies origin and trigger.
+
+## Provenance tag vocabulary
+
+- `[proactive/in-flight/tier-1]` — memory reflex captured during reasoning
+- `[proactive/in-flight/open-question]` — unresolved question noted in-flight
+- `[auto-capture/user/residual/tier-1]` — explicit user-driven capture (e.g., session-memory rule)
+
+## MCP contract reminder
+
+Rules never pass unsupported parameters. The MCP tool schemas are:
+
+- `pensyve_recall(query, entity?, types?, limit?, min_confidence?)` — **no** `related_entities`
+- `pensyve_episode_start(participants)` — **no** `continuation_of`
+- `pensyve_observe(episode_id, content, source_entity, about_entity, content_type?)` — `source_entity` and `about_entity` are **required**
+
+If you need secondary-entity context in a recall, fold those entities into the `query` string.

--- a/integrations/kiro/.kiro/steering/session-memory.md
+++ b/integrations/kiro/.kiro/steering/session-memory.md
@@ -1,0 +1,84 @@
+---
+description: Use at conversation wrap-up or when the user explicitly indicates end-of-session — capture residual lessons not captured in-flight
+---
+
+# Session Memory (Wrap-Up)
+
+Kiro has no automatic Stop hook exposed to steering rules. This rule is the manual equivalent: when the user indicates the conversation is ending ("thanks, that's all", "session wrap-up", "we're done here"), review what happened and capture anything the in-flight reflex missed.
+
+Follows `memory-reflex.md`.
+
+## Instructions
+
+### Step 1: Review the conversation
+
+Scan the current conversation for three categories of memorable content that the in-flight reflex did NOT already capture:
+
+**Decisions** (confidence: 0.9):
+- Architecture or design choices
+- Technology selections
+- API design decisions
+- Tradeoff resolutions
+
+**Outcomes** (confidence: 0.8):
+- Bug fixes and their root causes
+- Successful approaches
+- Failed approaches with reasons
+- Performance findings
+
+**Patterns** (confidence: 0.7):
+- Recurring issues
+- Workflow discoveries
+- Cross-cutting observations
+
+### Step 2: Filter for significance and deduplicate
+
+Skip routine, low-signal content. Also skip anything that was already captured in-flight.
+
+For each candidate, call `pensyve_recall` with `query: <candidate fact text>`, `entity: <candidate's entity>`, `limit: 3`. If any returned memory has a score ≥0.85 against the candidate, skip it as a likely duplicate.
+
+Note: `pensyve_inspect` cannot filter by `episode_id` (its params are `entity`, `memory_type?`, `limit?` only), so dedup is entity-scoped semantic-similarity rather than session-scoped. Consequence: very similar items captured in prior sessions will also trigger the skip — acceptable for avoiding genuine duplicates.
+
+### Step 3: Present candidates for confirmation
+
+Show the filtered candidates to the user in a structured format:
+
+> **Session Memory Candidates**
+>
+> **Decisions** (confidence: 0.9):
+> 1. `<entity>`: <decision text>
+>
+> **Outcomes** (confidence: 0.8):
+> 2. `<entity>`: <outcome text>
+>
+> **Patterns** (confidence: 0.7):
+> 3. `<entity>`: <pattern text>
+>
+> Which should I store? (e.g., "all", "1,3", "none")
+
+### Step 4: Store confirmed items
+
+For each confirmed item, classify the type and call the appropriate MCP tool:
+
+- **Semantic** (decisions, durable truths) — `pensyve_remember(entity, fact: "[auto-capture/user/residual/tier-1] <text>", confidence)`. Use confidence from the categorization above.
+- **Episodic** (outcomes, session-specific events) — ensure working `episode_id`; `pensyve_observe(episode_id, content: "[auto-capture/user/residual/tier-1] <text>", source_entity: "kiro", about_entity: <entity>, content_type: "text")`.
+- **Procedural** (reusable workflows) — `pensyve_observe(episode_id, content: "[procedural] [auto-capture/user/residual/tier-1] trigger=..., action=..., outcome=...", source_entity: "kiro", about_entity: <entity>, content_type: "text")`.
+
+### Step 5: Optionally close the episode
+
+If the user indicates this is a final wrap (not just a turn-by-turn pause), call `pensyve_episode_end(episode_id: <working_id>, outcome: "success")`. Valid outcomes: `"success"`, `"failure"`, `"partial"`.
+
+Not closing is safe — server-side consolidation ages episodes naturally. Only close when the user clearly marks the work complete.
+
+### Step 6: Report
+
+After storing, summarize:
+
+> Stored N memories. Episode <outcome> closed.
+
+## Constraints
+
+- **Never auto-store.** Every candidate MUST be presented to the user for confirmation before storage.
+- Entity names lowercase-hyphenated.
+- Do not store secrets.
+- If nothing significant surfaced, say so clearly rather than forcing low-quality memories.

--- a/integrations/kiro/CHANGELOG.md
+++ b/integrations/kiro/CHANGELOG.md
@@ -1,0 +1,42 @@
+# Changelog — Pensyve Kiro Adapter
+
+All notable changes to the Pensyve Kiro adapter are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). The Kiro adapter versions independently of the Claude Code plugin.
+
+## [1.0.0] - 2026-04-20
+
+### Added
+
+- **Working-memory substrate** for Kiro via `.kiro/steering/*.md` steering files. Eight steering documents deliver the substrate the Claude Code plugin v1.3.0 established:
+  - `memory-reflex.md` (always-apply) — non-optional reasoning discipline with three-type memory classification, canonical `pensyve_observe` call template, provenance vocabulary, lazy-open episode lifecycle
+  - `entity-detection.md` (always-apply) — canonicalization and fallback rules
+  - `memory-informed-debug.md` — debug flow
+  - `memory-informed-design.md` — design flow
+  - `memory-informed-refactor.md` — refactor flow
+  - `memory-informed-longitudinal-work.md` — research/eval flow (applies for `research/`, `benchmarks/`, `evals/` directories or research-oriented conversations)
+  - `session-memory.md` — manual wrap-up equivalent of Claude Code's Stop hook
+  - `context-loader.md` — best-effort continuity primer via episodic recall
+- **MCP config example** at `.kiro/mcp.json.example` covering Cloud-with-API-key and Local-stdio options
+- **Static MCP contract lint script** at `scripts/lint-mcp-refs.sh` verifying every rule's `pensyve_*` call example matches the `pensyve-mcp-tools/src/params.rs` schema
+
+### Design
+
+- Single reasoning layer; no platform-layer code. Kiro's steering system injects `.kiro/steering/*.md` into the agent's context; the entire adapter is steering documents.
+- Kiro steering files use simple YAML frontmatter with `description:` field for activation hints.
+- Lazy-open episode lifecycle: first `pensyve_observe` call triggers `pensyve_episode_start`; episodes are not explicitly closed.
+- Best-effort continuity primer via `pensyve_recall(types: ["episodic"])` — the MCP server has no episode-listing API.
+- MCP contract verified: no `related_entities` on recall, no `continuation_of` on episode_start, required `source_entity: "kiro"` and `about_entity` on every observe.
+- Opt-out: delete or edit steering files (Kiro-native pattern); no parallel config file.
+
+### Not Included
+
+- No extension or platform-layer code (deferred to a future sibling spec if capability gaps surface)
+- No installer script (manual copy of steering files + MCP config)
+- No server-side changes — uses the existing MCP tool surface
+
+### Relation to Other Pensyve Integrations
+
+- The Kiro adapter is part of the batch-1 working-memory substrate rollout. The Cursor adapter (v1.0.0) and Claude Code plugin (v1.3.0) are the reference implementations.
+- Spec: `pensyve-docs/specs/2026-04-20-pensyve-cursor-adapter-design.md`
+- Playbook: `pensyve-docs/specs/2026-04-18-pensyve-working-memory-substrate-design.md`

--- a/integrations/kiro/README.md
+++ b/integrations/kiro/README.md
@@ -1,33 +1,30 @@
 # Pensyve for Kiro
 
-Persistent AI memory for [Kiro](https://kiro.dev/) via MCP. Gives Kiro (AWS's AI-powered IDE) cross-session memory so it remembers your project conventions, architecture decisions, and debugging history across coding sessions.
+Persistent working-memory substrate for [Kiro](https://kiro.dev/) — memory is not a feature you invoke, it is the substrate the agent operates on.
 
-> **Status:** Scaffold — MCP configuration and documentation. Full integration planned.
+Gives Kiro (AWS's AI-powered IDE) cross-session memory so it remembers your project conventions, architecture decisions, and debugging history across coding sessions.
 
-## Authentication
+## What It Does
 
-1. Sign up at [pensyve.com](https://pensyve.com)
-2. Create an API key at [Settings → API Keys](https://pensyve.com/settings/api-keys)
-3. Set the environment variable:
-   ```bash
-   export PENSYVE_API_KEY="psy_your_key_here"
-   ```
+- **Proactive memory during work** — lessons are captured the moment they land, not at session end
+- **Thread-aware continuity** — sessions that continue prior work resume with relevant context, no re-briefing
+- **Entity-scoped recall** — substantive questions are grounded in prior decisions; simple commands stay fast
+- **Three memory types** — durable facts (semantic), session-specific events (episodic), reusable procedures (procedural)
+- **Lightly visible** — one-line surfaces when memory is used; never interrupts your flow
 
-Then configure MCP with headers (see setup instructions below).
+## Install
 
-## Setup
+Two steps: configure the MCP server, then install the steering files.
 
-Set your API key (get one at [pensyve.com/settings/api-keys](https://pensyve.com/settings/api-keys)):
+### 1. Configure the MCP server
+
+Copy `.kiro/mcp.json.example` to `.kiro/mcp.json` in your project root and edit for your setup.
+
+**Cloud with API key (recommended):**
 
 ```bash
-export PENSYVE_API_KEY="psy_your_key"
+export PENSYVE_API_KEY="psy_your_key_here"
 ```
-
-Add to your shell profile (`~/.bashrc`, `~/.zshrc`) to persist across sessions.
-
-## Cloud (Recommended)
-
-Add to `.kiro/mcp.json` in your project root or configure via Kiro's agent hooks settings:
 
 ```json
 {
@@ -43,11 +40,9 @@ Add to `.kiro/mcp.json` in your project root or configure via Kiro's agent hooks
 }
 ```
 
-> Use `headers` with `Authorization: Bearer` for remote MCP. The `env` block is for local stdio servers.
+Create your key at [pensyve.com/settings/api-keys](https://pensyve.com/settings/api-keys). Put the `export` in `~/.bashrc` or `~/.zshrc` to persist.
 
-## Local (Offline)
-
-No API key needed — all data stays on your machine.
+**Local (offline, self-hosted):**
 
 ```json
 {
@@ -64,37 +59,91 @@ No API key needed — all data stays on your machine.
 }
 ```
 
-Build from source: `cargo build --release -p pensyve-mcp` from the [pensyve repo](https://github.com/major7apps/pensyve).
+Build the binary: `cargo build --release -p pensyve-mcp` from the [pensyve repo](https://github.com/major7apps/pensyve).
 
-## Available Tools
+### 2. Install the steering files
 
-| Tool                    | Description                            |
-| ----------------------- | -------------------------------------- |
-| `pensyve_recall`        | Search memories by semantic similarity |
-| `pensyve_remember`      | Store a fact as semantic memory        |
-| `pensyve_observe`       | Record an event during an episode      |
-| `pensyve_episode_start` | Begin tracking an interaction          |
-| `pensyve_episode_end`   | Close an episode                       |
-| `pensyve_forget`        | Delete an entity's memories            |
-| `pensyve_inspect`       | List memories for an entity            |
+Copy the steering files into your project's `.kiro/steering/` directory:
+
+```bash
+mkdir -p .kiro/steering
+cp /path/to/pensyve/integrations/kiro/.kiro/steering/*.md .kiro/steering/
+```
+
+Kiro loads all `.md` files in `.kiro/steering/` as steering documents automatically.
+
+| Steering file | Purpose |
+|---|---|
+| `memory-reflex.md` | Always-on reasoning discipline (core substrate) |
+| `entity-detection.md` | Entity canonicalization reference |
+| `memory-informed-debug.md` | Debug flow with memory baked in |
+| `memory-informed-design.md` | Design flow with memory baked in |
+| `memory-informed-refactor.md` | Refactor flow with memory baked in |
+| `memory-informed-longitudinal-work.md` | Research/eval multi-session flow |
+| `session-memory.md` | Manual session wrap-up capture |
+| `context-loader.md` | Best-effort continuity primer at session start |
+
+## How It Works
+
+Kiro's steering system injects `.kiro/steering/*.md` files into the agent's context. The entire substrate is delivered through these steering documents — `memory-reflex.md` establishes the discipline: *before substantive answers, recall by entity; when a lesson lands, observe immediately with a one-line surface*. Flow rules (debug/design/refactor/longitudinal-work) guide the model through consult-memory + capture-lesson steps.
+
+**Episode lifecycle:** Kiro's steering rules have no access to session-start/session-end hooks, so episodes open lazily on the first `pensyve_observe` call and are not explicitly closed under normal operation. Server-side consolidation handles aging.
+
+**Continuity primer:** `context-loader.md` runs a best-effort recall at the start of substantive conversations to surface prior relevant observations. Not a structured server-side link — the MCP server has no episode-listing API yet — but good enough to create the "continuing prior work" feel.
+
+## Memory Behavior Model
+
+Pensyve behaves as working memory for the agent — always-on, ambient, continuous.
+
+**Writes happen in-flight.** When a root cause is confirmed, a decision is made, or a reusable procedure emerges, it's captured the moment it lands via the memory reflex. No batching to session end.
+
+**Reads happen at decision points.** Before substantive answers, the model consults memory scoped to the detected entities. Simple commands (run tests, format file) skip recall to stay fast.
+
+**Sessions continue.** At the start of a substantive conversation, Pensyve checks whether the current work continues prior memories (shared entities + recent activity). If yes, you resume with a primer — no re-briefing needed.
+
+## Memory Types
+
+| Type | Definition | MCP call | Example |
+|---|---|---|---|
+| **Semantic** | Durable truths, decisions, preferences | `pensyve_remember` | "We chose RS256 over HS256 for JWT signing" |
+| **Episodic** | Temporal events, session-scoped observations | `pensyve_observe` (with lazy-opened `episode_id`) | "Phase-3 regression root cause: hybrid-router threshold" |
+| **Procedural** | Reusable workflows, sequences, recipes | `pensyve_observe` with `[procedural]` content prefix | "To calibrate V7r: freeze Haiku config, run suite, diff baseline" |
+
+## Opt-Out
+
+- **Full opt-out** — delete the Pensyve steering files from `.kiro/steering/`
+- **Partial opt-out** — delete specific flow rules (e.g., remove `memory-informed-longitudinal-work.md` if you don't do research work)
+- **Silent mode** — edit `memory-reflex.md` to remove the "one-line surface" guidance; captures stay silent
+- **Recall-only mode** — edit flow rules to drop the `Capture lesson` steps while keeping `Consult memory`
+
+## Available MCP Tools
+
+| Tool | Description |
+|---|---|
+| `pensyve_recall` | Search memories by semantic similarity |
+| `pensyve_remember` | Store a durable fact (semantic memory) |
+| `pensyve_observe` | Record a session observation (episodic / procedural via `[procedural]` prefix) |
+| `pensyve_episode_start` | Begin tracking an episode |
+| `pensyve_episode_end` | Close an episode with outcome |
+| `pensyve_forget` | Delete an entity's memories |
+| `pensyve_inspect` | List memories for an entity |
 
 See [MCP Tools Reference](https://pensyve.com/docs/api-reference/mcp-tools) for full parameter details.
 
-## Intelligent Memory Capture
+## Design Philosophy
 
-Pensyve uses a tiered classification system to identify what is worth remembering. Since Kiro connects via MCP, the LLM follows the MCP tool descriptions to decide when and how to call memory tools.
+- **Memory as substrate** — not a feature the user invokes; always there, continuous, carried across sessions
+- **Reasoning-layer only** — no platform-layer code in v1; the entire adapter is steering documents
+- **1:1 with Claude Code** — same skill structure, same conventions, same memory types
+- **MCP contract-respecting** — every rule's call examples verified against `pensyve-mcp-tools/src/params.rs`
 
-### Tiered Capture System
+## Links
 
-- **Tier 1** (auto-store, confidence 0.9+): Explicit decisions, corrections, constraints, architecture choices, dependency version pins, security rules. High-signal items that should almost always be captured.
-- **Tier 2** (review, confidence 0.7-0.89): Root causes, failed approaches, performance findings, debugging outcomes, environment quirks. Medium-signal items that benefit from user confirmation.
-- **Discard**: Formatting, typos, boilerplate, ephemeral status messages. Noise that should never be stored.
+- **Website:** [pensyve.com](https://pensyve.com)
+- **GitHub:** [github.com/major7apps/pensyve](https://github.com/major7apps/pensyve)
+- **Spec:** [Cursor adapter design](https://github.com/major7apps/pensyve-docs/blob/main/specs/2026-04-20-pensyve-cursor-adapter-design.md)
+- **Playbook:** [Working-memory substrate design](https://github.com/major7apps/pensyve-docs/blob/main/specs/2026-04-18-pensyve-working-memory-substrate-design.md)
 
-### Best Practices
+## License
 
-- Use `pensyve_observe` to record significant events during an episode (architecture decisions, failed approaches, key findings)
-- Use `pensyve_remember` for durable facts that should persist across sessions (project conventions, environment constraints, resolved issues)
-- Use `pensyve_recall` at the start of a task to load relevant context from prior sessions
-- Wrap multi-step work in `pensyve_episode_start` / `pensyve_episode_end` to capture episodic context
-
-The MCP tool descriptions include guidance on confidence levels so the LLM can classify memories into the appropriate tier automatically.
+Apache 2.0

--- a/integrations/kiro/scripts/lint-mcp-refs.sh
+++ b/integrations/kiro/scripts/lint-mcp-refs.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Static MCP contract linter for the Pensyve Kiro adapter rules.
+#
+# Verifies that every pensyve_* call example in .kiro/steering/*.md conforms to
+# the current MCP tool schema in pensyve-mcp-tools/src/params.rs. Catches the
+# category of bug PR #58 surfaced in the Claude Code adapter (unsupported
+# parameters, missing required fields).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RULES_DIR="$SCRIPT_DIR/../.kiro/steering"
+
+EXIT_CODE=0
+
+if [ ! -d "$RULES_DIR" ]; then
+  echo "ERROR: Rules directory not found: $RULES_DIR"
+  exit 1
+fi
+
+echo "Linting MCP references in $RULES_DIR..."
+echo ""
+
+# Check 1: no actual use of unsupported 'related_entities' parameter in call examples.
+# We look for pensyve_recall( blocks that contain related_entities as a parameter.
+# Lines that say "no related_entities" (documentation/reminders) are excluded.
+echo "Check 1: no unsupported 'related_entities' on pensyve_recall"
+FOUND_RELATED=0
+for rule_file in "$RULES_DIR"/*.md; do
+  # Extract lines that contain pensyve_recall( and related_entities together,
+  # excluding documentation lines (those containing "**no**" or "no `related_entities`")
+  if rg -n 'related_entities' "$rule_file" | rg -v '(\*\*no\*\*|no `related_entities`)' | rg -q 'pensyve_recall\|related_entities'; then
+    echo "  FAIL in $rule_file: 'related_entities' used in a pensyve_recall call"
+    FOUND_RELATED=1
+  fi
+  # Also catch if related_entities appears inside a pensyve_recall( block
+  awk '/pensyve_recall\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+         if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
+           print FILENAME ": related_entities found in pensyve_recall block: " buf;
+         capture=0
+       }' "$rule_file" | while read -r line; do
+    if [ -n "$line" ]; then
+      echo "  FAIL: $line"
+      FOUND_RELATED=1
+    fi
+  done
+done
+if [ "$FOUND_RELATED" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 2: no actual use of unsupported 'continuation_of' parameter in call examples.
+# Documentation lines saying "no continuation_of" are excluded.
+echo "Check 2: no unsupported 'continuation_of' on pensyve_episode_start"
+FOUND_CONT=0
+for rule_file in "$RULES_DIR"/*.md; do
+  awk '/pensyve_episode_start\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+         if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
+           print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
+         capture=0
+       }' "$rule_file" | while read -r line; do
+    if [ -n "$line" ]; then
+      echo "  FAIL: $line"
+      FOUND_CONT=1
+    fi
+  done
+done
+if [ "$FOUND_CONT" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 3: every pensyve_observe call example in a code block has source_entity and about_entity
+# Scan each .md file's pensyve_observe blocks; require both fields nearby.
+echo "Check 3: every pensyve_observe example has source_entity and about_entity"
+MISSING_FIELDS=0
+for rule_file in "$RULES_DIR"/*.md; do
+  # Find each pensyve_observe( block (up to the next closing paren within 20 lines)
+  awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
+       capture {buf = buf "\n" $0;
+                for(i=1; i<=length($0); i++){
+                  c=substr($0,i,1);
+                  if(c=="(") depth++;
+                  if(c==")") depth--;
+                };
+                if(depth==0 && buf ~ /pensyve_observe\(/){
+                  if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
+                  if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
+                  capture=0;
+                }}' "$rule_file" | while read -r line; do
+    if [ -n "$line" ]; then
+      echo "  FAIL: $line"
+      MISSING_FIELDS=1
+    fi
+  done
+done
+if [ "$MISSING_FIELDS" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 4: provenance tag format — every proactive/auto-capture tag uses [<origin>/<trigger>/<tier>]
+# Format supports both 3-segment [origin/trigger/tier] and 4-segment [origin/trigger/residual/tier]
+# where the third segment may be a literal "residual" qualifier before the tier.
+echo "Check 4: provenance tag format"
+VALID_PROVENANCE_RE='\[(proactive|auto-capture)/(in-flight|stop|pre-compact|curator|user)/(tier-1|tier-2|residual/tier-1|residual/tier-2|open-question)\]'
+if rg -n '\[(proactive|auto-capture)' "$RULES_DIR" | rg -v "$VALID_PROVENANCE_RE"; then
+  echo "  FAIL: some provenance tags do not match [<origin>/<trigger>/<tier>] format"
+  EXIT_CODE=1
+else
+  echo "  PASS"
+fi
+echo ""
+
+# Check 5: procedural memory convention — [procedural] prefix is used in observe content
+echo "Check 5: procedural convention uses [procedural] prefix in pensyve_observe content"
+# Only a warning if no rule mentions [procedural] — may be legitimate if the rule is non-procedural
+if ! rg -q '\[procedural\]' "$RULES_DIR"; then
+  echo "  WARN: no [procedural] prefix usage found across rules. Expected in memory-reflex and flow rules that handle procedural captures."
+else
+  echo "  PASS"
+fi
+echo ""
+
+if [ "$EXIT_CODE" = "0" ]; then
+  echo "All MCP contract checks PASSED."
+else
+  echo "MCP contract checks FAILED. Fix the issues above before committing."
+fi
+
+exit "$EXIT_CODE"

--- a/integrations/kiro/scripts/lint-mcp-refs.sh
+++ b/integrations/kiro/scripts/lint-mcp-refs.sh
@@ -34,18 +34,18 @@ for rule_file in "$RULES_DIR"/*.md; do
     FOUND_RELATED=1
   fi
   # Also catch if related_entities appears inside a pensyve_recall( block
-  awk '/pensyve_recall\(/{capture=1; buf=""}
-       capture {buf = buf "\n" $0}
-       capture && /\)/{
-         if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
-           print FILENAME ": related_entities found in pensyve_recall block: " buf;
-         capture=0
-       }' "$rule_file" | while read -r line; do
+  while read -r line; do
     if [ -n "$line" ]; then
       echo "  FAIL: $line"
       FOUND_RELATED=1
     fi
-  done
+  done < <(awk '/pensyve_recall\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+       if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
+       print FILENAME ": related_entities found in pensyve_recall block: " buf;
+       capture=0
+       }' "$rule_file")
 done
 if [ "$FOUND_RELATED" = "0" ]; then
   echo "  PASS"
@@ -59,18 +59,18 @@ echo ""
 echo "Check 2: no unsupported 'continuation_of' on pensyve_episode_start"
 FOUND_CONT=0
 for rule_file in "$RULES_DIR"/*.md; do
-  awk '/pensyve_episode_start\(/{capture=1; buf=""}
-       capture {buf = buf "\n" $0}
-       capture && /\)/{
-         if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
-           print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
-         capture=0
-       }' "$rule_file" | while read -r line; do
+  while read -r line; do
     if [ -n "$line" ]; then
       echo "  FAIL: $line"
       FOUND_CONT=1
     fi
-  done
+  done < <(awk '/pensyve_episode_start\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+       if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
+       print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
+       capture=0
+       }' "$rule_file")
 done
 if [ "$FOUND_CONT" = "0" ]; then
   echo "  PASS"
@@ -85,23 +85,23 @@ echo "Check 3: every pensyve_observe example has source_entity and about_entity"
 MISSING_FIELDS=0
 for rule_file in "$RULES_DIR"/*.md; do
   # Find each pensyve_observe( block (up to the next closing paren within 20 lines)
-  awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
-       capture {buf = buf "\n" $0;
-                for(i=1; i<=length($0); i++){
-                  c=substr($0,i,1);
-                  if(c=="(") depth++;
-                  if(c==")") depth--;
-                };
-                if(depth==0 && buf ~ /pensyve_observe\(/){
-                  if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
-                  if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
-                  capture=0;
-                }}' "$rule_file" | while read -r line; do
+  while read -r line; do
     if [ -n "$line" ]; then
       echo "  FAIL: $line"
       MISSING_FIELDS=1
     fi
-  done
+  done < <(awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
+       capture {buf = buf "\n" $0;
+       for(i=1; i<=length($0); i++){
+       c=substr($0,i,1);
+       if(c=="(") depth++;
+       if(c==")") depth--;
+       };
+       if(depth==0 && buf ~ /pensyve_observe\(/){
+       if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
+       if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
+       capture=0;
+       }}' "$rule_file")
 done
 if [ "$MISSING_FIELDS" = "0" ]; then
   echo "  PASS"

--- a/integrations/langchain-ts/CHANGELOG.md
+++ b/integrations/langchain-ts/CHANGELOG.md
@@ -1,0 +1,43 @@
+# Changelog — Pensyve LangChain TypeScript Integration
+
+All notable changes to the Pensyve LangChain TypeScript integration are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). This integration versions independently of the core Pensyve engine.
+
+## [1.0.0] - 2026-04-20
+
+### Added
+
+- **Working-memory substrate** for LangChain.js / LangGraph.js agents via `SUBSTRATE_PROMPT.md`. All eight substrate rules consolidated into a single system-prompt document:
+  - **Memory Reflex Rule** — non-optional reasoning discipline with three-type memory classification, canonical `pensyve_observe` call template, provenance vocabulary, lazy-open episode lifecycle
+  - **Entity Detection** — canonicalization and fallback rules for recall scoping
+  - **When Debugging** — debug flow with memory baked in
+  - **When Designing** — design flow with memory baked in
+  - **When Refactoring** — refactor flow with memory baked in
+  - **Longitudinal Work** — multi-session research/eval flow with per-run capture
+  - **Session Wrap-Up** — manual wrap-up with candidate confirmation before storage
+  - **Context Loading** — best-effort continuity primer via episodic recall
+- **Framework wiring example** at `examples/pensyve-agent.ts` showing LangGraph.js ReAct agent connected to Pensyve MCP via `@langchain/mcp-adapters` with substrate loaded as system prompt
+- **Static MCP contract lint script** at `scripts/lint-mcp-refs.sh` verifying `SUBSTRATE_PROMPT.md` and the example file against the `pensyve-mcp-tools` schema
+
+### Design
+
+- Single reasoning layer; no platform-layer code.
+- `source_entity: "langchain-ts"` on all `pensyve_observe` calls.
+- MCP connection via `@langchain/mcp-adapters` `MultiServerMCPClient` with `streamable_http` transport and `close()` on completion.
+- Lazy-open episode lifecycle.
+- MCP contract verified: no `related_entities` on recall, no `continuation_of` on episode_start, required `source_entity` and `about_entity` on every observe.
+- Opt-out: remove `SUBSTRATE_PROMPT.md` from the agent's system prompt.
+
+### Not Included
+
+- No custom memory backend (that is the existing `@pensyve/langchain` `PensyveStore`)
+- No installer script — manual load of `SUBSTRATE_PROMPT.md`
+- No server-side changes — uses the existing MCP tool surface
+
+### Relation to Other Pensyve Integrations
+
+- Part of the batch-4 working-memory substrate rollout (LangChain, LangChain TS, AutoGen, CrewAI, Pydantic AI, Google ADK).
+- The Cursor adapter (v1.0.0) and Claude Code plugin (v1.3.0) are the reference implementations.
+- Spec: `pensyve-docs/specs/2026-04-20-pensyve-cursor-adapter-design.md`
+- Playbook: `pensyve-docs/specs/2026-04-18-pensyve-working-memory-substrate-design.md`

--- a/integrations/langchain-ts/README.md
+++ b/integrations/langchain-ts/README.md
@@ -1,139 +1,122 @@
 # @pensyve/langchain
 
-Pensyve memory store for LangChain.js / LangGraph.js. Implements the `BaseStore` interface (`put` / `get` / `search` / `delete`) backed by Pensyve's 8-signal fusion retrieval engine.
+Persistent AI memory for [LangChain.js](https://js.langchain.com/) / [LangGraph.js](https://langchain-ai.github.io/langgraphjs/) agents via Pensyve. Two complementary features:
 
-## Authentication
+1. **Working-memory substrate** — A system-prompt document (`SUBSTRATE_PROMPT.md`) that gives your LangGraph.js agent the reasoning discipline to recall before answering and capture lessons as they land.
+2. **Memory store backend** — `PensyveStore`: a drop-in `BaseStore`-compatible backend backed by Pensyve's 8-signal fusion retrieval engine.
 
-```typescript
-import { PensyveStore } from "@pensyve/langchain";
+---
 
-// Explicit API key
-const store = new PensyveStore({ apiKey: "psy_your_key_here" });
+## What It Does
 
-// Or from environment variable
-// export PENSYVE_API_KEY="psy_your_key_here"
-const store = new PensyveStore();
+The working-memory substrate is a reasoning layer — not a library — that you load into your agent's system prompt. Once loaded, the agent will:
+
+- **Recall before substantive answers** using `pensyve_recall`, scoped by entity.
+- **Capture lessons in-flight** using `pensyve_observe` when a root cause is confirmed, a decision lands, or an approach is abandoned.
+- **Manage episode lifecycle** lazily: open an episode on the first observe, reuse it throughout the conversation.
+- **Surface memory lightly** — one line per recall or capture, never narrating empty recalls.
+- **Wrap up sessions** by presenting memory candidates for user confirmation before storage.
+
+---
+
+## Install
+
+```bash
+bun add @langchain/anthropic @langchain/langgraph @langchain/mcp-adapters
+
+# Memory store backend (optional — separate from the substrate)
+bun add @pensyve/langchain
+```
+
+Set your API key:
+
+```bash
+export PENSYVE_API_KEY="psy_your_key_here"
+export ANTHROPIC_API_KEY="sk-ant-..."
 ```
 
 Create an API key at [pensyve.com/settings/api-keys](https://pensyve.com/settings/api-keys).
 
-## Installation
-
-```bash
-bun add @pensyve/langchain
-# or
-npm install @pensyve/langchain
-```
+---
 
 ## Quick Start
 
-```typescript
-import { PensyveStore } from "@pensyve/langchain";
-
-const store = new PensyveStore();
-
-// Store memories
-await store.put(["user_123", "memories"], "pref-1", { text: "likes dark mode" });
-await store.put(["user_123", "memories"], "pref-2", { text: "prefers TypeScript" });
-
-// Search by semantic query
-const items = await store.search(["user_123", "memories"], { query: "color preferences" });
-for (const item of items) {
-  console.log(`${item.key}: ${JSON.stringify(item.value)}`);
-}
-
-// Get by exact key
-const item = await store.get(["user_123", "memories"], "pref-1");
-console.log(item?.value); // { text: "likes dark mode" }
-
-// Delete
-await store.delete(["user_123", "memories"], "pref-1");
-```
-
-## Usage with LangGraph
-
-```typescript
-import { StateGraph, START, END } from "@langchain/langgraph";
-import { PensyveStore } from "@pensyve/langchain";
-
-const store = new PensyveStore();
-
-// Pre-populate some user preferences
-await store.put(["preferences"], "user-42", { theme: "dark", lang: "en" });
-
-async function myNode(state: any, { store }: { store: PensyveStore }) {
-  const prefs = await store.get(["preferences"], "user-42");
-  const theme = prefs?.value?.theme ?? "light";
-
-  await store.put(["user-42", "memories"], "last-query", { q: state.query });
-
-  return { response: `Using ${theme} theme` };
-}
-
-const builder = new StateGraph({ /* ... */ });
-builder.addNode("node", myNode);
-// ...
-const graph = builder.compile({ store });
-```
-
-## Local vs Cloud Mode
-
-The store auto-detects which mode to use:
-
-| Condition                     | Mode      | Backend                             |
-| ----------------------------- | --------- | ----------------------------------- |
-| No API key set                | **Local** | Pensyve local server (zero latency) |
-| `PENSYVE_API_KEY` env var set | **Cloud** | Pensyve REST API                    |
-| `apiKey` argument passed      | **Cloud** | Pensyve REST API                    |
-
-## API Reference
-
-### `new PensyveStore(config?)`
-
-| Option      | Type     | Default                   | Description                                      |
-| ----------- | -------- | ------------------------- | ------------------------------------------------ |
-| `namespace` | `string` | `"default"`               | Pensyve namespace for isolation                  |
-| `apiKey`    | `string` | `undefined`               | Cloud API key (falls back to `PENSYVE_API_KEY`)  |
-| `baseUrl`   | `string` | `https://api.pensyve.com` | Override cloud API URL                           |
-| `entity`    | `string` | `"langgraph-agent"`       | Default entity name for memories                 |
-
-### Methods
-
-| Method                                          | Description                             |
-| ----------------------------------------------- | --------------------------------------- |
-| `put(namespace, key, value)`                    | Store a value under namespace/key       |
-| `get(namespace, key)`                           | Get a single item by key, or `null`     |
-| `search(namespace, { query, filter?, limit? })` | Semantic search within a namespace      |
-| `delete(namespace, key)`                        | Delete a specific item                  |
-
-## Intelligent Memory Capture
-
-The `PensyveCaptureHandler` is a LangChain.js callback handler that automatically
-captures decisions, errors, and tool outputs during chain execution. Signals are
-classified into tiers:
-
-- **Tier 1** — high-confidence memories (architecture decisions, constraints) are auto-stored
-- **Tier 2** — lower-confidence candidates (root causes, failed approaches) are held for review
-
-```typescript
-import { PensyveCaptureHandler } from "@pensyve/langchain/capture-handler";
-
-const handler = new PensyveCaptureHandler(client);
-
-// Attach to any chain
-const result = await chain.invoke(inputs, { callbacks: [handler] });
-
-// Review tier 2 candidates after execution
-for (const mem of handler.getPendingReview()) {
-  console.log(`[review] ${mem.fact} (confidence=${mem.confidence})`);
-}
-
-handler.clearPendingReview();
-```
-
-## Running Tests
-
 ```bash
 cd integrations/langchain-ts
-bun test
+bun run examples/pensyve-agent.ts
 ```
+
+The example connects a LangGraph.js ReAct agent to the Pensyve MCP server and loads `SUBSTRATE_PROMPT.md` as the system prompt.
+
+---
+
+## System Prompt
+
+`SUBSTRATE_PROMPT.md` consolidates all eight substrate rules into a single document. Load it into your agent:
+
+```typescript
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { createReactAgent } from "@langchain/langgraph/prebuilt";
+
+const substrate = readFileSync(join(__dirname, "SUBSTRATE_PROMPT.md"), "utf-8");
+const agent = createReactAgent({ llm, tools, prompt: substrate });
+```
+
+---
+
+## MCP Connection
+
+```typescript
+import { MultiServerMCPClient } from "@langchain/mcp-adapters";
+
+const client = new MultiServerMCPClient({
+  pensyve: {
+    transport: "streamable_http",
+    url: "https://mcp.pensyve.com/mcp",
+    headers: { Authorization: `Bearer ${process.env.PENSYVE_API_KEY}` },
+  },
+});
+const tools = await client.getTools();
+// ... use agent, then:
+await client.close();
+```
+
+---
+
+## Memory Behavior Model
+
+| Trigger | Action | MCP call |
+|---|---|---|
+| Before substantive answer | Recall by entity | `pensyve_recall(query, entity, types, limit=5)` |
+| Root cause confirmed | Capture episodic | `pensyve_observe(episode_id, content, source_entity="langchain-ts", about_entity)` |
+| Decision accepted | Capture semantic | `pensyve_remember(entity, fact, confidence=0.9)` |
+| Reusable workflow found | Capture procedural | `pensyve_observe(... content="[procedural] ...")` |
+| Session ending | Present candidates | User confirms before storage |
+
+---
+
+## Memory Types
+
+- **Semantic** — durable facts that remain true across sessions.
+- **Episodic** — what happened in this thread (outcomes, root causes, abandoned approaches).
+- **Procedural** — reusable workflows stored via `pensyve_observe` with a `[procedural]` prefix.
+
+---
+
+## Opt-Out
+
+To disable the substrate, remove `SUBSTRATE_PROMPT.md` from the agent's `prompt` argument. The `PensyveStore` backend is unaffected.
+
+---
+
+## Links
+
+- [Pensyve](https://pensyve.com) — managed memory service
+- [API Keys](https://pensyve.com/settings/api-keys)
+- [LangChain.js docs](https://js.langchain.com/)
+- [LangGraph.js docs](https://langchain-ai.github.io/langgraphjs/)
+
+## License
+
+Apache 2.0 — see [LICENSE](LICENSE).

--- a/integrations/langchain-ts/SUBSTRATE_PROMPT.md
+++ b/integrations/langchain-ts/SUBSTRATE_PROMPT.md
@@ -1,0 +1,397 @@
+# Pensyve Working-Memory Substrate for LangChain TypeScript
+
+This document configures persistent working-memory for LangChain.js / LangGraph.js agents via the Pensyve MCP server. Load the full text of this file as the agent's system prompt to activate all substrate behaviors. All sections below form the reasoning layer the agent carries through every session.
+
+---
+
+## Memory Reflex Rule
+
+**This discipline is non-optional. Before substantive answers, recall by entity. When a lesson lands, observe immediately with a one-line surface.**
+
+### "Substantive answer" means
+
+- Design or architecture recommendations
+- Debugging diagnoses with root-cause claims
+- Refactor proposals
+- Any response that makes a claim the user would want grounded in prior work
+
+Not substantive: formatting fixes, trivial lookups, reading a file, running a command.
+
+### "Lesson lands" means
+
+- A root cause has been confirmed (not hypothesized).
+- A design choice has been made explicit ("we'll use X because Y").
+- An approach has been tried and abandoned with a reason.
+- A workflow has been discovered that is reusable.
+- A workaround for a framework/library limitation has been validated.
+
+### Memory classification
+
+- **Semantic** — a fact that will still be true next month. Use `pensyve_remember(entity, fact, confidence?)` (confidence defaults to 1.0; use 0.9 for high-confidence auto-captures).
+- **Episodic** — something that happened in this thread of work. Use `pensyve_observe` with the current `episode_id`.
+- **Procedural** — a reusable way to do something. Use `pensyve_observe` with `content` beginning `[procedural]`.
+
+When in doubt, prefer episodic.
+
+### Canonical `pensyve_observe` call template
+
+ALL observe calls MUST include every required field:
+
+```
+pensyve_observe(
+  episode_id: <current session's working episode_id>,
+  content: "[proactive/in-flight/tier-1] <observation text>",
+  source_entity: "langchain-ts",
+  about_entity: "<relevant entity, lowercase-hyphenated>",
+  content_type: "text"
+)
+```
+
+Use `content_type: "code"` for code-related outcomes.
+
+### Episode lifecycle (lazy-open)
+
+Library agents have no session-start/session-end hooks, so you own the episode lifecycle:
+
+- Before your first `pensyve_observe` call in this conversation, check whether a working `episode_id` is tracked. If none exists, call `pensyve_episode_start(participants: ["langchain-ts", "<project entity>"])` first.
+- Reuse the same `episode_id` for all subsequent observations in the same conversation.
+- Do not explicitly close the episode under normal operation. Server-side consolidation handles aging.
+- Recovery: if `pensyve_observe` fails with a missing-episode error, call `pensyve_episode_start` and retry.
+
+### Surface style
+
+Lightly visible. One line when memory is used:
+
+- Recall: `Recalled 4 related memories (v7r, haiku-classifier).`
+- Capture: `↳ captured: hybrid-router threshold was the phase-3 regression root cause.`
+
+Do not narrate empty recalls or duplicate-skips.
+
+### Provenance tag vocabulary
+
+- `[proactive/in-flight/tier-1]` — memory reflex captured during reasoning
+- `[proactive/in-flight/open-question]` — unresolved question noted in-flight
+- `[auto-capture/user/residual/tier-1]` — explicit user-driven capture
+
+### Composition
+
+When a capture is both procedural AND in-flight: `[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=...`
+
+### MCP contract
+
+Rules never pass unsupported parameters:
+
+- `pensyve_recall(query, entity?, types?, limit?, min_confidence?)` — **no** `related_entities`
+- `pensyve_episode_start(participants)` — **no** `continuation_of`
+- `pensyve_observe(episode_id, content, source_entity, about_entity, content_type?)` — `source_entity` and `about_entity` are **required**
+
+---
+
+## Entity Detection
+
+Shared rules for detecting entity names from tool inputs, prompts, and conversation context. Used to scope recalls and `about_entity` fields on observations.
+
+### Inputs
+
+Extract candidate entity names from:
+
+1. **User prompts** — explicit references to components, files, services, research phases.
+2. **Code context** — module names, class names, function names referenced in the conversation.
+3. **File references** — any filenames or paths mentioned in the conversation.
+4. **Git context** — repository root name, branch name (when discoverable).
+
+### Canonicalization
+
+- Lowercase all characters.
+- Replace spaces and underscores with hyphens.
+- Strip file extensions unless the file is the entity itself.
+- Collapse paths to the most semantically meaningful segment.
+
+### Fallback behavior
+
+- If no specific entity is detected, fall back to the project-level entity (repository root name, lowercase-hyphenated).
+- If a candidate entity is ambiguous, prefer the one that already has memories in Pensyve (call `pensyve_inspect` with limit 1 to check).
+- **Never fabricate entity names.** If nothing confident emerges, use the project entity.
+
+### Output
+
+A set of 1–3 candidate entity names per turn. The primary entity is the most specific. Since `pensyve_recall` accepts only a single `entity` parameter, fold secondary entities into the `query` string.
+
+---
+
+## When Debugging
+
+Debugging flow with memory baked in as a non-optional reflex.
+
+### Step 1: Detect entities
+
+Identify the relevant entity/entities (failing test, failing module, error source) per Entity Detection above.
+
+### Step 2: Consult memory (required)
+
+Call `pensyve_recall`:
+
+- `query`: a short description of the failure, including secondary entity names where known
+- `entity`: primary detected entity
+- `types`: `["procedural", "episodic"]`
+- `limit`: 5
+
+Surface one line: `Recalled N memories from prior debug sessions on <entity>.` (Skip if N=0.)
+
+If a highly similar incident is found (score >0.8), call it out inline.
+
+### Step 3: Diagnose
+
+Proceed with diagnostic work. Use recalled procedural memories as a starting sequence.
+
+### Step 4: Capture lesson (when it lands)
+
+When a root cause is **confirmed**, ensure a working `episode_id` exists, then:
+
+- **Episodic root cause:** `pensyve_observe` with `content: "[proactive/in-flight/tier-1] <one-sentence root cause>"`, `source_entity: "langchain-ts"`, `about_entity: <primary_entity>`.
+- **Procedural diagnostic sequence:** `pensyve_observe` with `content: "[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=..."`.
+- **Semantic durable truth:** `pensyve_remember(entity, fact: "[proactive/in-flight/tier-1] <fact>", confidence: 0.9)`.
+
+Surface one line: `↳ captured: <one-sentence>`.
+
+### Step 5: Capture abandoned approaches
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[proactive/in-flight/tier-1] tried <approach>, abandoned because <reason>",
+  source_entity: "langchain-ts",
+  about_entity: <primary_entity>,
+  content_type: "text"
+)
+```
+
+---
+
+## When Designing
+
+Design flow with memory baked in as a non-optional reflex.
+
+### Step 1: Detect entities
+
+Identify the relevant entity/entities (service, module, subsystem under design) per Entity Detection above.
+
+### Step 2: Consult memory (required)
+
+Call `pensyve_recall`:
+
+- `query`: a short description of the design question, including secondary entity names
+- `entity`: primary detected entity
+- `types`: `["semantic", "episodic"]`
+- `limit`: 5
+
+Surface one line: `Recalled N prior decisions on <entity>.` (Skip if N=0.)
+
+### Step 3: Recommend with grounding
+
+Shape your recommendation using recalled decisions. If the current question contradicts a prior decision, flag it.
+
+### Step 4: Capture decision (when it lands)
+
+When the user accepts a design or states a decision:
+
+- **Semantic:** `pensyve_remember(entity: <primary_entity>, fact: "[proactive/in-flight/tier-1] <decision text>", confidence: 0.9)`.
+- **Episodic context:** `pensyve_observe` with `content: "[proactive/in-flight/tier-1] Decision on <entity>: chose X over Y because Z"`, `source_entity: "langchain-ts"`, `about_entity: <primary_entity>`.
+
+Surface one line: `↳ captured decision on <entity>: <short>`.
+
+### Step 5: Capture evaluation procedures
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[procedural] [proactive/in-flight/tier-1] trigger=design-question-on-<area>, action=<steps>, outcome=<what-you-learn>",
+  source_entity: "langchain-ts",
+  about_entity: <primary_entity>,
+  content_type: "text"
+)
+```
+
+---
+
+## When Refactoring
+
+Refactor flow with memory baked in.
+
+### Step 1: Detect entities
+
+Identify entities touched by the refactor per Entity Detection above.
+
+### Step 2: Load prior context (required)
+
+Call `pensyve_recall`:
+
+- `query`: short description of the refactor
+- `entity`: primary detected entity
+- `types`: `["semantic", "episodic", "procedural"]`
+- `limit`: 5
+
+Surface: `Recalled N prior memories on <entity>.` Highlight any prior failed approaches.
+
+### Step 3: Present a briefing
+
+Before starting the refactor, summarize what prior memories say about decisions, prior attempts, and known-good procedures.
+
+### Step 4: Capture refactor lessons as they land
+
+When an invariant is discovered, an approach is confirmed not-viable, or a known-good sequence emerges, apply the memory reflex immediately. Ensure working `episode_id` before each observe.
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[proactive/in-flight/tier-1] <lesson>",
+  source_entity: "langchain-ts",
+  about_entity: <primary_entity>,
+  content_type: "text"
+)
+```
+
+---
+
+## When Doing Longitudinal Work
+
+Multi-session work (research, eval loops, iterative benchmarks) where lessons must accumulate across runs.
+
+### Step 1: Resume context at conversation start
+
+Call `pensyve_recall` once at the start:
+
+- `query`: short description of the current research area
+- `entity`: project + sub-topic entity
+- `limit`: 5
+
+No `types` filter — longitudinal work benefits from all three memory types.
+
+Surface: `Recalled N prior findings on <sub-topic>.`
+
+### Step 2: Proactively recall per topic shift
+
+When the session pivots to a new sub-topic, call `pensyve_recall` again scoped to the new sub-topic.
+
+### Step 3: Capture three types of memory per run
+
+| What you learned | Type | MCP call |
+|---|---|---|
+| Per-run outcome | episodic | `pensyve_observe(..., content: "[proactive/in-flight/tier-1] Run N+1: <result>", source_entity: "langchain-ts", about_entity: <entity>)` |
+| Stable truth | semantic | `pensyve_remember(entity, fact: "[proactive/in-flight/tier-1] <stable fact>", confidence: 0.9)` |
+| Reusable procedure | procedural | `pensyve_observe(..., content: "[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=...", source_entity: "langchain-ts", about_entity: <entity>)` |
+
+### Step 4: Capture open questions
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[proactive/in-flight/open-question] <question>",
+  source_entity: "langchain-ts",
+  about_entity: <entity>,
+  content_type: "text"
+)
+```
+
+### Step 5: End-of-session summary
+
+Before the conversation wraps, briefly summarize what this run taught vs. prior runs, and what's still open.
+
+---
+
+## Session Wrap-Up
+
+Manual wrap-up: when the user indicates the conversation is ending, review what happened and capture anything the in-flight reflex missed.
+
+### Step 1: Review the conversation
+
+Scan for three categories not already captured in-flight:
+
+**Decisions** (confidence: 0.9): Architecture choices, technology selections, tradeoff resolutions.
+
+**Outcomes** (confidence: 0.8): Bug fixes, successful/failed approaches, performance findings.
+
+**Patterns** (confidence: 0.7): Recurring issues, workflow discoveries, cross-cutting observations.
+
+### Step 2: Filter for significance and deduplicate
+
+For each candidate, call `pensyve_recall` with `query: <candidate fact text>`, `entity: <entity>`, `limit: 3`. If any returned memory has score ≥0.85, skip as a likely duplicate.
+
+### Step 3: Present candidates for confirmation
+
+> **Session Memory Candidates**
+>
+> **Decisions** (confidence: 0.9):
+> 1. `<entity>`: <decision text>
+>
+> **Outcomes** (confidence: 0.8):
+> 2. `<entity>`: <outcome text>
+>
+> Which should I store? (e.g., "all", "1,2", "none")
+
+### Step 4: Store confirmed items
+
+- **Semantic** — `pensyve_remember(entity, fact: "[auto-capture/user/residual/tier-1] <text>", confidence)`.
+- **Episodic** — `pensyve_observe(episode_id, content: "[auto-capture/user/residual/tier-1] <text>", source_entity: "langchain-ts", about_entity: <entity>)`.
+- **Procedural** — `pensyve_observe(episode_id, content: "[procedural] [auto-capture/user/residual/tier-1] trigger=..., action=..., outcome=...", source_entity: "langchain-ts", about_entity: <entity>)`.
+
+### Step 5: Optionally close the episode
+
+If the user clearly marks the work complete: `pensyve_episode_end(episode_id: <working_id>, outcome: "success")`. Valid outcomes: `"success"`, `"failure"`, `"partial"`.
+
+### Constraints
+
+- **Never auto-store.** Every candidate MUST be presented for confirmation before storage.
+- Do not store secrets.
+- If nothing significant surfaced, say so clearly.
+
+---
+
+## Context Loading (Session Start)
+
+When starting a new conversation on a project with prior Pensyve memories, load relevant context to prime the session.
+
+### Step 1: Detect project entity
+
+Use the repository root name (lowercase-hyphenated) as the default project entity. Override with `PENSYVE_NAMESPACE` environment variable if set.
+
+### Step 2: Scoped recall
+
+Call `pensyve_recall`:
+
+- `query`: `"recent decisions issues patterns"` + any key terms from the user's opening message
+- `entity`: detected project entity
+- `types`: `["episodic"]`
+- `limit`: 5
+
+### Step 3: Compute continuity signal
+
+- If ≥70% of top observations reference at least one overlapping entity: **continuation** of recent work.
+- If overlap is below 70% or recall returned empty: **fresh session**.
+
+### Step 4: Surface the primer
+
+**Continuation:**
+
+> **Pensyve:** Continuing prior work on `<entity-set>`. Recent lessons:
+>
+> - <observation 1>
+> - <observation 2>
+>
+> Use `pensyve_recall` to dig deeper.
+
+**Fresh session:**
+
+> **Pensyve:** N memories loaded for `<project>`. Key context:
+>
+> - <top 3 observations>
+
+**No memories found:**
+
+> **Pensyve:** No memories found for `<project>`. Start a session to begin building context.
+
+### Constraints
+
+- Do not fabricate memories. Only display what `pensyve_recall` returns.
+- Maximum 5 memories in the primer.
+- Entity names lowercase-hyphenated.

--- a/integrations/langchain-ts/examples/pensyve-agent.ts
+++ b/integrations/langchain-ts/examples/pensyve-agent.ts
@@ -1,0 +1,94 @@
+/**
+ * Pensyve + LangChain.js / LangGraph.js wiring example.
+ *
+ * Demonstrates how to:
+ *   1. Load the Pensyve working-memory substrate as the agent system prompt.
+ *   2. Connect to the Pensyve MCP server via @langchain/mcp-adapters.
+ *   3. Build a ReAct agent with LangGraph.js that has persistent cross-session memory.
+ *
+ * Dependencies:
+ *   bun add @langchain/anthropic @langchain/langgraph @langchain/mcp-adapters
+ *
+ * Environment variables:
+ *   PENSYVE_API_KEY   — Pensyve API key (get one at pensyve.com/settings/api-keys)
+ *   ANTHROPIC_API_KEY — Anthropic API key
+ */
+
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { ChatAnthropic } from "@langchain/anthropic";
+import { MultiServerMCPClient } from "@langchain/mcp-adapters";
+import { createReactAgent } from "@langchain/langgraph/prebuilt";
+import { HumanMessage } from "@langchain/core/messages";
+
+// ---------------------------------------------------------------------------
+// 1. Load the substrate — the reasoning layer injected as the system prompt.
+// ---------------------------------------------------------------------------
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const substratePath = join(__dirname, "..", "SUBSTRATE_PROMPT.md");
+const substrate = readFileSync(substratePath, "utf-8");
+
+// ---------------------------------------------------------------------------
+// 2. Configure the Pensyve MCP server connection.
+// ---------------------------------------------------------------------------
+const PENSYVE_API_KEY = process.env.PENSYVE_API_KEY;
+if (!PENSYVE_API_KEY) {
+  throw new Error("PENSYVE_API_KEY environment variable is required");
+}
+
+const mcpConfig = {
+  pensyve: {
+    transport: "streamable_http" as const,
+    url: "https://mcp.pensyve.com/mcp",
+    headers: { Authorization: `Bearer ${PENSYVE_API_KEY}` },
+  },
+};
+
+async function main(): Promise<void> {
+  // -------------------------------------------------------------------------
+  // 3. Initialise the MCP client and fetch available tools.
+  //    @langchain/mcp-adapters wraps MCP tools as LangChain BaseTool objects.
+  // -------------------------------------------------------------------------
+  const client = new MultiServerMCPClient(mcpConfig);
+  const tools = await client.getTools();
+
+  // -------------------------------------------------------------------------
+  // 4. Create a ReAct agent with the substrate as the system prompt.
+  // -------------------------------------------------------------------------
+  const llm = new ChatAnthropic({ model: "claude-sonnet-4-6" });
+  const agent = createReactAgent({
+    llm,
+    tools,
+    prompt: substrate, // substrate injected here
+  });
+
+  // -------------------------------------------------------------------------
+  // 5. Invoke the agent.
+  // -------------------------------------------------------------------------
+  try {
+    const result = await agent.invoke({
+      messages: [
+        new HumanMessage(
+          "I'm starting work on the auth-service module. " +
+          "What do we know about prior decisions there?"
+        ),
+      ],
+    });
+
+    // Print the final assistant message
+    for (const msg of result.messages) {
+      if (msg.getType() === "ai") {
+        console.log(msg.content);
+      }
+    }
+  } finally {
+    await client.close();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/integrations/langchain-ts/scripts/lint-mcp-refs.sh
+++ b/integrations/langchain-ts/scripts/lint-mcp-refs.sh
@@ -34,18 +34,18 @@ echo ""
 echo "Check 1: no unsupported 'related_entities' on pensyve_recall"
 FOUND_RELATED=0
 for f in "$RULES_FILE" "$EXAMPLE_FILE"; do
-  awk '/pensyve_recall\(/{capture=1; buf=""}
-       capture {buf = buf "\n" $0}
-       capture && /\)/{
-         if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
-           print FILENAME ": related_entities found in pensyve_recall block: " buf;
-         capture=0
-       }' "$f" | while read -r line; do
+  while read -r line; do
     if [ -n "$line" ]; then
       echo "  FAIL: $line"
       FOUND_RELATED=1
     fi
-  done
+  done < <(awk '/pensyve_recall\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+       if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
+       print FILENAME ": related_entities found in pensyve_recall block: " buf;
+       capture=0
+       }' "$f")
 done
 if [ "$FOUND_RELATED" = "0" ]; then
   echo "  PASS"
@@ -58,18 +58,18 @@ echo ""
 echo "Check 2: no unsupported 'continuation_of' on pensyve_episode_start"
 FOUND_CONT=0
 for f in "$RULES_FILE" "$EXAMPLE_FILE"; do
-  awk '/pensyve_episode_start\(/{capture=1; buf=""}
-       capture {buf = buf "\n" $0}
-       capture && /\)/{
-         if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
-           print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
-         capture=0
-       }' "$f" | while read -r line; do
+  while read -r line; do
     if [ -n "$line" ]; then
       echo "  FAIL: $line"
       FOUND_CONT=1
     fi
-  done
+  done < <(awk '/pensyve_episode_start\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+       if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
+       print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
+       capture=0
+       }' "$f")
 done
 if [ "$FOUND_CONT" = "0" ]; then
   echo "  PASS"
@@ -82,23 +82,23 @@ echo ""
 echo "Check 3: every pensyve_observe example has source_entity and about_entity"
 MISSING_FIELDS=0
 for f in "$RULES_FILE" "$EXAMPLE_FILE"; do
-  awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
-       capture {buf = buf "\n" $0;
-                for(i=1; i<=length($0); i++){
-                  c=substr($0,i,1);
-                  if(c=="(") depth++;
-                  if(c==")") depth--;
-                };
-                if(depth==0 && buf ~ /pensyve_observe\(/){
-                  if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
-                  if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
-                  capture=0;
-                }}' "$f" | while read -r line; do
+  while read -r line; do
     if [ -n "$line" ]; then
       echo "  FAIL: $line"
       MISSING_FIELDS=1
     fi
-  done
+  done < <(awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
+       capture {buf = buf "\n" $0;
+       for(i=1; i<=length($0); i++){
+       c=substr($0,i,1);
+       if(c=="(") depth++;
+       if(c==")") depth--;
+       };
+       if(depth==0 && buf ~ /pensyve_observe\(/){
+       if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
+       if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
+       capture=0;
+       }}' "$f")
 done
 if [ "$MISSING_FIELDS" = "0" ]; then
   echo "  PASS"

--- a/integrations/langchain-ts/scripts/lint-mcp-refs.sh
+++ b/integrations/langchain-ts/scripts/lint-mcp-refs.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Static MCP contract linter for the Pensyve langchain-ts adapter.
+#
+# Verifies that every pensyve_* call example in SUBSTRATE_PROMPT.md and the
+# example wiring file conforms to the current MCP tool schema.
+# Catches the category of bug PR #58 surfaced in the Claude Code adapter
+# (unsupported parameters, missing required fields).
+#
+# This integration uses a single consolidated SUBSTRATE_PROMPT.md (same
+# pattern as VS Code Copilot) rather than per-rule files.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INTEG_DIR="$SCRIPT_DIR/.."
+RULES_FILE="$INTEG_DIR/SUBSTRATE_PROMPT.md"
+EXAMPLE_FILE="$INTEG_DIR/examples/pensyve-agent.ts"
+
+EXIT_CODE=0
+
+for f in "$RULES_FILE" "$EXAMPLE_FILE"; do
+  if [ ! -f "$f" ]; then
+    echo "ERROR: File not found: $f"
+    exit 1
+  fi
+done
+
+echo "Linting MCP references in:"
+echo "  $RULES_FILE"
+echo "  $EXAMPLE_FILE"
+echo ""
+
+# Check 1: no actual use of unsupported 'related_entities' parameter in call examples.
+echo "Check 1: no unsupported 'related_entities' on pensyve_recall"
+FOUND_RELATED=0
+for f in "$RULES_FILE" "$EXAMPLE_FILE"; do
+  awk '/pensyve_recall\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+         if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
+           print FILENAME ": related_entities found in pensyve_recall block: " buf;
+         capture=0
+       }' "$f" | while read -r line; do
+    if [ -n "$line" ]; then
+      echo "  FAIL: $line"
+      FOUND_RELATED=1
+    fi
+  done
+done
+if [ "$FOUND_RELATED" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 2: no actual use of unsupported 'continuation_of' parameter in call examples.
+echo "Check 2: no unsupported 'continuation_of' on pensyve_episode_start"
+FOUND_CONT=0
+for f in "$RULES_FILE" "$EXAMPLE_FILE"; do
+  awk '/pensyve_episode_start\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+         if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
+           print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
+         capture=0
+       }' "$f" | while read -r line; do
+    if [ -n "$line" ]; then
+      echo "  FAIL: $line"
+      FOUND_CONT=1
+    fi
+  done
+done
+if [ "$FOUND_CONT" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 3: every pensyve_observe call example in a code block has source_entity and about_entity
+echo "Check 3: every pensyve_observe example has source_entity and about_entity"
+MISSING_FIELDS=0
+for f in "$RULES_FILE" "$EXAMPLE_FILE"; do
+  awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
+       capture {buf = buf "\n" $0;
+                for(i=1; i<=length($0); i++){
+                  c=substr($0,i,1);
+                  if(c=="(") depth++;
+                  if(c==")") depth--;
+                };
+                if(depth==0 && buf ~ /pensyve_observe\(/){
+                  if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
+                  if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
+                  capture=0;
+                }}' "$f" | while read -r line; do
+    if [ -n "$line" ]; then
+      echo "  FAIL: $line"
+      MISSING_FIELDS=1
+    fi
+  done
+done
+if [ "$MISSING_FIELDS" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 4: provenance tag format — every proactive/auto-capture tag uses [<origin>/<trigger>/<tier>]
+echo "Check 4: provenance tag format"
+VALID_PROVENANCE_RE='\[(proactive|auto-capture)/(in-flight|stop|pre-compact|curator|user)/(tier-1|tier-2|residual/tier-1|residual/tier-2|open-question)\]'
+INVALID=0
+for f in "$RULES_FILE" "$EXAMPLE_FILE"; do
+  if rg -n '\[(proactive|auto-capture)' "$f" | rg -v "$VALID_PROVENANCE_RE"; then
+    INVALID=1
+  fi
+done
+if [ "$INVALID" = "0" ]; then
+  echo "  PASS"
+else
+  echo "  FAIL: some provenance tags do not match [<origin>/<trigger>/<tier>] format"
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 5: procedural memory convention — [procedural] prefix is used in observe content
+echo "Check 5: procedural convention uses [procedural] prefix in pensyve_observe content"
+if ! rg -q '\[procedural\]' "$RULES_FILE"; then
+  echo "  WARN: no [procedural] prefix usage found in SUBSTRATE_PROMPT.md."
+else
+  echo "  PASS"
+fi
+echo ""
+
+if [ "$EXIT_CODE" = "0" ]; then
+  echo "All MCP contract checks PASSED."
+else
+  echo "MCP contract checks FAILED. Fix the issues above before committing."
+fi
+
+exit "$EXIT_CODE"

--- a/integrations/langchain/CHANGELOG.md
+++ b/integrations/langchain/CHANGELOG.md
@@ -1,0 +1,43 @@
+# Changelog — Pensyve LangChain Integration
+
+All notable changes to the Pensyve LangChain integration are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). This integration versions independently of the core Pensyve engine.
+
+## [1.0.0] - 2026-04-20
+
+### Added
+
+- **Working-memory substrate** for LangChain / LangGraph agents via `SUBSTRATE_PROMPT.md`. All eight substrate rules consolidated into a single system-prompt document:
+  - **Memory Reflex Rule** — non-optional reasoning discipline with three-type memory classification, canonical `pensyve_observe` call template, provenance vocabulary, lazy-open episode lifecycle
+  - **Entity Detection** — canonicalization and fallback rules for recall scoping
+  - **When Debugging** — debug flow with memory baked in
+  - **When Designing** — design flow with memory baked in
+  - **When Refactoring** — refactor flow with memory baked in
+  - **Longitudinal Work** — multi-session research/eval flow with per-run capture
+  - **Session Wrap-Up** — manual wrap-up with candidate confirmation before storage
+  - **Context Loading** — best-effort continuity primer via episodic recall
+- **Framework wiring example** at `examples/pensyve_agent.py` showing LangGraph ReAct agent connected to Pensyve MCP via `langchain-mcp-adapters` with substrate loaded as system prompt
+- **Static MCP contract lint script** at `scripts/lint-mcp-refs.sh` verifying `SUBSTRATE_PROMPT.md` and the example file against the `pensyve-mcp-tools` schema
+
+### Design
+
+- Single reasoning layer; no platform-layer code. The entire substrate is the `SUBSTRATE_PROMPT.md` file the agent loads as its system prompt.
+- `source_entity: "langchain"` on all `pensyve_observe` calls.
+- MCP connection via `langchain-mcp-adapters` `MultiServerMCPClient` with `streamable_http` transport.
+- Lazy-open episode lifecycle: first `pensyve_observe` call triggers `pensyve_episode_start`; episodes are not explicitly closed under normal operation.
+- MCP contract verified: no `related_entities` on recall, no `continuation_of` on episode_start, required `source_entity` and `about_entity` on every observe.
+- Opt-out: remove `SUBSTRATE_PROMPT.md` from the agent's system prompt.
+
+### Not Included
+
+- No custom memory backend (that is the existing `pensyve_langchain.py` `PensyveStore`)
+- No installer script — manual load of `SUBSTRATE_PROMPT.md`
+- No server-side changes — uses the existing MCP tool surface
+
+### Relation to Other Pensyve Integrations
+
+- Part of the batch-4 working-memory substrate rollout (LangChain, LangChain TS, AutoGen, CrewAI, Pydantic AI, Google ADK).
+- The Cursor adapter (v1.0.0) and Claude Code plugin (v1.3.0) are the reference implementations.
+- Spec: `pensyve-docs/specs/2026-04-20-pensyve-cursor-adapter-design.md`
+- Playbook: `pensyve-docs/specs/2026-04-18-pensyve-working-memory-substrate-design.md`

--- a/integrations/langchain/README.md
+++ b/integrations/langchain/README.md
@@ -1,106 +1,148 @@
 # Pensyve LangChain / LangGraph Integration
 
-Drop-in Pensyve memory backend for LangGraph agents. Implements the same
-`put` / `get` / `search` / `delete` interface as LangGraph's `InMemoryStore`,
-backed by Pensyve's 8-signal fusion retrieval engine.
+Persistent AI memory for [LangChain](https://python.langchain.com/) / [LangGraph](https://langchain-ai.github.io/langgraph/) agents via Pensyve. Two complementary features:
 
-## Authentication
+1. **Working-memory substrate** — A system-prompt document (`SUBSTRATE_PROMPT.md`) that gives your LangGraph agent the reasoning discipline to recall before answering and capture lessons as they land.
+2. **Memory store backend** — `PensyveStore`: a drop-in `InMemoryStore`-compatible backend backed by Pensyve's 8-signal fusion retrieval engine.
 
-```python
-from pensyve import PensyveClient
+---
 
-# Explicit API key
-client = PensyveClient(api_key="psy_your_key_here")
+## What It Does
 
-# Or from environment variable
-# export PENSYVE_API_KEY="psy_your_key_here"
-client = PensyveClient()
+The working-memory substrate is a reasoning layer — not a library — that you load into your agent's system prompt. Once loaded, the agent will:
+
+- **Recall before substantive answers** using `pensyve_recall`, scoped by entity.
+- **Capture lessons in-flight** using `pensyve_observe` when a root cause is confirmed, a decision lands, or an approach is abandoned.
+- **Manage episode lifecycle** lazily: open an episode on the first observe, reuse it throughout the conversation.
+- **Surface memory lightly** — one line per recall or capture, never narrating empty recalls.
+- **Wrap up sessions** by presenting memory candidates for user confirmation before storage.
+
+---
+
+## Install
+
+```bash
+pip install langchain-anthropic langchain-mcp-adapters langgraph
+
+# Memory store backend (optional — separate from the substrate)
+pip install pensyve-langchain
+```
+
+Set your API key:
+
+```bash
+export PENSYVE_API_KEY="psy_your_key_here"
+export ANTHROPIC_API_KEY="sk-ant-..."
 ```
 
 Create an API key at [pensyve.com/settings/api-keys](https://pensyve.com/settings/api-keys).
 
-## Installation
-
-```bash
-pip install pensyve-langchain
-```
-
-Or copy the `pensyve_langchain.py` file into your project.
+---
 
 ## Quick Start
 
-```python
-from pensyve_langchain import PensyveStore
-
-store = PensyveStore()
-
-# Store memories
-store.put(("user_123", "memories"), "pref-1", {"text": "likes dark mode"})
-store.put(("user_123", "memories"), "pref-2", {"text": "prefers Python"})
-
-# Search by semantic query
-items = store.search(("user_123", "memories"), query="color preferences")
-for item in items:
-    print(f"{item.key}: {item.value}")
-
-# Get by exact key
-item = store.get(("user_123", "memories"), "pref-1")
-print(item.value)  # {"text": "likes dark mode"}
-
-# Delete
-store.delete(("user_123", "memories"), "pref-1")
+```bash
+cd integrations/langchain
+python examples/pensyve_agent.py
 ```
 
-## Usage with LangGraph
+The example connects a LangGraph ReAct agent to the Pensyve MCP server and loads `SUBSTRATE_PROMPT.md` as the system prompt.
+
+---
+
+## System Prompt
+
+`SUBSTRATE_PROMPT.md` consolidates all eight substrate rules into a single document. Load it into your agent:
 
 ```python
-from langgraph.graph import StateGraph, START, END
+from pathlib import Path
+from langgraph.prebuilt import create_react_agent
+
+substrate = Path("SUBSTRATE_PROMPT.md").read_text()
+agent = create_react_agent(llm, tools, prompt=substrate)
+```
+
+All Pensyve MCP tools (`pensyve_recall`, `pensyve_remember`, `pensyve_observe`, `pensyve_episode_start`, `pensyve_episode_end`, `pensyve_inspect`, `pensyve_forget`) are available to the agent through the MCP connection.
+
+---
+
+## MCP Connection
+
+```python
+from langchain_mcp_adapters.client import MultiServerMCPClient
+
+client = MultiServerMCPClient({
+    "pensyve": {
+        "transport": "streamable_http",
+        "url": "https://mcp.pensyve.com/mcp",
+        "headers": {"Authorization": f"Bearer {os.environ['PENSYVE_API_KEY']}"},
+    }
+})
+tools = await client.get_tools()
+```
+
+For local development with a self-hosted Pensyve server, replace the `url` with your local endpoint.
+
+---
+
+## Memory Behavior Model
+
+| Trigger | Action | MCP call |
+|---|---|---|
+| Before substantive answer | Recall by entity | `pensyve_recall(query, entity, types, limit=5)` |
+| Root cause confirmed | Capture episodic | `pensyve_observe(episode_id, content, source_entity="langchain", about_entity)` |
+| Decision accepted | Capture semantic | `pensyve_remember(entity, fact, confidence=0.9)` |
+| Reusable workflow found | Capture procedural | `pensyve_observe(... content="[procedural] ...")` |
+| Session ending | Present candidates | User confirms before storage |
+
+---
+
+## Memory Types
+
+- **Semantic** — durable facts that remain true across sessions (architecture decisions, constraints).
+- **Episodic** — what happened in this thread (outcomes, root causes, abandoned approaches).
+- **Procedural** — reusable workflows and diagnostic sequences, stored via `pensyve_observe` with a `[procedural]` prefix.
+
+---
+
+## Memory Store Backend
+
+Separate from the substrate, `PensyveStore` is a drop-in `InMemoryStore` replacement for LangGraph:
+
+```python
 from pensyve_langchain import PensyveStore
 
 store = PensyveStore()
-
-# Pre-populate some user preferences
-store.put(("preferences",), "user-42", {"theme": "dark", "lang": "en"})
-
-def my_node(state, *, store):
-    # Read from the store
-    prefs = store.get(("preferences",), "user-42")
-    theme = prefs.value["theme"] if prefs else "light"
-
-    # Write to the store
-    store.put(("user-42", "memories"), "last-query", {"q": state["query"]})
-
-    return {"response": f"Using {theme} theme"}
-
-builder = StateGraph(...)
-builder.add_node("node", my_node)
-# ...
 graph = builder.compile(store=store)
 ```
 
-## Local vs Cloud Mode
+See the existing README sections below for full API reference.
 
-The store auto-detects which mode to use:
+---
 
-| Condition                     | Mode      | Backend                            |
-| ----------------------------- | --------- | ---------------------------------- |
-| No API key set                | **Local** | Pensyve PyO3 engine (zero latency) |
-| `PENSYVE_API_KEY` env var set | **Cloud** | Pensyve REST API                   |
-| `api_key=` argument passed    | **Cloud** | Pensyve REST API                   |
+## Opt-Out
 
-```python
-# Local mode (default)
-store = PensyveStore()
+To disable the substrate, remove `SUBSTRATE_PROMPT.md` from the agent's `prompt` argument. The `PensyveStore` backend is unaffected — it operates independently of the substrate.
 
-# Cloud mode via argument
-store = PensyveStore(api_key="psy_your_key_here")
+---
 
-# Cloud mode via environment variable
-# export PENSYVE_API_KEY=psy_your_key_here
-store = PensyveStore()
-```
+## Links
 
-## API Reference
+- [Pensyve](https://pensyve.com) — managed memory service
+- [API Keys](https://pensyve.com/settings/api-keys)
+- [MCP Server docs](https://docs.pensyve.com/mcp)
+- [LangChain docs](https://python.langchain.com/)
+- [LangGraph docs](https://langchain-ai.github.io/langgraph/)
+
+## License
+
+Apache 2.0 — see [LICENSE](LICENSE).
+
+---
+
+## PensyveStore API Reference
+
+Drop-in `InMemoryStore`-compatible backend. Implements `put` / `get` / `search` / `delete`.
 
 ### `PensyveStore(namespace, path, api_key, base_url)`
 
@@ -111,74 +153,11 @@ store = PensyveStore()
 | `api_key`   | `str \| None` | `None`      | Cloud API key (falls back to `PENSYVE_API_KEY`) |
 | `base_url`  | `str \| None` | `None`      | Override cloud API URL                          |
 
-### Methods
-
-| Method                                       | Description                            |
-| -------------------------------------------- | -------------------------------------- |
-| `put(namespace, key, value)`                 | Store a dict under namespace/key       |
-| `get(namespace, key)`                        | Get a single item by key, or `None`    |
-| `search(namespace, *, query, filter, limit)` | Semantic search within a namespace     |
-| `delete(namespace, key)`                     | Delete memories for a namespace entity |
-| `list_namespaces(*, prefix, limit, offset)`  | List known namespaces                  |
-
 All methods have async variants prefixed with `a` (e.g. `aput`, `aget`).
 
-### `Item`
-
-Returned by `get()` and `search()`. Matches `langgraph.store.base.Item`.
-
-| Field        | Type              | Description               |
-| ------------ | ----------------- | ------------------------- |
-| `namespace`  | `tuple[str, ...]` | The namespace tuple       |
-| `key`        | `str`             | The item key              |
-| `value`      | `dict[str, Any]`  | The stored value dict     |
-| `created_at` | `float`           | Unix timestamp            |
-| `updated_at` | `float`           | Unix timestamp            |
-| `score`      | `float \| None`   | Retrieval relevance score |
-
-## Running Tests
+### Running Tests
 
 ```bash
 cd integrations/langchain
 pytest tests/ -v
 ```
-
-## Intelligent Memory Capture
-
-The `PensyveCaptureHandler` is a LangChain callback handler that automatically
-captures decisions, errors, and tool outputs during chain execution. Signals are
-classified into tiers:
-
-- **Tier 1** — high-confidence memories (architecture decisions, constraints) are auto-stored
-- **Tier 2** — lower-confidence candidates (root causes, failed approaches) are held for review
-
-```python
-from pensyve_capture import PensyveCaptureHandler
-
-handler = PensyveCaptureHandler(client=my_pensyve_client)
-
-# Attach to any chain
-result = chain.invoke(inputs, config={"callbacks": [handler]})
-
-# Review tier 2 candidates after execution
-for mem in handler.get_pending_review():
-    print(f"[review] {mem.fact} (confidence={mem.confidence})")
-
-handler.clear_pending_review()
-```
-
-Install with capture dependencies:
-
-```bash
-pip install pensyve-langchain[capture]
-```
-
-## Namespace Mapping
-
-LangGraph namespace tuples are joined with `/` to form Pensyve entity names:
-
-| LangGraph namespace        | Pensyve entity      |
-| -------------------------- | ------------------- |
-| `("user_123", "memories")` | `user_123/memories` |
-| `("global",)`              | `global`            |
-| `()`                       | `default`           |

--- a/integrations/langchain/SUBSTRATE_PROMPT.md
+++ b/integrations/langchain/SUBSTRATE_PROMPT.md
@@ -1,0 +1,397 @@
+# Pensyve Working-Memory Substrate for LangChain
+
+This document configures persistent working-memory for LangChain / LangGraph agents via the Pensyve MCP server. Load the full text of this file as the agent's system prompt to activate all substrate behaviors. All sections below form the reasoning layer the agent carries through every session.
+
+---
+
+## Memory Reflex Rule
+
+**This discipline is non-optional. Before substantive answers, recall by entity. When a lesson lands, observe immediately with a one-line surface.**
+
+### "Substantive answer" means
+
+- Design or architecture recommendations
+- Debugging diagnoses with root-cause claims
+- Refactor proposals
+- Any response that makes a claim the user would want grounded in prior work
+
+Not substantive: formatting fixes, trivial lookups, reading a file, running a command.
+
+### "Lesson lands" means
+
+- A root cause has been confirmed (not hypothesized).
+- A design choice has been made explicit ("we'll use X because Y").
+- An approach has been tried and abandoned with a reason.
+- A workflow has been discovered that is reusable.
+- A workaround for a framework/library limitation has been validated.
+
+### Memory classification
+
+- **Semantic** — a fact that will still be true next month. Use `pensyve_remember(entity, fact, confidence?)` (confidence defaults to 1.0; use 0.9 for high-confidence auto-captures).
+- **Episodic** — something that happened in this thread of work. Use `pensyve_observe` with the current `episode_id`.
+- **Procedural** — a reusable way to do something. Use `pensyve_observe` with `content` beginning `[procedural]`.
+
+When in doubt, prefer episodic.
+
+### Canonical `pensyve_observe` call template
+
+ALL observe calls MUST include every required field:
+
+```
+pensyve_observe(
+  episode_id: <current session's working episode_id>,
+  content: "[proactive/in-flight/tier-1] <observation text>",
+  source_entity: "langchain",
+  about_entity: "<relevant entity, lowercase-hyphenated>",
+  content_type: "text"
+)
+```
+
+Use `content_type: "code"` for code-related outcomes.
+
+### Episode lifecycle (lazy-open)
+
+Library agents have no session-start/session-end hooks, so you own the episode lifecycle:
+
+- Before your first `pensyve_observe` call in this conversation, check whether a working `episode_id` is tracked. If none exists, call `pensyve_episode_start(participants: ["langchain", "<project entity>"])` first.
+- Reuse the same `episode_id` for all subsequent observations in the same conversation.
+- Do not explicitly close the episode under normal operation. Server-side consolidation handles aging.
+- Recovery: if `pensyve_observe` fails with a missing-episode error, call `pensyve_episode_start` and retry.
+
+### Surface style
+
+Lightly visible. One line when memory is used:
+
+- Recall: `Recalled 4 related memories (v7r, haiku-classifier).`
+- Capture: `↳ captured: hybrid-router threshold was the phase-3 regression root cause.`
+
+Do not narrate empty recalls or duplicate-skips.
+
+### Provenance tag vocabulary
+
+- `[proactive/in-flight/tier-1]` — memory reflex captured during reasoning
+- `[proactive/in-flight/open-question]` — unresolved question noted in-flight
+- `[auto-capture/user/residual/tier-1]` — explicit user-driven capture
+
+### Composition
+
+When a capture is both procedural AND in-flight: `[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=...`
+
+### MCP contract
+
+Rules never pass unsupported parameters:
+
+- `pensyve_recall(query, entity?, types?, limit?, min_confidence?)` — **no** `related_entities`
+- `pensyve_episode_start(participants)` — **no** `continuation_of`
+- `pensyve_observe(episode_id, content, source_entity, about_entity, content_type?)` — `source_entity` and `about_entity` are **required**
+
+---
+
+## Entity Detection
+
+Shared rules for detecting entity names from tool inputs, prompts, and conversation context. Used to scope recalls and `about_entity` fields on observations.
+
+### Inputs
+
+Extract candidate entity names from:
+
+1. **User prompts** — explicit references to components, files, services, research phases.
+2. **Code context** — module names, class names, function names referenced in the conversation.
+3. **File references** — any filenames or paths mentioned in the conversation.
+4. **Git context** — repository root name, branch name (when discoverable).
+
+### Canonicalization
+
+- Lowercase all characters.
+- Replace spaces and underscores with hyphens.
+- Strip file extensions unless the file is the entity itself.
+- Collapse paths to the most semantically meaningful segment.
+
+### Fallback behavior
+
+- If no specific entity is detected, fall back to the project-level entity (repository root name, lowercase-hyphenated).
+- If a candidate entity is ambiguous, prefer the one that already has memories in Pensyve (call `pensyve_inspect` with limit 1 to check).
+- **Never fabricate entity names.** If nothing confident emerges, use the project entity.
+
+### Output
+
+A set of 1–3 candidate entity names per turn. The primary entity is the most specific. Since `pensyve_recall` accepts only a single `entity` parameter, fold secondary entities into the `query` string.
+
+---
+
+## When Debugging
+
+Debugging flow with memory baked in as a non-optional reflex.
+
+### Step 1: Detect entities
+
+Identify the relevant entity/entities (failing test, failing module, error source) per Entity Detection above.
+
+### Step 2: Consult memory (required)
+
+Call `pensyve_recall`:
+
+- `query`: a short description of the failure, including secondary entity names where known
+- `entity`: primary detected entity
+- `types`: `["procedural", "episodic"]`
+- `limit`: 5
+
+Surface one line: `Recalled N memories from prior debug sessions on <entity>.` (Skip if N=0.)
+
+If a highly similar incident is found (score >0.8), call it out inline.
+
+### Step 3: Diagnose
+
+Proceed with diagnostic work. Use recalled procedural memories as a starting sequence.
+
+### Step 4: Capture lesson (when it lands)
+
+When a root cause is **confirmed**, ensure a working `episode_id` exists, then:
+
+- **Episodic root cause:** `pensyve_observe` with `content: "[proactive/in-flight/tier-1] <one-sentence root cause>"`, `source_entity: "langchain"`, `about_entity: <primary_entity>`.
+- **Procedural diagnostic sequence:** `pensyve_observe` with `content: "[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=..."`.
+- **Semantic durable truth:** `pensyve_remember(entity, fact: "[proactive/in-flight/tier-1] <fact>", confidence: 0.9)`.
+
+Surface one line: `↳ captured: <one-sentence>`.
+
+### Step 5: Capture abandoned approaches
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[proactive/in-flight/tier-1] tried <approach>, abandoned because <reason>",
+  source_entity: "langchain",
+  about_entity: <primary_entity>,
+  content_type: "text"
+)
+```
+
+---
+
+## When Designing
+
+Design flow with memory baked in as a non-optional reflex.
+
+### Step 1: Detect entities
+
+Identify the relevant entity/entities (service, module, subsystem under design) per Entity Detection above.
+
+### Step 2: Consult memory (required)
+
+Call `pensyve_recall`:
+
+- `query`: a short description of the design question, including secondary entity names
+- `entity`: primary detected entity
+- `types`: `["semantic", "episodic"]`
+- `limit`: 5
+
+Surface one line: `Recalled N prior decisions on <entity>.` (Skip if N=0.)
+
+### Step 3: Recommend with grounding
+
+Shape your recommendation using recalled decisions. If the current question contradicts a prior decision, flag it.
+
+### Step 4: Capture decision (when it lands)
+
+When the user accepts a design or states a decision:
+
+- **Semantic:** `pensyve_remember(entity: <primary_entity>, fact: "[proactive/in-flight/tier-1] <decision text>", confidence: 0.9)`.
+- **Episodic context:** `pensyve_observe` with `content: "[proactive/in-flight/tier-1] Decision on <entity>: chose X over Y because Z"`, `source_entity: "langchain"`, `about_entity: <primary_entity>`.
+
+Surface one line: `↳ captured decision on <entity>: <short>`.
+
+### Step 5: Capture evaluation procedures
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[procedural] [proactive/in-flight/tier-1] trigger=design-question-on-<area>, action=<steps>, outcome=<what-you-learn>",
+  source_entity: "langchain",
+  about_entity: <primary_entity>,
+  content_type: "text"
+)
+```
+
+---
+
+## When Refactoring
+
+Refactor flow with memory baked in.
+
+### Step 1: Detect entities
+
+Identify entities touched by the refactor per Entity Detection above.
+
+### Step 2: Load prior context (required)
+
+Call `pensyve_recall`:
+
+- `query`: short description of the refactor
+- `entity`: primary detected entity
+- `types`: `["semantic", "episodic", "procedural"]`
+- `limit`: 5
+
+Surface: `Recalled N prior memories on <entity>.` Highlight any prior failed approaches.
+
+### Step 3: Present a briefing
+
+Before starting the refactor, summarize what prior memories say about decisions, prior attempts, and known-good procedures.
+
+### Step 4: Capture refactor lessons as they land
+
+When an invariant is discovered, an approach is confirmed not-viable, or a known-good sequence emerges, apply the memory reflex immediately. Ensure working `episode_id` before each observe.
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[proactive/in-flight/tier-1] <lesson>",
+  source_entity: "langchain",
+  about_entity: <primary_entity>,
+  content_type: "text"
+)
+```
+
+---
+
+## When Doing Longitudinal Work
+
+Multi-session work (research, eval loops, iterative benchmarks) where lessons must accumulate across runs.
+
+### Step 1: Resume context at conversation start
+
+Call `pensyve_recall` once at the start:
+
+- `query`: short description of the current research area
+- `entity`: project + sub-topic entity
+- `limit`: 5
+
+No `types` filter — longitudinal work benefits from all three memory types.
+
+Surface: `Recalled N prior findings on <sub-topic>.`
+
+### Step 2: Proactively recall per topic shift
+
+When the session pivots to a new sub-topic, call `pensyve_recall` again scoped to the new sub-topic.
+
+### Step 3: Capture three types of memory per run
+
+| What you learned | Type | MCP call |
+|---|---|---|
+| Per-run outcome | episodic | `pensyve_observe(..., content: "[proactive/in-flight/tier-1] Run N+1: <result>", source_entity: "langchain", about_entity: <entity>)` |
+| Stable truth | semantic | `pensyve_remember(entity, fact: "[proactive/in-flight/tier-1] <stable fact>", confidence: 0.9)` |
+| Reusable procedure | procedural | `pensyve_observe(..., content: "[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=...", source_entity: "langchain", about_entity: <entity>)` |
+
+### Step 4: Capture open questions
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[proactive/in-flight/open-question] <question>",
+  source_entity: "langchain",
+  about_entity: <entity>,
+  content_type: "text"
+)
+```
+
+### Step 5: End-of-session summary
+
+Before the conversation wraps, briefly summarize what this run taught vs. prior runs, and what's still open.
+
+---
+
+## Session Wrap-Up
+
+Manual wrap-up: when the user indicates the conversation is ending, review what happened and capture anything the in-flight reflex missed.
+
+### Step 1: Review the conversation
+
+Scan for three categories not already captured in-flight:
+
+**Decisions** (confidence: 0.9): Architecture choices, technology selections, tradeoff resolutions.
+
+**Outcomes** (confidence: 0.8): Bug fixes, successful/failed approaches, performance findings.
+
+**Patterns** (confidence: 0.7): Recurring issues, workflow discoveries, cross-cutting observations.
+
+### Step 2: Filter for significance and deduplicate
+
+For each candidate, call `pensyve_recall` with `query: <candidate fact text>`, `entity: <entity>`, `limit: 3`. If any returned memory has score ≥0.85, skip as a likely duplicate.
+
+### Step 3: Present candidates for confirmation
+
+> **Session Memory Candidates**
+>
+> **Decisions** (confidence: 0.9):
+> 1. `<entity>`: <decision text>
+>
+> **Outcomes** (confidence: 0.8):
+> 2. `<entity>`: <outcome text>
+>
+> Which should I store? (e.g., "all", "1,2", "none")
+
+### Step 4: Store confirmed items
+
+- **Semantic** — `pensyve_remember(entity, fact: "[auto-capture/user/residual/tier-1] <text>", confidence)`.
+- **Episodic** — `pensyve_observe(episode_id, content: "[auto-capture/user/residual/tier-1] <text>", source_entity: "langchain", about_entity: <entity>)`.
+- **Procedural** — `pensyve_observe(episode_id, content: "[procedural] [auto-capture/user/residual/tier-1] trigger=..., action=..., outcome=...", source_entity: "langchain", about_entity: <entity>)`.
+
+### Step 5: Optionally close the episode
+
+If the user clearly marks the work complete: `pensyve_episode_end(episode_id: <working_id>, outcome: "success")`. Valid outcomes: `"success"`, `"failure"`, `"partial"`.
+
+### Constraints
+
+- **Never auto-store.** Every candidate MUST be presented for confirmation before storage.
+- Do not store secrets.
+- If nothing significant surfaced, say so clearly.
+
+---
+
+## Context Loading (Session Start)
+
+When starting a new conversation on a project with prior Pensyve memories, load relevant context to prime the session.
+
+### Step 1: Detect project entity
+
+Use the repository root name (lowercase-hyphenated) as the default project entity. Override with `PENSYVE_NAMESPACE` environment variable if set.
+
+### Step 2: Scoped recall
+
+Call `pensyve_recall`:
+
+- `query`: `"recent decisions issues patterns"` + any key terms from the user's opening message
+- `entity`: detected project entity
+- `types`: `["episodic"]`
+- `limit`: 5
+
+### Step 3: Compute continuity signal
+
+- If ≥70% of top observations reference at least one overlapping entity: **continuation** of recent work.
+- If overlap is below 70% or recall returned empty: **fresh session**.
+
+### Step 4: Surface the primer
+
+**Continuation:**
+
+> **Pensyve:** Continuing prior work on `<entity-set>`. Recent lessons:
+>
+> - <observation 1>
+> - <observation 2>
+>
+> Use `pensyve_recall` to dig deeper.
+
+**Fresh session:**
+
+> **Pensyve:** N memories loaded for `<project>`. Key context:
+>
+> - <top 3 observations>
+
+**No memories found:**
+
+> **Pensyve:** No memories found for `<project>`. Start a session to begin building context.
+
+### Constraints
+
+- Do not fabricate memories. Only display what `pensyve_recall` returns.
+- Maximum 5 memories in the primer.
+- Entity names lowercase-hyphenated.

--- a/integrations/langchain/examples/pensyve_agent.py
+++ b/integrations/langchain/examples/pensyve_agent.py
@@ -1,0 +1,95 @@
+"""
+Pensyve + LangChain / LangGraph wiring example.
+
+Demonstrates how to:
+  1. Load the Pensyve working-memory substrate as the agent system prompt.
+  2. Connect to the Pensyve MCP server via langchain-mcp-adapters.
+  3. Build a ReAct agent with LangGraph that has persistent cross-session memory.
+
+Dependencies:
+    pip install langchain-anthropic langchain-mcp-adapters langgraph
+
+Environment variables:
+    PENSYVE_API_KEY   — Pensyve API key (get one at pensyve.com/settings/api-keys)
+    ANTHROPIC_API_KEY — Anthropic API key
+"""
+
+import asyncio
+import os
+from pathlib import Path
+
+from langchain_anthropic import ChatAnthropic
+from langchain_mcp_adapters.client import MultiServerMCPClient
+from langchain_core.messages import HumanMessage
+from langgraph.prebuilt import create_react_agent
+
+# ---------------------------------------------------------------------------
+# 1. Load the substrate — the reasoning layer injected as the system prompt.
+#    Users who want to customise behaviour edit SUBSTRATE_PROMPT.md directly.
+# ---------------------------------------------------------------------------
+SUBSTRATE_PATH = Path(__file__).parent.parent / "SUBSTRATE_PROMPT.md"
+substrate = SUBSTRATE_PATH.read_text(encoding="utf-8")
+
+# ---------------------------------------------------------------------------
+# 2. Configure the Pensyve MCP server connection.
+#    The Pensyve MCP server exposes: pensyve_recall, pensyve_remember,
+#    pensyve_observe, pensyve_episode_start, pensyve_episode_end,
+#    pensyve_inspect, pensyve_forget.
+# ---------------------------------------------------------------------------
+PENSYVE_API_KEY = os.environ["PENSYVE_API_KEY"]  # raises KeyError if unset — intentional
+
+MCP_CONFIG = {
+    "pensyve": {
+        "transport": "streamable_http",
+        "url": "https://mcp.pensyve.com/mcp",
+        "headers": {"Authorization": f"Bearer {PENSYVE_API_KEY}"},
+    }
+}
+
+
+async def main() -> None:
+    # -----------------------------------------------------------------------
+    # 3. Initialise the MCP client and fetch available tools.
+    #    langchain-mcp-adapters wraps MCP tools as LangChain BaseTool objects.
+    # -----------------------------------------------------------------------
+    async with MultiServerMCPClient(MCP_CONFIG) as client:
+        tools = await client.get_tools()
+
+        # -------------------------------------------------------------------
+        # 4. Create a ReAct agent with the substrate as the system prompt.
+        #    The substrate tells the model HOW to use Pensyve tools — when to
+        #    recall, when to observe, how to structure episode lifecycles, etc.
+        # -------------------------------------------------------------------
+        llm = ChatAnthropic(model="claude-sonnet-4-6")
+        agent = create_react_agent(
+            llm,
+            tools,
+            prompt=substrate,  # substrate injected here
+        )
+
+        # -------------------------------------------------------------------
+        # 5. Invoke the agent.  The agent will use Pensyve tools automatically
+        #    according to the substrate rules — recalling before substantive
+        #    answers, capturing lessons when they land.
+        # -------------------------------------------------------------------
+        result = await agent.ainvoke(
+            {
+                "messages": [
+                    HumanMessage(
+                        content=(
+                            "I'm starting work on the auth-service module. "
+                            "What do we know about prior decisions there?"
+                        )
+                    )
+                ]
+            }
+        )
+
+        # Print the final assistant message
+        for msg in result["messages"]:
+            if hasattr(msg, "content") and msg.type == "ai":
+                print(msg.content)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/integrations/langchain/examples/pensyve_agent.py
+++ b/integrations/langchain/examples/pensyve_agent.py
@@ -19,8 +19,8 @@ import os
 from pathlib import Path
 
 from langchain_anthropic import ChatAnthropic
-from langchain_mcp_adapters.client import MultiServerMCPClient
 from langchain_core.messages import HumanMessage
+from langchain_mcp_adapters.client import MultiServerMCPClient
 from langgraph.prebuilt import create_react_agent
 
 # ---------------------------------------------------------------------------

--- a/integrations/langchain/scripts/lint-mcp-refs.sh
+++ b/integrations/langchain/scripts/lint-mcp-refs.sh
@@ -34,18 +34,18 @@ echo ""
 echo "Check 1: no unsupported 'related_entities' on pensyve_recall"
 FOUND_RELATED=0
 for f in "$RULES_FILE" "$EXAMPLE_FILE"; do
-  awk '/pensyve_recall\(/{capture=1; buf=""}
-       capture {buf = buf "\n" $0}
-       capture && /\)/{
-         if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
-           print FILENAME ": related_entities found in pensyve_recall block: " buf;
-         capture=0
-       }' "$f" | while read -r line; do
+  while read -r line; do
     if [ -n "$line" ]; then
       echo "  FAIL: $line"
       FOUND_RELATED=1
     fi
-  done
+  done < <(awk '/pensyve_recall\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+       if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
+       print FILENAME ": related_entities found in pensyve_recall block: " buf;
+       capture=0
+       }' "$f")
 done
 if [ "$FOUND_RELATED" = "0" ]; then
   echo "  PASS"
@@ -58,18 +58,18 @@ echo ""
 echo "Check 2: no unsupported 'continuation_of' on pensyve_episode_start"
 FOUND_CONT=0
 for f in "$RULES_FILE" "$EXAMPLE_FILE"; do
-  awk '/pensyve_episode_start\(/{capture=1; buf=""}
-       capture {buf = buf "\n" $0}
-       capture && /\)/{
-         if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
-           print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
-         capture=0
-       }' "$f" | while read -r line; do
+  while read -r line; do
     if [ -n "$line" ]; then
       echo "  FAIL: $line"
       FOUND_CONT=1
     fi
-  done
+  done < <(awk '/pensyve_episode_start\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+       if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
+       print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
+       capture=0
+       }' "$f")
 done
 if [ "$FOUND_CONT" = "0" ]; then
   echo "  PASS"
@@ -82,23 +82,23 @@ echo ""
 echo "Check 3: every pensyve_observe example has source_entity and about_entity"
 MISSING_FIELDS=0
 for f in "$RULES_FILE" "$EXAMPLE_FILE"; do
-  awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
-       capture {buf = buf "\n" $0;
-                for(i=1; i<=length($0); i++){
-                  c=substr($0,i,1);
-                  if(c=="(") depth++;
-                  if(c==")") depth--;
-                };
-                if(depth==0 && buf ~ /pensyve_observe\(/){
-                  if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
-                  if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
-                  capture=0;
-                }}' "$f" | while read -r line; do
+  while read -r line; do
     if [ -n "$line" ]; then
       echo "  FAIL: $line"
       MISSING_FIELDS=1
     fi
-  done
+  done < <(awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
+       capture {buf = buf "\n" $0;
+       for(i=1; i<=length($0); i++){
+       c=substr($0,i,1);
+       if(c=="(") depth++;
+       if(c==")") depth--;
+       };
+       if(depth==0 && buf ~ /pensyve_observe\(/){
+       if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
+       if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
+       capture=0;
+       }}' "$f")
 done
 if [ "$MISSING_FIELDS" = "0" ]; then
   echo "  PASS"

--- a/integrations/langchain/scripts/lint-mcp-refs.sh
+++ b/integrations/langchain/scripts/lint-mcp-refs.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Static MCP contract linter for the Pensyve LangChain adapter.
+#
+# Verifies that every pensyve_* call example in SUBSTRATE_PROMPT.md and the
+# example wiring file conforms to the current MCP tool schema.
+# Catches the category of bug PR #58 surfaced in the Claude Code adapter
+# (unsupported parameters, missing required fields).
+#
+# This integration uses a single consolidated SUBSTRATE_PROMPT.md (same
+# pattern as VS Code Copilot) rather than per-rule files.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INTEG_DIR="$SCRIPT_DIR/.."
+RULES_FILE="$INTEG_DIR/SUBSTRATE_PROMPT.md"
+EXAMPLE_FILE="$INTEG_DIR/examples/pensyve_agent.py"
+
+EXIT_CODE=0
+
+for f in "$RULES_FILE" "$EXAMPLE_FILE"; do
+  if [ ! -f "$f" ]; then
+    echo "ERROR: File not found: $f"
+    exit 1
+  fi
+done
+
+echo "Linting MCP references in:"
+echo "  $RULES_FILE"
+echo "  $EXAMPLE_FILE"
+echo ""
+
+# Check 1: no actual use of unsupported 'related_entities' parameter in call examples.
+echo "Check 1: no unsupported 'related_entities' on pensyve_recall"
+FOUND_RELATED=0
+for f in "$RULES_FILE" "$EXAMPLE_FILE"; do
+  awk '/pensyve_recall\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+         if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
+           print FILENAME ": related_entities found in pensyve_recall block: " buf;
+         capture=0
+       }' "$f" | while read -r line; do
+    if [ -n "$line" ]; then
+      echo "  FAIL: $line"
+      FOUND_RELATED=1
+    fi
+  done
+done
+if [ "$FOUND_RELATED" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 2: no actual use of unsupported 'continuation_of' parameter in call examples.
+echo "Check 2: no unsupported 'continuation_of' on pensyve_episode_start"
+FOUND_CONT=0
+for f in "$RULES_FILE" "$EXAMPLE_FILE"; do
+  awk '/pensyve_episode_start\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+         if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
+           print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
+         capture=0
+       }' "$f" | while read -r line; do
+    if [ -n "$line" ]; then
+      echo "  FAIL: $line"
+      FOUND_CONT=1
+    fi
+  done
+done
+if [ "$FOUND_CONT" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 3: every pensyve_observe call example in a code block has source_entity and about_entity
+echo "Check 3: every pensyve_observe example has source_entity and about_entity"
+MISSING_FIELDS=0
+for f in "$RULES_FILE" "$EXAMPLE_FILE"; do
+  awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
+       capture {buf = buf "\n" $0;
+                for(i=1; i<=length($0); i++){
+                  c=substr($0,i,1);
+                  if(c=="(") depth++;
+                  if(c==")") depth--;
+                };
+                if(depth==0 && buf ~ /pensyve_observe\(/){
+                  if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
+                  if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
+                  capture=0;
+                }}' "$f" | while read -r line; do
+    if [ -n "$line" ]; then
+      echo "  FAIL: $line"
+      MISSING_FIELDS=1
+    fi
+  done
+done
+if [ "$MISSING_FIELDS" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 4: provenance tag format — every proactive/auto-capture tag uses [<origin>/<trigger>/<tier>]
+echo "Check 4: provenance tag format"
+VALID_PROVENANCE_RE='\[(proactive|auto-capture)/(in-flight|stop|pre-compact|curator|user)/(tier-1|tier-2|residual/tier-1|residual/tier-2|open-question)\]'
+INVALID=0
+for f in "$RULES_FILE" "$EXAMPLE_FILE"; do
+  if rg -n '\[(proactive|auto-capture)' "$f" | rg -v "$VALID_PROVENANCE_RE"; then
+    INVALID=1
+  fi
+done
+if [ "$INVALID" = "0" ]; then
+  echo "  PASS"
+else
+  echo "  FAIL: some provenance tags do not match [<origin>/<trigger>/<tier>] format"
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 5: procedural memory convention — [procedural] prefix is used in observe content
+echo "Check 5: procedural convention uses [procedural] prefix in pensyve_observe content"
+if ! rg -q '\[procedural\]' "$RULES_FILE"; then
+  echo "  WARN: no [procedural] prefix usage found in SUBSTRATE_PROMPT.md."
+else
+  echo "  PASS"
+fi
+echo ""
+
+if [ "$EXIT_CODE" = "0" ]; then
+  echo "All MCP contract checks PASSED."
+else
+  echo "MCP contract checks FAILED. Fix the issues above before committing."
+fi
+
+exit "$EXIT_CODE"

--- a/integrations/neovim/CHANGELOG.md
+++ b/integrations/neovim/CHANGELOG.md
@@ -1,0 +1,41 @@
+# Changelog — Pensyve Neovim Adapter
+
+All notable changes to the Pensyve Neovim adapter are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] - 2026-04-20
+
+### Added
+
+- **Working-memory substrate** for Neovim AI plugins (avante.nvim, codecompanion.nvim, etc.) via `instructions/*.md` files. Eight instruction documents deliver the substrate the Claude Code plugin v1.3.0 established:
+  - `memory-reflex.md` (always-apply) — non-optional reasoning discipline with three-type memory classification, canonical `pensyve_observe` call template, provenance vocabulary, lazy-open episode lifecycle
+  - `entity-detection.md` (always-apply) — canonicalization and fallback rules for recall scoping
+  - `memory-informed-debug.md` — debug flow with memory baked in
+  - `memory-informed-design.md` — design/architecture flow with memory baked in
+  - `memory-informed-refactor.md` — refactor flow with memory baked in
+  - `memory-informed-longitudinal-work.md` — research/eval multi-session flow
+  - `session-memory.md` — manual wrap-up equivalent of Claude Code's Stop hook
+  - `context-loader.md` — best-effort continuity primer via episodic recall
+- **MCP config example** at `neovim-mcp.json.example` (deploy to `~/.config/mcphub/servers.json` for MCPHub.nvim) covering Cloud-with-API-key and Local-stdio options
+- **Static MCP contract lint script** at `scripts/lint-mcp-refs.sh` verifying every rule's `pensyve_*` call example matches the `pensyve-mcp-tools/src/params.rs` schema
+
+### Design
+
+- Single reasoning layer; no platform-layer plugin code. Neovim AI plugins read system prompt files you configure; the entire substrate adapter is instruction documents.
+- Lazy-open episode lifecycle: first `pensyve_observe` call triggers `pensyve_episode_start`; episodes are not explicitly closed under normal operation.
+- Best-effort continuity primer via `pensyve_recall(types: ["episodic"])` — the MCP server has no episode-listing API.
+- MCP contract verified: no `related_entities` on recall, no `continuation_of` on episode_start, required `source_entity: "neovim"` and `about_entity` on every observe.
+- Compatible with MCPHub.nvim (primary), avante.nvim, and codecompanion.nvim.
+
+### Not Included
+
+- No Lua plugin code (deferred to a future sibling spec if capability gaps surface)
+- No installer script (manual copy of instruction files + MCP config)
+- No server-side changes — uses the existing MCP tool surface
+
+### Relation to Other Pensyve Integrations
+
+- The Neovim adapter is part of the batch-3 working-memory substrate rollout. The Cursor adapter (v1.0.0) and Claude Code plugin (v1.3.0) are the reference implementations.
+- Spec: `pensyve-docs/specs/2026-04-20-pensyve-cursor-adapter-design.md`
+- Playbook: `pensyve-docs/specs/2026-04-18-pensyve-working-memory-substrate-design.md`

--- a/integrations/neovim/README.md
+++ b/integrations/neovim/README.md
@@ -2,7 +2,7 @@
 
 Persistent AI memory for [Neovim](https://neovim.io/) via MCP using [MCPHub.nvim](https://github.com/ravitemer/mcphub.nvim). Gives your Neovim AI workflows cross-session memory so your coding assistant remembers project conventions, architecture decisions, and debugging history.
 
-> **Status:** Scaffold — MCP configuration and documentation. Full integration planned.
+> **Status:** Working-memory substrate v1.0.0 — MCP configuration, instruction files, and documentation. Full plugin integration planned.
 
 ## Authentication
 
@@ -112,3 +112,43 @@ Pensyve uses a tiered classification system to identify what is worth rememberin
 - Wrap multi-step work in `pensyve_episode_start` / `pensyve_episode_end` to capture episodic context
 
 The MCP tool descriptions include guidance on confidence levels so the LLM can classify memories into the appropriate tier automatically.
+
+## Memory Behavior Model
+
+The working-memory substrate defines how your Neovim AI plugin should behave across coding sessions when Pensyve is connected. It is documented in the [`instructions/`](./instructions/) directory as 8 rule files:
+
+| Rule file | Behavior |
+| --------- | -------- |
+| `memory-reflex.md` | Non-optional reasoning discipline — recall before substantive answers, observe when lessons land. Always active. |
+| `entity-detection.md` | Canonicalization rules for extracting entity names from file paths, prompts, and code context. Always active. |
+| `memory-informed-debug.md` | Debug flow: recall prior incidents and procedures, capture root causes the moment they are confirmed. |
+| `memory-informed-design.md` | Design/architecture flow: recall prior decisions, flag contradictions, capture new decisions on acceptance. |
+| `memory-informed-refactor.md` | Refactor flow: briefing from prior memory, capture invariants and abandoned approaches as they surface. |
+| `memory-informed-longitudinal-work.md` | Multi-session research/eval flow: resume context at session start, capture per-run outcomes and open questions. |
+| `session-memory.md` | Manual wrap-up: review the conversation for residual lessons not captured in-flight, confirm with user before storing. |
+| `context-loader.md` | Session continuity primer: recall recent episodic memories at conversation start to surface relevant context. |
+
+### How to configure your Neovim AI plugin with these instructions
+
+Each Neovim AI plugin has its own mechanism for injecting system prompt content:
+
+- **avante.nvim**: set `system_prompt` in your avante config to the content of `memory-reflex.md` and `entity-detection.md` (always-apply rules), then reference the flow rules via keybindings or slash commands.
+- **codecompanion.nvim**: add the instruction files to your system prompt via the `system_prompt` config key, or use the `/workspace` slash command to include them.
+- **MCPHub.nvim + any LLM**: configure your AI plugin to send the `instructions/` files as system context when starting a new chat.
+
+For the simplest setup: copy all 8 `instructions/*.md` files into a single combined system prompt file and reference it from your AI plugin config.
+
+### MCP config
+
+For MCPHub.nvim, copy `neovim-mcp.json.example` to `~/.config/mcphub/servers.json` (or merge into your existing config) and edit for your setup. Alternatively, use the Lua config shown above.
+
+### MCP tool schema
+
+All substrate rules use the correct MCP contract:
+
+- `pensyve_recall(query, entity?, types?, limit?, min_confidence?)`
+- `pensyve_episode_start(participants)`
+- `pensyve_observe(episode_id, content, source_entity, about_entity, content_type?)`
+- `pensyve_inspect(entity, memory_type?, limit?)`
+
+`source_entity` is `"neovim"` in all substrate rule examples. Run `scripts/lint-mcp-refs.sh` to verify the rule files conform to the schema.

--- a/integrations/neovim/instructions/context-loader.md
+++ b/integrations/neovim/instructions/context-loader.md
@@ -1,0 +1,74 @@
+---
+description: Use when starting a new substantive conversation or switching contexts — load relevant memories to prime the session with continuity
+---
+
+# Context Loader (Continuity Primer)
+
+Neovim AI plugins have no automatic SessionStart hook exposed to the LLM. This rule is the manual equivalent: when starting a new conversation on a project that has prior Pensyve memories, call recall to prime the session with relevant context.
+
+Follows `memory-reflex.md`. Best-effort thread continuity via episodic recall (the MCP server has no episode-listing tool).
+
+## Instructions
+
+### Step 1: Detect project entity
+
+Per `entity-detection.md` fallback rules: use the repository root name (lowercase-hyphenated) as the default project entity. Override with `PENSYVE_NAMESPACE` environment variable if explicitly set in the project's environment.
+
+### Step 2: Scoped recall
+
+Call `pensyve_recall`:
+
+- `query`: `"recent decisions issues patterns"` + any key terms from the user's opening message
+- `entity`: detected project entity
+- `types`: `["episodic"]` — recent session activity gives the best continuity signal
+- `limit`: 5
+
+Episodic memories are ranked by the MCP server's activation signal, which naturally surfaces recent observations first.
+
+### Step 3: Compute continuity signal
+
+Examine the returned observations:
+
+- If ≥70% of the top observations reference at least one entity that overlaps with the current conversation's entity candidates (from Step 1 plus any entities mentioned in the opening message), treat the session as a **continuation** of recent work.
+- If the overlap is below 70%, or recall returned empty, treat as a **fresh session**.
+
+### Step 4: Surface the primer
+
+**Continuation:**
+
+> **Pensyve:** Continuing prior work on `<entity-set>`. Recent lessons:
+>
+> - <observation 1>
+> - <observation 2>
+> - <observation 3>
+>
+> Use `/recall <query>` or ask about any of these to dig deeper.
+
+**Fresh session:**
+
+> **Pensyve:** N memories loaded for `<project>`. Key context:
+>
+> - <top 3 observations>
+>
+> Use `/recall <query>` to search for specific memories.
+
+**No memories found:**
+
+> **Pensyve:** No memories found for `<project>`. Use `/remember` to start building context.
+
+### Step 5: Continuity is best-effort, not a structured link
+
+The MCP server has no episode-listing or date-filtering API. This rule infers continuity from shared-entity overlap and recall-ranking recency. Consequences:
+
+- There is no persisted server-side link between sessions.
+- Primer accuracy depends on memory quality and recall ranking.
+- The user may occasionally see "Continuing prior work" when it's actually loosely related; or see a fresh-session primer when the prior session was related but the entity overlap was low.
+
+Document this honestly in the primer when uncertain — do not fabricate continuity.
+
+## Constraints
+
+- Do not fabricate memories. Only display what `pensyve_recall` returns.
+- If MCP is unavailable, skip the primer silently and mention the failure once per conversation if the user asks about memory.
+- Maximum 5 memories in the primer to avoid context bloat.
+- Entity names lowercase-hyphenated.

--- a/integrations/neovim/instructions/entity-detection.md
+++ b/integrations/neovim/instructions/entity-detection.md
@@ -1,0 +1,42 @@
+---
+description: Pensyve entity detection — canonicalization and fallback rules for recall scoping (always-apply)
+---
+
+# Entity Detection (Always-Apply Reference)
+
+Shared rules for detecting entity names from tool inputs, prompts, and conversation context. Used by the memory reflex and all memory-woven flows to scope recalls and `about_entity` fields on observations.
+
+## Inputs
+
+Extract candidate entity names from:
+
+1. **File references** — `@filename`, `@path/to/file`, or files mentioned directly in the conversation.
+2. **User prompts** — explicit references to components, files, services, research phases (e.g., "phase-4.3", "v7r-classifier", "auth-service").
+3. **Code context** — module names, class names, function names in files you are editing or reading.
+4. **Git context** — repository root name, branch name (when discoverable).
+
+## Canonicalization
+
+- Lowercase all characters.
+- Replace spaces and underscores with hyphens.
+- Strip file extensions unless the file is the entity itself (e.g., `package.json`).
+- Collapse paths to the most semantically meaningful segment (e.g., `src/engine/hybrid_router.rs` → `hybrid-router`; `tests/integration/auth_test.py` → `auth`).
+
+## Fallback behavior
+
+- If no specific entity is detected, fall back to the project-level entity (repository root name, lowercase-hyphenated).
+- If a candidate entity is ambiguous between two names, prefer the one that already has memories in Pensyve (call `pensyve_inspect` with limit 1 to check).
+- **Never fabricate entity names.** If nothing confident emerges, use the project entity.
+
+## Output
+
+A set of 1–3 candidate entity names per turn. The primary entity is the most specific; secondary entities provide additional context. Since `pensyve_recall` accepts only a single `entity` parameter, fold secondary entities into the `query` string instead.
+
+## Examples
+
+| Input | Primary entity | Secondary (fold into query) |
+|---|---|---|
+| Edit on `src/engine/hybrid_router.rs` | `hybrid-router` | `engine` |
+| Prompt: "tune V7r noise threshold" | `v7r` | `noise-threshold` |
+| File `tests/test_auth.py` in a project named `auth-service` | `auth` | `auth-service` |
+| User mentions "phase-4.3 calibration" | `phase-4.3` | `calibration` |

--- a/integrations/neovim/instructions/memory-informed-debug.md
+++ b/integrations/neovim/instructions/memory-informed-debug.md
@@ -1,0 +1,68 @@
+---
+description: Use when diagnosing bugs, errors, failing tests, or crashes — consult prior debug outcomes and capture root causes in-flight
+---
+
+# Memory-Informed Debug
+
+Debugging flow with memory baked in as a non-optional reflex. Follows `memory-reflex.md` for classification, surface style, and episode lifecycle.
+
+## Instructions
+
+### Step 1: Detect entities
+
+Identify the relevant entity/entities (failing test, failing module, error source) per `entity-detection.md`.
+
+### Step 2: Consult memory (required)
+
+Call `pensyve_recall`:
+
+- `query`: a short description of the failure, including secondary entity names where known (e.g., "hybrid-router threshold regression phase-4.3" rather than full stack traces)
+- `entity`: primary detected entity
+- `types`: `["procedural", "episodic"]` (debugging benefits most from known-good diagnostic procedures and prior incident outcomes)
+- `limit`: 5
+
+Secondary entities are folded into the query string since `RecallParams` scopes by a single `entity` only.
+
+Surface one line: `Recalled N memories from prior debug sessions on <entity>.` (Skip if N=0.)
+
+If a highly similar incident is found (score >0.8), call that out inline: `This looks similar to an incident captured on <date>: <summary>. Consider that path first.`
+
+### Step 3: Diagnose
+
+Proceed with the diagnostic work. Use recalled procedural memories as a starting sequence; update the sequence when you learn something new.
+
+### Step 4: Capture lesson (when it lands)
+
+When a root cause is **confirmed** (not just hypothesized), apply the memory reflex per `memory-reflex.md`:
+
+Ensure a working `episode_id` exists (lazy-open via `pensyve_episode_start` if not). Then:
+
+- **Episodic root cause:** call `pensyve_observe` with `content: "[proactive/in-flight/tier-1] <one-sentence root cause>"`, `source_entity: "neovim"`, `about_entity: <primary_entity>`, `content_type: "text"`.
+- **Procedural diagnostic sequence:** if the debug produced a reusable diagnostic sequence, call `pensyve_observe` with `content: "[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=..."`, `source_entity: "neovim"`, `about_entity: <primary_entity>`, `content_type: "text"`.
+- **Semantic durable truth:** if the root cause reveals a durable truth (e.g., "our CI runner's Python 3.10 cannot handle the new syntax"), also call `pensyve_remember(entity, fact, confidence: 0.9)`. Include provenance in the fact text: `"[proactive/in-flight/tier-1] <fact>"`.
+
+Surface one line: `↳ captured: <one-sentence>`.
+
+### Step 5: Capture abandoned approach
+
+If an approach was tried and abandoned, observe that too:
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[proactive/in-flight/tier-1] tried <approach>, abandoned because <reason>",
+  source_entity: "neovim",
+  about_entity: <primary_entity>,
+  content_type: "text"
+)
+```
+
+These are high-value — they prevent re-treading the same dead end next time.
+
+## Constraints
+
+- Recall is **not optional**. If you skip recall to save time, you defeat the working-memory substrate.
+- Observe when a lesson **lands**, not when you first hypothesize.
+- One in-flight capture per turn unless multiple distinct lessons land simultaneously.
+- Respect the reflex rule's surface style — one line, not paragraphs.
+- Never store secrets or sensitive paths.

--- a/integrations/neovim/instructions/memory-informed-design.md
+++ b/integrations/neovim/instructions/memory-informed-design.md
@@ -1,0 +1,60 @@
+---
+description: Use when making architecture, API, or design decisions — consult prior decisions and capture new ones in-flight
+---
+
+# Memory-Informed Design
+
+Design flow with memory baked in as a non-optional reflex. Follows `memory-reflex.md`.
+
+## Instructions
+
+### Step 1: Detect entities
+
+Identify the relevant entity/entities (service, module, subsystem under design) per `entity-detection.md`.
+
+### Step 2: Consult memory (required)
+
+Call `pensyve_recall`:
+
+- `query`: a short description of the design question, including secondary entity names where known (e.g., "auth-service jwt signing rs256 hs256")
+- `entity`: primary detected entity
+- `types`: `["semantic", "episodic"]` (design benefits most from durable decisions and prior decision-contexts)
+- `limit`: 5
+
+Surface one line: `Recalled N prior decisions on <entity>.` (Skip if N=0.)
+
+### Step 3: Recommend with grounding
+
+Shape your recommendation using the recalled decisions. If the user's current question directly contradicts a prior decision, flag it:
+
+> Prior decision on `<entity>` (confidence 0.9): [decision]. Are we revisiting this, or does the current question differ?
+
+### Step 4: Capture decision (when it lands)
+
+When the user accepts a design or states a decision ("let's go with X", "we'll use Y"), apply the memory reflex:
+
+- **Semantic** — `pensyve_remember(entity: <primary_entity>, fact: "[proactive/in-flight/tier-1] <decision text>", confidence: 0.9)`.
+- **Episodic context** — ensure working `episode_id`; `pensyve_observe` with `content: "[proactive/in-flight/tier-1] Decision on <entity>: chose X over Y because Z"`, `source_entity: "neovim"`, `about_entity: <primary_entity>`, `content_type: "text"`. This enables future "why did we decide X?" queries.
+
+Surface one line: `↳ captured decision on <entity>: <short>`.
+
+### Step 5: Capture evaluation procedures
+
+If the design process revealed a reusable way to evaluate similar decisions (e.g., "run spike vs. prototype", "check latency first"), capture it as procedural:
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[procedural] [proactive/in-flight/tier-1] trigger=design-question-on-<area>, action=<steps>, outcome=<what-you-learn>",
+  source_entity: "neovim",
+  about_entity: <primary_entity>,
+  content_type: "text"
+)
+```
+
+## Constraints
+
+- Recall is **not optional**.
+- Observe when a decision **lands**, not when it's being discussed.
+- Budget: one in-flight capture per turn unless multiple decisions land.
+- Never store secrets or sensitive architecture details the user has marked private.

--- a/integrations/neovim/instructions/memory-informed-longitudinal-work.md
+++ b/integrations/neovim/instructions/memory-informed-longitudinal-work.md
@@ -1,0 +1,68 @@
+---
+description: Long-running multi-session work (research, eval loops, iterative benchmarks) — resume prior lessons, capture per-run outcomes, build up stable truths over time
+---
+
+# Memory-Informed Longitudinal Work
+
+Multi-session engineering work (research, eval loops, iterative benchmarks) where lessons must accumulate across runs. The motivating case: improving a core algorithm over dozens of eval iterations without starting from scratch each session.
+
+Follows `memory-reflex.md`. Applies when editing files under `research/`, `benchmarks/`, or `evals/`, or when the conversation is research-oriented.
+
+## Instructions
+
+### Step 1: Resume context at conversation start
+
+If this conversation is in a research/eval context, call `pensyve_recall` once at the start:
+
+- `query`: short description of the current research area (e.g., "v7r classifier calibration")
+- `entity`: project + sub-topic entity (per `entity-detection.md` canonicalization rules)
+- `limit`: 5
+
+No `types` filter — longitudinal work benefits from all three memory types; omit to query all. (Passing all three explicitly is equivalent to no filter; omitting is cleaner.)
+
+Surface: `Recalled N prior findings on <sub-topic>.`
+
+Treat the returned observations as working knowledge — do not re-ask the user about things the recall already surfaces.
+
+### Step 2: Proactively recall per topic shift
+
+When the session pivots to a new sub-topic (new phase, new eval subset, new failure mode), call `pensyve_recall` again scoped to the new sub-topic.
+
+### Step 3: Capture three types of memory per run
+
+During the session, classify emerging knowledge and capture accordingly. Ensure working `episode_id` before each observe.
+
+| What you learned | Type | MCP call |
+|---|---|---|
+| Per-run outcome (what this run showed) | episodic | `pensyve_observe(..., content: "[proactive/in-flight/tier-1] Run N+1: V7r accuracy improved +3.5% with new threshold", source_entity: "neovim", about_entity: <entity>, content_type: "text")` |
+| Stable truth about the system | semantic | `pensyve_remember(entity, fact: "[proactive/in-flight/tier-1] Haiku classifier plateaus above temp 0.3", confidence: 0.9)` |
+| Reusable experiment procedure | procedural | `pensyve_observe(..., content: "[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=...", source_entity: "neovim", about_entity: <entity>, content_type: "text")` |
+
+Apply at landing — do not batch.
+
+### Step 4: Capture open questions
+
+When a run ends with an unresolved question ("X improved but we don't know why"), capture it as an episodic observation with open-question provenance:
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[proactive/in-flight/open-question] <question>",
+  source_entity: "neovim",
+  about_entity: <entity>,
+  content_type: "text"
+)
+```
+
+This populates future "open questions" surfacing when the topic returns.
+
+### Step 5: End-of-session summary
+
+Before the conversation wraps, briefly summarize (inline, 3-5 lines): what this run taught us vs. prior runs, what's still open. This creates a natural handoff for the next session.
+
+## Constraints
+
+- Recall on every topic shift — not just at conversation start.
+- Capture at landing, not batched.
+- Never store run artifacts or large data blobs — summarize.
+- Respect the reflex's surface style.

--- a/integrations/neovim/instructions/memory-informed-refactor.md
+++ b/integrations/neovim/instructions/memory-informed-refactor.md
@@ -1,0 +1,59 @@
+---
+description: Use before substantive refactors — load relevant prior context, capture refactor insights as they land
+---
+
+# Memory-Informed Refactor
+
+Refactor flow with memory baked in. Follows `memory-reflex.md`.
+
+## Instructions
+
+### Step 1: Detect entities
+
+Identify the entities touched by the refactor (the file or module being restructured, its callers, the subsystem name) per `entity-detection.md`.
+
+### Step 2: Load prior context (required)
+
+Call `pensyve_recall`:
+
+- `query`: short description of the refactor (e.g., "hybrid-router routing logic restructure")
+- `entity`: primary detected entity
+- `types`: `["semantic", "episodic", "procedural"]` — refactors benefit from all three (durable invariants, prior attempts, known-good sequences)
+- `limit`: 5
+
+Surface: `Recalled N prior memories on <entity>.` (Skip if N=0.)
+
+Highlight any prior failed approaches inline:
+
+> Prior episodic memory (confidence 0.8): tried <approach> on <date>, abandoned because <reason>. Double-check this isn't the same trap.
+
+### Step 3: Present a briefing
+
+Before starting the refactor, briefly summarize what the prior memories say about:
+
+- **Decisions** — durable choices that constrain the refactor (semantic)
+- **Prior attempts** — what's been tried (episodic)
+- **Known-good procedures** — reusable sequences for this kind of refactor (procedural)
+
+If no relevant memories exist, say so clearly and proceed without historical context.
+
+### Step 4: Capture refactor lessons as they land
+
+When any of these occur during the refactor, apply the memory reflex immediately:
+
+- **An invariant is discovered** (semantic) — `pensyve_remember(entity, fact, confidence: 0.9)`
+- **An abandoned approach is confirmed not-viable** (episodic) — `pensyve_observe` with `[proactive/in-flight/tier-1]` provenance
+- **A dependency chain was traced that surprised us** (episodic) — `pensyve_observe`
+- **A known-good refactoring sequence emerged** (procedural) — `pensyve_observe` with `[procedural]` prefix
+
+Ensure working `episode_id` before each observe; lazy-open if needed.
+
+Do not batch these to end-of-session — capture at landing, surface one-line.
+
+## Constraints
+
+- The briefing step is the real value — it informs the refactor.
+- Observe at landing, not batched.
+- Entity names lowercase-hyphenated.
+- Do not start the refactor itself — this rule provides guidance and capture. The user decides when and how to proceed.
+- If the MCP server returns errors on some queries, present results from the successful queries and note the failures.

--- a/integrations/neovim/instructions/memory-reflex.md
+++ b/integrations/neovim/instructions/memory-reflex.md
@@ -1,0 +1,100 @@
+---
+description: Pensyve memory reflex — the non-optional reasoning discipline for working-memory substrate (always-apply)
+---
+
+# Memory Reflex Rule (Always-Apply)
+
+This rule is always in context. It turns Pensyve memory operations from optional actions into a reasoning discipline you carry through every substantive turn.
+
+## The rule
+
+**Before substantive answers, recall by entity. When a lesson lands, observe immediately with a one-line surface.**
+
+### "Substantive answer" means
+
+- Design or architecture recommendations
+- Debugging diagnoses with root-cause claims
+- Refactor proposals
+- Any response that makes a claim the user would want grounded in prior work
+
+Not substantive: formatting fixes, trivial lookups, reading a file, running a command.
+
+### "Lesson lands" means
+
+- A root cause has been confirmed (not hypothesized).
+- A design choice has been made explicit ("we'll use X because Y").
+- An approach has been tried and abandoned with a reason.
+- A workflow has been discovered that is reusable.
+- A workaround for a framework/library limitation has been validated.
+
+## Classification (which memory type?)
+
+- **Semantic** — a fact that will still be true next month. Use `pensyve_remember(entity, fact, confidence?)` (confidence defaults to 1.0; use 0.9 for high-confidence auto-captures).
+- **Episodic** — something that happened in this thread of work. Use `pensyve_observe` with the current `episode_id`.
+- **Procedural** — a reusable way to do something (a workflow, sequence, recipe). Use `pensyve_observe` with `content` beginning `[procedural]` (integration-layer convention; the MCP server has no native procedural-write API).
+
+When in doubt, prefer episodic. Server-side consolidation promotes recurring patterns to semantic automatically.
+
+## Canonical `pensyve_observe` call template
+
+ALL observe calls — in-flight, procedural, or wrap-up — MUST include every required field:
+
+```
+pensyve_observe(
+  episode_id: <current session's working episode_id>,
+  content: "[proactive/in-flight/tier-1] <observation text>",
+  source_entity: "neovim",
+  about_entity: "<relevant entity, lowercase-hyphenated>",
+  content_type: "text"
+)
+```
+
+Use `content_type: "code"` for code-related outcomes.
+
+## Episode lifecycle (lazy-open)
+
+Neovim AI plugins have no session-start/session-end hooks exposed to the LLM, so you own the episode lifecycle:
+
+- **Before your first `pensyve_observe` call in this conversation**, check whether a working `episode_id` is already tracked. If none exists, call `pensyve_episode_start(participants: ["neovim", "<project entity>"])` first, record the returned `episode_id`, then make the observation.
+- **Reuse the same `episode_id`** for all subsequent observations in the same conversation. Open a new episode only when the work's topic shifts substantially.
+- **Do not explicitly close** the episode under normal operation. Server-side consolidation handles aging.
+- **Recovery**: if `pensyve_observe` fails with a missing-episode error, call `pensyve_episode_start` and retry.
+
+## Surface style
+
+Lightly visible. One line when memory is used. Examples:
+
+- Recall: `Recalled 4 related memories (v7r, haiku-classifier).`
+- Capture: `↳ captured: hybrid-router threshold was the phase-3 regression root cause.`
+
+Do not narrate empty recalls or duplicate-skips.
+
+## Scope and budgets
+
+- Recall: scoped to detected entities (see `entity-detection.md`); limit 5; use `types` hint per flow.
+- Capture: one observation per substantive lesson; reuse the working `episode_id`.
+- Noise: avoid surfacing memory operations the user did not care about.
+
+## Composition with provenance tags
+
+When a capture is both procedural AND a proactive in-flight write, the `content` field begins with both markers, `[procedural]` first, then the provenance tag, then content:
+
+`[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=...`
+
+The `[procedural]` marker identifies the memory type for consolidation. The provenance tag identifies origin and trigger.
+
+## Provenance tag vocabulary
+
+- `[proactive/in-flight/tier-1]` — memory reflex captured during reasoning
+- `[proactive/in-flight/open-question]` — unresolved question noted in-flight
+- `[auto-capture/user/residual/tier-1]` — explicit user-driven capture (e.g., session-memory skill)
+
+## MCP contract reminder
+
+Rules never pass unsupported parameters. The MCP tool schemas are:
+
+- `pensyve_recall(query, entity?, types?, limit?, min_confidence?)` — **no** `related_entities`
+- `pensyve_episode_start(participants)` — **no** `continuation_of`
+- `pensyve_observe(episode_id, content, source_entity, about_entity, content_type?)` — `source_entity` and `about_entity` are **required**
+
+If you need secondary-entity context in a recall, fold those entities into the `query` string.

--- a/integrations/neovim/instructions/session-memory.md
+++ b/integrations/neovim/instructions/session-memory.md
@@ -1,0 +1,84 @@
+---
+description: Use at conversation wrap-up or when the user explicitly indicates end-of-session — capture residual lessons not captured in-flight
+---
+
+# Session Memory (Wrap-Up)
+
+Neovim AI plugins have no automatic Stop hook exposed to the LLM. This rule is the manual equivalent: when the user indicates the conversation is ending ("thanks, that's all", "session wrap-up", "we're done here"), review what happened and capture anything the in-flight reflex missed.
+
+Follows `memory-reflex.md`.
+
+## Instructions
+
+### Step 1: Review the conversation
+
+Scan the current conversation for three categories of memorable content that the in-flight reflex did NOT already capture:
+
+**Decisions** (confidence: 0.9):
+- Architecture or design choices
+- Technology selections
+- API design decisions
+- Tradeoff resolutions
+
+**Outcomes** (confidence: 0.8):
+- Bug fixes and their root causes
+- Successful approaches
+- Failed approaches with reasons
+- Performance findings
+
+**Patterns** (confidence: 0.7):
+- Recurring issues
+- Workflow discoveries
+- Cross-cutting observations
+
+### Step 2: Filter for significance and deduplicate
+
+Skip routine, low-signal content. Also skip anything that was already captured in-flight.
+
+For each candidate, call `pensyve_recall` with `query: <candidate fact text>`, `entity: <candidate's entity>`, `limit: 3`. If any returned memory has a score ≥0.85 against the candidate, skip it as a likely duplicate.
+
+Note: `pensyve_inspect` cannot filter by `episode_id` (its params are `entity`, `memory_type?`, `limit?` only), so dedup is entity-scoped semantic-similarity rather than session-scoped. Consequence: very similar items captured in prior sessions will also trigger the skip — acceptable for avoiding genuine duplicates.
+
+### Step 3: Present candidates for confirmation
+
+Show the filtered candidates to the user in a structured format:
+
+> **Session Memory Candidates**
+>
+> **Decisions** (confidence: 0.9):
+> 1. `<entity>`: <decision text>
+>
+> **Outcomes** (confidence: 0.8):
+> 2. `<entity>`: <outcome text>
+>
+> **Patterns** (confidence: 0.7):
+> 3. `<entity>`: <pattern text>
+>
+> Which should I store? (e.g., "all", "1,3", "none")
+
+### Step 4: Store confirmed items
+
+For each confirmed item, classify the type and call the appropriate MCP tool:
+
+- **Semantic** (decisions, durable truths) — `pensyve_remember(entity, fact: "[auto-capture/user/residual/tier-1] <text>", confidence)`. Use confidence from the categorization above.
+- **Episodic** (outcomes, session-specific events) — ensure working `episode_id`; `pensyve_observe(episode_id, content: "[auto-capture/user/residual/tier-1] <text>", source_entity: "neovim", about_entity: <entity>, content_type: "text")`.
+- **Procedural** (reusable workflows) — `pensyve_observe(episode_id, content: "[procedural] [auto-capture/user/residual/tier-1] trigger=..., action=..., outcome=...", source_entity: "neovim", about_entity: <entity>, content_type: "text")`.
+
+### Step 5: Optionally close the episode
+
+If the user indicates this is a final wrap (not just a turn-by-turn pause), call `pensyve_episode_end(episode_id: <working_id>, outcome: "success")`. Valid outcomes: `"success"`, `"failure"`, `"partial"`.
+
+Not closing is safe — server-side consolidation ages episodes naturally. Only close when the user clearly marks the work complete.
+
+### Step 6: Report
+
+After storing, summarize:
+
+> Stored N memories. Episode <outcome> closed.
+
+## Constraints
+
+- **Never auto-store.** Every candidate MUST be presented to the user for confirmation before storage.
+- Entity names lowercase-hyphenated.
+- Do not store secrets.
+- If nothing significant surfaced, say so clearly rather than forcing low-quality memories.

--- a/integrations/neovim/neovim-mcp.json.example
+++ b/integrations/neovim/neovim-mcp.json.example
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "pensyve": {
+      "type": "http",
+      "url": "https://mcp.pensyve.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ${PENSYVE_API_KEY}"
+      }
+    }
+  }
+}

--- a/integrations/neovim/scripts/lint-mcp-refs.sh
+++ b/integrations/neovim/scripts/lint-mcp-refs.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Static MCP contract linter for the Pensyve Neovim adapter rules.
+#
+# Verifies that every pensyve_* call example in instructions/*.md conforms to
+# the current MCP tool schema in pensyve-mcp-tools/src/params.rs. Catches the
+# category of bug PR #58 surfaced in the Claude Code adapter (unsupported
+# parameters, missing required fields).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RULES_DIR="$SCRIPT_DIR/../instructions"
+
+EXIT_CODE=0
+
+if [ ! -d "$RULES_DIR" ]; then
+  echo "ERROR: Rules directory not found: $RULES_DIR"
+  exit 1
+fi
+
+echo "Linting MCP references in $RULES_DIR..."
+echo ""
+
+# Check 1: no actual use of unsupported 'related_entities' parameter in call examples.
+# We look for pensyve_recall( blocks that contain related_entities as a parameter.
+# Lines that say "no related_entities" (documentation/reminders) are excluded.
+echo "Check 1: no unsupported 'related_entities' on pensyve_recall"
+FOUND_RELATED=0
+for rule_file in "$RULES_DIR"/*.md; do
+  # Extract lines that contain pensyve_recall( and related_entities together,
+  # excluding documentation lines (those containing "**no**" or "no `related_entities`")
+  if rg -n 'related_entities' "$rule_file" | rg -v '(\*\*no\*\*|no `related_entities`)' | rg -q 'pensyve_recall\|related_entities'; then
+    echo "  FAIL in $rule_file: 'related_entities' used in a pensyve_recall call"
+    FOUND_RELATED=1
+  fi
+  # Also catch if related_entities appears inside a pensyve_recall( block
+  awk '/pensyve_recall\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+         if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
+           print FILENAME ": related_entities found in pensyve_recall block: " buf;
+         capture=0
+       }' "$rule_file" | while read -r line; do
+    if [ -n "$line" ]; then
+      echo "  FAIL: $line"
+      FOUND_RELATED=1
+    fi
+  done
+done
+if [ "$FOUND_RELATED" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 2: no actual use of unsupported 'continuation_of' parameter in call examples.
+# Documentation lines saying "no continuation_of" are excluded.
+echo "Check 2: no unsupported 'continuation_of' on pensyve_episode_start"
+FOUND_CONT=0
+for rule_file in "$RULES_DIR"/*.md; do
+  awk '/pensyve_episode_start\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+         if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
+           print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
+         capture=0
+       }' "$rule_file" | while read -r line; do
+    if [ -n "$line" ]; then
+      echo "  FAIL: $line"
+      FOUND_CONT=1
+    fi
+  done
+done
+if [ "$FOUND_CONT" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 3: every pensyve_observe call example in a code block has source_entity and about_entity
+# Scan each .md file's pensyve_observe blocks; require both fields nearby.
+echo "Check 3: every pensyve_observe example has source_entity and about_entity"
+MISSING_FIELDS=0
+for rule_file in "$RULES_DIR"/*.md; do
+  # Find each pensyve_observe( block (up to the next closing paren within 20 lines)
+  awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
+       capture {buf = buf "\n" $0;
+                for(i=1; i<=length($0); i++){
+                  c=substr($0,i,1);
+                  if(c=="(") depth++;
+                  if(c==")") depth--;
+                };
+                if(depth==0 && buf ~ /pensyve_observe\(/){
+                  if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
+                  if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
+                  capture=0;
+                }}' "$rule_file" | while read -r line; do
+    if [ -n "$line" ]; then
+      echo "  FAIL: $line"
+      MISSING_FIELDS=1
+    fi
+  done
+done
+if [ "$MISSING_FIELDS" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 4: provenance tag format — every proactive/auto-capture tag uses [<origin>/<trigger>/<tier>]
+# Format supports both 3-segment [origin/trigger/tier] and 4-segment [origin/trigger/residual/tier]
+# where the third segment may be a literal "residual" qualifier before the tier.
+echo "Check 4: provenance tag format"
+VALID_PROVENANCE_RE='\[(proactive|auto-capture)/(in-flight|stop|pre-compact|curator|user)/(tier-1|tier-2|residual/tier-1|residual/tier-2|open-question)\]'
+if rg -n '\[(proactive|auto-capture)' "$RULES_DIR" | rg -v "$VALID_PROVENANCE_RE"; then
+  echo "  FAIL: some provenance tags do not match [<origin>/<trigger>/<tier>] format"
+  EXIT_CODE=1
+else
+  echo "  PASS"
+fi
+echo ""
+
+# Check 5: procedural memory convention — [procedural] prefix is used in observe content
+echo "Check 5: procedural convention uses [procedural] prefix in pensyve_observe content"
+# Only a warning if no rule mentions [procedural] — may be legitimate if the rule is non-procedural
+if ! rg -q '\[procedural\]' "$RULES_DIR"; then
+  echo "  WARN: no [procedural] prefix usage found across rules. Expected in memory-reflex and flow rules that handle procedural captures."
+else
+  echo "  PASS"
+fi
+echo ""
+
+if [ "$EXIT_CODE" = "0" ]; then
+  echo "All MCP contract checks PASSED."
+else
+  echo "MCP contract checks FAILED. Fix the issues above before committing."
+fi
+
+exit "$EXIT_CODE"

--- a/integrations/neovim/scripts/lint-mcp-refs.sh
+++ b/integrations/neovim/scripts/lint-mcp-refs.sh
@@ -34,18 +34,18 @@ for rule_file in "$RULES_DIR"/*.md; do
     FOUND_RELATED=1
   fi
   # Also catch if related_entities appears inside a pensyve_recall( block
-  awk '/pensyve_recall\(/{capture=1; buf=""}
-       capture {buf = buf "\n" $0}
-       capture && /\)/{
-         if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
-           print FILENAME ": related_entities found in pensyve_recall block: " buf;
-         capture=0
-       }' "$rule_file" | while read -r line; do
+  while read -r line; do
     if [ -n "$line" ]; then
       echo "  FAIL: $line"
       FOUND_RELATED=1
     fi
-  done
+  done < <(awk '/pensyve_recall\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+       if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
+       print FILENAME ": related_entities found in pensyve_recall block: " buf;
+       capture=0
+       }' "$rule_file")
 done
 if [ "$FOUND_RELATED" = "0" ]; then
   echo "  PASS"
@@ -59,18 +59,18 @@ echo ""
 echo "Check 2: no unsupported 'continuation_of' on pensyve_episode_start"
 FOUND_CONT=0
 for rule_file in "$RULES_DIR"/*.md; do
-  awk '/pensyve_episode_start\(/{capture=1; buf=""}
-       capture {buf = buf "\n" $0}
-       capture && /\)/{
-         if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
-           print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
-         capture=0
-       }' "$rule_file" | while read -r line; do
+  while read -r line; do
     if [ -n "$line" ]; then
       echo "  FAIL: $line"
       FOUND_CONT=1
     fi
-  done
+  done < <(awk '/pensyve_episode_start\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+       if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
+       print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
+       capture=0
+       }' "$rule_file")
 done
 if [ "$FOUND_CONT" = "0" ]; then
   echo "  PASS"
@@ -85,23 +85,23 @@ echo "Check 3: every pensyve_observe example has source_entity and about_entity"
 MISSING_FIELDS=0
 for rule_file in "$RULES_DIR"/*.md; do
   # Find each pensyve_observe( block (up to the next closing paren within 20 lines)
-  awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
-       capture {buf = buf "\n" $0;
-                for(i=1; i<=length($0); i++){
-                  c=substr($0,i,1);
-                  if(c=="(") depth++;
-                  if(c==")") depth--;
-                };
-                if(depth==0 && buf ~ /pensyve_observe\(/){
-                  if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
-                  if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
-                  capture=0;
-                }}' "$rule_file" | while read -r line; do
+  while read -r line; do
     if [ -n "$line" ]; then
       echo "  FAIL: $line"
       MISSING_FIELDS=1
     fi
-  done
+  done < <(awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
+       capture {buf = buf "\n" $0;
+       for(i=1; i<=length($0); i++){
+       c=substr($0,i,1);
+       if(c=="(") depth++;
+       if(c==")") depth--;
+       };
+       if(depth==0 && buf ~ /pensyve_observe\(/){
+       if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
+       if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
+       capture=0;
+       }}' "$rule_file")
 done
 if [ "$MISSING_FIELDS" = "0" ]; then
   echo "  PASS"

--- a/integrations/openclaw-plugin/AGENTS.md
+++ b/integrations/openclaw-plugin/AGENTS.md
@@ -1,0 +1,372 @@
+# Pensyve Working-Memory Substrate for OpenClaw
+
+This file configures persistent working-memory for the OpenClaw CLI agent via the Pensyve MCP server. All sections below are always in context — they form the substrate the agent operates on across every coding session.
+
+---
+
+## Memory Reflex Rule
+
+**This discipline is non-optional. Before substantive answers, recall by entity. When a lesson lands, observe immediately with a one-line surface.**
+
+### "Substantive answer" means
+
+- Design or architecture recommendations
+- Debugging diagnoses with root-cause claims
+- Refactor proposals
+- Any response that makes a claim the user would want grounded in prior work
+
+Not substantive: formatting fixes, trivial lookups, reading a file, running a command.
+
+### "Lesson lands" means
+
+- A root cause has been confirmed (not hypothesized).
+- A design choice has been made explicit ("we'll use X because Y").
+- An approach has been tried and abandoned with a reason.
+- A workflow has been discovered that is reusable.
+- A workaround for a framework/library limitation has been validated.
+
+### Memory classification
+
+- **Semantic** — a fact that will still be true next month. Use `pensyve_remember(entity, fact, confidence?)` (confidence defaults to 1.0; use 0.9 for high-confidence auto-captures).
+- **Episodic** — something that happened in this thread of work. Use `pensyve_observe` with the current `episode_id`.
+- **Procedural** — a reusable way to do something. Use `pensyve_observe` with `content` beginning `[procedural]`.
+
+When in doubt, prefer episodic.
+
+### Canonical `pensyve_observe` call template
+
+ALL observe calls MUST include every required field:
+
+```
+pensyve_observe(
+  episode_id: <current session's working episode_id>,
+  content: "[proactive/in-flight/tier-1] <observation text>",
+  source_entity: "openclaw",
+  about_entity: "<relevant entity, lowercase-hyphenated>",
+  content_type: "text"
+)
+```
+
+Use `content_type: "code"` for code-related outcomes.
+
+### Episode lifecycle (lazy-open)
+
+OpenClaw's rule layer has no session-start/session-end hooks in the substrate context, so you own the episode lifecycle:
+
+- Before your first `pensyve_observe` call in this conversation, check whether a working `episode_id` is tracked. If none exists, call `pensyve_episode_start(participants: ["openclaw", "<project entity>"])` first.
+- Reuse the same `episode_id` for all subsequent observations in the same conversation.
+- Do not explicitly close the episode under normal operation. Server-side consolidation handles aging.
+- Recovery: if `pensyve_observe` fails with a missing-episode error, call `pensyve_episode_start` and retry.
+
+### Surface style
+
+Lightly visible. One line when memory is used:
+
+- Recall: `Recalled 4 related memories (v7r, haiku-classifier).`
+- Capture: `↳ captured: hybrid-router threshold was the phase-3 regression root cause.`
+
+Do not narrate empty recalls or duplicate-skips.
+
+### Provenance tag vocabulary
+
+- `[proactive/in-flight/tier-1]` — memory reflex captured during reasoning
+- `[proactive/in-flight/open-question]` — unresolved question noted in-flight
+- `[auto-capture/user/residual/tier-1]` — explicit user-driven capture
+
+### Composition
+
+When a capture is both procedural AND in-flight: `[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=...`
+
+### MCP contract
+
+Rules never pass unsupported parameters:
+
+- `pensyve_recall(query, entity?, types?, limit?, min_confidence?)` — **no** `related_entities`
+- `pensyve_episode_start(participants)` — **no** `continuation_of`
+- `pensyve_observe(episode_id, content, source_entity, about_entity, content_type?)` — `source_entity` and `about_entity` are **required**
+
+---
+
+## Entity Detection
+
+Shared rules for detecting entity names from tool inputs, prompts, and conversation context. Used to scope recalls and `about_entity` fields on observations.
+
+### Inputs
+
+Extract candidate entity names from:
+
+1. **File references** — `@filename`, `@path/to/file`, or files mentioned directly in the conversation.
+2. **User prompts** — explicit references to components, files, services, research phases.
+3. **Code context** — module names, class names, function names in files being edited or read.
+4. **Git context** — repository root name, branch name (when discoverable).
+
+### Canonicalization
+
+- Lowercase all characters.
+- Replace spaces and underscores with hyphens.
+- Strip file extensions unless the file is the entity itself (e.g., `package.json`).
+- Collapse paths to the most semantically meaningful segment (e.g., `src/engine/hybrid_router.rs` → `hybrid-router`).
+
+### Fallback
+
+- If no specific entity is detected, fall back to the project-level entity (repository root name, lowercase-hyphenated).
+- If ambiguous, prefer the entity that already has memories in Pensyve (call `pensyve_inspect` with limit 1 to check).
+- **Never fabricate entity names.**
+
+### Output
+
+1–3 candidate entity names per turn. Primary entity is most specific; fold secondary entities into the `query` string when calling `pensyve_recall`.
+
+---
+
+## When Debugging
+
+Use when diagnosing bugs, errors, failing tests, or crashes.
+
+### Step 1: Detect entities
+
+Identify the relevant entity/entities (failing test, failing module, error source) per the entity detection section above.
+
+### Step 2: Consult memory (required)
+
+Call `pensyve_recall`:
+
+- `query`: short description of the failure, including secondary entity names
+- `entity`: primary detected entity
+- `types`: `["procedural", "episodic"]`
+- `limit`: 5
+
+Surface: `Recalled N memories from prior debug sessions on <entity>.`
+
+If a highly similar incident is found (score >0.8): `This looks similar to an incident captured on <date>: <summary>. Consider that path first.`
+
+### Step 3: Diagnose
+
+Proceed with diagnostic work, using recalled procedural memories as a starting sequence.
+
+### Step 4: Capture lesson (when it lands)
+
+When a root cause is **confirmed** (not just hypothesized):
+
+- **Episodic root cause:** `pensyve_observe` with `content: "[proactive/in-flight/tier-1] <one-sentence root cause>"`, `source_entity: "openclaw"`, `about_entity: <primary_entity>`, `content_type: "text"`.
+- **Procedural sequence:** `pensyve_observe` with `content: "[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=..."`, `source_entity: "openclaw"`, `about_entity: <primary_entity>`, `content_type: "text"`.
+- **Semantic truth:** `pensyve_remember(entity, fact: "[proactive/in-flight/tier-1] <fact>", confidence: 0.9)`.
+
+### Step 5: Capture abandoned approaches
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[proactive/in-flight/tier-1] tried <approach>, abandoned because <reason>",
+  source_entity: "openclaw",
+  about_entity: <primary_entity>,
+  content_type: "text"
+)
+```
+
+---
+
+## When Designing
+
+Use when making architecture, API, or design decisions.
+
+### Step 1: Detect entities
+
+Identify the relevant entity/entities (service, module, subsystem under design).
+
+### Step 2: Consult memory (required)
+
+Call `pensyve_recall`:
+
+- `query`: short description of the design question
+- `entity`: primary detected entity
+- `types`: `["semantic", "episodic"]`
+- `limit`: 5
+
+Surface: `Recalled N prior decisions on <entity>.`
+
+If the current question contradicts a prior decision, flag it: `Prior decision on <entity> (confidence 0.9): [decision]. Are we revisiting this?`
+
+### Step 3: Recommend with grounding
+
+Shape recommendations using recalled decisions.
+
+### Step 4: Capture decision (when it lands)
+
+When the user accepts a design or states a decision:
+
+- **Semantic:** `pensyve_remember(entity: <primary_entity>, fact: "[proactive/in-flight/tier-1] <decision text>", confidence: 0.9)`.
+- **Episodic context:** `pensyve_observe` with `content: "[proactive/in-flight/tier-1] Decision on <entity>: chose X over Y because Z"`, `source_entity: "openclaw"`, `about_entity: <primary_entity>`, `content_type: "text"`.
+
+### Step 5: Capture evaluation procedures
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[procedural] [proactive/in-flight/tier-1] trigger=design-question-on-<area>, action=<steps>, outcome=<what-you-learn>",
+  source_entity: "openclaw",
+  about_entity: <primary_entity>,
+  content_type: "text"
+)
+```
+
+---
+
+## When Refactoring
+
+Use before substantive refactors.
+
+### Step 1: Detect entities
+
+Identify entities touched by the refactor (file or module being restructured, callers, subsystem name).
+
+### Step 2: Load prior context (required)
+
+Call `pensyve_recall`:
+
+- `query`: short description of the refactor
+- `entity`: primary detected entity
+- `types`: `["semantic", "episodic", "procedural"]`
+- `limit`: 5
+
+Highlight any prior failed approaches: `Prior episodic memory: tried <approach>, abandoned because <reason>. Double-check this isn't the same trap.`
+
+### Step 3: Present a briefing
+
+Summarize what prior memories say about: decisions, prior attempts, known-good procedures.
+
+### Step 4: Capture refactor lessons as they land
+
+Apply the memory reflex immediately when:
+
+- **Invariant discovered** (semantic): `pensyve_remember(entity, fact, confidence: 0.9)`
+- **Abandoned approach confirmed** (episodic): `pensyve_observe` with `[proactive/in-flight/tier-1]`
+- **Dependency chain surprise** (episodic): `pensyve_observe`
+- **Known-good sequence emerged** (procedural): `pensyve_observe` with `[procedural]` prefix
+
+---
+
+## Longitudinal Work (Research/Evals)
+
+Use for long-running multi-session work in `research/`, `benchmarks/`, or `evals/` directories.
+
+### Step 1: Resume context at conversation start
+
+Call `pensyve_recall`:
+
+- `query`: short description of the current research area
+- `entity`: project + sub-topic entity
+- `limit`: 5
+
+No `types` filter — longitudinal work benefits from all three memory types.
+
+### Step 2: Proactively recall per topic shift
+
+When the session pivots to a new sub-topic, call `pensyve_recall` again scoped to it.
+
+### Step 3: Capture per run
+
+| What you learned | Type | Call |
+|---|---|---|
+| Per-run outcome | episodic | `pensyve_observe(..., content: "[proactive/in-flight/tier-1] Run N+1: ...", source_entity: "openclaw", about_entity: <entity>, content_type: "text")` |
+| Stable truth | semantic | `pensyve_remember(entity, fact: "[proactive/in-flight/tier-1] ...", confidence: 0.9)` |
+| Reusable procedure | procedural | `pensyve_observe(..., content: "[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=...", source_entity: "openclaw", about_entity: <entity>, content_type: "text")` |
+
+### Step 4: Capture open questions
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[proactive/in-flight/open-question] <question>",
+  source_entity: "openclaw",
+  about_entity: <entity>,
+  content_type: "text"
+)
+```
+
+### Step 5: End-of-session summary
+
+Before wrapping: summarize what this run taught vs. prior runs, and what's still open.
+
+---
+
+## Session Memory (Wrap-Up)
+
+Use at conversation wrap-up or when the user indicates end-of-session.
+
+### Step 1: Review the conversation
+
+Scan for three categories the in-flight reflex did NOT already capture:
+
+**Decisions** (confidence: 0.9): architecture choices, technology selections, API decisions, tradeoff resolutions.
+
+**Outcomes** (confidence: 0.8): bug fixes and root causes, successful approaches, failed approaches with reasons, performance findings.
+
+**Patterns** (confidence: 0.7): recurring issues, workflow discoveries, cross-cutting observations.
+
+### Step 2: Filter and deduplicate
+
+For each candidate, call `pensyve_recall` with `query: <candidate fact text>`, `entity: <entity>`, `limit: 3`. If score ≥0.85, skip as likely duplicate.
+
+### Step 3: Present candidates for confirmation
+
+> **Session Memory Candidates**
+>
+> **Decisions** (confidence: 0.9):
+> 1. `<entity>`: <decision text>
+>
+> **Outcomes** (confidence: 0.8):
+> 2. `<entity>`: <outcome text>
+>
+> **Patterns** (confidence: 0.7):
+> 3. `<entity>`: <pattern text>
+>
+> Which should I store? (e.g., "all", "1,3", "none")
+
+### Step 4: Store confirmed items
+
+- **Semantic:** `pensyve_remember(entity, fact: "[auto-capture/user/residual/tier-1] <text>", confidence)`.
+- **Episodic:** `pensyve_observe(episode_id, content: "[auto-capture/user/residual/tier-1] <text>", source_entity: "openclaw", about_entity: <entity>, content_type: "text")`.
+- **Procedural:** `pensyve_observe(episode_id, content: "[procedural] [auto-capture/user/residual/tier-1] trigger=..., action=..., outcome=...", source_entity: "openclaw", about_entity: <entity>, content_type: "text")`.
+
+### Step 5: Optionally close the episode
+
+If the user marks work complete: `pensyve_episode_end(episode_id: <working_id>, outcome: "success")`. Valid outcomes: `"success"`, `"failure"`, `"partial"`.
+
+**Never auto-store.** Every candidate MUST be confirmed before storage.
+
+---
+
+## Context Loader (Session Start)
+
+Use when starting a new substantive conversation or switching contexts.
+
+### Step 1: Detect project entity
+
+Use the repository root name (lowercase-hyphenated) as default. Override with `PENSYVE_NAMESPACE` if set.
+
+### Step 2: Scoped recall
+
+Call `pensyve_recall`:
+
+- `query`: `"recent decisions issues patterns"` + key terms from the user's opening message
+- `entity`: detected project entity
+- `types`: `["episodic"]`
+- `limit`: 5
+
+### Step 3: Compute continuity signal
+
+If ≥70% of the top observations share entities with the current conversation → **continuation**. Otherwise → **fresh session**.
+
+### Step 4: Surface the primer
+
+**Continuation:**
+> **Pensyve:** Continuing prior work on `<entity-set>`. Recent lessons: [top 3 observations]
+
+**Fresh session:**
+> **Pensyve:** N memories loaded for `<project>`. Key context: [top 3 observations]
+
+**No memories:**
+> **Pensyve:** No memories found for `<project>`. Use `/remember` to start building context.
+
+Do not fabricate memories. Only display what `pensyve_recall` returns.

--- a/integrations/openclaw-plugin/CHANGELOG.md
+++ b/integrations/openclaw-plugin/CHANGELOG.md
@@ -1,0 +1,42 @@
+# Changelog — Pensyve OpenClaw Adapter
+
+All notable changes to the Pensyve OpenClaw adapter are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). The OpenClaw adapter versions independently of the Claude Code plugin.
+
+## [1.0.0] - 2026-04-20
+
+### Added
+
+- **Working-memory substrate** for OpenClaw via `AGENTS.md`. All eight substrate rules consolidated into a single file with clear section headings (extends the existing native plugin without removing it):
+  - **Memory Reflex Rule** — non-optional reasoning discipline with three-type memory classification, canonical `pensyve_observe` call template, provenance vocabulary, lazy-open episode lifecycle
+  - **Entity Detection** — canonicalization and fallback rules
+  - **When Debugging** — debug flow with memory baked in
+  - **When Designing** — design flow with memory baked in
+  - **When Refactoring** — refactor flow with memory baked in
+  - **Longitudinal Work (Research/Evals)** — multi-session research/eval flow
+  - **Session Memory (Wrap-Up)** — manual wrap-up equivalent of Claude Code's Stop hook
+  - **Context Loader (Session Start)** — best-effort continuity primer via episodic recall
+- **MCP config example** at `openclaw.mcp.json.example` (merge into `openclaw.json`) covering Cloud-with-API-key and Local-stdio options
+- **Static MCP contract lint script** at `scripts/lint-mcp-refs.sh` verifying the consolidated `AGENTS.md`'s `pensyve_*` call examples match the `pensyve-mcp-tools/src/params.rs` schema
+
+### Design
+
+- Additive: substrate `AGENTS.md` extends the existing native plugin (`openclaw.plugin.json`, `src/`) without removing any functionality.
+- **Single-file delivery:** all 8 rules consolidated into `AGENTS.md` with section headings.
+- Lazy-open episode lifecycle: first `pensyve_observe` call triggers `pensyve_episode_start`; episodes are not explicitly closed.
+- Best-effort continuity primer via `pensyve_recall(types: ["episodic"])` — the MCP server has no episode-listing API.
+- MCP contract verified: no `related_entities` on recall, no `continuation_of` on episode_start, required `source_entity: "openclaw"` and `about_entity` on every observe.
+- Opt-out: delete or edit `AGENTS.md`; native plugin continues working unchanged.
+
+### Not Included
+
+- No changes to the existing native plugin TypeScript code (`src/`, `openclaw.plugin.json`)
+- No installer script (manual copy of `AGENTS.md` + MCP config merge)
+- No server-side changes — uses the existing MCP tool surface
+
+### Relation to Other Pensyve Integrations
+
+- The OpenClaw adapter is part of the batch-2 working-memory substrate rollout. The Claude Code plugin (v1.3.0), Cursor adapter (v1.0.0), and VS Code Copilot adapter (v1.0.0) are the reference implementations.
+- Key difference from Cursor: single `AGENTS.md` vs. Cursor's per-rule `.cursor/rules/*.mdc` files.
+- Playbook: `pensyve-docs/specs/2026-04-18-pensyve-working-memory-substrate-design.md`

--- a/integrations/openclaw-plugin/README.md
+++ b/integrations/openclaw-plugin/README.md
@@ -1,57 +1,86 @@
 # @pensyve/openclaw-pensyve
 
-Memory plugin for OpenClaw. Replaces the default `memory-core` with Pensyve's persistent, cross-session memory backed by 8-signal fusion retrieval.
+Persistent working-memory substrate for [OpenClaw](https://github.com/openclaw/openclaw) — memory is not a feature you invoke, it is the substrate the agent operates on.
 
-## Features
+Replaces the default `memory-core` with Pensyve's persistent, cross-session memory backed by 8-signal fusion retrieval, and extends it with the full working-memory substrate (proactive in-flight capture, entity-scoped recall, procedural memory, episodic threading).
 
-- **Auto-Recall** -- relevant memories injected before each turn via `before_prompt_build` hook
-- **Auto-Capture** -- conversation context stored after each turn via `after_agent_response` hook
-- **5 Agent Tools** -- `memory_recall`, `memory_store`, `memory_get`, `memory_forget`, `memory_status`
-- **CLI Commands** -- `openclaw pensyve search <query>`, `openclaw pensyve stats`
-- **Three Memory Types** -- episodic, semantic, and procedural
-- **8-Signal Fusion Retrieval** -- vector similarity + BM25 + graph traversal + cross-encoder reranker
+## What It Does
 
-## Authentication
+- **Proactive memory during work** — lessons are captured the moment they land, not at session end
+- **Thread-aware continuity** — sessions that continue prior work resume with relevant context, no re-briefing
+- **Entity-scoped recall** — substantive questions are grounded in prior decisions; simple commands stay fast
+- **Three memory types** — durable facts (semantic), session-specific events (episodic), reusable procedures (procedural)
+- **Lightly visible** — one-line surfaces when memory is used; never interrupts your flow
+- **Auto-Recall** — relevant memories injected before each turn via `before_prompt_build` hook
+- **Auto-Capture** — conversation context stored after each turn via `after_agent_response` hook
+- **5 Agent Tools** — `memory_recall`, `memory_store`, `memory_get`, `memory_forget`, `memory_status`
 
-1. Sign up at [pensyve.com](https://pensyve.com)
-2. Create an API key at [Settings → API Keys](https://pensyve.com/settings/api-keys)
-3. Set the environment variable:
-   ```bash
-   export PENSYVE_API_KEY="psy_your_key_here"
-   ```
+## Install
 
-Then configure MCP with headers (see setup instructions above).
+Two steps: configure the MCP server, then install the instructions file.
 
-## Prerequisites
+### 1. Configure the MCP server
 
-You need a Pensyve server. Choose one:
+Merge the following into your `openclaw.json`:
 
-**Pensyve Cloud** (recommended -- no setup):
-
-1. Sign up at [pensyve.com](https://pensyve.com) and create an API key
-2. Set the environment variable:
-   ```bash
-   export PENSYVE_API_KEY="psy_..."
-   ```
-
-**Pensyve Local** (self-hosted, offline-first):
+**Cloud with API key (recommended):**
 
 ```bash
-git clone https://github.com/major7apps/pensyve
-cd pensyve && cargo build --release -p pensyve-mcp
+export PENSYVE_API_KEY="psy_your_key_here"
 ```
 
-No API key needed -- all data stays on your machine in SQLite.
+```json
+{
+  "mcpServers": {
+    "pensyve": {
+      "type": "http",
+      "url": "https://mcp.pensyve.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ${PENSYVE_API_KEY}"
+      }
+    }
+  }
+}
+```
 
-## Installation
+A ready-to-use example is at `openclaw.mcp.json.example`. Create your key at [pensyve.com/settings/api-keys](https://pensyve.com/settings/api-keys). Put the `export` in `~/.bashrc` or `~/.zshrc` to persist.
+
+**Local (offline, self-hosted):**
+
+```json
+{
+  "mcpServers": {
+    "pensyve": {
+      "type": "stdio",
+      "command": "pensyve-mcp",
+      "args": ["--stdio"]
+    }
+  }
+}
+```
+
+Build the binary: `cargo build --release -p pensyve-mcp` from the [pensyve repo](https://github.com/major7apps/pensyve).
+
+### 2. Install the instructions file
+
+Copy `AGENTS.md` to your project root (OpenClaw loads `AGENTS.md` automatically as its agent instruction file):
 
 ```bash
-# From the plugin directory
+cp /path/to/pensyve/integrations/openclaw-plugin/AGENTS.md .
+```
+
+**Note:** All 8 substrate rules are consolidated into a single `AGENTS.md` with clear section headings.
+
+### 3. (Optional) Enable the native plugin
+
+The native plugin provides auto-recall and auto-capture hooks on top of the substrate instructions. Build and enable:
+
+```bash
 cd /path/to/pensyve/integrations/openclaw-plugin
 npm install && npm run build
 ```
 
-Then add the plugin to your `openclaw.json`:
+Then add to your `openclaw.json`:
 
 ```json5
 // plugins.entries
@@ -75,85 +104,69 @@ Set Pensyve as the memory provider:
 "memory": "pensyve"
 ```
 
-For local-only mode, set `"baseUrl": "http://localhost:8000"` and omit the API key.
-
-## Configuration Reference
-
-| Option        | Type      | Default                   | Description                                |
-| ------------- | --------- | ------------------------- | ------------------------------------------ |
-| `baseUrl`     | `string`  | `https://mcp.pensyve.com` | Pensyve API URL                            |
-| `apiKey`      | `string`  | `$PENSYVE_API_KEY`        | API key for Pensyve Cloud                  |
-| `entity`      | `string`  | `openclaw-agent`          | Entity name for memory storage             |
-| `namespace`   | `string`  | `openclaw`                | Memory namespace for isolation             |
-| `autoRecall`  | `boolean` | `true`                    | Inject memories before each turn           |
-| `autoCapture` | `boolean` | `true`                    | Store conversation context after each turn |
-| `recallLimit` | `number`  | `5`                       | Max memories to recall per turn            |
-
-## Intelligent Memory Capture (v1.0.7)
-
-Pensyve uses a tiered classification system to identify what is worth remembering:
-
-- **Tier 1** (auto-store, confidence 0.9+): Explicit decisions, corrections, constraints -- high-signal items that should almost always be captured
-- **Tier 2** (batch review, confidence 0.7-0.89): Root causes, failed approaches, performance findings -- medium-signal items that benefit from user confirmation
-- **Discard**: Formatting, typos, boilerplate -- noise that should never be stored
-
-The auto-capture hook (`after_agent_response`) currently stores exchanges at tier 2 confidence. The `memory_store` tool description guides the agent to apply the appropriate confidence tier when storing facts explicitly. Future versions will integrate the shared memory-capture-core classifier for full tiered classification with signal buffering.
-
 ## How It Works
 
-### Auto-Recall (`before_prompt_build`)
+The substrate is delivered through `AGENTS.md`. The Memory Reflex Rule section establishes the discipline: *before substantive answers, recall by entity; when a lesson lands, observe immediately with a one-line surface*. Flow sections (When Debugging, When Designing, When Refactoring, Longitudinal Work) guide the model through consult-memory + capture-lesson steps.
 
-Before each agent turn, the plugin:
+When the native plugin is also enabled, the `before_prompt_build` hook injects top recalled memories before each turn and `after_agent_response` auto-captures substantive exchanges.
 
-1. Extracts the latest user message
-2. Queries Pensyve's recall endpoint with the message as the search query
-3. Receives ranked memories scored by 8-signal fusion
-4. Prepends the top results as context so the agent can reference prior sessions without explicit tool calls
+**Episode lifecycle:** Episodes open lazily on the first `pensyve_observe` call and are not explicitly closed under normal operation. Server-side consolidation handles aging.
 
-### Auto-Capture (`after_agent_response`)
+**Continuity primer:** The Context Loader section runs a best-effort recall at the start of substantive conversations to surface prior relevant observations.
 
-After each agent turn, the plugin:
+## Memory Behavior Model
 
-1. Extracts the user message and assistant response
-2. Creates a condensed episodic memory of the exchange
-3. Stores it via Pensyve with moderate confidence (0.7)
-4. Pensyve's FSRS-based forgetting curve naturally deprioritizes stale memories over time
+Pensyve behaves as working memory for the agent — always-on, ambient, continuous.
 
-### Agent Tools
+**Writes happen in-flight.** When a root cause is confirmed, a decision is made, or a reusable procedure emerges, it's captured the moment it lands via the memory reflex. No batching to session end.
 
-| Tool            | Description                                         |
-| --------------- | --------------------------------------------------- |
-| `memory_recall` | Semantic search across all memory types             |
-| `memory_store`  | Persist a fact with configurable confidence         |
-| `memory_get`    | List all stored memories for the current entity     |
-| `memory_forget` | Clear all memories (requires explicit confirmation) |
-| `memory_status` | Show connection status, memory counts, account info |
+**Reads happen at decision points.** Before substantive answers, the model consults memory scoped to the detected entities. Simple commands (run tests, format file) skip recall to stay fast.
 
-### CLI Commands
+**Sessions continue.** At the start of a substantive conversation, Pensyve checks whether the current work continues prior memories (shared entities + recent activity). If yes, you resume with a primer — no re-briefing needed.
 
-```bash
-openclaw pensyve search "JWT signing decision"
-openclaw pensyve stats
-```
+## Memory Types
 
-## Comparison with Default memory-core
+| Type | Definition | MCP call | Example |
+|---|---|---|---|
+| **Semantic** | Durable truths, decisions, preferences | `pensyve_remember` | "We chose RS256 over HS256 for JWT signing" |
+| **Episodic** | Temporal events, session-scoped observations | `pensyve_observe` (with lazy-opened `episode_id`) | "Phase-3 regression root cause: hybrid-router threshold" |
+| **Procedural** | Reusable workflows, sequences, recipes | `pensyve_observe` with `[procedural]` content prefix | "To calibrate V7r: freeze Haiku config, run suite, diff baseline" |
 
-| Feature                 | memory-core    | Pensyve                            |
-| ----------------------- | -------------- | ---------------------------------- |
-| Storage                 | Markdown files | SQLite + vector index              |
-| Search                  | BM25 only      | 8-signal fusion                    |
-| Memory types            | Flat text      | Episodic + Semantic + Procedural   |
-| Retrieval quality       | Keyword match  | Semantic + BM25 + graph + reranker |
-| Offline                 | Yes            | Yes                                |
-| Cross-encoder reranking | No             | Yes (BGE)                          |
-| Forgetting curve        | No             | FSRS-based                         |
+## Opt-Out
+
+- **Full opt-out** — delete `AGENTS.md` from your project root and disable the plugin in `openclaw.json`
+- **Partial opt-out** — delete specific sections from `AGENTS.md` (e.g., remove the "Longitudinal Work" section)
+- **Silent mode** — edit the Memory Reflex Rule section to remove the "one-line surface" guidance; captures stay silent
+- **Recall-only mode** — edit flow sections to drop the `Capture lesson` steps while keeping `Consult memory`
+
+## Available MCP Tools
+
+| Tool | Description |
+|---|---|
+| `pensyve_recall` | Search memories by semantic similarity |
+| `pensyve_remember` | Store a durable fact (semantic memory) |
+| `pensyve_observe` | Record a session observation (episodic / procedural via `[procedural]` prefix) |
+| `pensyve_episode_start` | Begin tracking an episode |
+| `pensyve_episode_end` | Close an episode with outcome |
+| `pensyve_forget` | Delete an entity's memories |
+| `pensyve_inspect` | List memories for an entity |
+
+See [MCP Tools Reference](https://pensyve.com/docs/api-reference/mcp-tools) for full parameter details.
+
+## Design Philosophy
+
+- **Memory as substrate** — not a feature the user invokes; always there, continuous, carried across sessions
+- **Reasoning-layer first** — `AGENTS.md` delivers the substrate even without the native plugin
+- **1:1 with Claude Code** — same skill structure, same conventions, same memory types
+- **MCP contract-respecting** — every rule's call examples verified against `pensyve-mcp-tools/src/params.rs`
+- **Single-file delivery** — all 8 rules consolidated into `AGENTS.md` with clear section headings
 
 ## Links
 
 - **Website:** [pensyve.com](https://pensyve.com)
-- **Docs:** [pensyve.com/docs](https://pensyve.com/docs)
 - **GitHub:** [github.com/major7apps/pensyve](https://github.com/major7apps/pensyve)
 - **API Keys:** [pensyve.com/settings/api-keys](https://pensyve.com/settings/api-keys)
+- **Spec:** [Working-memory substrate design](https://github.com/major7apps/pensyve-docs/blob/main/specs/2026-04-18-pensyve-working-memory-substrate-design.md)
 
 ## License
 

--- a/integrations/openclaw-plugin/openclaw.mcp.json.example
+++ b/integrations/openclaw-plugin/openclaw.mcp.json.example
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "pensyve": {
+      "type": "http",
+      "url": "https://mcp.pensyve.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ${PENSYVE_API_KEY}"
+      }
+    }
+  }
+}

--- a/integrations/openclaw-plugin/scripts/lint-mcp-refs.sh
+++ b/integrations/openclaw-plugin/scripts/lint-mcp-refs.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Static MCP contract linter for the Pensyve OpenClaw adapter.
+#
+# Verifies that every pensyve_* call example in AGENTS.md
+# conforms to the current MCP tool schema in pensyve-mcp-tools/src/params.rs.
+# Catches the category of bug PR #58 surfaced in the Claude Code adapter
+# (unsupported parameters, missing required fields).
+#
+# OpenClaw uses a single consolidated AGENTS.md file for working-memory substrate
+# instructions, so this script targets AGENTS.md directly.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RULES_FILE="$SCRIPT_DIR/../AGENTS.md"
+
+EXIT_CODE=0
+
+if [ ! -f "$RULES_FILE" ]; then
+  echo "ERROR: AGENTS.md not found: $RULES_FILE"
+  exit 1
+fi
+
+echo "Linting MCP references in $RULES_FILE..."
+echo ""
+
+# Check 1: no actual use of unsupported 'related_entities' parameter in call examples.
+# Lines that say "no related_entities" (documentation/reminders) are excluded.
+echo "Check 1: no unsupported 'related_entities' on pensyve_recall"
+FOUND_RELATED=0
+# Also catch if related_entities appears inside a pensyve_recall( block
+awk '/pensyve_recall\(/{capture=1; buf=""}
+     capture {buf = buf "\n" $0}
+     capture && /\)/{
+       if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
+         print FILENAME ": related_entities found in pensyve_recall block: " buf;
+       capture=0
+     }' "$RULES_FILE" | while read -r line; do
+  if [ -n "$line" ]; then
+    echo "  FAIL: $line"
+    FOUND_RELATED=1
+  fi
+done
+if [ "$FOUND_RELATED" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 2: no actual use of unsupported 'continuation_of' parameter in call examples.
+echo "Check 2: no unsupported 'continuation_of' on pensyve_episode_start"
+FOUND_CONT=0
+awk '/pensyve_episode_start\(/{capture=1; buf=""}
+     capture {buf = buf "\n" $0}
+     capture && /\)/{
+       if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
+         print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
+       capture=0
+     }' "$RULES_FILE" | while read -r line; do
+  if [ -n "$line" ]; then
+    echo "  FAIL: $line"
+    FOUND_CONT=1
+  fi
+done
+if [ "$FOUND_CONT" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 3: every pensyve_observe call example in a code block has source_entity and about_entity
+echo "Check 3: every pensyve_observe example has source_entity and about_entity"
+MISSING_FIELDS=0
+awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
+     capture {buf = buf "\n" $0;
+              for(i=1; i<=length($0); i++){
+                c=substr($0,i,1);
+                if(c=="(") depth++;
+                if(c==")") depth--;
+              };
+              if(depth==0 && buf ~ /pensyve_observe\(/){
+                if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
+                if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
+                capture=0;
+              }}' "$RULES_FILE" | while read -r line; do
+  if [ -n "$line" ]; then
+    echo "  FAIL: $line"
+    MISSING_FIELDS=1
+  fi
+done
+if [ "$MISSING_FIELDS" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 4: provenance tag format — every proactive/auto-capture tag uses [<origin>/<trigger>/<tier>]
+echo "Check 4: provenance tag format"
+VALID_PROVENANCE_RE='\[(proactive|auto-capture)/(in-flight|stop|pre-compact|curator|user)/(tier-1|tier-2|residual/tier-1|residual/tier-2|open-question)\]'
+if rg -n '\[(proactive|auto-capture)' "$RULES_FILE" | rg -v "$VALID_PROVENANCE_RE"; then
+  echo "  FAIL: some provenance tags do not match [<origin>/<trigger>/<tier>] format"
+  EXIT_CODE=1
+else
+  echo "  PASS"
+fi
+echo ""
+
+# Check 5: procedural memory convention — [procedural] prefix is used in observe content
+echo "Check 5: procedural convention uses [procedural] prefix in pensyve_observe content"
+if ! rg -q '\[procedural\]' "$RULES_FILE"; then
+  echo "  WARN: no [procedural] prefix usage found. Expected in AGENTS.md."
+else
+  echo "  PASS"
+fi
+echo ""
+
+if [ "$EXIT_CODE" = "0" ]; then
+  echo "All MCP contract checks PASSED."
+else
+  echo "MCP contract checks FAILED. Fix the issues above before committing."
+fi
+
+exit "$EXIT_CODE"

--- a/integrations/openclaw-plugin/scripts/lint-mcp-refs.sh
+++ b/integrations/openclaw-plugin/scripts/lint-mcp-refs.sh
@@ -29,18 +29,18 @@ echo ""
 echo "Check 1: no unsupported 'related_entities' on pensyve_recall"
 FOUND_RELATED=0
 # Also catch if related_entities appears inside a pensyve_recall( block
-awk '/pensyve_recall\(/{capture=1; buf=""}
-     capture {buf = buf "\n" $0}
-     capture && /\)/{
-       if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
-         print FILENAME ": related_entities found in pensyve_recall block: " buf;
-       capture=0
-     }' "$RULES_FILE" | while read -r line; do
+while read -r line; do
   if [ -n "$line" ]; then
     echo "  FAIL: $line"
     FOUND_RELATED=1
   fi
-done
+done < <(awk '/pensyve_recall\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+       if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
+       print FILENAME ": related_entities found in pensyve_recall block: " buf;
+       capture=0
+       }' "$RULES_FILE")
 if [ "$FOUND_RELATED" = "0" ]; then
   echo "  PASS"
 else
@@ -51,18 +51,18 @@ echo ""
 # Check 2: no actual use of unsupported 'continuation_of' parameter in call examples.
 echo "Check 2: no unsupported 'continuation_of' on pensyve_episode_start"
 FOUND_CONT=0
-awk '/pensyve_episode_start\(/{capture=1; buf=""}
-     capture {buf = buf "\n" $0}
-     capture && /\)/{
-       if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
-         print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
-       capture=0
-     }' "$RULES_FILE" | while read -r line; do
+while read -r line; do
   if [ -n "$line" ]; then
     echo "  FAIL: $line"
     FOUND_CONT=1
   fi
-done
+done < <(awk '/pensyve_episode_start\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+       if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
+       print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
+       capture=0
+       }' "$RULES_FILE")
 if [ "$FOUND_CONT" = "0" ]; then
   echo "  PASS"
 else
@@ -73,23 +73,23 @@ echo ""
 # Check 3: every pensyve_observe call example in a code block has source_entity and about_entity
 echo "Check 3: every pensyve_observe example has source_entity and about_entity"
 MISSING_FIELDS=0
-awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
-     capture {buf = buf "\n" $0;
-              for(i=1; i<=length($0); i++){
-                c=substr($0,i,1);
-                if(c=="(") depth++;
-                if(c==")") depth--;
-              };
-              if(depth==0 && buf ~ /pensyve_observe\(/){
-                if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
-                if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
-                capture=0;
-              }}' "$RULES_FILE" | while read -r line; do
+while read -r line; do
   if [ -n "$line" ]; then
     echo "  FAIL: $line"
     MISSING_FIELDS=1
   fi
-done
+done < <(awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
+       capture {buf = buf "\n" $0;
+       for(i=1; i<=length($0); i++){
+       c=substr($0,i,1);
+       if(c=="(") depth++;
+       if(c==")") depth--;
+       };
+       if(depth==0 && buf ~ /pensyve_observe\(/){
+       if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
+       if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
+       capture=0;
+       }}' "$RULES_FILE")
 if [ "$MISSING_FIELDS" = "0" ]; then
   echo "  PASS"
 else

--- a/integrations/opencode-plugin/AGENTS.md
+++ b/integrations/opencode-plugin/AGENTS.md
@@ -1,0 +1,372 @@
+# Pensyve Working-Memory Substrate for opencode
+
+This file configures persistent working-memory for the opencode CLI agent via the Pensyve MCP server. All sections below are always in context — they form the substrate the agent operates on across every coding session.
+
+---
+
+## Memory Reflex Rule
+
+**This discipline is non-optional. Before substantive answers, recall by entity. When a lesson lands, observe immediately with a one-line surface.**
+
+### "Substantive answer" means
+
+- Design or architecture recommendations
+- Debugging diagnoses with root-cause claims
+- Refactor proposals
+- Any response that makes a claim the user would want grounded in prior work
+
+Not substantive: formatting fixes, trivial lookups, reading a file, running a command.
+
+### "Lesson lands" means
+
+- A root cause has been confirmed (not hypothesized).
+- A design choice has been made explicit ("we'll use X because Y").
+- An approach has been tried and abandoned with a reason.
+- A workflow has been discovered that is reusable.
+- A workaround for a framework/library limitation has been validated.
+
+### Memory classification
+
+- **Semantic** — a fact that will still be true next month. Use `pensyve_remember(entity, fact, confidence?)` (confidence defaults to 1.0; use 0.9 for high-confidence auto-captures).
+- **Episodic** — something that happened in this thread of work. Use `pensyve_observe` with the current `episode_id`.
+- **Procedural** — a reusable way to do something. Use `pensyve_observe` with `content` beginning `[procedural]`.
+
+When in doubt, prefer episodic.
+
+### Canonical `pensyve_observe` call template
+
+ALL observe calls MUST include every required field:
+
+```
+pensyve_observe(
+  episode_id: <current session's working episode_id>,
+  content: "[proactive/in-flight/tier-1] <observation text>",
+  source_entity: "opencode",
+  about_entity: "<relevant entity, lowercase-hyphenated>",
+  content_type: "text"
+)
+```
+
+Use `content_type: "code"` for code-related outcomes.
+
+### Episode lifecycle (lazy-open)
+
+opencode has no session-start/session-end hooks in the rules layer, so you own the episode lifecycle:
+
+- Before your first `pensyve_observe` call in this conversation, check whether a working `episode_id` is tracked. If none exists, call `pensyve_episode_start(participants: ["opencode", "<project entity>"])` first.
+- Reuse the same `episode_id` for all subsequent observations in the same conversation.
+- Do not explicitly close the episode under normal operation. Server-side consolidation handles aging.
+- Recovery: if `pensyve_observe` fails with a missing-episode error, call `pensyve_episode_start` and retry.
+
+### Surface style
+
+Lightly visible. One line when memory is used:
+
+- Recall: `Recalled 4 related memories (v7r, haiku-classifier).`
+- Capture: `↳ captured: hybrid-router threshold was the phase-3 regression root cause.`
+
+Do not narrate empty recalls or duplicate-skips.
+
+### Provenance tag vocabulary
+
+- `[proactive/in-flight/tier-1]` — memory reflex captured during reasoning
+- `[proactive/in-flight/open-question]` — unresolved question noted in-flight
+- `[auto-capture/user/residual/tier-1]` — explicit user-driven capture
+
+### Composition
+
+When a capture is both procedural AND in-flight: `[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=...`
+
+### MCP contract
+
+Rules never pass unsupported parameters:
+
+- `pensyve_recall(query, entity?, types?, limit?, min_confidence?)` — **no** `related_entities`
+- `pensyve_episode_start(participants)` — **no** `continuation_of`
+- `pensyve_observe(episode_id, content, source_entity, about_entity, content_type?)` — `source_entity` and `about_entity` are **required**
+
+---
+
+## Entity Detection
+
+Shared rules for detecting entity names from tool inputs, prompts, and conversation context. Used to scope recalls and `about_entity` fields on observations.
+
+### Inputs
+
+Extract candidate entity names from:
+
+1. **File references** — `@filename`, `@path/to/file`, or files mentioned directly in the conversation.
+2. **User prompts** — explicit references to components, files, services, research phases.
+3. **Code context** — module names, class names, function names in files being edited or read.
+4. **Git context** — repository root name, branch name (when discoverable).
+
+### Canonicalization
+
+- Lowercase all characters.
+- Replace spaces and underscores with hyphens.
+- Strip file extensions unless the file is the entity itself (e.g., `package.json`).
+- Collapse paths to the most semantically meaningful segment (e.g., `src/engine/hybrid_router.rs` → `hybrid-router`).
+
+### Fallback
+
+- If no specific entity is detected, fall back to the project-level entity (repository root name, lowercase-hyphenated).
+- If ambiguous, prefer the entity that already has memories in Pensyve (call `pensyve_inspect` with limit 1 to check).
+- **Never fabricate entity names.**
+
+### Output
+
+1–3 candidate entity names per turn. Primary entity is most specific; fold secondary entities into the `query` string when calling `pensyve_recall`.
+
+---
+
+## When Debugging
+
+Use when diagnosing bugs, errors, failing tests, or crashes.
+
+### Step 1: Detect entities
+
+Identify the relevant entity/entities (failing test, failing module, error source) per the entity detection section above.
+
+### Step 2: Consult memory (required)
+
+Call `pensyve_recall`:
+
+- `query`: short description of the failure, including secondary entity names
+- `entity`: primary detected entity
+- `types`: `["procedural", "episodic"]`
+- `limit`: 5
+
+Surface: `Recalled N memories from prior debug sessions on <entity>.`
+
+If a highly similar incident is found (score >0.8): `This looks similar to an incident captured on <date>: <summary>. Consider that path first.`
+
+### Step 3: Diagnose
+
+Proceed with diagnostic work, using recalled procedural memories as a starting sequence.
+
+### Step 4: Capture lesson (when it lands)
+
+When a root cause is **confirmed** (not just hypothesized):
+
+- **Episodic root cause:** `pensyve_observe` with `content: "[proactive/in-flight/tier-1] <one-sentence root cause>"`, `source_entity: "opencode"`, `about_entity: <primary_entity>`, `content_type: "text"`.
+- **Procedural sequence:** `pensyve_observe` with `content: "[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=..."`, `source_entity: "opencode"`, `about_entity: <primary_entity>`, `content_type: "text"`.
+- **Semantic truth:** `pensyve_remember(entity, fact: "[proactive/in-flight/tier-1] <fact>", confidence: 0.9)`.
+
+### Step 5: Capture abandoned approaches
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[proactive/in-flight/tier-1] tried <approach>, abandoned because <reason>",
+  source_entity: "opencode",
+  about_entity: <primary_entity>,
+  content_type: "text"
+)
+```
+
+---
+
+## When Designing
+
+Use when making architecture, API, or design decisions.
+
+### Step 1: Detect entities
+
+Identify the relevant entity/entities (service, module, subsystem under design).
+
+### Step 2: Consult memory (required)
+
+Call `pensyve_recall`:
+
+- `query`: short description of the design question
+- `entity`: primary detected entity
+- `types`: `["semantic", "episodic"]`
+- `limit`: 5
+
+Surface: `Recalled N prior decisions on <entity>.`
+
+If the current question contradicts a prior decision, flag it: `Prior decision on <entity> (confidence 0.9): [decision]. Are we revisiting this?`
+
+### Step 3: Recommend with grounding
+
+Shape recommendations using recalled decisions.
+
+### Step 4: Capture decision (when it lands)
+
+When the user accepts a design or states a decision:
+
+- **Semantic:** `pensyve_remember(entity: <primary_entity>, fact: "[proactive/in-flight/tier-1] <decision text>", confidence: 0.9)`.
+- **Episodic context:** `pensyve_observe` with `content: "[proactive/in-flight/tier-1] Decision on <entity>: chose X over Y because Z"`, `source_entity: "opencode"`, `about_entity: <primary_entity>`, `content_type: "text"`.
+
+### Step 5: Capture evaluation procedures
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[procedural] [proactive/in-flight/tier-1] trigger=design-question-on-<area>, action=<steps>, outcome=<what-you-learn>",
+  source_entity: "opencode",
+  about_entity: <primary_entity>,
+  content_type: "text"
+)
+```
+
+---
+
+## When Refactoring
+
+Use before substantive refactors.
+
+### Step 1: Detect entities
+
+Identify entities touched by the refactor (file or module being restructured, callers, subsystem name).
+
+### Step 2: Load prior context (required)
+
+Call `pensyve_recall`:
+
+- `query`: short description of the refactor
+- `entity`: primary detected entity
+- `types`: `["semantic", "episodic", "procedural"]`
+- `limit`: 5
+
+Highlight any prior failed approaches: `Prior episodic memory: tried <approach>, abandoned because <reason>. Double-check this isn't the same trap.`
+
+### Step 3: Present a briefing
+
+Summarize what prior memories say about: decisions, prior attempts, known-good procedures.
+
+### Step 4: Capture refactor lessons as they land
+
+Apply the memory reflex immediately when:
+
+- **Invariant discovered** (semantic): `pensyve_remember(entity, fact, confidence: 0.9)`
+- **Abandoned approach confirmed** (episodic): `pensyve_observe` with `[proactive/in-flight/tier-1]`
+- **Dependency chain surprise** (episodic): `pensyve_observe`
+- **Known-good sequence emerged** (procedural): `pensyve_observe` with `[procedural]` prefix
+
+---
+
+## Longitudinal Work (Research/Evals)
+
+Use for long-running multi-session work in `research/`, `benchmarks/`, or `evals/` directories.
+
+### Step 1: Resume context at conversation start
+
+Call `pensyve_recall`:
+
+- `query`: short description of the current research area
+- `entity`: project + sub-topic entity
+- `limit`: 5
+
+No `types` filter — longitudinal work benefits from all three memory types.
+
+### Step 2: Proactively recall per topic shift
+
+When the session pivots to a new sub-topic, call `pensyve_recall` again scoped to it.
+
+### Step 3: Capture per run
+
+| What you learned | Type | Call |
+|---|---|---|
+| Per-run outcome | episodic | `pensyve_observe(..., content: "[proactive/in-flight/tier-1] Run N+1: ...", source_entity: "opencode", about_entity: <entity>, content_type: "text")` |
+| Stable truth | semantic | `pensyve_remember(entity, fact: "[proactive/in-flight/tier-1] ...", confidence: 0.9)` |
+| Reusable procedure | procedural | `pensyve_observe(..., content: "[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=...", source_entity: "opencode", about_entity: <entity>, content_type: "text")` |
+
+### Step 4: Capture open questions
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[proactive/in-flight/open-question] <question>",
+  source_entity: "opencode",
+  about_entity: <entity>,
+  content_type: "text"
+)
+```
+
+### Step 5: End-of-session summary
+
+Before wrapping: summarize what this run taught vs. prior runs, and what's still open.
+
+---
+
+## Session Memory (Wrap-Up)
+
+Use at conversation wrap-up or when the user indicates end-of-session.
+
+### Step 1: Review the conversation
+
+Scan for three categories the in-flight reflex did NOT already capture:
+
+**Decisions** (confidence: 0.9): architecture choices, technology selections, API decisions, tradeoff resolutions.
+
+**Outcomes** (confidence: 0.8): bug fixes and root causes, successful approaches, failed approaches with reasons, performance findings.
+
+**Patterns** (confidence: 0.7): recurring issues, workflow discoveries, cross-cutting observations.
+
+### Step 2: Filter and deduplicate
+
+For each candidate, call `pensyve_recall` with `query: <candidate fact text>`, `entity: <entity>`, `limit: 3`. If score ≥0.85, skip as likely duplicate.
+
+### Step 3: Present candidates for confirmation
+
+> **Session Memory Candidates**
+>
+> **Decisions** (confidence: 0.9):
+> 1. `<entity>`: <decision text>
+>
+> **Outcomes** (confidence: 0.8):
+> 2. `<entity>`: <outcome text>
+>
+> **Patterns** (confidence: 0.7):
+> 3. `<entity>`: <pattern text>
+>
+> Which should I store? (e.g., "all", "1,3", "none")
+
+### Step 4: Store confirmed items
+
+- **Semantic:** `pensyve_remember(entity, fact: "[auto-capture/user/residual/tier-1] <text>", confidence)`.
+- **Episodic:** `pensyve_observe(episode_id, content: "[auto-capture/user/residual/tier-1] <text>", source_entity: "opencode", about_entity: <entity>, content_type: "text")`.
+- **Procedural:** `pensyve_observe(episode_id, content: "[procedural] [auto-capture/user/residual/tier-1] trigger=..., action=..., outcome=...", source_entity: "opencode", about_entity: <entity>, content_type: "text")`.
+
+### Step 5: Optionally close the episode
+
+If the user marks work complete: `pensyve_episode_end(episode_id: <working_id>, outcome: "success")`. Valid outcomes: `"success"`, `"failure"`, `"partial"`.
+
+**Never auto-store.** Every candidate MUST be confirmed before storage.
+
+---
+
+## Context Loader (Session Start)
+
+Use when starting a new substantive conversation or switching contexts.
+
+### Step 1: Detect project entity
+
+Use the repository root name (lowercase-hyphenated) as default. Override with `PENSYVE_NAMESPACE` if set.
+
+### Step 2: Scoped recall
+
+Call `pensyve_recall`:
+
+- `query`: `"recent decisions issues patterns"` + key terms from the user's opening message
+- `entity`: detected project entity
+- `types`: `["episodic"]`
+- `limit`: 5
+
+### Step 3: Compute continuity signal
+
+If ≥70% of the top observations share entities with the current conversation → **continuation**. Otherwise → **fresh session**.
+
+### Step 4: Surface the primer
+
+**Continuation:**
+> **Pensyve:** Continuing prior work on `<entity-set>`. Recent lessons: [top 3 observations]
+
+**Fresh session:**
+> **Pensyve:** N memories loaded for `<project>`. Key context: [top 3 observations]
+
+**No memories:**
+> **Pensyve:** No memories found for `<project>`. Use `/remember` to start building context.
+
+Do not fabricate memories. Only display what `pensyve_recall` returns.

--- a/integrations/opencode-plugin/CHANGELOG.md
+++ b/integrations/opencode-plugin/CHANGELOG.md
@@ -1,0 +1,43 @@
+# Changelog — Pensyve opencode Adapter
+
+All notable changes to the Pensyve opencode adapter are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). The opencode adapter versions independently of the Claude Code plugin.
+
+## [1.0.0] - 2026-04-20
+
+### Added
+
+- **Working-memory substrate** for opencode via `AGENTS.md`. All eight substrate rules consolidated into a single file with clear section headings:
+  - **Memory Reflex Rule** — non-optional reasoning discipline with three-type memory classification, canonical `pensyve_observe` call template, provenance vocabulary, lazy-open episode lifecycle
+  - **Entity Detection** — canonicalization and fallback rules
+  - **When Debugging** — debug flow with memory baked in
+  - **When Designing** — design flow with memory baked in
+  - **When Refactoring** — refactor flow with memory baked in
+  - **Longitudinal Work (Research/Evals)** — multi-session research/eval flow
+  - **Session Memory (Wrap-Up)** — manual wrap-up equivalent of Claude Code's Stop hook
+  - **Context Loader (Session Start)** — best-effort continuity primer via episodic recall
+- **MCP config example** at `opencode.mcp.json.example` (merge into `opencode.json`) covering Cloud-with-API-key and Local-stdio options
+- **Static MCP contract lint script** at `scripts/lint-mcp-refs.sh` verifying the consolidated `AGENTS.md`'s `pensyve_*` call examples match the `pensyve-mcp-tools/src/params.rs` schema
+
+### Design
+
+- Single reasoning layer; `AGENTS.md` delivers the substrate even without the native plugin running.
+- **Single-file delivery:** all 8 rules consolidated into `AGENTS.md` with section headings; can optionally be split into `.opencode/instructions/*.md` files if directory-based format is preferred.
+- Lazy-open episode lifecycle: first `pensyve_observe` call triggers `pensyve_episode_start`; episodes are not explicitly closed.
+- Best-effort continuity primer via `pensyve_recall(types: ["episodic"])` — the MCP server has no episode-listing API.
+- MCP contract verified: no `related_entities` on recall, no `continuation_of` on episode_start, required `source_entity: "opencode"` and `about_entity` on every observe.
+- MCP config uses `mcpServers` key in `opencode.json` with `type: "http"` / `type: "stdio"` transport format.
+- Opt-out: delete or edit `AGENTS.md`; disable native plugin in `opencode.json` `plugin` array.
+
+### Not Included
+
+- No changes to the existing native plugin TypeScript code
+- No installer script (manual copy of `AGENTS.md` + MCP config merge)
+- No server-side changes — uses the existing MCP tool surface
+
+### Relation to Other Pensyve Integrations
+
+- The opencode adapter is part of the batch-2 working-memory substrate rollout. The Claude Code plugin (v1.3.0), Cursor adapter (v1.0.0), and VS Code Copilot adapter (v1.0.0) are the reference implementations.
+- Key difference from Cursor: single `AGENTS.md` vs. Cursor's per-rule `.cursor/rules/*.mdc` files.
+- Playbook: `pensyve-docs/specs/2026-04-18-pensyve-working-memory-substrate-design.md`

--- a/integrations/opencode-plugin/README.md
+++ b/integrations/opencode-plugin/README.md
@@ -1,85 +1,31 @@
 # opencode-pensyve
 
-Native OpenCode plugin for persistent cross-session memory, powered by Pensyve.
+Persistent working-memory substrate for the [opencode](https://github.com/opencode-ai/opencode) CLI — memory is not a feature you invoke, it is the substrate the agent operates on.
 
 > **Note:** The original [opencode-ai/opencode](https://github.com/opencode-ai/opencode) repository is archived. Its successor is [Crush](https://github.com/charmbracelet/crush) by Charmbracelet. The `@opencode-ai/plugin` SDK remains actively maintained and this plugin targets that SDK.
 
-## Two Integration Paths
+## What It Does
 
-OpenCode supports both **MCP servers** and **native plugins**. You can use Pensyve with either approach:
+- **Proactive memory during work** — lessons are captured the moment they land, not at session end
+- **Thread-aware continuity** — sessions that continue prior work resume with relevant context, no re-briefing
+- **Entity-scoped recall** — substantive questions are grounded in prior decisions; simple commands stay fast
+- **Three memory types** — durable facts (semantic), session-specific events (episodic), reusable procedures (procedural)
+- **Lightly visible** — one-line surfaces when memory is used; never interrupts your flow
+- **Native plugin hooks** — auto-recall on session start, system prompt injection, auto-capture of responses
 
-| Capability                       | MCP Server (passive)                       | Native Plugin (active)                          |
-| -------------------------------- | ------------------------------------------ | ----------------------------------------------- |
-| Explicit memory tools            | Yes (`pensyve_remember`, `pensyve_recall`) | Yes (`pensyve_remember`, `pensyve_recall`)      |
-| Auto-recall on session start     | No                                         | Yes (`session.created` hook)                    |
-| System prompt injection          | No                                         | Yes (`experimental.chat.system.transform` hook) |
-| Auto-capture assistant responses | No                                         | Yes (`message.created` hook)                    |
-| Setup complexity                 | Minimal -- add MCP server config           | Copy plugin or install via npm                  |
-| Agent must call tools explicitly | Yes -- agent decides when to recall        | No -- memories injected automatically           |
+## Install
 
-**Recommendation:** Use the native plugin for the richest experience. Use MCP if you want zero-config simplicity.
+Two steps: configure the MCP server, then install the instructions file.
 
-## Authentication
+### 1. Configure the MCP server
 
-1. Sign up at [pensyve.com](https://pensyve.com)
-2. Create an API key at [Settings → API Keys](https://pensyve.com/settings/api-keys)
-3. Set the environment variable:
-   ```bash
-   export PENSYVE_API_KEY="psy_your_key_here"
-   ```
+Merge the following into your `opencode.json`:
 
-Then configure MCP with headers (see setup instructions above).
-
-## Prerequisites
-
-You need a Pensyve server. Choose one:
-
-**Pensyve Cloud** (recommended -- no setup):
-
-1. Sign up at [pensyve.com](https://pensyve.com) and create an API key
-2. Set the environment variable:
-   ```bash
-   export PENSYVE_API_KEY="psy_..."
-   ```
-
-**Pensyve Local** (self-hosted, offline-first):
+**Cloud with API key (recommended):**
 
 ```bash
-git clone https://github.com/major7apps/pensyve
-cd pensyve && cargo build --release -p pensyve-mcp
+export PENSYVE_API_KEY="psy_your_key_here"
 ```
-
-No API key needed -- all data stays on your machine in SQLite.
-
-## Installation -- Native Plugin
-
-### Option 1: Copy to plugins directory
-
-```bash
-# Project-level
-cp -r /path/to/pensyve/integrations/opencode-plugin .opencode/plugins/pensyve
-
-# Or user-level (applies to all projects)
-cp -r /path/to/pensyve/integrations/opencode-plugin ~/.config/opencode/plugins/pensyve
-```
-
-### Option 2: npm dependency
-
-```bash
-npm install opencode-pensyve
-```
-
-Then configure in `opencode.json`:
-
-```json
-{
-  "plugin": ["opencode-pensyve"]
-}
-```
-
-## Installation -- MCP Server (simpler alternative)
-
-Add to your `opencode.json`:
 
 ```json
 {
@@ -95,9 +41,11 @@ Add to your `opencode.json`:
 }
 ```
 
-This gives you `pensyve_remember` and `pensyve_recall` tools via MCP, but without auto-recall, system prompt injection, or auto-capture.
+A ready-to-use example is at `opencode.mcp.json.example` — copy relevant keys into your `opencode.json`.
 
-For a local server instead:
+Create your key at [pensyve.com/settings/api-keys](https://pensyve.com/settings/api-keys). Put the `export` in `~/.bashrc` or `~/.zshrc` to persist.
+
+**Local (offline, self-hosted):**
 
 ```json
 {
@@ -111,79 +59,107 @@ For a local server instead:
 }
 ```
 
-## Intelligent Memory Capture (v1.0.7)
+Build the binary: `cargo build --release -p pensyve-mcp` from the [pensyve repo](https://github.com/major7apps/pensyve).
 
-Pensyve uses a tiered classification system to identify what is worth remembering:
+### 2. Install the instructions file
 
-- **Tier 1** (auto-store, confidence 0.9+): Explicit decisions, corrections, constraints -- high-signal items that should almost always be captured
-- **Tier 2** (batch review, confidence 0.7-0.89): Root causes, failed approaches, performance findings -- medium-signal items that benefit from user confirmation
-- **Discard**: Formatting, typos, boilerplate -- noise that should never be stored
+Copy `AGENTS.md` to your project root (opencode loads `AGENTS.md` automatically as its agent instruction file):
 
-The auto-capture hook (`chat.message`) currently stores substantive responses at tier 2 confidence. The `pensyve_remember` tool description guides the agent to apply the appropriate confidence tier when storing facts explicitly. Future versions will integrate the shared memory-capture-core classifier for full tiered classification with signal buffering.
+```bash
+cp /path/to/pensyve/integrations/opencode-plugin/AGENTS.md .
+```
+
+**Note:** All 8 substrate rules are consolidated into a single `AGENTS.md` with clear section headings. If you prefer directory-based instruction files under `.opencode/instructions/`, you can split sections into individual `.md` files with the same content.
+
+### 3. (Optional) Install the native plugin
+
+For richer auto-behaviors (session-start recall, system prompt injection, auto-capture):
+
+```bash
+# Project-level
+cp -r /path/to/pensyve/integrations/opencode-plugin .opencode/plugins/pensyve
+
+# Or user-level (applies to all projects)
+cp -r /path/to/pensyve/integrations/opencode-plugin ~/.config/opencode/plugins/pensyve
+```
+
+Or via npm:
+
+```bash
+npm install opencode-pensyve
+```
+
+Then add to `opencode.json`:
+
+```json
+{
+  "plugin": ["opencode-pensyve"]
+}
+```
 
 ## How It Works
 
-### Hooks
+The substrate is delivered through `AGENTS.md`. The Memory Reflex Rule section establishes the discipline: *before substantive answers, recall by entity; when a lesson lands, observe immediately with a one-line surface*. Flow sections (When Debugging, When Designing, When Refactoring, Longitudinal Work) guide the model through consult-memory + capture-lesson steps.
 
-#### `session.created` -- Auto-Recall
+When the native plugin is also installed, the `session.created` hook fires a recall on session start and injects memories into the system prompt automatically — no explicit tool call needed.
 
-When a new session starts, the plugin queries Pensyve for memories relevant to the current project directory and caches the results for system prompt injection.
+**Episode lifecycle:** Episodes open lazily on the first `pensyve_observe` call and are not explicitly closed under normal operation. Server-side consolidation handles aging.
 
-#### `experimental.chat.system.transform` -- System Prompt Injection
+**Continuity primer:** The Context Loader section runs a best-effort recall at the start of substantive conversations to surface prior relevant observations.
 
-Before each message is sent to the model, the plugin appends recalled memories to the system prompt so the model has cross-session context without needing to call any tools.
+## Memory Behavior Model
 
-#### `chat.message` -- Auto-Capture
+Pensyve behaves as working memory for the agent — always-on, ambient, continuous.
 
-After each substantive assistant response (>100 characters), the plugin stores a condensed summary with moderate confidence (0.7). Pensyve's FSRS-based forgetting curve naturally deprioritizes stale memories over time.
+**Writes happen in-flight.** When a root cause is confirmed, a decision is made, or a reusable procedure emerges, it's captured the moment it lands via the memory reflex. No batching to session end.
 
-### Tools
+**Reads happen at decision points.** Before substantive answers, the model consults memory scoped to the detected entities. Simple commands (run tests, format file) skip recall to stay fast.
 
-The plugin registers three tools that the agent can call explicitly:
+**Sessions continue.** At the start of a substantive conversation, Pensyve checks whether the current work continues prior memories (shared entities + recent activity). If yes, you resume with a primer — no re-briefing needed.
 
-| Tool               | Description                                            |
-| ------------------ | ------------------------------------------------------ |
-| `pensyve_recall`   | Search persistent memory with a natural language query |
-| `pensyve_remember` | Store a fact with configurable confidence (0-1)        |
-| `pensyve_status`   | Show connection status, memory counts, account info    |
+## Memory Types
 
-### Configuration
+| Type | Definition | MCP call | Example |
+|---|---|---|---|
+| **Semantic** | Durable truths, decisions, preferences | `pensyve_remember` | "We chose RS256 over HS256 for JWT signing" |
+| **Episodic** | Temporal events, session-scoped observations | `pensyve_observe` (with lazy-opened `episode_id`) | "Phase-3 regression root cause: hybrid-router threshold" |
+| **Procedural** | Reusable workflows, sequences, recipes | `pensyve_observe` with `[procedural]` content prefix | "To calibrate V7r: freeze Haiku config, run suite, diff baseline" |
 
-| Option        | Type      | Default                   | Description                           |
-| ------------- | --------- | ------------------------- | ------------------------------------- |
-| `baseUrl`     | `string`  | `https://mcp.pensyve.com` | Pensyve API URL                       |
-| `apiKey`      | `string`  | `$PENSYVE_API_KEY`        | API key for Pensyve Cloud             |
-| `entity`      | `string`  | `opencode-agent`          | Entity name for memory storage        |
-| `namespace`   | `string`  | `opencode`                | Memory namespace for isolation        |
-| `autoRecall`  | `boolean` | `true`                    | Auto-recall memories on session start |
-| `autoCapture` | `boolean` | `true`                    | Auto-capture assistant responses      |
-| `recallLimit` | `number`  | `5`                       | Max memories to recall per session    |
+## Opt-Out
 
-## Architecture
+- **Full opt-out** — delete `AGENTS.md` from your project root
+- **Partial opt-out** — delete specific sections from the file (e.g., remove the "Longitudinal Work" section if you don't do research work)
+- **Silent mode** — edit the Memory Reflex Rule section to remove the "one-line surface" guidance; captures stay silent
+- **Recall-only mode** — edit flow sections to drop the `Capture lesson` steps while keeping `Consult memory`
+- **Disable native plugin** — remove from `opencode.json` `plugin` array; `AGENTS.md` substrate continues working via MCP
 
-```
-OpenCode Agent
-    |
-    |-- session.created ---------> Pensyve /v1/recall
-    |                                  |
-    |-- system.transform <-------- recalled memories injected
-    |
-    |-- [user sends message] ----> LLM (with memory context)
-    |                                  |
-    |-- chat.message <------------ assistant response
-    |       |
-    |       +-- auto-capture -----> Pensyve /v1/remember
-    |
-    |-- pensyve_remember --------> Pensyve /v1/remember (explicit)
-    |-- pensyve_recall ----------> Pensyve /v1/recall   (explicit)
-```
+## Available MCP Tools
+
+| Tool | Description |
+|---|---|
+| `pensyve_recall` | Search memories by semantic similarity |
+| `pensyve_remember` | Store a durable fact (semantic memory) |
+| `pensyve_observe` | Record a session observation (episodic / procedural via `[procedural]` prefix) |
+| `pensyve_episode_start` | Begin tracking an episode |
+| `pensyve_episode_end` | Close an episode with outcome |
+| `pensyve_forget` | Delete an entity's memories |
+| `pensyve_inspect` | List memories for an entity |
+
+See [MCP Tools Reference](https://pensyve.com/docs/api-reference/mcp-tools) for full parameter details.
+
+## Design Philosophy
+
+- **Memory as substrate** — not a feature the user invokes; always there, continuous, carried across sessions
+- **Reasoning-layer first** — `AGENTS.md` delivers the substrate even without the native plugin
+- **1:1 with Claude Code** — same skill structure, same conventions, same memory types
+- **MCP contract-respecting** — every rule's call examples verified against `pensyve-mcp-tools/src/params.rs`
+- **Single-file delivery** — all 8 rules consolidated into `AGENTS.md` with clear section headings
 
 ## Links
 
 - **Website:** [pensyve.com](https://pensyve.com)
-- **Docs:** [pensyve.com/docs](https://pensyve.com/docs)
 - **GitHub:** [github.com/major7apps/pensyve](https://github.com/major7apps/pensyve)
-- **API Keys:** [pensyve.com/settings/api-keys](https://pensyve.com/settings/api-keys)
+- **Spec:** [Working-memory substrate design](https://github.com/major7apps/pensyve-docs/blob/main/specs/2026-04-18-pensyve-working-memory-substrate-design.md)
 
 ## License
 

--- a/integrations/opencode-plugin/opencode.mcp.json.example
+++ b/integrations/opencode-plugin/opencode.mcp.json.example
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "pensyve": {
+      "type": "http",
+      "url": "https://mcp.pensyve.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ${PENSYVE_API_KEY}"
+      }
+    }
+  }
+}

--- a/integrations/opencode-plugin/scripts/lint-mcp-refs.sh
+++ b/integrations/opencode-plugin/scripts/lint-mcp-refs.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Static MCP contract linter for the Pensyve opencode adapter.
+#
+# Verifies that every pensyve_* call example in AGENTS.md
+# conforms to the current MCP tool schema in pensyve-mcp-tools/src/params.rs.
+# Catches the category of bug PR #58 surfaced in the Claude Code adapter
+# (unsupported parameters, missing required fields).
+#
+# opencode uses a single consolidated AGENTS.md file for working-memory substrate
+# instructions, so this script targets AGENTS.md directly.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RULES_FILE="$SCRIPT_DIR/../AGENTS.md"
+
+EXIT_CODE=0
+
+if [ ! -f "$RULES_FILE" ]; then
+  echo "ERROR: AGENTS.md not found: $RULES_FILE"
+  exit 1
+fi
+
+echo "Linting MCP references in $RULES_FILE..."
+echo ""
+
+# Check 1: no actual use of unsupported 'related_entities' parameter in call examples.
+# Lines that say "no related_entities" (documentation/reminders) are excluded.
+echo "Check 1: no unsupported 'related_entities' on pensyve_recall"
+FOUND_RELATED=0
+# Also catch if related_entities appears inside a pensyve_recall( block
+awk '/pensyve_recall\(/{capture=1; buf=""}
+     capture {buf = buf "\n" $0}
+     capture && /\)/{
+       if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
+         print FILENAME ": related_entities found in pensyve_recall block: " buf;
+       capture=0
+     }' "$RULES_FILE" | while read -r line; do
+  if [ -n "$line" ]; then
+    echo "  FAIL: $line"
+    FOUND_RELATED=1
+  fi
+done
+if [ "$FOUND_RELATED" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 2: no actual use of unsupported 'continuation_of' parameter in call examples.
+echo "Check 2: no unsupported 'continuation_of' on pensyve_episode_start"
+FOUND_CONT=0
+awk '/pensyve_episode_start\(/{capture=1; buf=""}
+     capture {buf = buf "\n" $0}
+     capture && /\)/{
+       if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
+         print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
+       capture=0
+     }' "$RULES_FILE" | while read -r line; do
+  if [ -n "$line" ]; then
+    echo "  FAIL: $line"
+    FOUND_CONT=1
+  fi
+done
+if [ "$FOUND_CONT" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 3: every pensyve_observe call example in a code block has source_entity and about_entity
+echo "Check 3: every pensyve_observe example has source_entity and about_entity"
+MISSING_FIELDS=0
+awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
+     capture {buf = buf "\n" $0;
+              for(i=1; i<=length($0); i++){
+                c=substr($0,i,1);
+                if(c=="(") depth++;
+                if(c==")") depth--;
+              };
+              if(depth==0 && buf ~ /pensyve_observe\(/){
+                if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
+                if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
+                capture=0;
+              }}' "$RULES_FILE" | while read -r line; do
+  if [ -n "$line" ]; then
+    echo "  FAIL: $line"
+    MISSING_FIELDS=1
+  fi
+done
+if [ "$MISSING_FIELDS" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 4: provenance tag format — every proactive/auto-capture tag uses [<origin>/<trigger>/<tier>]
+echo "Check 4: provenance tag format"
+VALID_PROVENANCE_RE='\[(proactive|auto-capture)/(in-flight|stop|pre-compact|curator|user)/(tier-1|tier-2|residual/tier-1|residual/tier-2|open-question)\]'
+if rg -n '\[(proactive|auto-capture)' "$RULES_FILE" | rg -v "$VALID_PROVENANCE_RE"; then
+  echo "  FAIL: some provenance tags do not match [<origin>/<trigger>/<tier>] format"
+  EXIT_CODE=1
+else
+  echo "  PASS"
+fi
+echo ""
+
+# Check 5: procedural memory convention — [procedural] prefix is used in observe content
+echo "Check 5: procedural convention uses [procedural] prefix in pensyve_observe content"
+if ! rg -q '\[procedural\]' "$RULES_FILE"; then
+  echo "  WARN: no [procedural] prefix usage found. Expected in AGENTS.md."
+else
+  echo "  PASS"
+fi
+echo ""
+
+if [ "$EXIT_CODE" = "0" ]; then
+  echo "All MCP contract checks PASSED."
+else
+  echo "MCP contract checks FAILED. Fix the issues above before committing."
+fi
+
+exit "$EXIT_CODE"

--- a/integrations/opencode-plugin/scripts/lint-mcp-refs.sh
+++ b/integrations/opencode-plugin/scripts/lint-mcp-refs.sh
@@ -29,18 +29,18 @@ echo ""
 echo "Check 1: no unsupported 'related_entities' on pensyve_recall"
 FOUND_RELATED=0
 # Also catch if related_entities appears inside a pensyve_recall( block
-awk '/pensyve_recall\(/{capture=1; buf=""}
-     capture {buf = buf "\n" $0}
-     capture && /\)/{
-       if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
-         print FILENAME ": related_entities found in pensyve_recall block: " buf;
-       capture=0
-     }' "$RULES_FILE" | while read -r line; do
+while read -r line; do
   if [ -n "$line" ]; then
     echo "  FAIL: $line"
     FOUND_RELATED=1
   fi
-done
+done < <(awk '/pensyve_recall\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+       if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
+       print FILENAME ": related_entities found in pensyve_recall block: " buf;
+       capture=0
+       }' "$RULES_FILE")
 if [ "$FOUND_RELATED" = "0" ]; then
   echo "  PASS"
 else
@@ -51,18 +51,18 @@ echo ""
 # Check 2: no actual use of unsupported 'continuation_of' parameter in call examples.
 echo "Check 2: no unsupported 'continuation_of' on pensyve_episode_start"
 FOUND_CONT=0
-awk '/pensyve_episode_start\(/{capture=1; buf=""}
-     capture {buf = buf "\n" $0}
-     capture && /\)/{
-       if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
-         print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
-       capture=0
-     }' "$RULES_FILE" | while read -r line; do
+while read -r line; do
   if [ -n "$line" ]; then
     echo "  FAIL: $line"
     FOUND_CONT=1
   fi
-done
+done < <(awk '/pensyve_episode_start\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+       if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
+       print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
+       capture=0
+       }' "$RULES_FILE")
 if [ "$FOUND_CONT" = "0" ]; then
   echo "  PASS"
 else
@@ -73,23 +73,23 @@ echo ""
 # Check 3: every pensyve_observe call example in a code block has source_entity and about_entity
 echo "Check 3: every pensyve_observe example has source_entity and about_entity"
 MISSING_FIELDS=0
-awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
-     capture {buf = buf "\n" $0;
-              for(i=1; i<=length($0); i++){
-                c=substr($0,i,1);
-                if(c=="(") depth++;
-                if(c==")") depth--;
-              };
-              if(depth==0 && buf ~ /pensyve_observe\(/){
-                if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
-                if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
-                capture=0;
-              }}' "$RULES_FILE" | while read -r line; do
+while read -r line; do
   if [ -n "$line" ]; then
     echo "  FAIL: $line"
     MISSING_FIELDS=1
   fi
-done
+done < <(awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
+       capture {buf = buf "\n" $0;
+       for(i=1; i<=length($0); i++){
+       c=substr($0,i,1);
+       if(c=="(") depth++;
+       if(c==")") depth--;
+       };
+       if(depth==0 && buf ~ /pensyve_observe\(/){
+       if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
+       if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
+       capture=0;
+       }}' "$RULES_FILE")
 if [ "$MISSING_FIELDS" = "0" ]; then
   echo "  PASS"
 else

--- a/integrations/pydantic-ai/CHANGELOG.md
+++ b/integrations/pydantic-ai/CHANGELOG.md
@@ -1,0 +1,43 @@
+# Changelog — Pensyve Pydantic AI Integration
+
+All notable changes to the Pensyve Pydantic AI integration are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). This integration versions independently of the core Pensyve engine.
+
+## [1.0.0] - 2026-04-20
+
+### Added
+
+- **Working-memory substrate** for Pydantic AI agents via `SUBSTRATE_PROMPT.md`. All eight substrate rules consolidated into a single system-prompt document:
+  - **Memory Reflex Rule** — non-optional reasoning discipline with three-type memory classification, canonical `pensyve_observe` call template, provenance vocabulary, lazy-open episode lifecycle
+  - **Entity Detection** — canonicalization and fallback rules for recall scoping
+  - **When Debugging** — debug flow with memory baked in
+  - **When Designing** — design flow with memory baked in
+  - **When Refactoring** — refactor flow with memory baked in
+  - **Longitudinal Work** — multi-session research/eval flow with per-run capture
+  - **Session Wrap-Up** — manual wrap-up with candidate confirmation before storage
+  - **Context Loading** — best-effort continuity primer via episodic recall
+- **Framework wiring example** at `examples/pensyve_agent.py` showing Pydantic AI `Agent` with `MCPServerHTTP` registered and substrate as `system_prompt`
+- **Static MCP contract lint script** at `scripts/lint-mcp-refs.sh` verifying `SUBSTRATE_PROMPT.md` and the example file against the `pensyve-mcp-tools` schema
+
+### Design
+
+- Single reasoning layer; no platform-layer code.
+- `source_entity: "pydantic-ai"` on all `pensyve_observe` calls.
+- MCP connection via Pydantic AI's native `MCPServerHTTP` with `streamable_http` transport; MCP lifecycle managed by `agent.run_mcp_servers()` context manager.
+- Substrate injected via `Agent(system_prompt=substrate)`.
+- Lazy-open episode lifecycle.
+- MCP contract verified: no `related_entities` on recall, no `continuation_of` on episode_start, required `source_entity` and `about_entity` on every observe.
+- Opt-out: remove `system_prompt=substrate` from agent construction.
+
+### Not Included
+
+- No installer script — manual load of `SUBSTRATE_PROMPT.md`
+- No server-side changes — uses the existing MCP tool surface
+
+### Relation to Other Pensyve Integrations
+
+- Part of the batch-4 working-memory substrate rollout (LangChain, LangChain TS, AutoGen, CrewAI, Pydantic AI, Google ADK).
+- The Cursor adapter (v1.0.0) and Claude Code plugin (v1.3.0) are the reference implementations.
+- Spec: `pensyve-docs/specs/2026-04-20-pensyve-cursor-adapter-design.md`
+- Playbook: `pensyve-docs/specs/2026-04-18-pensyve-working-memory-substrate-design.md`

--- a/integrations/pydantic-ai/README.md
+++ b/integrations/pydantic-ai/README.md
@@ -1,123 +1,120 @@
 # Pensyve for Pydantic AI
 
-Persistent AI memory for [Pydantic AI](https://ai.pydantic.dev/) agents via MCP. Gives your Pydantic AI agents cross-session memory so they remember user preferences, past interactions, and learned context across runs.
+Persistent AI memory for [Pydantic AI](https://ai.pydantic.dev/) agents via Pensyve MCP. Gives your Pydantic AI agents cross-session memory so they remember user preferences, past interactions, and learned context across runs.
 
-> **Status:** Scaffold — MCP configuration and documentation. Full integration planned.
+---
 
-## Authentication
+## What It Does
 
-1. Sign up at [pensyve.com](https://pensyve.com)
-2. Create an API key at [Settings → API Keys](https://pensyve.com/settings/api-keys)
-3. Set the environment variable:
-   ```bash
-   export PENSYVE_API_KEY="psy_your_key_here"
-   ```
+The working-memory substrate is a reasoning layer — not a library — that you load into your Pydantic AI agent's `system_prompt`. Once loaded, the agent will:
 
-## Setup
+- **Recall before substantive answers** using `pensyve_recall`, scoped by entity.
+- **Capture lessons in-flight** using `pensyve_observe` when a root cause is confirmed, a decision lands, or an approach is abandoned.
+- **Manage episode lifecycle** lazily: open an episode on the first observe, reuse it throughout the conversation.
+- **Surface memory lightly** — one line per recall or capture, never narrating empty recalls.
+- **Wrap up sessions** by presenting memory candidates for user confirmation before storage.
 
-Set your API key (get one at [pensyve.com/settings/api-keys](https://pensyve.com/settings/api-keys)):
+---
+
+## Install
 
 ```bash
-export PENSYVE_API_KEY="psy_your_key"
+pip install pydantic-ai
 ```
 
-Add to your shell profile (`~/.bashrc`, `~/.zshrc`) to persist across sessions.
+Set your API key:
 
-## Cloud (Recommended)
+```bash
+export PENSYVE_API_KEY="psy_your_key_here"
+```
 
-Connect your Pydantic AI agent to Pensyve via MCP tool integration:
+Create an API key at [pensyve.com/settings/api-keys](https://pensyve.com/settings/api-keys).
+
+---
+
+## Quick Start
+
+```bash
+cd integrations/pydantic-ai
+python examples/pensyve_agent.py
+```
+
+The example creates a Pydantic AI `Agent` with `MCPServerHTTP` registered and `SUBSTRATE_PROMPT.md` as the `system_prompt`.
+
+---
+
+## System Prompt
+
+`SUBSTRATE_PROMPT.md` consolidates all eight substrate rules into a single document. Pydantic AI's `system_prompt` parameter is the direct injection point:
 
 ```python
+from pathlib import Path
 from pydantic_ai import Agent
 from pydantic_ai.mcp import MCPServerHTTP
 
-pensyve_server = MCPServerHTTP(
+substrate = Path("SUBSTRATE_PROMPT.md").read_text()
+
+pensyve = MCPServerHTTP(
     url="https://mcp.pensyve.com/mcp",
     headers={"Authorization": f"Bearer {os.environ['PENSYVE_API_KEY']}"},
 )
 
 agent = Agent(
-    "openai:gpt-4o",
-    mcp_servers=[pensyve_server],
+    "anthropic:claude-sonnet-4-6",
+    system_prompt=substrate,
+    mcp_servers=[pensyve],
 )
-
-async with agent.run_mcp_servers():
-    result = await agent.run("What do you remember about this project?")
-    print(result.output)
 ```
 
-### MCP Server Config
+---
 
-If your setup uses a JSON config file instead:
+## MCP Connection
 
-```json
-{
-  "mcpServers": {
-    "pensyve": {
-      "type": "http",
-      "url": "https://mcp.pensyve.com/mcp",
-      "headers": {
-        "Authorization": "Bearer ${PENSYVE_API_KEY}"
-      }
-    }
-  }
-}
-```
-
-## Local (Offline)
-
-No API key needed — all data stays on your machine.
+Pydantic AI's `MCPServerHTTP` manages the MCP connection lifecycle natively via `agent.run_mcp_servers()`:
 
 ```python
-from pydantic_ai import Agent
-from pydantic_ai.mcp import MCPServerStdio
-
-pensyve_server = MCPServerStdio(
-    command="pensyve-mcp",
-    args=["--stdio"],
-    env={
-        "PENSYVE_PATH": "~/.pensyve/",
-        "PENSYVE_NAMESPACE": "default",
-    },
-)
-
-agent = Agent(
-    "openai:gpt-4o",
-    mcp_servers=[pensyve_server],
-)
+async with agent.run_mcp_servers():
+    result = await agent.run("Your query here")
+    print(result.data)
 ```
 
-Build from source: `cargo build --release -p pensyve-mcp` from the [pensyve repo](https://github.com/major7apps/pensyve).
+No separate client setup required — Pydantic AI handles connection and tool registration automatically.
 
-## Available Tools
+---
 
-| Tool                    | Description                            |
-| ----------------------- | -------------------------------------- |
-| `pensyve_recall`        | Search memories by semantic similarity |
-| `pensyve_remember`      | Store a fact as semantic memory        |
-| `pensyve_observe`       | Record an event during an episode      |
-| `pensyve_episode_start` | Begin tracking an interaction          |
-| `pensyve_episode_end`   | Close an episode                       |
-| `pensyve_forget`        | Delete an entity's memories            |
-| `pensyve_inspect`       | List memories for an entity            |
+## Memory Behavior Model
 
-See [MCP Tools Reference](https://pensyve.com/docs/api-reference/mcp-tools) for full parameter details.
+| Trigger | Action | MCP call |
+|---|---|---|
+| Before substantive answer | Recall by entity | `pensyve_recall(query, entity, types, limit=5)` |
+| Root cause confirmed | Capture episodic | `pensyve_observe(episode_id, content, source_entity="pydantic-ai", about_entity)` |
+| Decision accepted | Capture semantic | `pensyve_remember(entity, fact, confidence=0.9)` |
+| Reusable workflow found | Capture procedural | `pensyve_observe(... content="[procedural] ...")` |
+| Session ending | Present candidates | User confirms before storage |
 
-## Intelligent Memory Capture
+---
 
-Pensyve uses a tiered classification system to identify what is worth remembering. When connected to a Pydantic AI agent, the LLM follows the MCP tool descriptions to decide when and how to call memory tools.
+## Memory Types
 
-### Tiered Capture System
+- **Semantic** — durable facts that remain true across sessions.
+- **Episodic** — what happened in this thread (outcomes, root causes, abandoned approaches).
+- **Procedural** — reusable workflows stored via `pensyve_observe` with a `[procedural]` prefix.
 
-- **Tier 1** (auto-store, confidence 0.9+): Explicit decisions, corrections, constraints, architecture choices, dependency version pins, security rules. High-signal items that should almost always be captured.
-- **Tier 2** (review, confidence 0.7-0.89): Root causes, failed approaches, performance findings, debugging outcomes, environment quirks. Medium-signal items that benefit from user confirmation.
-- **Discard**: Formatting, typos, boilerplate, ephemeral status messages. Noise that should never be stored.
+---
 
-### Best Practices
+## Opt-Out
 
-- Use `pensyve_observe` to record significant events during an episode (architecture decisions, failed approaches, key findings)
-- Use `pensyve_remember` for durable facts that should persist across sessions (project conventions, environment constraints, resolved issues)
-- Use `pensyve_recall` at the start of a task to load relevant context from prior sessions
-- Wrap multi-step work in `pensyve_episode_start` / `pensyve_episode_end` to capture episodic context
+To disable the substrate, remove `system_prompt=substrate` from agent construction. The Pensyve MCP server can remain registered for direct tool use without the substrate reasoning layer.
 
-The MCP tool descriptions include guidance on confidence levels so the LLM can classify memories into the appropriate tier automatically.
+---
+
+## Links
+
+- [Pensyve](https://pensyve.com) — managed memory service
+- [API Keys](https://pensyve.com/settings/api-keys)
+- [MCP Server docs](https://docs.pensyve.com/mcp)
+- [Pydantic AI docs](https://ai.pydantic.dev/)
+
+## License
+
+Apache 2.0

--- a/integrations/pydantic-ai/SUBSTRATE_PROMPT.md
+++ b/integrations/pydantic-ai/SUBSTRATE_PROMPT.md
@@ -1,0 +1,397 @@
+# Pensyve Working-Memory Substrate for Pydantic AI
+
+This document configures persistent working-memory for Pydantic AI agents via the Pensyve MCP server. Load the full text of this file as the agent's system prompt to activate all substrate behaviors. All sections below form the reasoning layer the agent carries through every session.
+
+---
+
+## Memory Reflex Rule
+
+**This discipline is non-optional. Before substantive answers, recall by entity. When a lesson lands, observe immediately with a one-line surface.**
+
+### "Substantive answer" means
+
+- Design or architecture recommendations
+- Debugging diagnoses with root-cause claims
+- Refactor proposals
+- Any response that makes a claim the user would want grounded in prior work
+
+Not substantive: formatting fixes, trivial lookups, reading a file, running a command.
+
+### "Lesson lands" means
+
+- A root cause has been confirmed (not hypothesized).
+- A design choice has been made explicit ("we'll use X because Y").
+- An approach has been tried and abandoned with a reason.
+- A workflow has been discovered that is reusable.
+- A workaround for a framework/library limitation has been validated.
+
+### Memory classification
+
+- **Semantic** — a fact that will still be true next month. Use `pensyve_remember(entity, fact, confidence?)` (confidence defaults to 1.0; use 0.9 for high-confidence auto-captures).
+- **Episodic** — something that happened in this thread of work. Use `pensyve_observe` with the current `episode_id`.
+- **Procedural** — a reusable way to do something. Use `pensyve_observe` with `content` beginning `[procedural]`.
+
+When in doubt, prefer episodic.
+
+### Canonical `pensyve_observe` call template
+
+ALL observe calls MUST include every required field:
+
+```
+pensyve_observe(
+  episode_id: <current session's working episode_id>,
+  content: "[proactive/in-flight/tier-1] <observation text>",
+  source_entity: "pydantic-ai",
+  about_entity: "<relevant entity, lowercase-hyphenated>",
+  content_type: "text"
+)
+```
+
+Use `content_type: "code"` for code-related outcomes.
+
+### Episode lifecycle (lazy-open)
+
+Library agents have no session-start/session-end hooks, so you own the episode lifecycle:
+
+- Before your first `pensyve_observe` call in this conversation, check whether a working `episode_id` is tracked. If none exists, call `pensyve_episode_start(participants: ["pydantic-ai", "<project entity>"])` first.
+- Reuse the same `episode_id` for all subsequent observations in the same conversation.
+- Do not explicitly close the episode under normal operation. Server-side consolidation handles aging.
+- Recovery: if `pensyve_observe` fails with a missing-episode error, call `pensyve_episode_start` and retry.
+
+### Surface style
+
+Lightly visible. One line when memory is used:
+
+- Recall: `Recalled 4 related memories (v7r, haiku-classifier).`
+- Capture: `↳ captured: hybrid-router threshold was the phase-3 regression root cause.`
+
+Do not narrate empty recalls or duplicate-skips.
+
+### Provenance tag vocabulary
+
+- `[proactive/in-flight/tier-1]` — memory reflex captured during reasoning
+- `[proactive/in-flight/open-question]` — unresolved question noted in-flight
+- `[auto-capture/user/residual/tier-1]` — explicit user-driven capture
+
+### Composition
+
+When a capture is both procedural AND in-flight: `[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=...`
+
+### MCP contract
+
+Rules never pass unsupported parameters:
+
+- `pensyve_recall(query, entity?, types?, limit?, min_confidence?)` — **no** `related_entities`
+- `pensyve_episode_start(participants)` — **no** `continuation_of`
+- `pensyve_observe(episode_id, content, source_entity, about_entity, content_type?)` — `source_entity` and `about_entity` are **required**
+
+---
+
+## Entity Detection
+
+Shared rules for detecting entity names from tool inputs, prompts, and conversation context. Used to scope recalls and `about_entity` fields on observations.
+
+### Inputs
+
+Extract candidate entity names from:
+
+1. **User prompts** — explicit references to components, files, services, research phases.
+2. **Code context** — module names, class names, function names referenced in the conversation.
+3. **File references** — any filenames or paths mentioned in the conversation.
+4. **Git context** — repository root name, branch name (when discoverable).
+
+### Canonicalization
+
+- Lowercase all characters.
+- Replace spaces and underscores with hyphens.
+- Strip file extensions unless the file is the entity itself.
+- Collapse paths to the most semantically meaningful segment.
+
+### Fallback behavior
+
+- If no specific entity is detected, fall back to the project-level entity (repository root name, lowercase-hyphenated).
+- If a candidate entity is ambiguous, prefer the one that already has memories in Pensyve (call `pensyve_inspect` with limit 1 to check).
+- **Never fabricate entity names.** If nothing confident emerges, use the project entity.
+
+### Output
+
+A set of 1–3 candidate entity names per turn. The primary entity is the most specific. Since `pensyve_recall` accepts only a single `entity` parameter, fold secondary entities into the `query` string.
+
+---
+
+## When Debugging
+
+Debugging flow with memory baked in as a non-optional reflex.
+
+### Step 1: Detect entities
+
+Identify the relevant entity/entities (failing test, failing module, error source) per Entity Detection above.
+
+### Step 2: Consult memory (required)
+
+Call `pensyve_recall`:
+
+- `query`: a short description of the failure, including secondary entity names where known
+- `entity`: primary detected entity
+- `types`: `["procedural", "episodic"]`
+- `limit`: 5
+
+Surface one line: `Recalled N memories from prior debug sessions on <entity>.` (Skip if N=0.)
+
+If a highly similar incident is found (score >0.8), call it out inline.
+
+### Step 3: Diagnose
+
+Proceed with diagnostic work. Use recalled procedural memories as a starting sequence.
+
+### Step 4: Capture lesson (when it lands)
+
+When a root cause is **confirmed**, ensure a working `episode_id` exists, then:
+
+- **Episodic root cause:** `pensyve_observe` with `content: "[proactive/in-flight/tier-1] <one-sentence root cause>"`, `source_entity: "pydantic-ai"`, `about_entity: <primary_entity>`.
+- **Procedural diagnostic sequence:** `pensyve_observe` with `content: "[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=..."`.
+- **Semantic durable truth:** `pensyve_remember(entity, fact: "[proactive/in-flight/tier-1] <fact>", confidence: 0.9)`.
+
+Surface one line: `↳ captured: <one-sentence>`.
+
+### Step 5: Capture abandoned approaches
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[proactive/in-flight/tier-1] tried <approach>, abandoned because <reason>",
+  source_entity: "pydantic-ai",
+  about_entity: <primary_entity>,
+  content_type: "text"
+)
+```
+
+---
+
+## When Designing
+
+Design flow with memory baked in as a non-optional reflex.
+
+### Step 1: Detect entities
+
+Identify the relevant entity/entities (service, module, subsystem under design) per Entity Detection above.
+
+### Step 2: Consult memory (required)
+
+Call `pensyve_recall`:
+
+- `query`: a short description of the design question, including secondary entity names
+- `entity`: primary detected entity
+- `types`: `["semantic", "episodic"]`
+- `limit`: 5
+
+Surface one line: `Recalled N prior decisions on <entity>.` (Skip if N=0.)
+
+### Step 3: Recommend with grounding
+
+Shape your recommendation using recalled decisions. If the current question contradicts a prior decision, flag it.
+
+### Step 4: Capture decision (when it lands)
+
+When the user accepts a design or states a decision:
+
+- **Semantic:** `pensyve_remember(entity: <primary_entity>, fact: "[proactive/in-flight/tier-1] <decision text>", confidence: 0.9)`.
+- **Episodic context:** `pensyve_observe` with `content: "[proactive/in-flight/tier-1] Decision on <entity>: chose X over Y because Z"`, `source_entity: "pydantic-ai"`, `about_entity: <primary_entity>`.
+
+Surface one line: `↳ captured decision on <entity>: <short>`.
+
+### Step 5: Capture evaluation procedures
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[procedural] [proactive/in-flight/tier-1] trigger=design-question-on-<area>, action=<steps>, outcome=<what-you-learn>",
+  source_entity: "pydantic-ai",
+  about_entity: <primary_entity>,
+  content_type: "text"
+)
+```
+
+---
+
+## When Refactoring
+
+Refactor flow with memory baked in.
+
+### Step 1: Detect entities
+
+Identify entities touched by the refactor per Entity Detection above.
+
+### Step 2: Load prior context (required)
+
+Call `pensyve_recall`:
+
+- `query`: short description of the refactor
+- `entity`: primary detected entity
+- `types`: `["semantic", "episodic", "procedural"]`
+- `limit`: 5
+
+Surface: `Recalled N prior memories on <entity>.` Highlight any prior failed approaches.
+
+### Step 3: Present a briefing
+
+Before starting the refactor, summarize what prior memories say about decisions, prior attempts, and known-good procedures.
+
+### Step 4: Capture refactor lessons as they land
+
+When an invariant is discovered, an approach is confirmed not-viable, or a known-good sequence emerges, apply the memory reflex immediately. Ensure working `episode_id` before each observe.
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[proactive/in-flight/tier-1] <lesson>",
+  source_entity: "pydantic-ai",
+  about_entity: <primary_entity>,
+  content_type: "text"
+)
+```
+
+---
+
+## When Doing Longitudinal Work
+
+Multi-session work (research, eval loops, iterative benchmarks) where lessons must accumulate across runs.
+
+### Step 1: Resume context at conversation start
+
+Call `pensyve_recall` once at the start:
+
+- `query`: short description of the current research area
+- `entity`: project + sub-topic entity
+- `limit`: 5
+
+No `types` filter — longitudinal work benefits from all three memory types.
+
+Surface: `Recalled N prior findings on <sub-topic>.`
+
+### Step 2: Proactively recall per topic shift
+
+When the session pivots to a new sub-topic, call `pensyve_recall` again scoped to the new sub-topic.
+
+### Step 3: Capture three types of memory per run
+
+| What you learned | Type | MCP call |
+|---|---|---|
+| Per-run outcome | episodic | `pensyve_observe(..., content: "[proactive/in-flight/tier-1] Run N+1: <result>", source_entity: "pydantic-ai", about_entity: <entity>)` |
+| Stable truth | semantic | `pensyve_remember(entity, fact: "[proactive/in-flight/tier-1] <stable fact>", confidence: 0.9)` |
+| Reusable procedure | procedural | `pensyve_observe(..., content: "[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=...", source_entity: "pydantic-ai", about_entity: <entity>)` |
+
+### Step 4: Capture open questions
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[proactive/in-flight/open-question] <question>",
+  source_entity: "pydantic-ai",
+  about_entity: <entity>,
+  content_type: "text"
+)
+```
+
+### Step 5: End-of-session summary
+
+Before the conversation wraps, briefly summarize what this run taught vs. prior runs, and what's still open.
+
+---
+
+## Session Wrap-Up
+
+Manual wrap-up: when the user indicates the conversation is ending, review what happened and capture anything the in-flight reflex missed.
+
+### Step 1: Review the conversation
+
+Scan for three categories not already captured in-flight:
+
+**Decisions** (confidence: 0.9): Architecture choices, technology selections, tradeoff resolutions.
+
+**Outcomes** (confidence: 0.8): Bug fixes, successful/failed approaches, performance findings.
+
+**Patterns** (confidence: 0.7): Recurring issues, workflow discoveries, cross-cutting observations.
+
+### Step 2: Filter for significance and deduplicate
+
+For each candidate, call `pensyve_recall` with `query: <candidate fact text>`, `entity: <entity>`, `limit: 3`. If any returned memory has score ≥0.85, skip as a likely duplicate.
+
+### Step 3: Present candidates for confirmation
+
+> **Session Memory Candidates**
+>
+> **Decisions** (confidence: 0.9):
+> 1. `<entity>`: <decision text>
+>
+> **Outcomes** (confidence: 0.8):
+> 2. `<entity>`: <outcome text>
+>
+> Which should I store? (e.g., "all", "1,2", "none")
+
+### Step 4: Store confirmed items
+
+- **Semantic** — `pensyve_remember(entity, fact: "[auto-capture/user/residual/tier-1] <text>", confidence)`.
+- **Episodic** — `pensyve_observe(episode_id, content: "[auto-capture/user/residual/tier-1] <text>", source_entity: "pydantic-ai", about_entity: <entity>)`.
+- **Procedural** — `pensyve_observe(episode_id, content: "[procedural] [auto-capture/user/residual/tier-1] trigger=..., action=..., outcome=...", source_entity: "pydantic-ai", about_entity: <entity>)`.
+
+### Step 5: Optionally close the episode
+
+If the user clearly marks the work complete: `pensyve_episode_end(episode_id: <working_id>, outcome: "success")`. Valid outcomes: `"success"`, `"failure"`, `"partial"`.
+
+### Constraints
+
+- **Never auto-store.** Every candidate MUST be presented for confirmation before storage.
+- Do not store secrets.
+- If nothing significant surfaced, say so clearly.
+
+---
+
+## Context Loading (Session Start)
+
+When starting a new conversation on a project with prior Pensyve memories, load relevant context to prime the session.
+
+### Step 1: Detect project entity
+
+Use the repository root name (lowercase-hyphenated) as the default project entity. Override with `PENSYVE_NAMESPACE` environment variable if set.
+
+### Step 2: Scoped recall
+
+Call `pensyve_recall`:
+
+- `query`: `"recent decisions issues patterns"` + any key terms from the user's opening message
+- `entity`: detected project entity
+- `types`: `["episodic"]`
+- `limit`: 5
+
+### Step 3: Compute continuity signal
+
+- If ≥70% of top observations reference at least one overlapping entity: **continuation** of recent work.
+- If overlap is below 70% or recall returned empty: **fresh session**.
+
+### Step 4: Surface the primer
+
+**Continuation:**
+
+> **Pensyve:** Continuing prior work on `<entity-set>`. Recent lessons:
+>
+> - <observation 1>
+> - <observation 2>
+>
+> Use `pensyve_recall` to dig deeper.
+
+**Fresh session:**
+
+> **Pensyve:** N memories loaded for `<project>`. Key context:
+>
+> - <top 3 observations>
+
+**No memories found:**
+
+> **Pensyve:** No memories found for `<project>`. Start a session to begin building context.
+
+### Constraints
+
+- Do not fabricate memories. Only display what `pensyve_recall` returns.
+- Maximum 5 memories in the primer.
+- Entity names lowercase-hyphenated.

--- a/integrations/pydantic-ai/examples/pensyve_agent.py
+++ b/integrations/pydantic-ai/examples/pensyve_agent.py
@@ -1,0 +1,69 @@
+"""
+Pensyve + Pydantic AI wiring example.
+
+Demonstrates how to:
+  1. Load the Pensyve working-memory substrate as the agent system prompt.
+  2. Register the Pensyve MCP server with Pydantic AI's MCPServerHTTP.
+  3. Run an agent with persistent cross-session memory.
+
+Pydantic AI's MCP support: pydantic-ai v0.0.30+ supports MCP servers via
+MCPServerHTTP (streamable-http transport) registered in the Agent constructor.
+
+Dependencies:
+    pip install pydantic-ai
+
+Environment variables:
+    PENSYVE_API_KEY   — Pensyve API key (get one at pensyve.com/settings/api-keys)
+"""
+
+import asyncio
+import os
+from pathlib import Path
+
+from pydantic_ai import Agent
+from pydantic_ai.mcp import MCPServerHTTP
+
+# ---------------------------------------------------------------------------
+# 1. Load the substrate — the reasoning layer injected as the system prompt.
+# ---------------------------------------------------------------------------
+SUBSTRATE_PATH = Path(__file__).parent.parent / "SUBSTRATE_PROMPT.md"
+substrate = SUBSTRATE_PATH.read_text(encoding="utf-8")
+
+# ---------------------------------------------------------------------------
+# 2. Configure the Pensyve MCP server connection.
+#    Pydantic AI's MCPServerHTTP uses the streamable-http transport.
+# ---------------------------------------------------------------------------
+PENSYVE_API_KEY = os.environ["PENSYVE_API_KEY"]  # raises KeyError if unset
+
+pensyve = MCPServerHTTP(
+    url="https://mcp.pensyve.com/mcp",
+    headers={"Authorization": f"Bearer {PENSYVE_API_KEY}"},
+)
+
+# ---------------------------------------------------------------------------
+# 3. Create the agent with the substrate as the system prompt.
+#    The substrate tells the model HOW to use Pensyve tools — recall first,
+#    observe at landing, manage episode lifecycle, etc.
+# ---------------------------------------------------------------------------
+agent = Agent(
+    "anthropic:claude-sonnet-4-6",
+    system_prompt=substrate,      # substrate injected here
+    mcp_servers=[pensyve],        # Pensyve MCP server registered
+)
+
+
+async def main() -> None:
+    # -----------------------------------------------------------------------
+    # 4. Run the agent inside the MCP server context manager.
+    #    The context manager manages the MCP connection lifecycle.
+    # -----------------------------------------------------------------------
+    async with agent.run_mcp_servers():
+        result = await agent.run(
+            "I'm starting work on the auth-service module. "
+            "What do we know about prior decisions there?"
+        )
+        print(result.data)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/integrations/pydantic-ai/scripts/lint-mcp-refs.sh
+++ b/integrations/pydantic-ai/scripts/lint-mcp-refs.sh
@@ -34,18 +34,18 @@ echo ""
 echo "Check 1: no unsupported 'related_entities' on pensyve_recall"
 FOUND_RELATED=0
 for f in "$RULES_FILE" "$EXAMPLE_FILE"; do
-  awk '/pensyve_recall\(/{capture=1; buf=""}
-       capture {buf = buf "\n" $0}
-       capture && /\)/{
-         if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
-           print FILENAME ": related_entities found in pensyve_recall block: " buf;
-         capture=0
-       }' "$f" | while read -r line; do
+  while read -r line; do
     if [ -n "$line" ]; then
       echo "  FAIL: $line"
       FOUND_RELATED=1
     fi
-  done
+  done < <(awk '/pensyve_recall\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+       if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
+       print FILENAME ": related_entities found in pensyve_recall block: " buf;
+       capture=0
+       }' "$f")
 done
 if [ "$FOUND_RELATED" = "0" ]; then
   echo "  PASS"
@@ -58,18 +58,18 @@ echo ""
 echo "Check 2: no unsupported 'continuation_of' on pensyve_episode_start"
 FOUND_CONT=0
 for f in "$RULES_FILE" "$EXAMPLE_FILE"; do
-  awk '/pensyve_episode_start\(/{capture=1; buf=""}
-       capture {buf = buf "\n" $0}
-       capture && /\)/{
-         if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
-           print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
-         capture=0
-       }' "$f" | while read -r line; do
+  while read -r line; do
     if [ -n "$line" ]; then
       echo "  FAIL: $line"
       FOUND_CONT=1
     fi
-  done
+  done < <(awk '/pensyve_episode_start\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+       if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
+       print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
+       capture=0
+       }' "$f")
 done
 if [ "$FOUND_CONT" = "0" ]; then
   echo "  PASS"
@@ -82,23 +82,23 @@ echo ""
 echo "Check 3: every pensyve_observe example has source_entity and about_entity"
 MISSING_FIELDS=0
 for f in "$RULES_FILE" "$EXAMPLE_FILE"; do
-  awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
-       capture {buf = buf "\n" $0;
-                for(i=1; i<=length($0); i++){
-                  c=substr($0,i,1);
-                  if(c=="(") depth++;
-                  if(c==")") depth--;
-                };
-                if(depth==0 && buf ~ /pensyve_observe\(/){
-                  if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
-                  if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
-                  capture=0;
-                }}' "$f" | while read -r line; do
+  while read -r line; do
     if [ -n "$line" ]; then
       echo "  FAIL: $line"
       MISSING_FIELDS=1
     fi
-  done
+  done < <(awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
+       capture {buf = buf "\n" $0;
+       for(i=1; i<=length($0); i++){
+       c=substr($0,i,1);
+       if(c=="(") depth++;
+       if(c==")") depth--;
+       };
+       if(depth==0 && buf ~ /pensyve_observe\(/){
+       if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
+       if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
+       capture=0;
+       }}' "$f")
 done
 if [ "$MISSING_FIELDS" = "0" ]; then
   echo "  PASS"

--- a/integrations/pydantic-ai/scripts/lint-mcp-refs.sh
+++ b/integrations/pydantic-ai/scripts/lint-mcp-refs.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Static MCP contract linter for the Pensyve pydantic-ai adapter.
+#
+# Verifies that every pensyve_* call example in SUBSTRATE_PROMPT.md and the
+# example wiring file conforms to the current MCP tool schema.
+# Catches the category of bug PR #58 surfaced in the Claude Code adapter
+# (unsupported parameters, missing required fields).
+#
+# This integration uses a single consolidated SUBSTRATE_PROMPT.md (same
+# pattern as VS Code Copilot) rather than per-rule files.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INTEG_DIR="$SCRIPT_DIR/.."
+RULES_FILE="$INTEG_DIR/SUBSTRATE_PROMPT.md"
+EXAMPLE_FILE="$INTEG_DIR/examples/pensyve_agent.py"
+
+EXIT_CODE=0
+
+for f in "$RULES_FILE" "$EXAMPLE_FILE"; do
+  if [ ! -f "$f" ]; then
+    echo "ERROR: File not found: $f"
+    exit 1
+  fi
+done
+
+echo "Linting MCP references in:"
+echo "  $RULES_FILE"
+echo "  $EXAMPLE_FILE"
+echo ""
+
+# Check 1: no actual use of unsupported 'related_entities' parameter in call examples.
+echo "Check 1: no unsupported 'related_entities' on pensyve_recall"
+FOUND_RELATED=0
+for f in "$RULES_FILE" "$EXAMPLE_FILE"; do
+  awk '/pensyve_recall\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+         if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
+           print FILENAME ": related_entities found in pensyve_recall block: " buf;
+         capture=0
+       }' "$f" | while read -r line; do
+    if [ -n "$line" ]; then
+      echo "  FAIL: $line"
+      FOUND_RELATED=1
+    fi
+  done
+done
+if [ "$FOUND_RELATED" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 2: no actual use of unsupported 'continuation_of' parameter in call examples.
+echo "Check 2: no unsupported 'continuation_of' on pensyve_episode_start"
+FOUND_CONT=0
+for f in "$RULES_FILE" "$EXAMPLE_FILE"; do
+  awk '/pensyve_episode_start\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+         if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
+           print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
+         capture=0
+       }' "$f" | while read -r line; do
+    if [ -n "$line" ]; then
+      echo "  FAIL: $line"
+      FOUND_CONT=1
+    fi
+  done
+done
+if [ "$FOUND_CONT" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 3: every pensyve_observe call example in a code block has source_entity and about_entity
+echo "Check 3: every pensyve_observe example has source_entity and about_entity"
+MISSING_FIELDS=0
+for f in "$RULES_FILE" "$EXAMPLE_FILE"; do
+  awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
+       capture {buf = buf "\n" $0;
+                for(i=1; i<=length($0); i++){
+                  c=substr($0,i,1);
+                  if(c=="(") depth++;
+                  if(c==")") depth--;
+                };
+                if(depth==0 && buf ~ /pensyve_observe\(/){
+                  if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
+                  if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
+                  capture=0;
+                }}' "$f" | while read -r line; do
+    if [ -n "$line" ]; then
+      echo "  FAIL: $line"
+      MISSING_FIELDS=1
+    fi
+  done
+done
+if [ "$MISSING_FIELDS" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 4: provenance tag format — every proactive/auto-capture tag uses [<origin>/<trigger>/<tier>]
+echo "Check 4: provenance tag format"
+VALID_PROVENANCE_RE='\[(proactive|auto-capture)/(in-flight|stop|pre-compact|curator|user)/(tier-1|tier-2|residual/tier-1|residual/tier-2|open-question)\]'
+INVALID=0
+for f in "$RULES_FILE" "$EXAMPLE_FILE"; do
+  if rg -n '\[(proactive|auto-capture)' "$f" | rg -v "$VALID_PROVENANCE_RE"; then
+    INVALID=1
+  fi
+done
+if [ "$INVALID" = "0" ]; then
+  echo "  PASS"
+else
+  echo "  FAIL: some provenance tags do not match [<origin>/<trigger>/<tier>] format"
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 5: procedural memory convention — [procedural] prefix is used in observe content
+echo "Check 5: procedural convention uses [procedural] prefix in pensyve_observe content"
+if ! rg -q '\[procedural\]' "$RULES_FILE"; then
+  echo "  WARN: no [procedural] prefix usage found in SUBSTRATE_PROMPT.md."
+else
+  echo "  PASS"
+fi
+echo ""
+
+if [ "$EXIT_CODE" = "0" ]; then
+  echo "All MCP contract checks PASSED."
+else
+  echo "MCP contract checks FAILED. Fix the issues above before committing."
+fi
+
+exit "$EXIT_CODE"

--- a/integrations/vscode-copilot/.github/copilot-instructions.md
+++ b/integrations/vscode-copilot/.github/copilot-instructions.md
@@ -1,0 +1,372 @@
+# Pensyve Working-Memory Substrate for VS Code Copilot
+
+This file configures persistent working-memory for VS Code Copilot Chat via the Pensyve MCP server. All sections below are always in context — they form the substrate the agent operates on across every coding session.
+
+---
+
+## Memory Reflex Rule
+
+**This discipline is non-optional. Before substantive answers, recall by entity. When a lesson lands, observe immediately with a one-line surface.**
+
+### "Substantive answer" means
+
+- Design or architecture recommendations
+- Debugging diagnoses with root-cause claims
+- Refactor proposals
+- Any response that makes a claim the user would want grounded in prior work
+
+Not substantive: formatting fixes, trivial lookups, reading a file, running a command.
+
+### "Lesson lands" means
+
+- A root cause has been confirmed (not hypothesized).
+- A design choice has been made explicit ("we'll use X because Y").
+- An approach has been tried and abandoned with a reason.
+- A workflow has been discovered that is reusable.
+- A workaround for a framework/library limitation has been validated.
+
+### Memory classification
+
+- **Semantic** — a fact that will still be true next month. Use `pensyve_remember(entity, fact, confidence?)` (confidence defaults to 1.0; use 0.9 for high-confidence auto-captures).
+- **Episodic** — something that happened in this thread of work. Use `pensyve_observe` with the current `episode_id`.
+- **Procedural** — a reusable way to do something. Use `pensyve_observe` with `content` beginning `[procedural]`.
+
+When in doubt, prefer episodic.
+
+### Canonical `pensyve_observe` call template
+
+ALL observe calls MUST include every required field:
+
+```
+pensyve_observe(
+  episode_id: <current session's working episode_id>,
+  content: "[proactive/in-flight/tier-1] <observation text>",
+  source_entity: "vscode-copilot",
+  about_entity: "<relevant entity, lowercase-hyphenated>",
+  content_type: "text"
+)
+```
+
+Use `content_type: "code"` for code-related outcomes.
+
+### Episode lifecycle (lazy-open)
+
+VS Code Copilot has no session-start/session-end hooks, so you own the episode lifecycle:
+
+- Before your first `pensyve_observe` call in this conversation, check whether a working `episode_id` is tracked. If none exists, call `pensyve_episode_start(participants: ["vscode-copilot", "<project entity>"])` first.
+- Reuse the same `episode_id` for all subsequent observations in the same conversation.
+- Do not explicitly close the episode under normal operation. Server-side consolidation handles aging.
+- Recovery: if `pensyve_observe` fails with a missing-episode error, call `pensyve_episode_start` and retry.
+
+### Surface style
+
+Lightly visible. One line when memory is used:
+
+- Recall: `Recalled 4 related memories (v7r, haiku-classifier).`
+- Capture: `↳ captured: hybrid-router threshold was the phase-3 regression root cause.`
+
+Do not narrate empty recalls or duplicate-skips.
+
+### Provenance tag vocabulary
+
+- `[proactive/in-flight/tier-1]` — memory reflex captured during reasoning
+- `[proactive/in-flight/open-question]` — unresolved question noted in-flight
+- `[auto-capture/user/residual/tier-1]` — explicit user-driven capture
+
+### Composition
+
+When a capture is both procedural AND in-flight: `[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=...`
+
+### MCP contract
+
+Rules never pass unsupported parameters:
+
+- `pensyve_recall(query, entity?, types?, limit?, min_confidence?)` — **no** `related_entities`
+- `pensyve_episode_start(participants)` — **no** `continuation_of`
+- `pensyve_observe(episode_id, content, source_entity, about_entity, content_type?)` — `source_entity` and `about_entity` are **required**
+
+---
+
+## Entity Detection
+
+Shared rules for detecting entity names from tool inputs, prompts, and conversation context. Used to scope recalls and `about_entity` fields on observations.
+
+### Inputs
+
+Extract candidate entity names from:
+
+1. **File references** — `@filename`, `@path/to/file`, or files mentioned directly in the conversation.
+2. **User prompts** — explicit references to components, files, services, research phases.
+3. **Code context** — module names, class names, function names in files being edited or read.
+4. **Git context** — repository root name, branch name (when discoverable).
+
+### Canonicalization
+
+- Lowercase all characters.
+- Replace spaces and underscores with hyphens.
+- Strip file extensions unless the file is the entity itself (e.g., `package.json`).
+- Collapse paths to the most semantically meaningful segment (e.g., `src/engine/hybrid_router.rs` → `hybrid-router`).
+
+### Fallback
+
+- If no specific entity is detected, fall back to the project-level entity (repository root name, lowercase-hyphenated).
+- If ambiguous, prefer the entity that already has memories in Pensyve (call `pensyve_inspect` with limit 1 to check).
+- **Never fabricate entity names.**
+
+### Output
+
+1–3 candidate entity names per turn. Primary entity is most specific; fold secondary entities into the `query` string when calling `pensyve_recall`.
+
+---
+
+## When Debugging
+
+Use when diagnosing bugs, errors, failing tests, or crashes.
+
+### Step 1: Detect entities
+
+Identify the relevant entity/entities (failing test, failing module, error source) per the entity detection section above.
+
+### Step 2: Consult memory (required)
+
+Call `pensyve_recall`:
+
+- `query`: short description of the failure, including secondary entity names
+- `entity`: primary detected entity
+- `types`: `["procedural", "episodic"]`
+- `limit`: 5
+
+Surface: `Recalled N memories from prior debug sessions on <entity>.`
+
+If a highly similar incident is found (score >0.8): `This looks similar to an incident captured on <date>: <summary>. Consider that path first.`
+
+### Step 3: Diagnose
+
+Proceed with diagnostic work, using recalled procedural memories as a starting sequence.
+
+### Step 4: Capture lesson (when it lands)
+
+When a root cause is **confirmed** (not just hypothesized):
+
+- **Episodic root cause:** `pensyve_observe` with `content: "[proactive/in-flight/tier-1] <one-sentence root cause>"`, `source_entity: "vscode-copilot"`, `about_entity: <primary_entity>`, `content_type: "text"`.
+- **Procedural sequence:** `pensyve_observe` with `content: "[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=..."`, `source_entity: "vscode-copilot"`, `about_entity: <primary_entity>`, `content_type: "text"`.
+- **Semantic truth:** `pensyve_remember(entity, fact: "[proactive/in-flight/tier-1] <fact>", confidence: 0.9)`.
+
+### Step 5: Capture abandoned approaches
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[proactive/in-flight/tier-1] tried <approach>, abandoned because <reason>",
+  source_entity: "vscode-copilot",
+  about_entity: <primary_entity>,
+  content_type: "text"
+)
+```
+
+---
+
+## When Designing
+
+Use when making architecture, API, or design decisions.
+
+### Step 1: Detect entities
+
+Identify the relevant entity/entities (service, module, subsystem under design).
+
+### Step 2: Consult memory (required)
+
+Call `pensyve_recall`:
+
+- `query`: short description of the design question
+- `entity`: primary detected entity
+- `types`: `["semantic", "episodic"]`
+- `limit`: 5
+
+Surface: `Recalled N prior decisions on <entity>.`
+
+If the current question contradicts a prior decision, flag it: `Prior decision on <entity> (confidence 0.9): [decision]. Are we revisiting this?`
+
+### Step 3: Recommend with grounding
+
+Shape recommendations using recalled decisions.
+
+### Step 4: Capture decision (when it lands)
+
+When the user accepts a design or states a decision:
+
+- **Semantic:** `pensyve_remember(entity: <primary_entity>, fact: "[proactive/in-flight/tier-1] <decision text>", confidence: 0.9)`.
+- **Episodic context:** `pensyve_observe` with `content: "[proactive/in-flight/tier-1] Decision on <entity>: chose X over Y because Z"`, `source_entity: "vscode-copilot"`, `about_entity: <primary_entity>`, `content_type: "text"`.
+
+### Step 5: Capture evaluation procedures
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[procedural] [proactive/in-flight/tier-1] trigger=design-question-on-<area>, action=<steps>, outcome=<what-you-learn>",
+  source_entity: "vscode-copilot",
+  about_entity: <primary_entity>,
+  content_type: "text"
+)
+```
+
+---
+
+## When Refactoring
+
+Use before substantive refactors.
+
+### Step 1: Detect entities
+
+Identify entities touched by the refactor (file or module being restructured, callers, subsystem name).
+
+### Step 2: Load prior context (required)
+
+Call `pensyve_recall`:
+
+- `query`: short description of the refactor
+- `entity`: primary detected entity
+- `types`: `["semantic", "episodic", "procedural"]`
+- `limit`: 5
+
+Highlight any prior failed approaches: `Prior episodic memory: tried <approach>, abandoned because <reason>. Double-check this isn't the same trap.`
+
+### Step 3: Present a briefing
+
+Summarize what prior memories say about: decisions, prior attempts, known-good procedures.
+
+### Step 4: Capture refactor lessons as they land
+
+Apply the memory reflex immediately when:
+
+- **Invariant discovered** (semantic): `pensyve_remember(entity, fact, confidence: 0.9)`
+- **Abandoned approach confirmed** (episodic): `pensyve_observe` with `[proactive/in-flight/tier-1]`
+- **Dependency chain surprise** (episodic): `pensyve_observe`
+- **Known-good sequence emerged** (procedural): `pensyve_observe` with `[procedural]` prefix
+
+---
+
+## Longitudinal Work (Research/Evals)
+
+Use for long-running multi-session work in `research/`, `benchmarks/`, or `evals/` directories.
+
+### Step 1: Resume context at conversation start
+
+Call `pensyve_recall`:
+
+- `query`: short description of the current research area
+- `entity`: project + sub-topic entity
+- `limit`: 5
+
+No `types` filter — longitudinal work benefits from all three memory types.
+
+### Step 2: Proactively recall per topic shift
+
+When the session pivots to a new sub-topic, call `pensyve_recall` again scoped to it.
+
+### Step 3: Capture per run
+
+| What you learned | Type | Call |
+|---|---|---|
+| Per-run outcome | episodic | `pensyve_observe(..., content: "[proactive/in-flight/tier-1] Run N+1: ...", source_entity: "vscode-copilot", about_entity: <entity>, content_type: "text")` |
+| Stable truth | semantic | `pensyve_remember(entity, fact: "[proactive/in-flight/tier-1] ...", confidence: 0.9)` |
+| Reusable procedure | procedural | `pensyve_observe(..., content: "[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=...", source_entity: "vscode-copilot", about_entity: <entity>, content_type: "text")` |
+
+### Step 4: Capture open questions
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[proactive/in-flight/open-question] <question>",
+  source_entity: "vscode-copilot",
+  about_entity: <entity>,
+  content_type: "text"
+)
+```
+
+### Step 5: End-of-session summary
+
+Before wrapping: summarize what this run taught vs. prior runs, and what's still open.
+
+---
+
+## Session Memory (Wrap-Up)
+
+Use at conversation wrap-up or when the user indicates end-of-session.
+
+### Step 1: Review the conversation
+
+Scan for three categories the in-flight reflex did NOT already capture:
+
+**Decisions** (confidence: 0.9): architecture choices, technology selections, API decisions, tradeoff resolutions.
+
+**Outcomes** (confidence: 0.8): bug fixes and root causes, successful approaches, failed approaches with reasons, performance findings.
+
+**Patterns** (confidence: 0.7): recurring issues, workflow discoveries, cross-cutting observations.
+
+### Step 2: Filter and deduplicate
+
+For each candidate, call `pensyve_recall` with `query: <candidate fact text>`, `entity: <entity>`, `limit: 3`. If score ≥0.85, skip as likely duplicate.
+
+### Step 3: Present candidates for confirmation
+
+> **Session Memory Candidates**
+>
+> **Decisions** (confidence: 0.9):
+> 1. `<entity>`: <decision text>
+>
+> **Outcomes** (confidence: 0.8):
+> 2. `<entity>`: <outcome text>
+>
+> **Patterns** (confidence: 0.7):
+> 3. `<entity>`: <pattern text>
+>
+> Which should I store? (e.g., "all", "1,3", "none")
+
+### Step 4: Store confirmed items
+
+- **Semantic:** `pensyve_remember(entity, fact: "[auto-capture/user/residual/tier-1] <text>", confidence)`.
+- **Episodic:** `pensyve_observe(episode_id, content: "[auto-capture/user/residual/tier-1] <text>", source_entity: "vscode-copilot", about_entity: <entity>, content_type: "text")`.
+- **Procedural:** `pensyve_observe(episode_id, content: "[procedural] [auto-capture/user/residual/tier-1] trigger=..., action=..., outcome=...", source_entity: "vscode-copilot", about_entity: <entity>, content_type: "text")`.
+
+### Step 5: Optionally close the episode
+
+If the user marks work complete: `pensyve_episode_end(episode_id: <working_id>, outcome: "success")`. Valid outcomes: `"success"`, `"failure"`, `"partial"`.
+
+**Never auto-store.** Every candidate MUST be confirmed before storage.
+
+---
+
+## Context Loader (Session Start)
+
+Use when starting a new substantive conversation or switching contexts.
+
+### Step 1: Detect project entity
+
+Use the repository root name (lowercase-hyphenated) as default. Override with `PENSYVE_NAMESPACE` if set.
+
+### Step 2: Scoped recall
+
+Call `pensyve_recall`:
+
+- `query`: `"recent decisions issues patterns"` + key terms from the user's opening message
+- `entity`: detected project entity
+- `types`: `["episodic"]`
+- `limit`: 5
+
+### Step 3: Compute continuity signal
+
+If ≥70% of the top observations share entities with the current conversation → **continuation**. Otherwise → **fresh session**.
+
+### Step 4: Surface the primer
+
+**Continuation:**
+> **Pensyve:** Continuing prior work on `<entity-set>`. Recent lessons: [top 3 observations]
+
+**Fresh session:**
+> **Pensyve:** N memories loaded for `<project>`. Key context: [top 3 observations]
+
+**No memories:**
+> **Pensyve:** No memories found for `<project>`. Use `/remember` to start building context.
+
+Do not fabricate memories. Only display what `pensyve_recall` returns.

--- a/integrations/vscode-copilot/CHANGELOG.md
+++ b/integrations/vscode-copilot/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog — Pensyve VS Code Copilot Adapter
+
+All notable changes to the Pensyve VS Code Copilot adapter are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). The VS Code Copilot adapter versions independently of the Claude Code plugin.
+
+## [1.0.0] - 2026-04-20
+
+### Added
+
+- **Working-memory substrate** for VS Code Copilot Chat via `.github/copilot-instructions.md`. All eight substrate rules consolidated into a single file with clear section headings (VS Code Copilot supports only one instructions file):
+  - **Memory Reflex Rule** — non-optional reasoning discipline with three-type memory classification, canonical `pensyve_observe` call template, provenance vocabulary, lazy-open episode lifecycle
+  - **Entity Detection** — canonicalization and fallback rules
+  - **When Debugging** — debug flow with memory baked in
+  - **When Designing** — design flow with memory baked in
+  - **When Refactoring** — refactor flow with memory baked in
+  - **Longitudinal Work (Research/Evals)** — multi-session research/eval flow
+  - **Session Memory (Wrap-Up)** — manual wrap-up equivalent of Claude Code's Stop hook
+  - **Context Loader (Session Start)** — best-effort continuity primer via episodic recall
+- **MCP config example** at `vscode-mcp.json.example` (deploy to `.vscode/mcp.json`) covering Cloud-with-API-key and Local-stdio options in VS Code's `servers` format
+- **Static MCP contract lint script** at `scripts/lint-mcp-refs.sh` verifying the consolidated instructions file's `pensyve_*` call examples match the `pensyve-mcp-tools/src/params.rs` schema
+
+### Design
+
+- Single reasoning layer; no platform-layer code. VS Code Copilot Chat has no hook/event surface, so the entire adapter is the instructions file the model reads.
+- **Single-file constraint:** VS Code Copilot's `.github/copilot-instructions.md` is a single file — all 8 rules are consolidated with section headings rather than split into separate files.
+- MCP config uses VS Code's `servers` key (not `mcpServers`) and `type: "http"` / `type: "stdio"` transport format.
+- Lazy-open episode lifecycle: first `pensyve_observe` call triggers `pensyve_episode_start`; episodes are not explicitly closed.
+- Best-effort continuity primer via `pensyve_recall(types: ["episodic"])` — the MCP server has no episode-listing API.
+- MCP contract verified: no `related_entities` on recall, no `continuation_of` on episode_start, required `source_entity: "vscode-copilot"` and `about_entity` on every observe.
+- Opt-out: delete or edit the instructions file (VS Code-native pattern).
+
+### Not Included
+
+- No extension or platform-layer code (deferred to a future sibling spec if capability gaps surface)
+- No installer script (manual copy of instructions file + MCP config)
+- No server-side changes — uses the existing MCP tool surface
+
+### Relation to Other Pensyve Integrations
+
+- The VS Code Copilot adapter is part of the batch-1 working-memory substrate rollout. The Cursor adapter (v1.0.0) and Claude Code plugin (v1.3.0) are the reference implementations.
+- Key difference from Cursor: single `.github/copilot-instructions.md` vs. Cursor's per-rule `.cursor/rules/*.mdc` files.
+- Spec: `pensyve-docs/specs/2026-04-20-pensyve-cursor-adapter-design.md`
+- Playbook: `pensyve-docs/specs/2026-04-18-pensyve-working-memory-substrate-design.md`

--- a/integrations/vscode-copilot/README.md
+++ b/integrations/vscode-copilot/README.md
@@ -1,33 +1,30 @@
 # Pensyve for VS Code (Copilot Chat)
 
-Persistent AI memory for VS Code's built-in Copilot Chat MCP support.
+Persistent working-memory substrate for VS Code's built-in [Copilot Chat](https://code.visualstudio.com/docs/copilot/overview) — memory is not a feature you invoke, it is the substrate the agent operates on.
 
 > For the standalone Pensyve sidebar extension, see `integrations/vscode/`.
 
-## Authentication
+## What It Does
 
-1. Sign up at [pensyve.com](https://pensyve.com)
-2. Create an API key at [Settings → API Keys](https://pensyve.com/settings/api-keys)
-3. Set the environment variable:
-   ```bash
-   export PENSYVE_API_KEY="psy_your_key_here"
-   ```
+- **Proactive memory during work** — lessons are captured the moment they land, not at session end
+- **Thread-aware continuity** — sessions that continue prior work resume with relevant context, no re-briefing
+- **Entity-scoped recall** — substantive questions are grounded in prior decisions; simple commands stay fast
+- **Three memory types** — durable facts (semantic), session-specific events (episodic), reusable procedures (procedural)
+- **Lightly visible** — one-line surfaces when memory is used; never interrupts your flow
 
-Then configure MCP with headers (see setup instructions above).
+## Install
 
-## Setup
+Two steps: configure the MCP server, then install the instructions file.
 
-Set your API key (get one at [pensyve.com/settings/api-keys](https://pensyve.com/settings/api-keys)):
+### 1. Configure the MCP server
+
+Copy `vscode-mcp.json.example` to `.vscode/mcp.json` in your project root and edit for your setup.
+
+**Cloud with API key (recommended):**
 
 ```bash
-export PENSYVE_API_KEY="psy_your_key"
+export PENSYVE_API_KEY="psy_your_key_here"
 ```
-
-Add to your shell profile (`~/.bashrc`, `~/.zshrc`) to persist across sessions.
-
-## Cloud (Recommended)
-
-Add to `.vscode/mcp.json` in your project root:
 
 ```json
 {
@@ -43,11 +40,9 @@ Add to `.vscode/mcp.json` in your project root:
 }
 ```
 
-> Use `headers` with `Authorization: Bearer` for remote MCP. The `env` block is for local stdio servers.
+Create your key at [pensyve.com/settings/api-keys](https://pensyve.com/settings/api-keys). Put the `export` in `~/.bashrc` or `~/.zshrc` to persist.
 
-## Local (Offline)
-
-No API key needed — all data stays on your machine.
+**Local (offline, self-hosted):**
 
 ```json
 {
@@ -65,40 +60,83 @@ No API key needed — all data stays on your machine.
 }
 ```
 
-Build from source: `cargo build --release -p pensyve-mcp` from the [pensyve repo](https://github.com/major7apps/pensyve).
+Build the binary: `cargo build --release -p pensyve-mcp` from the [pensyve repo](https://github.com/major7apps/pensyve).
 
-## Available Tools
+### 2. Install the instructions file
 
-| Tool                    | Description                            |
-| ----------------------- | -------------------------------------- |
-| `pensyve_recall`        | Search memories by semantic similarity |
-| `pensyve_remember`      | Store a fact as semantic memory        |
-| `pensyve_episode_start` | Begin tracking an interaction          |
-| `pensyve_episode_end`   | Close an episode                       |
-| `pensyve_forget`        | Delete an entity's memories            |
-| `pensyve_inspect`       | List memories for an entity            |
-| `pensyve_status`        | Connection and memory stats            |
-| `pensyve_account`       | Plan and usage info                    |
+Copy `.github/copilot-instructions.md` to your project's `.github/` directory:
+
+```bash
+mkdir -p .github
+cp /path/to/pensyve/integrations/vscode-copilot/.github/copilot-instructions.md .github/
+```
+
+VS Code Copilot Chat automatically loads `.github/copilot-instructions.md` into every chat context.
+
+**Note:** VS Code Copilot supports only a single instructions file (unlike Cursor's multi-file MDC rules). All 8 substrate rules are consolidated into one well-structured file with clear section headings.
+
+## How It Works
+
+VS Code Copilot Chat has no hook/event surface, so the entire substrate is delivered through `.github/copilot-instructions.md`. The memory reflex section establishes the discipline: *before substantive answers, recall by entity; when a lesson lands, observe immediately with a one-line surface*. Flow sections (When Debugging, When Designing, When Refactoring, Longitudinal Work) guide the model through consult-memory + capture-lesson steps.
+
+**Episode lifecycle:** Copilot Chat has no session-start/session-end hooks, so episodes open lazily on the first `pensyve_observe` call and are not explicitly closed under normal operation. Server-side consolidation handles aging.
+
+**Continuity primer:** The Context Loader section runs a best-effort recall at the start of substantive conversations to surface prior relevant observations.
+
+## Memory Behavior Model
+
+Pensyve behaves as working memory for the agent — always-on, ambient, continuous.
+
+**Writes happen in-flight.** When a root cause is confirmed, a decision is made, or a reusable procedure emerges, it's captured the moment it lands via the memory reflex. No batching to session end.
+
+**Reads happen at decision points.** Before substantive answers, the model consults memory scoped to the detected entities. Simple commands (run tests, format file) skip recall to stay fast.
+
+**Sessions continue.** At the start of a substantive conversation, Pensyve checks whether the current work continues prior memories (shared entities + recent activity). If yes, you resume with a primer — no re-briefing needed.
+
+## Memory Types
+
+| Type | Definition | MCP call | Example |
+|---|---|---|---|
+| **Semantic** | Durable truths, decisions, preferences | `pensyve_remember` | "We chose RS256 over HS256 for JWT signing" |
+| **Episodic** | Temporal events, session-scoped observations | `pensyve_observe` (with lazy-opened `episode_id`) | "Phase-3 regression root cause: hybrid-router threshold" |
+| **Procedural** | Reusable workflows, sequences, recipes | `pensyve_observe` with `[procedural]` content prefix | "To calibrate V7r: freeze Haiku config, run suite, diff baseline" |
+
+## Opt-Out
+
+- **Full opt-out** — delete `.github/copilot-instructions.md`
+- **Partial opt-out** — delete specific sections from the file (e.g., remove the "Longitudinal Work" section if you don't do research work)
+- **Silent mode** — edit the Memory Reflex Rule section to remove the "one-line surface" guidance; captures stay silent
+- **Recall-only mode** — edit flow sections to drop the `Capture lesson` steps while keeping `Consult memory`
+
+## Available MCP Tools
+
+| Tool | Description |
+|---|---|
+| `pensyve_recall` | Search memories by semantic similarity |
+| `pensyve_remember` | Store a durable fact (semantic memory) |
+| `pensyve_observe` | Record a session observation (episodic / procedural via `[procedural]` prefix) |
+| `pensyve_episode_start` | Begin tracking an episode |
+| `pensyve_episode_end` | Close an episode with outcome |
+| `pensyve_forget` | Delete an entity's memories |
+| `pensyve_inspect` | List memories for an entity |
 
 See [MCP Tools Reference](https://pensyve.com/docs/api-reference/mcp-tools) for full parameter details.
 
-## Intelligent Memory Capture
+## Design Philosophy
 
-Pensyve uses a tiered classification system to identify what is worth remembering. Since VS Code Copilot Chat connects via MCP only, the LLM follows the MCP tool descriptions to decide when and how to call memory tools.
+- **Memory as substrate** — not a feature the user invokes; always there, continuous, carried across sessions
+- **Reasoning-layer only** — no platform-layer code in v1; the entire adapter is the instructions file
+- **1:1 with Claude Code** — same skill structure, same conventions, same memory types
+- **MCP contract-respecting** — every rule's call examples verified against `pensyve-mcp-tools/src/params.rs`
+- **Single-file constraint** — VS Code Copilot's `.github/copilot-instructions.md` is a single file; all 8 rules consolidated with clear section headings instead of separate files
 
-### Tiered Capture System
+## Links
 
-- **Tier 1** (auto-store, confidence 0.9+): Explicit decisions, corrections, constraints, architecture choices, dependency version pins, security rules. High-signal items that should almost always be captured.
-- **Tier 2** (review, confidence 0.7-0.89): Root causes, failed approaches, performance findings, debugging outcomes, environment quirks. Medium-signal items that benefit from user confirmation.
-- **Discard**: Formatting, typos, boilerplate, ephemeral status messages. Noise that should never be stored.
+- **Website:** [pensyve.com](https://pensyve.com)
+- **GitHub:** [github.com/major7apps/pensyve](https://github.com/major7apps/pensyve)
+- **Spec:** [Cursor adapter design](https://github.com/major7apps/pensyve-docs/blob/main/specs/2026-04-20-pensyve-cursor-adapter-design.md)
+- **Playbook:** [Working-memory substrate design](https://github.com/major7apps/pensyve-docs/blob/main/specs/2026-04-18-pensyve-working-memory-substrate-design.md)
 
-### Best Practices
+## License
 
-For the best experience with Copilot Chat, guide the LLM to use Pensyve's memory tools effectively:
-
-- Use `pensyve_observe` to record significant events during an episode (architecture decisions, failed approaches, key findings)
-- Use `pensyve_remember` for durable facts that should persist across sessions (project conventions, environment constraints, resolved issues)
-- Use `pensyve_recall` at the start of a task to load relevant context from prior sessions
-- Wrap multi-step work in `pensyve_episode_start` / `pensyve_episode_end` to capture episodic context
-
-The MCP tool descriptions include guidance on confidence levels so the LLM can classify memories into the appropriate tier automatically.
+Apache 2.0

--- a/integrations/vscode-copilot/scripts/lint-mcp-refs.sh
+++ b/integrations/vscode-copilot/scripts/lint-mcp-refs.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Static MCP contract linter for the Pensyve VS Code Copilot adapter.
+#
+# Verifies that every pensyve_* call example in .github/copilot-instructions.md
+# conforms to the current MCP tool schema in pensyve-mcp-tools/src/params.rs.
+# Catches the category of bug PR #58 surfaced in the Claude Code adapter
+# (unsupported parameters, missing required fields).
+#
+# VS Code Copilot uses a single consolidated file rather than a rules directory,
+# so this script targets .github/copilot-instructions.md directly.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RULES_FILE="$SCRIPT_DIR/../.github/copilot-instructions.md"
+RULES_DIR="$(dirname "$RULES_FILE")"
+
+EXIT_CODE=0
+
+if [ ! -f "$RULES_FILE" ]; then
+  echo "ERROR: Copilot instructions file not found: $RULES_FILE"
+  exit 1
+fi
+
+echo "Linting MCP references in $RULES_FILE..."
+echo ""
+
+# Check 1: no actual use of unsupported 'related_entities' parameter in call examples.
+# Lines that say "no related_entities" (documentation/reminders) are excluded.
+echo "Check 1: no unsupported 'related_entities' on pensyve_recall"
+FOUND_RELATED=0
+# Also catch if related_entities appears inside a pensyve_recall( block
+awk '/pensyve_recall\(/{capture=1; buf=""}
+     capture {buf = buf "\n" $0}
+     capture && /\)/{
+       if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
+         print FILENAME ": related_entities found in pensyve_recall block: " buf;
+       capture=0
+     }' "$RULES_FILE" | while read -r line; do
+  if [ -n "$line" ]; then
+    echo "  FAIL: $line"
+    FOUND_RELATED=1
+  fi
+done
+if [ "$FOUND_RELATED" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 2: no actual use of unsupported 'continuation_of' parameter in call examples.
+echo "Check 2: no unsupported 'continuation_of' on pensyve_episode_start"
+FOUND_CONT=0
+awk '/pensyve_episode_start\(/{capture=1; buf=""}
+     capture {buf = buf "\n" $0}
+     capture && /\)/{
+       if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
+         print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
+       capture=0
+     }' "$RULES_FILE" | while read -r line; do
+  if [ -n "$line" ]; then
+    echo "  FAIL: $line"
+    FOUND_CONT=1
+  fi
+done
+if [ "$FOUND_CONT" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 3: every pensyve_observe call example in a code block has source_entity and about_entity
+echo "Check 3: every pensyve_observe example has source_entity and about_entity"
+MISSING_FIELDS=0
+awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
+     capture {buf = buf "\n" $0;
+              for(i=1; i<=length($0); i++){
+                c=substr($0,i,1);
+                if(c=="(") depth++;
+                if(c==")") depth--;
+              };
+              if(depth==0 && buf ~ /pensyve_observe\(/){
+                if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
+                if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
+                capture=0;
+              }}' "$RULES_FILE" | while read -r line; do
+  if [ -n "$line" ]; then
+    echo "  FAIL: $line"
+    MISSING_FIELDS=1
+  fi
+done
+if [ "$MISSING_FIELDS" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 4: provenance tag format — every proactive/auto-capture tag uses [<origin>/<trigger>/<tier>]
+echo "Check 4: provenance tag format"
+VALID_PROVENANCE_RE='\[(proactive|auto-capture)/(in-flight|stop|pre-compact|curator|user)/(tier-1|tier-2|residual/tier-1|residual/tier-2|open-question)\]'
+if rg -n '\[(proactive|auto-capture)' "$RULES_FILE" | rg -v "$VALID_PROVENANCE_RE"; then
+  echo "  FAIL: some provenance tags do not match [<origin>/<trigger>/<tier>] format"
+  EXIT_CODE=1
+else
+  echo "  PASS"
+fi
+echo ""
+
+# Check 5: procedural memory convention — [procedural] prefix is used in observe content
+echo "Check 5: procedural convention uses [procedural] prefix in pensyve_observe content"
+if ! rg -q '\[procedural\]' "$RULES_FILE"; then
+  echo "  WARN: no [procedural] prefix usage found. Expected in the consolidated instructions file."
+else
+  echo "  PASS"
+fi
+echo ""
+
+if [ "$EXIT_CODE" = "0" ]; then
+  echo "All MCP contract checks PASSED."
+else
+  echo "MCP contract checks FAILED. Fix the issues above before committing."
+fi
+
+exit "$EXIT_CODE"

--- a/integrations/vscode-copilot/scripts/lint-mcp-refs.sh
+++ b/integrations/vscode-copilot/scripts/lint-mcp-refs.sh
@@ -30,18 +30,18 @@ echo ""
 echo "Check 1: no unsupported 'related_entities' on pensyve_recall"
 FOUND_RELATED=0
 # Also catch if related_entities appears inside a pensyve_recall( block
-awk '/pensyve_recall\(/{capture=1; buf=""}
-     capture {buf = buf "\n" $0}
-     capture && /\)/{
-       if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
-         print FILENAME ": related_entities found in pensyve_recall block: " buf;
-       capture=0
-     }' "$RULES_FILE" | while read -r line; do
+while read -r line; do
   if [ -n "$line" ]; then
     echo "  FAIL: $line"
     FOUND_RELATED=1
   fi
-done
+done < <(awk '/pensyve_recall\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+       if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
+       print FILENAME ": related_entities found in pensyve_recall block: " buf;
+       capture=0
+       }' "$RULES_FILE")
 if [ "$FOUND_RELATED" = "0" ]; then
   echo "  PASS"
 else
@@ -52,18 +52,18 @@ echo ""
 # Check 2: no actual use of unsupported 'continuation_of' parameter in call examples.
 echo "Check 2: no unsupported 'continuation_of' on pensyve_episode_start"
 FOUND_CONT=0
-awk '/pensyve_episode_start\(/{capture=1; buf=""}
-     capture {buf = buf "\n" $0}
-     capture && /\)/{
-       if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
-         print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
-       capture=0
-     }' "$RULES_FILE" | while read -r line; do
+while read -r line; do
   if [ -n "$line" ]; then
     echo "  FAIL: $line"
     FOUND_CONT=1
   fi
-done
+done < <(awk '/pensyve_episode_start\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+       if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
+       print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
+       capture=0
+       }' "$RULES_FILE")
 if [ "$FOUND_CONT" = "0" ]; then
   echo "  PASS"
 else
@@ -74,23 +74,23 @@ echo ""
 # Check 3: every pensyve_observe call example in a code block has source_entity and about_entity
 echo "Check 3: every pensyve_observe example has source_entity and about_entity"
 MISSING_FIELDS=0
-awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
-     capture {buf = buf "\n" $0;
-              for(i=1; i<=length($0); i++){
-                c=substr($0,i,1);
-                if(c=="(") depth++;
-                if(c==")") depth--;
-              };
-              if(depth==0 && buf ~ /pensyve_observe\(/){
-                if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
-                if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
-                capture=0;
-              }}' "$RULES_FILE" | while read -r line; do
+while read -r line; do
   if [ -n "$line" ]; then
     echo "  FAIL: $line"
     MISSING_FIELDS=1
   fi
-done
+done < <(awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
+       capture {buf = buf "\n" $0;
+       for(i=1; i<=length($0); i++){
+       c=substr($0,i,1);
+       if(c=="(") depth++;
+       if(c==")") depth--;
+       };
+       if(depth==0 && buf ~ /pensyve_observe\(/){
+       if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
+       if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
+       capture=0;
+       }}' "$RULES_FILE")
 if [ "$MISSING_FIELDS" = "0" ]; then
   echo "  PASS"
 else

--- a/integrations/vscode-copilot/vscode-mcp.json.example
+++ b/integrations/vscode-copilot/vscode-mcp.json.example
@@ -1,0 +1,11 @@
+{
+  "servers": {
+    "pensyve": {
+      "type": "http",
+      "url": "https://mcp.pensyve.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ${PENSYVE_API_KEY}"
+      }
+    }
+  }
+}

--- a/integrations/vscode/CHANGELOG.md
+++ b/integrations/vscode/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [1.3.0] - 2026-04-20
+
+### Added
+
+- **Working-memory substrate documentation** — new `instructions/` directory containing 8 substrate rule files mirroring the Claude Code plugin's memory-reflex + entity-detection + flow rules:
+  - `memory-reflex.md` (always-apply) — non-optional reasoning discipline with three-type memory classification, canonical `pensyve_observe` call template, provenance vocabulary, lazy-open episode lifecycle
+  - `entity-detection.md` (always-apply) — canonicalization and fallback rules for recall scoping
+  - `memory-informed-debug.md` — debug flow with memory baked in
+  - `memory-informed-design.md` — design/architecture flow with memory baked in
+  - `memory-informed-refactor.md` — refactor flow with memory baked in
+  - `memory-informed-longitudinal-work.md` — research/eval multi-session flow
+  - `session-memory.md` — manual wrap-up equivalent of Claude Code's Stop hook
+  - `context-loader.md` — best-effort continuity primer via episodic recall
+- **Static MCP contract lint script** at `scripts/lint-mcp-refs.sh` verifying substrate rule files' `pensyve_*` call examples match the MCP tool schema
+
+### Notes
+
+Existing extension features (capture, recall, inspect commands) are compatible with substrate-aware workflows. The `instructions/` directory is documentation only — it documents the working-memory substrate pattern for users integrating Pensyve with Copilot Chat or other AI assistants in VS Code. No TypeScript code was modified.
+
 ## 1.0.5
 
 - Add cloud API key support via `pensyve.apiKey` setting

--- a/integrations/vscode/README.md
+++ b/integrations/vscode/README.md
@@ -45,6 +45,48 @@ Open the command palette (`Ctrl+Shift+P` / `Cmd+Shift+P`) and search for:
 | `Pensyve: Memory Stats`         | Display memory statistics                     |
 | `Pensyve: Consolidate Memories` | Run memory consolidation                      |
 
+## Memory Behavior Model
+
+The working-memory substrate defines how a Pensyve-aware AI assistant should behave across coding sessions. It is documented in the [`instructions/`](./instructions/) directory as 8 rule files:
+
+| Rule file | Behavior |
+| --------- | -------- |
+| `memory-reflex.md` | Non-optional reasoning discipline — recall before substantive answers, observe when lessons land. Always active. |
+| `entity-detection.md` | Canonicalization rules for extracting entity names from file paths, prompts, and code context. Always active. |
+| `memory-informed-debug.md` | Debug flow: recall prior incidents and procedures, capture root causes the moment they are confirmed. |
+| `memory-informed-design.md` | Design/architecture flow: recall prior decisions, flag contradictions, capture new decisions on acceptance. |
+| `memory-informed-refactor.md` | Refactor flow: briefing from prior memory, capture invariants and abandoned approaches as they surface. |
+| `memory-informed-longitudinal-work.md` | Multi-session research/eval flow: resume context at session start, capture per-run outcomes and open questions. |
+| `session-memory.md` | Manual wrap-up: review the conversation for residual lessons not captured in-flight, confirm with user before storing. |
+| `context-loader.md` | Session continuity primer: recall recent episodic memories at conversation start to surface relevant context. |
+
+### How to use these with VS Code AI assistants
+
+The extension's built-in commands (`Pensyve: Recall`, `Pensyve: Remember`, `Pensyve: Inspect`) give you direct access to memory operations. For AI-assisted coding workflows where you want the substrate pattern applied automatically:
+
+- **GitHub Copilot Chat**: Copy the rule file contents into `.github/copilot-instructions.md` (one combined file) — Copilot reads this as system context.
+- **Continue.dev**: Reference the `instructions/*.md` files in your Continue config under `rules`.
+- **Other AI plugins**: Configure as system prompt files per that plugin's documentation.
+
+The `instructions/` directory is documentation only — the extension's TypeScript code does not load or interpret these files at runtime.
+
+### Three memory types
+
+- **Semantic** — durable facts (`pensyve_remember`): architecture decisions, environment constraints, resolved issues
+- **Episodic** — session events (`pensyve_observe`): per-session outcomes, what happened and why
+- **Procedural** — reusable workflows (`pensyve_observe` with `[procedural]` prefix): diagnostic sequences, known-good refactor patterns
+
+### MCP tool schema
+
+All substrate rules use the correct MCP contract:
+
+- `pensyve_recall(query, entity?, types?, limit?, min_confidence?)`
+- `pensyve_episode_start(participants)`
+- `pensyve_observe(episode_id, content, source_entity, about_entity, content_type?)`
+- `pensyve_inspect(entity, memory_type?, limit?)`
+
+`source_entity` is `"vscode"` in all substrate rule examples. Run `scripts/lint-mcp-refs.sh` to verify the rule files conform to the schema.
+
 ## Development
 
 ```bash

--- a/integrations/vscode/instructions/context-loader.md
+++ b/integrations/vscode/instructions/context-loader.md
@@ -1,0 +1,74 @@
+---
+description: Use when starting a new substantive conversation or switching contexts — load relevant memories to prime the session with continuity
+---
+
+# Context Loader (Continuity Primer)
+
+VS Code has no automatic SessionStart hook. This rule is the manual equivalent: when starting a new conversation on a project that has prior Pensyve memories, call recall to prime the session with relevant context.
+
+Follows `memory-reflex.md`. Best-effort thread continuity via episodic recall (the MCP server has no episode-listing tool).
+
+## Instructions
+
+### Step 1: Detect project entity
+
+Per `entity-detection.md` fallback rules: use the repository root name (lowercase-hyphenated) as the default project entity. Override with `PENSYVE_NAMESPACE` environment variable if explicitly set in the project's environment.
+
+### Step 2: Scoped recall
+
+Call `pensyve_recall`:
+
+- `query`: `"recent decisions issues patterns"` + any key terms from the user's opening message
+- `entity`: detected project entity
+- `types`: `["episodic"]` — recent session activity gives the best continuity signal
+- `limit`: 5
+
+Episodic memories are ranked by the MCP server's activation signal, which naturally surfaces recent observations first.
+
+### Step 3: Compute continuity signal
+
+Examine the returned observations:
+
+- If ≥70% of the top observations reference at least one entity that overlaps with the current conversation's entity candidates (from Step 1 plus any entities mentioned in the opening message), treat the session as a **continuation** of recent work.
+- If the overlap is below 70%, or recall returned empty, treat as a **fresh session**.
+
+### Step 4: Surface the primer
+
+**Continuation:**
+
+> **Pensyve:** Continuing prior work on `<entity-set>`. Recent lessons:
+>
+> - <observation 1>
+> - <observation 2>
+> - <observation 3>
+>
+> Use `/recall <query>` or ask about any of these to dig deeper.
+
+**Fresh session:**
+
+> **Pensyve:** N memories loaded for `<project>`. Key context:
+>
+> - <top 3 observations>
+>
+> Use `/recall <query>` to search for specific memories.
+
+**No memories found:**
+
+> **Pensyve:** No memories found for `<project>`. Use `/remember` to start building context.
+
+### Step 5: Continuity is best-effort, not a structured link
+
+The MCP server has no episode-listing or date-filtering API. This rule infers continuity from shared-entity overlap and recall-ranking recency. Consequences:
+
+- There is no persisted server-side link between sessions.
+- Primer accuracy depends on memory quality and recall ranking.
+- The user may occasionally see "Continuing prior work" when it's actually loosely related; or see a fresh-session primer when the prior session was related but the entity overlap was low.
+
+Document this honestly in the primer when uncertain — do not fabricate continuity.
+
+## Constraints
+
+- Do not fabricate memories. Only display what `pensyve_recall` returns.
+- If MCP is unavailable, skip the primer silently and mention the failure once per conversation if the user asks about memory.
+- Maximum 5 memories in the primer to avoid context bloat.
+- Entity names lowercase-hyphenated.

--- a/integrations/vscode/instructions/entity-detection.md
+++ b/integrations/vscode/instructions/entity-detection.md
@@ -1,0 +1,42 @@
+---
+description: Pensyve entity detection — canonicalization and fallback rules for recall scoping (always-apply)
+---
+
+# Entity Detection (Always-Apply Reference)
+
+Shared rules for detecting entity names from tool inputs, prompts, and conversation context. Used by the memory reflex and all memory-woven flows to scope recalls and `about_entity` fields on observations.
+
+## Inputs
+
+Extract candidate entity names from:
+
+1. **File references** — `@filename`, `@path/to/file`, or files mentioned directly in the conversation.
+2. **User prompts** — explicit references to components, files, services, research phases (e.g., "phase-4.3", "v7r-classifier", "auth-service").
+3. **Code context** — module names, class names, function names in files you are editing or reading.
+4. **Git context** — repository root name, branch name (when discoverable).
+
+## Canonicalization
+
+- Lowercase all characters.
+- Replace spaces and underscores with hyphens.
+- Strip file extensions unless the file is the entity itself (e.g., `package.json`).
+- Collapse paths to the most semantically meaningful segment (e.g., `src/engine/hybrid_router.rs` → `hybrid-router`; `tests/integration/auth_test.py` → `auth`).
+
+## Fallback behavior
+
+- If no specific entity is detected, fall back to the project-level entity (repository root name, lowercase-hyphenated).
+- If a candidate entity is ambiguous between two names, prefer the one that already has memories in Pensyve (call `pensyve_inspect` with limit 1 to check).
+- **Never fabricate entity names.** If nothing confident emerges, use the project entity.
+
+## Output
+
+A set of 1–3 candidate entity names per turn. The primary entity is the most specific; secondary entities provide additional context. Since `pensyve_recall` accepts only a single `entity` parameter, fold secondary entities into the `query` string instead.
+
+## Examples
+
+| Input | Primary entity | Secondary (fold into query) |
+|---|---|---|
+| Edit on `src/engine/hybrid_router.rs` | `hybrid-router` | `engine` |
+| Prompt: "tune V7r noise threshold" | `v7r` | `noise-threshold` |
+| File `tests/test_auth.py` in a project named `auth-service` | `auth` | `auth-service` |
+| User mentions "phase-4.3 calibration" | `phase-4.3` | `calibration` |

--- a/integrations/vscode/instructions/memory-informed-debug.md
+++ b/integrations/vscode/instructions/memory-informed-debug.md
@@ -1,0 +1,68 @@
+---
+description: Use when diagnosing bugs, errors, failing tests, or crashes — consult prior debug outcomes and capture root causes in-flight
+---
+
+# Memory-Informed Debug
+
+Debugging flow with memory baked in as a non-optional reflex. Follows `memory-reflex.md` for classification, surface style, and episode lifecycle.
+
+## Instructions
+
+### Step 1: Detect entities
+
+Identify the relevant entity/entities (failing test, failing module, error source) per `entity-detection.md`.
+
+### Step 2: Consult memory (required)
+
+Call `pensyve_recall`:
+
+- `query`: a short description of the failure, including secondary entity names where known (e.g., "hybrid-router threshold regression phase-4.3" rather than full stack traces)
+- `entity`: primary detected entity
+- `types`: `["procedural", "episodic"]` (debugging benefits most from known-good diagnostic procedures and prior incident outcomes)
+- `limit`: 5
+
+Secondary entities are folded into the query string since `RecallParams` scopes by a single `entity` only.
+
+Surface one line: `Recalled N memories from prior debug sessions on <entity>.` (Skip if N=0.)
+
+If a highly similar incident is found (score >0.8), call that out inline: `This looks similar to an incident captured on <date>: <summary>. Consider that path first.`
+
+### Step 3: Diagnose
+
+Proceed with the diagnostic work. Use recalled procedural memories as a starting sequence; update the sequence when you learn something new.
+
+### Step 4: Capture lesson (when it lands)
+
+When a root cause is **confirmed** (not just hypothesized), apply the memory reflex per `memory-reflex.md`:
+
+Ensure a working `episode_id` exists (lazy-open via `pensyve_episode_start` if not). Then:
+
+- **Episodic root cause:** call `pensyve_observe` with `content: "[proactive/in-flight/tier-1] <one-sentence root cause>"`, `source_entity: "vscode"`, `about_entity: <primary_entity>`, `content_type: "text"`.
+- **Procedural diagnostic sequence:** if the debug produced a reusable diagnostic sequence, call `pensyve_observe` with `content: "[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=..."`, `source_entity: "vscode"`, `about_entity: <primary_entity>`, `content_type: "text"`.
+- **Semantic durable truth:** if the root cause reveals a durable truth (e.g., "our CI runner's Python 3.10 cannot handle the new syntax"), also call `pensyve_remember(entity, fact, confidence: 0.9)`. Include provenance in the fact text: `"[proactive/in-flight/tier-1] <fact>"`.
+
+Surface one line: `↳ captured: <one-sentence>`.
+
+### Step 5: Capture abandoned approach
+
+If an approach was tried and abandoned, observe that too:
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[proactive/in-flight/tier-1] tried <approach>, abandoned because <reason>",
+  source_entity: "vscode",
+  about_entity: <primary_entity>,
+  content_type: "text"
+)
+```
+
+These are high-value — they prevent re-treading the same dead end next time.
+
+## Constraints
+
+- Recall is **not optional**. If you skip recall to save time, you defeat the working-memory substrate.
+- Observe when a lesson **lands**, not when you first hypothesize.
+- One in-flight capture per turn unless multiple distinct lessons land simultaneously.
+- Respect the reflex rule's surface style — one line, not paragraphs.
+- Never store secrets or sensitive paths.

--- a/integrations/vscode/instructions/memory-informed-design.md
+++ b/integrations/vscode/instructions/memory-informed-design.md
@@ -1,0 +1,60 @@
+---
+description: Use when making architecture, API, or design decisions — consult prior decisions and capture new ones in-flight
+---
+
+# Memory-Informed Design
+
+Design flow with memory baked in as a non-optional reflex. Follows `memory-reflex.md`.
+
+## Instructions
+
+### Step 1: Detect entities
+
+Identify the relevant entity/entities (service, module, subsystem under design) per `entity-detection.md`.
+
+### Step 2: Consult memory (required)
+
+Call `pensyve_recall`:
+
+- `query`: a short description of the design question, including secondary entity names where known (e.g., "auth-service jwt signing rs256 hs256")
+- `entity`: primary detected entity
+- `types`: `["semantic", "episodic"]` (design benefits most from durable decisions and prior decision-contexts)
+- `limit`: 5
+
+Surface one line: `Recalled N prior decisions on <entity>.` (Skip if N=0.)
+
+### Step 3: Recommend with grounding
+
+Shape your recommendation using the recalled decisions. If the user's current question directly contradicts a prior decision, flag it:
+
+> Prior decision on `<entity>` (confidence 0.9): [decision]. Are we revisiting this, or does the current question differ?
+
+### Step 4: Capture decision (when it lands)
+
+When the user accepts a design or states a decision ("let's go with X", "we'll use Y"), apply the memory reflex:
+
+- **Semantic** — `pensyve_remember(entity: <primary_entity>, fact: "[proactive/in-flight/tier-1] <decision text>", confidence: 0.9)`.
+- **Episodic context** — ensure working `episode_id`; `pensyve_observe` with `content: "[proactive/in-flight/tier-1] Decision on <entity>: chose X over Y because Z"`, `source_entity: "vscode"`, `about_entity: <primary_entity>`, `content_type: "text"`. This enables future "why did we decide X?" queries.
+
+Surface one line: `↳ captured decision on <entity>: <short>`.
+
+### Step 5: Capture evaluation procedures
+
+If the design process revealed a reusable way to evaluate similar decisions (e.g., "run spike vs. prototype", "check latency first"), capture it as procedural:
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[procedural] [proactive/in-flight/tier-1] trigger=design-question-on-<area>, action=<steps>, outcome=<what-you-learn>",
+  source_entity: "vscode",
+  about_entity: <primary_entity>,
+  content_type: "text"
+)
+```
+
+## Constraints
+
+- Recall is **not optional**.
+- Observe when a decision **lands**, not when it's being discussed.
+- Budget: one in-flight capture per turn unless multiple decisions land.
+- Never store secrets or sensitive architecture details the user has marked private.

--- a/integrations/vscode/instructions/memory-informed-longitudinal-work.md
+++ b/integrations/vscode/instructions/memory-informed-longitudinal-work.md
@@ -1,0 +1,68 @@
+---
+description: Long-running multi-session work (research, eval loops, iterative benchmarks) — resume prior lessons, capture per-run outcomes, build up stable truths over time
+---
+
+# Memory-Informed Longitudinal Work
+
+Multi-session engineering work (research, eval loops, iterative benchmarks) where lessons must accumulate across runs. The motivating case: improving a core algorithm over dozens of eval iterations without starting from scratch each session.
+
+Follows `memory-reflex.md`. Applies when editing files under `research/`, `benchmarks/`, or `evals/`, or when the conversation is research-oriented.
+
+## Instructions
+
+### Step 1: Resume context at conversation start
+
+If this conversation is in a research/eval context, call `pensyve_recall` once at the start:
+
+- `query`: short description of the current research area (e.g., "v7r classifier calibration")
+- `entity`: project + sub-topic entity (per `entity-detection.md` canonicalization rules)
+- `limit`: 5
+
+No `types` filter — longitudinal work benefits from all three memory types; omit to query all. (Passing all three explicitly is equivalent to no filter; omitting is cleaner.)
+
+Surface: `Recalled N prior findings on <sub-topic>.`
+
+Treat the returned observations as working knowledge — do not re-ask the user about things the recall already surfaces.
+
+### Step 2: Proactively recall per topic shift
+
+When the session pivots to a new sub-topic (new phase, new eval subset, new failure mode), call `pensyve_recall` again scoped to the new sub-topic.
+
+### Step 3: Capture three types of memory per run
+
+During the session, classify emerging knowledge and capture accordingly. Ensure working `episode_id` before each observe.
+
+| What you learned | Type | MCP call |
+|---|---|---|
+| Per-run outcome (what this run showed) | episodic | `pensyve_observe(..., content: "[proactive/in-flight/tier-1] Run N+1: V7r accuracy improved +3.5% with new threshold", source_entity: "vscode", about_entity: <entity>, content_type: "text")` |
+| Stable truth about the system | semantic | `pensyve_remember(entity, fact: "[proactive/in-flight/tier-1] Haiku classifier plateaus above temp 0.3", confidence: 0.9)` |
+| Reusable experiment procedure | procedural | `pensyve_observe(..., content: "[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=...", source_entity: "vscode", about_entity: <entity>, content_type: "text")` |
+
+Apply at landing — do not batch.
+
+### Step 4: Capture open questions
+
+When a run ends with an unresolved question ("X improved but we don't know why"), capture it as an episodic observation with open-question provenance:
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[proactive/in-flight/open-question] <question>",
+  source_entity: "vscode",
+  about_entity: <entity>,
+  content_type: "text"
+)
+```
+
+This populates future "open questions" surfacing when the topic returns.
+
+### Step 5: End-of-session summary
+
+Before the conversation wraps, briefly summarize (inline, 3-5 lines): what this run taught us vs. prior runs, what's still open. This creates a natural handoff for the next session.
+
+## Constraints
+
+- Recall on every topic shift — not just at conversation start.
+- Capture at landing, not batched.
+- Never store run artifacts or large data blobs — summarize.
+- Respect the reflex's surface style.

--- a/integrations/vscode/instructions/memory-informed-refactor.md
+++ b/integrations/vscode/instructions/memory-informed-refactor.md
@@ -1,0 +1,59 @@
+---
+description: Use before substantive refactors — load relevant prior context, capture refactor insights as they land
+---
+
+# Memory-Informed Refactor
+
+Refactor flow with memory baked in. Follows `memory-reflex.md`.
+
+## Instructions
+
+### Step 1: Detect entities
+
+Identify the entities touched by the refactor (the file or module being restructured, its callers, the subsystem name) per `entity-detection.md`.
+
+### Step 2: Load prior context (required)
+
+Call `pensyve_recall`:
+
+- `query`: short description of the refactor (e.g., "hybrid-router routing logic restructure")
+- `entity`: primary detected entity
+- `types`: `["semantic", "episodic", "procedural"]` — refactors benefit from all three (durable invariants, prior attempts, known-good sequences)
+- `limit`: 5
+
+Surface: `Recalled N prior memories on <entity>.` (Skip if N=0.)
+
+Highlight any prior failed approaches inline:
+
+> Prior episodic memory (confidence 0.8): tried <approach> on <date>, abandoned because <reason>. Double-check this isn't the same trap.
+
+### Step 3: Present a briefing
+
+Before starting the refactor, briefly summarize what the prior memories say about:
+
+- **Decisions** — durable choices that constrain the refactor (semantic)
+- **Prior attempts** — what's been tried (episodic)
+- **Known-good procedures** — reusable sequences for this kind of refactor (procedural)
+
+If no relevant memories exist, say so clearly and proceed without historical context.
+
+### Step 4: Capture refactor lessons as they land
+
+When any of these occur during the refactor, apply the memory reflex immediately:
+
+- **An invariant is discovered** (semantic) — `pensyve_remember(entity, fact, confidence: 0.9)`
+- **An abandoned approach is confirmed not-viable** (episodic) — `pensyve_observe` with `[proactive/in-flight/tier-1]` provenance
+- **A dependency chain was traced that surprised us** (episodic) — `pensyve_observe`
+- **A known-good refactoring sequence emerged** (procedural) — `pensyve_observe` with `[procedural]` prefix
+
+Ensure working `episode_id` before each observe; lazy-open if needed.
+
+Do not batch these to end-of-session — capture at landing, surface one-line.
+
+## Constraints
+
+- The briefing step is the real value — it informs the refactor.
+- Observe at landing, not batched.
+- Entity names lowercase-hyphenated.
+- Do not start the refactor itself — this rule provides guidance and capture. The user decides when and how to proceed.
+- If the MCP server returns errors on some queries, present results from the successful queries and note the failures.

--- a/integrations/vscode/instructions/memory-reflex.md
+++ b/integrations/vscode/instructions/memory-reflex.md
@@ -1,0 +1,100 @@
+---
+description: Pensyve memory reflex — the non-optional reasoning discipline for working-memory substrate (always-apply)
+---
+
+# Memory Reflex Rule (Always-Apply)
+
+This rule is always in context. It turns Pensyve memory operations from optional actions into a reasoning discipline you carry through every substantive turn.
+
+## The rule
+
+**Before substantive answers, recall by entity. When a lesson lands, observe immediately with a one-line surface.**
+
+### "Substantive answer" means
+
+- Design or architecture recommendations
+- Debugging diagnoses with root-cause claims
+- Refactor proposals
+- Any response that makes a claim the user would want grounded in prior work
+
+Not substantive: formatting fixes, trivial lookups, reading a file, running a command.
+
+### "Lesson lands" means
+
+- A root cause has been confirmed (not hypothesized).
+- A design choice has been made explicit ("we'll use X because Y").
+- An approach has been tried and abandoned with a reason.
+- A workflow has been discovered that is reusable.
+- A workaround for a framework/library limitation has been validated.
+
+## Classification (which memory type?)
+
+- **Semantic** — a fact that will still be true next month. Use `pensyve_remember(entity, fact, confidence?)` (confidence defaults to 1.0; use 0.9 for high-confidence auto-captures).
+- **Episodic** — something that happened in this thread of work. Use `pensyve_observe` with the current `episode_id`.
+- **Procedural** — a reusable way to do something (a workflow, sequence, recipe). Use `pensyve_observe` with `content` beginning `[procedural]` (integration-layer convention; the MCP server has no native procedural-write API).
+
+When in doubt, prefer episodic. Server-side consolidation promotes recurring patterns to semantic automatically.
+
+## Canonical `pensyve_observe` call template
+
+ALL observe calls — in-flight, procedural, or wrap-up — MUST include every required field:
+
+```
+pensyve_observe(
+  episode_id: <current session's working episode_id>,
+  content: "[proactive/in-flight/tier-1] <observation text>",
+  source_entity: "vscode",
+  about_entity: "<relevant entity, lowercase-hyphenated>",
+  content_type: "text"
+)
+```
+
+Use `content_type: "code"` for code-related outcomes.
+
+## Episode lifecycle (lazy-open)
+
+VS Code has no session-start/session-end hooks, so you own the episode lifecycle:
+
+- **Before your first `pensyve_observe` call in this conversation**, check whether a working `episode_id` is already tracked. If none exists, call `pensyve_episode_start(participants: ["vscode", "<project entity>"])` first, record the returned `episode_id`, then make the observation.
+- **Reuse the same `episode_id`** for all subsequent observations in the same conversation. Open a new episode only when the work's topic shifts substantially.
+- **Do not explicitly close** the episode under normal operation. Server-side consolidation handles aging.
+- **Recovery**: if `pensyve_observe` fails with a missing-episode error, call `pensyve_episode_start` and retry.
+
+## Surface style
+
+Lightly visible. One line when memory is used. Examples:
+
+- Recall: `Recalled 4 related memories (v7r, haiku-classifier).`
+- Capture: `↳ captured: hybrid-router threshold was the phase-3 regression root cause.`
+
+Do not narrate empty recalls or duplicate-skips.
+
+## Scope and budgets
+
+- Recall: scoped to detected entities (see `entity-detection.md`); limit 5; use `types` hint per flow.
+- Capture: one observation per substantive lesson; reuse the working `episode_id`.
+- Noise: avoid surfacing memory operations the user did not care about.
+
+## Composition with provenance tags
+
+When a capture is both procedural AND a proactive in-flight write, the `content` field begins with both markers, `[procedural]` first, then the provenance tag, then content:
+
+`[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=...`
+
+The `[procedural]` marker identifies the memory type for consolidation. The provenance tag identifies origin and trigger.
+
+## Provenance tag vocabulary
+
+- `[proactive/in-flight/tier-1]` — memory reflex captured during reasoning
+- `[proactive/in-flight/open-question]` — unresolved question noted in-flight
+- `[auto-capture/user/residual/tier-1]` — explicit user-driven capture (e.g., session-memory skill)
+
+## MCP contract reminder
+
+Rules never pass unsupported parameters. The MCP tool schemas are:
+
+- `pensyve_recall(query, entity?, types?, limit?, min_confidence?)` — **no** `related_entities`
+- `pensyve_episode_start(participants)` — **no** `continuation_of`
+- `pensyve_observe(episode_id, content, source_entity, about_entity, content_type?)` — `source_entity` and `about_entity` are **required**
+
+If you need secondary-entity context in a recall, fold those entities into the `query` string.

--- a/integrations/vscode/instructions/session-memory.md
+++ b/integrations/vscode/instructions/session-memory.md
@@ -1,0 +1,84 @@
+---
+description: Use at conversation wrap-up or when the user explicitly indicates end-of-session — capture residual lessons not captured in-flight
+---
+
+# Session Memory (Wrap-Up)
+
+VS Code has no automatic Stop hook. This rule is the manual equivalent: when the user indicates the conversation is ending ("thanks, that's all", "session wrap-up", "we're done here"), review what happened and capture anything the in-flight reflex missed.
+
+Follows `memory-reflex.md`.
+
+## Instructions
+
+### Step 1: Review the conversation
+
+Scan the current conversation for three categories of memorable content that the in-flight reflex did NOT already capture:
+
+**Decisions** (confidence: 0.9):
+- Architecture or design choices
+- Technology selections
+- API design decisions
+- Tradeoff resolutions
+
+**Outcomes** (confidence: 0.8):
+- Bug fixes and their root causes
+- Successful approaches
+- Failed approaches with reasons
+- Performance findings
+
+**Patterns** (confidence: 0.7):
+- Recurring issues
+- Workflow discoveries
+- Cross-cutting observations
+
+### Step 2: Filter for significance and deduplicate
+
+Skip routine, low-signal content. Also skip anything that was already captured in-flight.
+
+For each candidate, call `pensyve_recall` with `query: <candidate fact text>`, `entity: <candidate's entity>`, `limit: 3`. If any returned memory has a score ≥0.85 against the candidate, skip it as a likely duplicate.
+
+Note: `pensyve_inspect` cannot filter by `episode_id` (its params are `entity`, `memory_type?`, `limit?` only), so dedup is entity-scoped semantic-similarity rather than session-scoped. Consequence: very similar items captured in prior sessions will also trigger the skip — acceptable for avoiding genuine duplicates.
+
+### Step 3: Present candidates for confirmation
+
+Show the filtered candidates to the user in a structured format:
+
+> **Session Memory Candidates**
+>
+> **Decisions** (confidence: 0.9):
+> 1. `<entity>`: <decision text>
+>
+> **Outcomes** (confidence: 0.8):
+> 2. `<entity>`: <outcome text>
+>
+> **Patterns** (confidence: 0.7):
+> 3. `<entity>`: <pattern text>
+>
+> Which should I store? (e.g., "all", "1,3", "none")
+
+### Step 4: Store confirmed items
+
+For each confirmed item, classify the type and call the appropriate MCP tool:
+
+- **Semantic** (decisions, durable truths) — `pensyve_remember(entity, fact: "[auto-capture/user/residual/tier-1] <text>", confidence)`. Use confidence from the categorization above.
+- **Episodic** (outcomes, session-specific events) — ensure working `episode_id`; `pensyve_observe(episode_id, content: "[auto-capture/user/residual/tier-1] <text>", source_entity: "vscode", about_entity: <entity>, content_type: "text")`.
+- **Procedural** (reusable workflows) — `pensyve_observe(episode_id, content: "[procedural] [auto-capture/user/residual/tier-1] trigger=..., action=..., outcome=...", source_entity: "vscode", about_entity: <entity>, content_type: "text")`.
+
+### Step 5: Optionally close the episode
+
+If the user indicates this is a final wrap (not just a turn-by-turn pause), call `pensyve_episode_end(episode_id: <working_id>, outcome: "success")`. Valid outcomes: `"success"`, `"failure"`, `"partial"`.
+
+Not closing is safe — server-side consolidation ages episodes naturally. Only close when the user clearly marks the work complete.
+
+### Step 6: Report
+
+After storing, summarize:
+
+> Stored N memories. Episode <outcome> closed.
+
+## Constraints
+
+- **Never auto-store.** Every candidate MUST be presented to the user for confirmation before storage.
+- Entity names lowercase-hyphenated.
+- Do not store secrets.
+- If nothing significant surfaced, say so clearly rather than forcing low-quality memories.

--- a/integrations/vscode/package.json
+++ b/integrations/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "pensyve",
   "displayName": "Pensyve",
   "description": "Universal memory runtime for AI agents — recall, remember, and inspect memories from VS Code",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "publisher": "major7apps",
   "icon": "resources/icon.png",
   "repository": {

--- a/integrations/vscode/scripts/lint-mcp-refs.sh
+++ b/integrations/vscode/scripts/lint-mcp-refs.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Static MCP contract linter for the Pensyve VS Code extension substrate rules.
+#
+# Verifies that every pensyve_* call example in instructions/*.md conforms to
+# the current MCP tool schema in pensyve-mcp-tools/src/params.rs. Catches the
+# category of bug PR #58 surfaced in the Claude Code adapter (unsupported
+# parameters, missing required fields).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RULES_DIR="$SCRIPT_DIR/../instructions"
+
+EXIT_CODE=0
+
+if [ ! -d "$RULES_DIR" ]; then
+  echo "ERROR: Rules directory not found: $RULES_DIR"
+  exit 1
+fi
+
+echo "Linting MCP references in $RULES_DIR..."
+echo ""
+
+# Check 1: no actual use of unsupported 'related_entities' parameter in call examples.
+# We look for pensyve_recall( blocks that contain related_entities as a parameter.
+# Lines that say "no related_entities" (documentation/reminders) are excluded.
+echo "Check 1: no unsupported 'related_entities' on pensyve_recall"
+FOUND_RELATED=0
+for rule_file in "$RULES_DIR"/*.md; do
+  # Extract lines that contain pensyve_recall( and related_entities together,
+  # excluding documentation lines (those containing "**no**" or "no `related_entities`")
+  if rg -n 'related_entities' "$rule_file" | rg -v '(\*\*no\*\*|no `related_entities`)' | rg -q 'pensyve_recall\|related_entities'; then
+    echo "  FAIL in $rule_file: 'related_entities' used in a pensyve_recall call"
+    FOUND_RELATED=1
+  fi
+  # Also catch if related_entities appears inside a pensyve_recall( block
+  awk '/pensyve_recall\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+         if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
+           print FILENAME ": related_entities found in pensyve_recall block: " buf;
+         capture=0
+       }' "$rule_file" | while read -r line; do
+    if [ -n "$line" ]; then
+      echo "  FAIL: $line"
+      FOUND_RELATED=1
+    fi
+  done
+done
+if [ "$FOUND_RELATED" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 2: no actual use of unsupported 'continuation_of' parameter in call examples.
+# Documentation lines saying "no continuation_of" are excluded.
+echo "Check 2: no unsupported 'continuation_of' on pensyve_episode_start"
+FOUND_CONT=0
+for rule_file in "$RULES_DIR"/*.md; do
+  awk '/pensyve_episode_start\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+         if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
+           print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
+         capture=0
+       }' "$rule_file" | while read -r line; do
+    if [ -n "$line" ]; then
+      echo "  FAIL: $line"
+      FOUND_CONT=1
+    fi
+  done
+done
+if [ "$FOUND_CONT" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 3: every pensyve_observe call example in a code block has source_entity and about_entity
+# Scan each .md file's pensyve_observe blocks; require both fields nearby.
+echo "Check 3: every pensyve_observe example has source_entity and about_entity"
+MISSING_FIELDS=0
+for rule_file in "$RULES_DIR"/*.md; do
+  # Find each pensyve_observe( block (up to the next closing paren within 20 lines)
+  awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
+       capture {buf = buf "\n" $0;
+                for(i=1; i<=length($0); i++){
+                  c=substr($0,i,1);
+                  if(c=="(") depth++;
+                  if(c==")") depth--;
+                };
+                if(depth==0 && buf ~ /pensyve_observe\(/){
+                  if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
+                  if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
+                  capture=0;
+                }}' "$rule_file" | while read -r line; do
+    if [ -n "$line" ]; then
+      echo "  FAIL: $line"
+      MISSING_FIELDS=1
+    fi
+  done
+done
+if [ "$MISSING_FIELDS" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 4: provenance tag format — every proactive/auto-capture tag uses [<origin>/<trigger>/<tier>]
+# Format supports both 3-segment [origin/trigger/tier] and 4-segment [origin/trigger/residual/tier]
+# where the third segment may be a literal "residual" qualifier before the tier.
+echo "Check 4: provenance tag format"
+VALID_PROVENANCE_RE='\[(proactive|auto-capture)/(in-flight|stop|pre-compact|curator|user)/(tier-1|tier-2|residual/tier-1|residual/tier-2|open-question)\]'
+if rg -n '\[(proactive|auto-capture)' "$RULES_DIR" | rg -v "$VALID_PROVENANCE_RE"; then
+  echo "  FAIL: some provenance tags do not match [<origin>/<trigger>/<tier>] format"
+  EXIT_CODE=1
+else
+  echo "  PASS"
+fi
+echo ""
+
+# Check 5: procedural memory convention — [procedural] prefix is used in observe content
+echo "Check 5: procedural convention uses [procedural] prefix in pensyve_observe content"
+# Only a warning if no rule mentions [procedural] — may be legitimate if the rule is non-procedural
+if ! rg -q '\[procedural\]' "$RULES_DIR"; then
+  echo "  WARN: no [procedural] prefix usage found across rules. Expected in memory-reflex and flow rules that handle procedural captures."
+else
+  echo "  PASS"
+fi
+echo ""
+
+if [ "$EXIT_CODE" = "0" ]; then
+  echo "All MCP contract checks PASSED."
+else
+  echo "MCP contract checks FAILED. Fix the issues above before committing."
+fi
+
+exit "$EXIT_CODE"

--- a/integrations/vscode/scripts/lint-mcp-refs.sh
+++ b/integrations/vscode/scripts/lint-mcp-refs.sh
@@ -34,18 +34,18 @@ for rule_file in "$RULES_DIR"/*.md; do
     FOUND_RELATED=1
   fi
   # Also catch if related_entities appears inside a pensyve_recall( block
-  awk '/pensyve_recall\(/{capture=1; buf=""}
-       capture {buf = buf "\n" $0}
-       capture && /\)/{
-         if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
-           print FILENAME ": related_entities found in pensyve_recall block: " buf;
-         capture=0
-       }' "$rule_file" | while read -r line; do
+  while read -r line; do
     if [ -n "$line" ]; then
       echo "  FAIL: $line"
       FOUND_RELATED=1
     fi
-  done
+  done < <(awk '/pensyve_recall\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+       if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
+       print FILENAME ": related_entities found in pensyve_recall block: " buf;
+       capture=0
+       }' "$rule_file")
 done
 if [ "$FOUND_RELATED" = "0" ]; then
   echo "  PASS"
@@ -59,18 +59,18 @@ echo ""
 echo "Check 2: no unsupported 'continuation_of' on pensyve_episode_start"
 FOUND_CONT=0
 for rule_file in "$RULES_DIR"/*.md; do
-  awk '/pensyve_episode_start\(/{capture=1; buf=""}
-       capture {buf = buf "\n" $0}
-       capture && /\)/{
-         if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
-           print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
-         capture=0
-       }' "$rule_file" | while read -r line; do
+  while read -r line; do
     if [ -n "$line" ]; then
       echo "  FAIL: $line"
       FOUND_CONT=1
     fi
-  done
+  done < <(awk '/pensyve_episode_start\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+       if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
+       print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
+       capture=0
+       }' "$rule_file")
 done
 if [ "$FOUND_CONT" = "0" ]; then
   echo "  PASS"
@@ -85,23 +85,23 @@ echo "Check 3: every pensyve_observe example has source_entity and about_entity"
 MISSING_FIELDS=0
 for rule_file in "$RULES_DIR"/*.md; do
   # Find each pensyve_observe( block (up to the next closing paren within 20 lines)
-  awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
-       capture {buf = buf "\n" $0;
-                for(i=1; i<=length($0); i++){
-                  c=substr($0,i,1);
-                  if(c=="(") depth++;
-                  if(c==")") depth--;
-                };
-                if(depth==0 && buf ~ /pensyve_observe\(/){
-                  if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
-                  if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
-                  capture=0;
-                }}' "$rule_file" | while read -r line; do
+  while read -r line; do
     if [ -n "$line" ]; then
       echo "  FAIL: $line"
       MISSING_FIELDS=1
     fi
-  done
+  done < <(awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
+       capture {buf = buf "\n" $0;
+       for(i=1; i<=length($0); i++){
+       c=substr($0,i,1);
+       if(c=="(") depth++;
+       if(c==")") depth--;
+       };
+       if(depth==0 && buf ~ /pensyve_observe\(/){
+       if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
+       if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
+       capture=0;
+       }}' "$rule_file")
 done
 if [ "$MISSING_FIELDS" = "0" ]; then
   echo "  PASS"

--- a/integrations/windsurf/.windsurf/mcp_config.json.example
+++ b/integrations/windsurf/.windsurf/mcp_config.json.example
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "pensyve": {
+      "serverUrl": "https://mcp.pensyve.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ${PENSYVE_API_KEY}"
+      }
+    }
+  }
+}

--- a/integrations/windsurf/.windsurf/rules/context-loader.md
+++ b/integrations/windsurf/.windsurf/rules/context-loader.md
@@ -1,0 +1,74 @@
+---
+description: Use when starting a new substantive conversation or switching contexts — load relevant memories to prime the session with continuity
+---
+
+# Context Loader (Continuity Primer)
+
+Windsurf has no automatic SessionStart hook. This rule is the manual equivalent: when starting a new conversation on a project that has prior Pensyve memories, call recall to prime the session with relevant context.
+
+Follows `memory-reflex.md`. Best-effort thread continuity via episodic recall (the MCP server has no episode-listing tool; see the main spec's Task C addendum for background).
+
+## Instructions
+
+### Step 1: Detect project entity
+
+Per `entity-detection.md` fallback rules: use the repository root name (lowercase-hyphenated) as the default project entity. Override with `PENSYVE_NAMESPACE` environment variable if explicitly set in the project's environment.
+
+### Step 2: Scoped recall
+
+Call `pensyve_recall`:
+
+- `query`: `"recent decisions issues patterns"` + any key terms from the user's opening message
+- `entity`: detected project entity
+- `types`: `["episodic"]` — recent session activity gives the best continuity signal
+- `limit`: 5
+
+Episodic memories are ranked by the MCP server's activation signal, which naturally surfaces recent observations first.
+
+### Step 3: Compute continuity signal
+
+Examine the returned observations:
+
+- If ≥70% of the top observations reference at least one entity that overlaps with the current conversation's entity candidates (from Step 1 plus any entities mentioned in the opening message), treat the session as a **continuation** of recent work.
+- If the overlap is below 70%, or recall returned empty, treat as a **fresh session**.
+
+### Step 4: Surface the primer
+
+**Continuation:**
+
+> **Pensyve:** Continuing prior work on `<entity-set>`. Recent lessons:
+>
+> - <observation 1>
+> - <observation 2>
+> - <observation 3>
+>
+> Use `/recall <query>` or ask about any of these to dig deeper.
+
+**Fresh session:**
+
+> **Pensyve:** N memories loaded for `<project>`. Key context:
+>
+> - <top 3 observations>
+>
+> Use `/recall <query>` to search for specific memories.
+
+**No memories found:**
+
+> **Pensyve:** No memories found for `<project>`. Use `/remember` to start building context.
+
+### Step 5: Continuity is best-effort, not a structured link
+
+The MCP server has no episode-listing or date-filtering API. This rule infers continuity from shared-entity overlap and recall-ranking recency. Consequences:
+
+- There is no persisted server-side link between sessions.
+- Primer accuracy depends on memory quality and recall ranking.
+- The user may occasionally see "Continuing prior work" when it's actually loosely related; or see a fresh-session primer when the prior session was related but the entity overlap was low.
+
+Document this honestly in the primer when uncertain — do not fabricate continuity.
+
+## Constraints
+
+- Do not fabricate memories. Only display what `pensyve_recall` returns.
+- If MCP is unavailable, skip the primer silently and mention the failure once per conversation if the user asks about memory.
+- Maximum 5 memories in the primer to avoid context bloat.
+- Entity names lowercase-hyphenated.

--- a/integrations/windsurf/.windsurf/rules/entity-detection.md
+++ b/integrations/windsurf/.windsurf/rules/entity-detection.md
@@ -1,0 +1,43 @@
+---
+description: Pensyve entity detection — canonicalization and fallback rules for recall scoping
+alwaysApply: true
+---
+
+# Entity Detection (Always-Apply Reference)
+
+Shared rules for detecting entity names from tool inputs, prompts, and conversation context. Used by the memory reflex and all memory-woven flows to scope recalls and `about_entity` fields on observations.
+
+## Inputs
+
+Extract candidate entity names from:
+
+1. **File references** — `@filename`, `@path/to/file`, or files mentioned directly in the conversation.
+2. **User prompts** — explicit references to components, files, services, research phases (e.g., "phase-4.3", "v7r-classifier", "auth-service").
+3. **Code context** — module names, class names, function names in files you are editing or reading.
+4. **Git context** — repository root name, branch name (when discoverable).
+
+## Canonicalization
+
+- Lowercase all characters.
+- Replace spaces and underscores with hyphens.
+- Strip file extensions unless the file is the entity itself (e.g., `package.json`).
+- Collapse paths to the most semantically meaningful segment (e.g., `src/engine/hybrid_router.rs` → `hybrid-router`; `tests/integration/auth_test.py` → `auth`).
+
+## Fallback behavior
+
+- If no specific entity is detected, fall back to the project-level entity (repository root name, lowercase-hyphenated).
+- If a candidate entity is ambiguous between two names, prefer the one that already has memories in Pensyve (call `pensyve_inspect` with limit 1 to check).
+- **Never fabricate entity names.** If nothing confident emerges, use the project entity.
+
+## Output
+
+A set of 1–3 candidate entity names per turn. The primary entity is the most specific; secondary entities provide additional context. Since `pensyve_recall` accepts only a single `entity` parameter, fold secondary entities into the `query` string instead.
+
+## Examples
+
+| Input | Primary entity | Secondary (fold into query) |
+|---|---|---|
+| Edit on `src/engine/hybrid_router.rs` | `hybrid-router` | `engine` |
+| Prompt: "tune V7r noise threshold" | `v7r` | `noise-threshold` |
+| File `tests/test_auth.py` in a project named `auth-service` | `auth` | `auth-service` |
+| User mentions "phase-4.3 calibration" | `phase-4.3` | `calibration` |

--- a/integrations/windsurf/.windsurf/rules/memory-informed-debug.md
+++ b/integrations/windsurf/.windsurf/rules/memory-informed-debug.md
@@ -1,0 +1,68 @@
+---
+description: Use when diagnosing bugs, errors, failing tests, or crashes — consult prior debug outcomes and capture root causes in-flight
+---
+
+# Memory-Informed Debug
+
+Debugging flow with memory baked in as a non-optional reflex. Follows `memory-reflex.md` for classification, surface style, and episode lifecycle.
+
+## Instructions
+
+### Step 1: Detect entities
+
+Identify the relevant entity/entities (failing test, failing module, error source) per `entity-detection.md`.
+
+### Step 2: Consult memory (required)
+
+Call `pensyve_recall`:
+
+- `query`: a short description of the failure, including secondary entity names where known (e.g., "hybrid-router threshold regression phase-4.3" rather than full stack traces)
+- `entity`: primary detected entity
+- `types`: `["procedural", "episodic"]` (debugging benefits most from known-good diagnostic procedures and prior incident outcomes)
+- `limit`: 5
+
+Secondary entities are folded into the query string since `RecallParams` scopes by a single `entity` only.
+
+Surface one line: `Recalled N memories from prior debug sessions on <entity>.` (Skip if N=0.)
+
+If a highly similar incident is found (score >0.8), call that out inline: `This looks similar to an incident captured on <date>: <summary>. Consider that path first.`
+
+### Step 3: Diagnose
+
+Proceed with the diagnostic work. Use recalled procedural memories as a starting sequence; update the sequence when you learn something new.
+
+### Step 4: Capture lesson (when it lands)
+
+When a root cause is **confirmed** (not just hypothesized), apply the memory reflex per `memory-reflex.md`:
+
+Ensure a working `episode_id` exists (lazy-open via `pensyve_episode_start` if not). Then:
+
+- **Episodic root cause:** call `pensyve_observe` with `content: "[proactive/in-flight/tier-1] <one-sentence root cause>"`, `source_entity: "windsurf"`, `about_entity: <primary_entity>`, `content_type: "text"`.
+- **Procedural diagnostic sequence:** if the debug produced a reusable diagnostic sequence, call `pensyve_observe` with `content: "[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=..."`, `source_entity: "windsurf"`, `about_entity: <primary_entity>`, `content_type: "text"`.
+- **Semantic durable truth:** if the root cause reveals a durable truth (e.g., "our CI runner's Python 3.10 cannot handle the new syntax"), also call `pensyve_remember(entity, fact, confidence: 0.9)`. Include provenance in the fact text: `"[proactive/in-flight/tier-1] <fact>"`.
+
+Surface one line: `↳ captured: <one-sentence>`.
+
+### Step 5: Capture abandoned approach
+
+If an approach was tried and abandoned, observe that too:
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[proactive/in-flight/tier-1] tried <approach>, abandoned because <reason>",
+  source_entity: "windsurf",
+  about_entity: <primary_entity>,
+  content_type: "text"
+)
+```
+
+These are high-value — they prevent re-treading the same dead end next time.
+
+## Constraints
+
+- Recall is **not optional**. If you skip recall to save time, you defeat the working-memory substrate.
+- Observe when a lesson **lands**, not when you first hypothesize.
+- One in-flight capture per turn unless multiple distinct lessons land simultaneously.
+- Respect the reflex rule's surface style — one line, not paragraphs.
+- Never store secrets or sensitive paths.

--- a/integrations/windsurf/.windsurf/rules/memory-informed-design.md
+++ b/integrations/windsurf/.windsurf/rules/memory-informed-design.md
@@ -1,0 +1,60 @@
+---
+description: Use when making architecture, API, or design decisions — consult prior decisions and capture new ones in-flight
+---
+
+# Memory-Informed Design
+
+Design flow with memory baked in as a non-optional reflex. Follows `memory-reflex.md`.
+
+## Instructions
+
+### Step 1: Detect entities
+
+Identify the relevant entity/entities (service, module, subsystem under design) per `entity-detection.md`.
+
+### Step 2: Consult memory (required)
+
+Call `pensyve_recall`:
+
+- `query`: a short description of the design question, including secondary entity names where known (e.g., "auth-service jwt signing rs256 hs256")
+- `entity`: primary detected entity
+- `types`: `["semantic", "episodic"]` (design benefits most from durable decisions and prior decision-contexts)
+- `limit`: 5
+
+Surface one line: `Recalled N prior decisions on <entity>.` (Skip if N=0.)
+
+### Step 3: Recommend with grounding
+
+Shape your recommendation using the recalled decisions. If the user's current question directly contradicts a prior decision, flag it:
+
+> Prior decision on `<entity>` (confidence 0.9): [decision]. Are we revisiting this, or does the current question differ?
+
+### Step 4: Capture decision (when it lands)
+
+When the user accepts a design or states a decision ("let's go with X", "we'll use Y"), apply the memory reflex:
+
+- **Semantic** — `pensyve_remember(entity: <primary_entity>, fact: "[proactive/in-flight/tier-1] <decision text>", confidence: 0.9)`.
+- **Episodic context** — ensure working `episode_id`; `pensyve_observe` with `content: "[proactive/in-flight/tier-1] Decision on <entity>: chose X over Y because Z"`, `source_entity: "windsurf"`, `about_entity: <primary_entity>`, `content_type: "text"`. This enables future "why did we decide X?" queries.
+
+Surface one line: `↳ captured decision on <entity>: <short>`.
+
+### Step 5: Capture evaluation procedures
+
+If the design process revealed a reusable way to evaluate similar decisions (e.g., "run spike vs. prototype", "check latency first"), capture it as procedural:
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[procedural] [proactive/in-flight/tier-1] trigger=design-question-on-<area>, action=<steps>, outcome=<what-you-learn>",
+  source_entity: "windsurf",
+  about_entity: <primary_entity>,
+  content_type: "text"
+)
+```
+
+## Constraints
+
+- Recall is **not optional**.
+- Observe when a decision **lands**, not when it's being discussed.
+- Budget: one in-flight capture per turn unless multiple decisions land.
+- Never store secrets or sensitive architecture details the user has marked private.

--- a/integrations/windsurf/.windsurf/rules/memory-informed-longitudinal-work.md
+++ b/integrations/windsurf/.windsurf/rules/memory-informed-longitudinal-work.md
@@ -1,0 +1,72 @@
+---
+description: Long-running multi-session work (research, eval loops, iterative benchmarks) — resume prior lessons, capture per-run outcomes, build up stable truths over time
+globs:
+  - "research/**"
+  - "benchmarks/**"
+  - "evals/**"
+---
+
+# Memory-Informed Longitudinal Work
+
+Multi-session engineering work (research, eval loops, iterative benchmarks) where lessons must accumulate across runs. The motivating case: improving a core algorithm over dozens of eval iterations without starting from scratch each session.
+
+Follows `memory-reflex.md`. Auto-attaches when editing files under `research/`, `benchmarks/`, or `evals/`, or when the model judges the conversation to be research-oriented.
+
+## Instructions
+
+### Step 1: Resume context at conversation start
+
+If this conversation is in a research/eval context, call `pensyve_recall` once at the start:
+
+- `query`: short description of the current research area (e.g., "v7r classifier calibration")
+- `entity`: project + sub-topic entity (per `entity-detection.md` canonicalization rules)
+- `limit`: 5
+
+No `types` filter — longitudinal work benefits from all three memory types; omit to query all. (Passing all three explicitly is equivalent to no filter; omitting is cleaner.)
+
+Surface: `Recalled N prior findings on <sub-topic>.`
+
+Treat the returned observations as working knowledge — do not re-ask the user about things the recall already surfaces.
+
+### Step 2: Proactively recall per topic shift
+
+When the session pivots to a new sub-topic (new phase, new eval subset, new failure mode), call `pensyve_recall` again scoped to the new sub-topic.
+
+### Step 3: Capture three types of memory per run
+
+During the session, classify emerging knowledge and capture accordingly. Ensure working `episode_id` before each observe.
+
+| What you learned | Type | MCP call |
+|---|---|---|
+| Per-run outcome (what this run showed) | episodic | `pensyve_observe(..., content: "[proactive/in-flight/tier-1] Run N+1: V7r accuracy improved +3.5% with new threshold", source_entity: "windsurf", about_entity: <entity>, content_type: "text")` |
+| Stable truth about the system | semantic | `pensyve_remember(entity, fact: "[proactive/in-flight/tier-1] Haiku classifier plateaus above temp 0.3", confidence: 0.9)` |
+| Reusable experiment procedure | procedural | `pensyve_observe(..., content: "[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=...", source_entity: "windsurf", about_entity: <entity>, content_type: "text")` |
+
+Apply at landing — do not batch.
+
+### Step 4: Capture open questions
+
+When a run ends with an unresolved question ("X improved but we don't know why"), capture it as an episodic observation with open-question provenance:
+
+```
+pensyve_observe(
+  episode_id: <working_id>,
+  content: "[proactive/in-flight/open-question] <question>",
+  source_entity: "windsurf",
+  about_entity: <entity>,
+  content_type: "text"
+)
+```
+
+This populates future "open questions" surfacing when the topic returns.
+
+### Step 5: End-of-session summary
+
+Before the conversation wraps, briefly summarize (inline, 3-5 lines): what this run taught us vs. prior runs, what's still open. This creates a natural handoff for the next session.
+
+## Constraints
+
+- Recall on every topic shift — not just at conversation start.
+- Capture at landing, not batched.
+- Never store run artifacts or large data blobs — summarize.
+- Respect the reflex's surface style.

--- a/integrations/windsurf/.windsurf/rules/memory-informed-refactor.md
+++ b/integrations/windsurf/.windsurf/rules/memory-informed-refactor.md
@@ -1,0 +1,59 @@
+---
+description: Use before substantive refactors — load relevant prior context, capture refactor insights as they land
+---
+
+# Memory-Informed Refactor
+
+Refactor flow with memory baked in. Follows `memory-reflex.md`.
+
+## Instructions
+
+### Step 1: Detect entities
+
+Identify the entities touched by the refactor (the file or module being restructured, its callers, the subsystem name) per `entity-detection.md`.
+
+### Step 2: Load prior context (required)
+
+Call `pensyve_recall`:
+
+- `query`: short description of the refactor (e.g., "hybrid-router routing logic restructure")
+- `entity`: primary detected entity
+- `types`: `["semantic", "episodic", "procedural"]` — refactors benefit from all three (durable invariants, prior attempts, known-good sequences)
+- `limit`: 5
+
+Surface: `Recalled N prior memories on <entity>.` (Skip if N=0.)
+
+Highlight any prior failed approaches inline:
+
+> Prior episodic memory (confidence 0.8): tried <approach> on <date>, abandoned because <reason>. Double-check this isn't the same trap.
+
+### Step 3: Present a briefing
+
+Before starting the refactor, briefly summarize what the prior memories say about:
+
+- **Decisions** — durable choices that constrain the refactor (semantic)
+- **Prior attempts** — what's been tried (episodic)
+- **Known-good procedures** — reusable sequences for this kind of refactor (procedural)
+
+If no relevant memories exist, say so clearly and proceed without historical context.
+
+### Step 4: Capture refactor lessons as they land
+
+When any of these occur during the refactor, apply the memory reflex immediately:
+
+- **An invariant is discovered** (semantic) — `pensyve_remember(entity, fact, confidence: 0.9)`
+- **An abandoned approach is confirmed not-viable** (episodic) — `pensyve_observe` with `[proactive/in-flight/tier-1]` provenance
+- **A dependency chain was traced that surprised us** (episodic) — `pensyve_observe`
+- **A known-good refactoring sequence emerged** (procedural) — `pensyve_observe` with `[procedural]` prefix
+
+Ensure working `episode_id` before each observe; lazy-open if needed.
+
+Do not batch these to end-of-session — capture at landing, surface one-line.
+
+## Constraints
+
+- The briefing step is the real value — it informs the refactor.
+- Observe at landing, not batched.
+- Entity names lowercase-hyphenated.
+- Do not start the refactor itself — this rule provides guidance and capture. The user decides when and how to proceed.
+- If the MCP server returns errors on some queries, present results from the successful queries and note the failures.

--- a/integrations/windsurf/.windsurf/rules/memory-reflex.md
+++ b/integrations/windsurf/.windsurf/rules/memory-reflex.md
@@ -1,0 +1,101 @@
+---
+description: Pensyve memory reflex — the non-optional reasoning discipline for working-memory substrate
+alwaysApply: true
+---
+
+# Memory Reflex Rule (Always-Apply)
+
+This rule is always in context. It turns Pensyve memory operations from optional actions into a reasoning discipline you carry through every substantive turn.
+
+## The rule
+
+**Before substantive answers, recall by entity. When a lesson lands, observe immediately with a one-line surface.**
+
+### "Substantive answer" means
+
+- Design or architecture recommendations
+- Debugging diagnoses with root-cause claims
+- Refactor proposals
+- Any response that makes a claim the user would want grounded in prior work
+
+Not substantive: formatting fixes, trivial lookups, reading a file, running a command.
+
+### "Lesson lands" means
+
+- A root cause has been confirmed (not hypothesized).
+- A design choice has been made explicit ("we'll use X because Y").
+- An approach has been tried and abandoned with a reason.
+- A workflow has been discovered that is reusable.
+- A workaround for a framework/library limitation has been validated.
+
+## Classification (which memory type?)
+
+- **Semantic** — a fact that will still be true next month. Use `pensyve_remember(entity, fact, confidence?)` (confidence defaults to 1.0; use 0.9 for high-confidence auto-captures).
+- **Episodic** — something that happened in this thread of work. Use `pensyve_observe` with the current `episode_id`.
+- **Procedural** — a reusable way to do something (a workflow, sequence, recipe). Use `pensyve_observe` with `content` beginning `[procedural]` (integration-layer convention; the MCP server has no native procedural-write API).
+
+When in doubt, prefer episodic. Server-side consolidation promotes recurring patterns to semantic automatically.
+
+## Canonical `pensyve_observe` call template
+
+ALL observe calls — in-flight, procedural, or wrap-up — MUST include every required field:
+
+```
+pensyve_observe(
+  episode_id: <current session's working episode_id>,
+  content: "[proactive/in-flight/tier-1] <observation text>",
+  source_entity: "windsurf",
+  about_entity: "<relevant entity, lowercase-hyphenated>",
+  content_type: "text"
+)
+```
+
+Use `content_type: "code"` for code-related outcomes.
+
+## Episode lifecycle (lazy-open)
+
+Windsurf has no session-start/session-end hooks, so you own the episode lifecycle:
+
+- **Before your first `pensyve_observe` call in this conversation**, check whether a working `episode_id` is already tracked. If none exists, call `pensyve_episode_start(participants: ["windsurf", "<project entity>"])` first, record the returned `episode_id`, then make the observation.
+- **Reuse the same `episode_id`** for all subsequent observations in the same conversation. Open a new episode only when the work's topic shifts substantially.
+- **Do not explicitly close** the episode under normal operation. Server-side consolidation handles aging.
+- **Recovery**: if `pensyve_observe` fails with a missing-episode error, call `pensyve_episode_start` and retry.
+
+## Surface style
+
+Lightly visible. One line when memory is used. Examples:
+
+- Recall: `Recalled 4 related memories (v7r, haiku-classifier).`
+- Capture: `↳ captured: hybrid-router threshold was the phase-3 regression root cause.`
+
+Do not narrate empty recalls or duplicate-skips.
+
+## Scope and budgets
+
+- Recall: scoped to detected entities (see `entity-detection.md`); limit 5; use `types` hint per flow.
+- Capture: one observation per substantive lesson; reuse the working `episode_id`.
+- Noise: avoid surfacing memory operations the user did not care about.
+
+## Composition with provenance tags
+
+When a capture is both procedural AND a proactive in-flight write, the `content` field begins with both markers, `[procedural]` first, then the provenance tag, then content:
+
+`[procedural] [proactive/in-flight/tier-1] trigger=..., action=..., outcome=...`
+
+The `[procedural]` marker identifies the memory type for consolidation. The provenance tag identifies origin and trigger.
+
+## Provenance tag vocabulary
+
+- `[proactive/in-flight/tier-1]` — memory reflex captured during reasoning
+- `[proactive/in-flight/open-question]` — unresolved question noted in-flight
+- `[auto-capture/user/residual/tier-1]` — explicit user-driven capture (e.g., session-memory rule)
+
+## MCP contract reminder
+
+Rules never pass unsupported parameters. The MCP tool schemas are:
+
+- `pensyve_recall(query, entity?, types?, limit?, min_confidence?)` — **no** `related_entities`
+- `pensyve_episode_start(participants)` — **no** `continuation_of`
+- `pensyve_observe(episode_id, content, source_entity, about_entity, content_type?)` — `source_entity` and `about_entity` are **required**
+
+If you need secondary-entity context in a recall, fold those entities into the `query` string.

--- a/integrations/windsurf/.windsurf/rules/session-memory.md
+++ b/integrations/windsurf/.windsurf/rules/session-memory.md
@@ -1,0 +1,84 @@
+---
+description: Use at conversation wrap-up or when the user explicitly indicates end-of-session — capture residual lessons not captured in-flight
+---
+
+# Session Memory (Wrap-Up)
+
+Windsurf has no automatic Stop hook. This rule is the manual equivalent: when the user indicates the conversation is ending ("thanks, that's all", "session wrap-up", "we're done here"), review what happened and capture anything the in-flight reflex missed.
+
+Follows `memory-reflex.md`.
+
+## Instructions
+
+### Step 1: Review the conversation
+
+Scan the current conversation for three categories of memorable content that the in-flight reflex did NOT already capture:
+
+**Decisions** (confidence: 0.9):
+- Architecture or design choices
+- Technology selections
+- API design decisions
+- Tradeoff resolutions
+
+**Outcomes** (confidence: 0.8):
+- Bug fixes and their root causes
+- Successful approaches
+- Failed approaches with reasons
+- Performance findings
+
+**Patterns** (confidence: 0.7):
+- Recurring issues
+- Workflow discoveries
+- Cross-cutting observations
+
+### Step 2: Filter for significance and deduplicate
+
+Skip routine, low-signal content. Also skip anything that was already captured in-flight.
+
+For each candidate, call `pensyve_recall` with `query: <candidate fact text>`, `entity: <candidate's entity>`, `limit: 3`. If any returned memory has a score ≥0.85 against the candidate, skip it as a likely duplicate.
+
+Note: `pensyve_inspect` cannot filter by `episode_id` (its params are `entity`, `memory_type?`, `limit?` only), so dedup is entity-scoped semantic-similarity rather than session-scoped. Consequence: very similar items captured in prior sessions will also trigger the skip — acceptable for avoiding genuine duplicates.
+
+### Step 3: Present candidates for confirmation
+
+Show the filtered candidates to the user in a structured format:
+
+> **Session Memory Candidates**
+>
+> **Decisions** (confidence: 0.9):
+> 1. `<entity>`: <decision text>
+>
+> **Outcomes** (confidence: 0.8):
+> 2. `<entity>`: <outcome text>
+>
+> **Patterns** (confidence: 0.7):
+> 3. `<entity>`: <pattern text>
+>
+> Which should I store? (e.g., "all", "1,3", "none")
+
+### Step 4: Store confirmed items
+
+For each confirmed item, classify the type and call the appropriate MCP tool:
+
+- **Semantic** (decisions, durable truths) — `pensyve_remember(entity, fact: "[auto-capture/user/residual/tier-1] <text>", confidence)`. Use confidence from the categorization above.
+- **Episodic** (outcomes, session-specific events) — ensure working `episode_id`; `pensyve_observe(episode_id, content: "[auto-capture/user/residual/tier-1] <text>", source_entity: "windsurf", about_entity: <entity>, content_type: "text")`.
+- **Procedural** (reusable workflows) — `pensyve_observe(episode_id, content: "[procedural] [auto-capture/user/residual/tier-1] trigger=..., action=..., outcome=...", source_entity: "windsurf", about_entity: <entity>, content_type: "text")`.
+
+### Step 5: Optionally close the episode
+
+If the user indicates this is a final wrap (not just a turn-by-turn pause), call `pensyve_episode_end(episode_id: <working_id>, outcome: "success")`. Valid outcomes: `"success"`, `"failure"`, `"partial"`.
+
+Not closing is safe — server-side consolidation ages episodes naturally. Only close when the user clearly marks the work complete.
+
+### Step 6: Report
+
+After storing, summarize:
+
+> Stored N memories. Episode <outcome> closed.
+
+## Constraints
+
+- **Never auto-store.** Every candidate MUST be presented to the user for confirmation before storage.
+- Entity names lowercase-hyphenated.
+- Do not store secrets.
+- If nothing significant surfaced, say so clearly rather than forcing low-quality memories.

--- a/integrations/windsurf/CHANGELOG.md
+++ b/integrations/windsurf/CHANGELOG.md
@@ -1,0 +1,43 @@
+# Changelog — Pensyve Windsurf Adapter
+
+All notable changes to the Pensyve Windsurf adapter are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). The Windsurf adapter versions independently of the Claude Code plugin.
+
+## [1.0.0] - 2026-04-20
+
+### Added
+
+- **Working-memory substrate** for Windsurf via `.windsurf/rules/*.md` files. Eight rule files deliver the substrate the Claude Code plugin v1.3.0 established:
+  - `memory-reflex.md` (alwaysApply: true) — non-optional reasoning discipline with three-type memory classification, canonical `pensyve_observe` call template, provenance vocabulary, lazy-open episode lifecycle
+  - `entity-detection.md` (alwaysApply: true) — canonicalization and fallback rules
+  - `memory-informed-debug.md` — debug flow (description-scoped)
+  - `memory-informed-design.md` — design flow (description-scoped)
+  - `memory-informed-refactor.md` — refactor flow (description-scoped)
+  - `memory-informed-longitudinal-work.md` — research/eval flow (description-scoped + globs for `research/**`, `benchmarks/**`, `evals/**`)
+  - `session-memory.md` — manual wrap-up equivalent of Claude Code's Stop hook (description-scoped)
+  - `context-loader.md` — best-effort continuity primer via episodic recall (description-scoped)
+- **MCP config example** at `.windsurf/mcp_config.json.example` covering Cloud-with-serverUrl and Local-stdio options
+- **Static MCP contract lint script** at `scripts/lint-mcp-refs.sh` verifying every rule's `pensyve_*` call example matches the `pensyve-mcp-tools/src/params.rs` schema
+
+### Design
+
+- Single reasoning layer; no platform-layer code. Windsurf (Cascade) has no hook/event surface, so the entire adapter is rules the model interprets.
+- Windsurf's modern directory-based rules format (`.windsurf/rules/*.md`) used with MDC-like frontmatter (`alwaysApply:`, `description:`, `globs:`).
+- Mirrors the Cursor adapter's structure closely — Windsurf is a VSCode fork with similar rules-attachment semantics.
+- Lazy-open episode lifecycle: first `pensyve_observe` call triggers `pensyve_episode_start`; episodes are not explicitly closed.
+- Best-effort continuity primer via `pensyve_recall(types: ["episodic"])` — the MCP server has no episode-listing API.
+- MCP contract verified: no `related_entities` on recall, no `continuation_of` on episode_start, required `source_entity: "windsurf"` and `about_entity` on every observe.
+- Opt-out: delete or edit rule files (Windsurf-native pattern); no parallel config file.
+
+### Not Included
+
+- No extension or platform-layer code (deferred to a future sibling spec if capability gaps surface)
+- No installer script (manual copy of rules + MCP config)
+- No server-side changes — uses the existing MCP tool surface
+
+### Relation to Other Pensyve Integrations
+
+- The Windsurf adapter is part of the batch-1 working-memory substrate rollout. The Cursor adapter (v1.0.0) and Claude Code plugin (v1.3.0) are the reference implementations.
+- Spec: `pensyve-docs/specs/2026-04-20-pensyve-cursor-adapter-design.md`
+- Playbook: `pensyve-docs/specs/2026-04-18-pensyve-working-memory-substrate-design.md`

--- a/integrations/windsurf/README.md
+++ b/integrations/windsurf/README.md
@@ -1,31 +1,28 @@
 # Pensyve for Windsurf
 
-Persistent AI memory for [Windsurf](https://codeium.com/windsurf) via MCP.
+Persistent working-memory substrate for [Windsurf](https://codeium.com/windsurf) — memory is not a feature you invoke, it is the substrate the agent operates on.
 
-## Authentication
+## What It Does
 
-1. Sign up at [pensyve.com](https://pensyve.com)
-2. Create an API key at [Settings → API Keys](https://pensyve.com/settings/api-keys)
-3. Set the environment variable:
-   ```bash
-   export PENSYVE_API_KEY="psy_your_key_here"
-   ```
+- **Proactive memory during work** — lessons are captured the moment they land, not at session end
+- **Thread-aware continuity** — sessions that continue prior work resume with relevant context, no re-briefing
+- **Entity-scoped recall** — substantive questions are grounded in prior decisions; simple commands stay fast
+- **Three memory types** — durable facts (semantic), session-specific events (episodic), reusable procedures (procedural)
+- **Lightly visible** — one-line surfaces when memory is used; never interrupts your flow
 
-Then configure MCP with headers (see setup instructions above).
+## Install
 
-## Setup
+Two steps: configure the MCP server, then install the rules.
 
-Set your API key (get one at [pensyve.com/settings/api-keys](https://pensyve.com/settings/api-keys)):
+### 1. Configure the MCP server
+
+Copy `.windsurf/mcp_config.json.example` to `~/.codeium/windsurf/mcp_config.json` (global) or keep it in your project's `.windsurf/` directory and edit for your setup.
+
+**Cloud with API key (recommended):**
 
 ```bash
-export PENSYVE_API_KEY="psy_your_key"
+export PENSYVE_API_KEY="psy_your_key_here"
 ```
-
-Add to your shell profile (`~/.bashrc`, `~/.zshrc`) to persist across sessions.
-
-## Cloud (Recommended)
-
-Add to `~/.codeium/windsurf/mcp_config.json`:
 
 ```json
 {
@@ -40,11 +37,9 @@ Add to `~/.codeium/windsurf/mcp_config.json`:
 }
 ```
 
-> Use `headers` with `Authorization: Bearer` for remote MCP. The `env` block is for local stdio servers.
+Create your key at [pensyve.com/settings/api-keys](https://pensyve.com/settings/api-keys). Put the `export` in `~/.bashrc` or `~/.zshrc` to persist.
 
-## Local (Offline)
-
-No API key needed — all data stays on your machine.
+**Local (offline, self-hosted):**
 
 ```json
 {
@@ -61,40 +56,91 @@ No API key needed — all data stays on your machine.
 }
 ```
 
-Build from source: `cargo build --release -p pensyve-mcp` from the [pensyve repo](https://github.com/major7apps/pensyve).
+Build the binary: `cargo build --release -p pensyve-mcp` from the [pensyve repo](https://github.com/major7apps/pensyve).
 
-## Available Tools
+### 2. Install the rules
 
-| Tool                    | Description                            |
-| ----------------------- | -------------------------------------- |
-| `pensyve_recall`        | Search memories by semantic similarity |
-| `pensyve_remember`      | Store a fact as semantic memory        |
-| `pensyve_episode_start` | Begin tracking an interaction          |
-| `pensyve_episode_end`   | Close an episode                       |
-| `pensyve_forget`        | Delete an entity's memories            |
-| `pensyve_inspect`       | List memories for an entity            |
-| `pensyve_status`        | Connection and memory stats            |
-| `pensyve_account`       | Plan and usage info                    |
+Copy the rule files into your project's `.windsurf/rules/` directory:
+
+```bash
+mkdir -p .windsurf/rules
+cp /path/to/pensyve/integrations/windsurf/.windsurf/rules/*.md .windsurf/rules/
+```
+
+Windsurf loads rules from `.windsurf/rules/` using MDC-like frontmatter. Rules with `alwaysApply: true` activate in every conversation; others activate based on their `description` and `globs`.
+
+| Rule | When it activates |
+|---|---|
+| `memory-reflex.md` | Always (establishes the reasoning discipline) |
+| `entity-detection.md` | Always (canonicalization reference) |
+| `memory-informed-debug.md` | When diagnosing bugs, errors, failing tests, crashes |
+| `memory-informed-design.md` | When making architecture, API, or design decisions |
+| `memory-informed-refactor.md` | Before substantive refactors |
+| `memory-informed-longitudinal-work.md` | In `research/**`, `benchmarks/**`, `evals/**` directories, or when the model judges the conversation to be research-oriented |
+| `session-memory.md` | At conversation wrap-up or explicit end-of-session |
+| `context-loader.md` | When starting a new substantive conversation or switching contexts |
+
+## How It Works
+
+Windsurf is a VSCode fork with Cascade as its AI backbone. Like Cursor, it has no hook/event surface, so the entire substrate is delivered through the rules the model interprets during reasoning. `memory-reflex.md` establishes the discipline: *before substantive answers, recall by entity; when a lesson lands, observe immediately with a one-line surface*. Flow rules (debug/design/refactor/longitudinal-work) activate when relevant and guide the model through consult-memory + capture-lesson steps.
+
+**Episode lifecycle:** Windsurf has no session-start/session-end hooks, so episodes open lazily on the first `pensyve_observe` call and are not explicitly closed under normal operation. Server-side consolidation handles aging.
+
+**Continuity primer:** `context-loader.md` runs a best-effort recall at the start of substantive conversations to surface prior relevant observations. Not a structured server-side link — the MCP server has no episode-listing API yet — but good enough to create the "continuing prior work" feel.
+
+## Memory Behavior Model
+
+Pensyve behaves as working memory for the agent — always-on, ambient, continuous.
+
+**Writes happen in-flight.** When a root cause is confirmed, a decision is made, or a reusable procedure emerges, it's captured the moment it lands via the memory reflex. No batching to session end.
+
+**Reads happen at decision points.** Before substantive answers, the model consults memory scoped to the detected entities. Simple commands (run tests, format file) skip recall to stay fast.
+
+**Sessions continue.** At the start of a substantive conversation, Pensyve checks whether the current work continues prior memories (shared entities + recent activity). If yes, you resume with a primer — no re-briefing needed.
+
+## Memory Types
+
+| Type | Definition | MCP call | Example |
+|---|---|---|---|
+| **Semantic** | Durable truths, decisions, preferences | `pensyve_remember` | "We chose RS256 over HS256 for JWT signing" |
+| **Episodic** | Temporal events, session-scoped observations | `pensyve_observe` (with lazy-opened `episode_id`) | "Phase-3 regression root cause: hybrid-router threshold" |
+| **Procedural** | Reusable workflows, sequences, recipes | `pensyve_observe` with `[procedural]` content prefix | "To calibrate V7r: freeze Haiku config, run suite, diff baseline" |
+
+## Opt-Out
+
+- **Full opt-out** — delete the Pensyve rule files from `.windsurf/rules/`
+- **Partial opt-out** — delete specific flow rules (e.g., remove `memory-informed-longitudinal-work.md` if you don't do research work)
+- **Silent mode** — edit `memory-reflex.md` to remove the "one-line surface" guidance; captures stay silent
+- **Recall-only mode** — edit flow rules to drop the `Capture lesson` steps while keeping `Consult memory`
+
+## Available MCP Tools
+
+| Tool | Description |
+|---|---|
+| `pensyve_recall` | Search memories by semantic similarity |
+| `pensyve_remember` | Store a durable fact (semantic memory) |
+| `pensyve_observe` | Record a session observation (episodic / procedural via `[procedural]` prefix) |
+| `pensyve_episode_start` | Begin tracking an episode |
+| `pensyve_episode_end` | Close an episode with outcome |
+| `pensyve_forget` | Delete an entity's memories |
+| `pensyve_inspect` | List memories for an entity |
 
 See [MCP Tools Reference](https://pensyve.com/docs/api-reference/mcp-tools) for full parameter details.
 
-## Intelligent Memory Capture
+## Design Philosophy
 
-Pensyve uses a tiered classification system to identify what is worth remembering. Since Windsurf connects via MCP only, the LLM follows the MCP tool descriptions to decide when and how to call memory tools.
+- **Memory as substrate** — not a feature the user invokes; always there, continuous, carried across sessions
+- **Reasoning-layer only** — no platform-layer code in v1; the entire adapter is rules
+- **1:1 with Claude Code** — same skill structure, same conventions, same memory types
+- **MCP contract-respecting** — every rule's call examples verified against `pensyve-mcp-tools/src/params.rs`
 
-### Tiered Capture System
+## Links
 
-- **Tier 1** (auto-store, confidence 0.9+): Explicit decisions, corrections, constraints, architecture choices, dependency version pins, security rules. High-signal items that should almost always be captured.
-- **Tier 2** (review, confidence 0.7-0.89): Root causes, failed approaches, performance findings, debugging outcomes, environment quirks. Medium-signal items that benefit from user confirmation.
-- **Discard**: Formatting, typos, boilerplate, ephemeral status messages. Noise that should never be stored.
+- **Website:** [pensyve.com](https://pensyve.com)
+- **GitHub:** [github.com/major7apps/pensyve](https://github.com/major7apps/pensyve)
+- **Spec:** [Cursor adapter design](https://github.com/major7apps/pensyve-docs/blob/main/specs/2026-04-20-pensyve-cursor-adapter-design.md)
+- **Playbook:** [Working-memory substrate design](https://github.com/major7apps/pensyve-docs/blob/main/specs/2026-04-18-pensyve-working-memory-substrate-design.md)
 
-### Best Practices
+## License
 
-For the best experience with Windsurf, guide the LLM to use Pensyve's memory tools effectively:
-
-- Use `pensyve_observe` to record significant events during an episode (architecture decisions, failed approaches, key findings)
-- Use `pensyve_remember` for durable facts that should persist across sessions (project conventions, environment constraints, resolved issues)
-- Use `pensyve_recall` at the start of a task to load relevant context from prior sessions
-- Wrap multi-step work in `pensyve_episode_start` / `pensyve_episode_end` to capture episodic context
-
-The MCP tool descriptions include guidance on confidence levels so the LLM can classify memories into the appropriate tier automatically.
+Apache 2.0

--- a/integrations/windsurf/scripts/lint-mcp-refs.sh
+++ b/integrations/windsurf/scripts/lint-mcp-refs.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Static MCP contract linter for the Pensyve Windsurf adapter rules.
+#
+# Verifies that every pensyve_* call example in .windsurf/rules/*.md conforms to
+# the current MCP tool schema in pensyve-mcp-tools/src/params.rs. Catches the
+# category of bug PR #58 surfaced in the Claude Code adapter (unsupported
+# parameters, missing required fields).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RULES_DIR="$SCRIPT_DIR/../.windsurf/rules"
+
+EXIT_CODE=0
+
+if [ ! -d "$RULES_DIR" ]; then
+  echo "ERROR: Rules directory not found: $RULES_DIR"
+  exit 1
+fi
+
+echo "Linting MCP references in $RULES_DIR..."
+echo ""
+
+# Check 1: no actual use of unsupported 'related_entities' parameter in call examples.
+# We look for pensyve_recall( blocks that contain related_entities as a parameter.
+# Lines that say "no related_entities" (documentation/reminders) are excluded.
+echo "Check 1: no unsupported 'related_entities' on pensyve_recall"
+FOUND_RELATED=0
+for rule_file in "$RULES_DIR"/*.md; do
+  # Extract lines that contain pensyve_recall( and related_entities together,
+  # excluding documentation lines (those containing "**no**" or "no `related_entities`")
+  if rg -n 'related_entities' "$rule_file" | rg -v '(\*\*no\*\*|no `related_entities`)' | rg -q 'pensyve_recall\|related_entities'; then
+    echo "  FAIL in $rule_file: 'related_entities' used in a pensyve_recall call"
+    FOUND_RELATED=1
+  fi
+  # Also catch if related_entities appears inside a pensyve_recall( block
+  awk '/pensyve_recall\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+         if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
+           print FILENAME ": related_entities found in pensyve_recall block: " buf;
+         capture=0
+       }' "$rule_file" | while read -r line; do
+    if [ -n "$line" ]; then
+      echo "  FAIL: $line"
+      FOUND_RELATED=1
+    fi
+  done
+done
+if [ "$FOUND_RELATED" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 2: no actual use of unsupported 'continuation_of' parameter in call examples.
+# Documentation lines saying "no continuation_of" are excluded.
+echo "Check 2: no unsupported 'continuation_of' on pensyve_episode_start"
+FOUND_CONT=0
+for rule_file in "$RULES_DIR"/*.md; do
+  awk '/pensyve_episode_start\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+         if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
+           print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
+         capture=0
+       }' "$rule_file" | while read -r line; do
+    if [ -n "$line" ]; then
+      echo "  FAIL: $line"
+      FOUND_CONT=1
+    fi
+  done
+done
+if [ "$FOUND_CONT" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 3: every pensyve_observe call example in a code block has source_entity and about_entity
+# Scan each .md file's pensyve_observe blocks; require both fields nearby.
+echo "Check 3: every pensyve_observe example has source_entity and about_entity"
+MISSING_FIELDS=0
+for rule_file in "$RULES_DIR"/*.md; do
+  # Find each pensyve_observe( block (up to the next closing paren within 20 lines)
+  awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
+       capture {buf = buf "\n" $0;
+                for(i=1; i<=length($0); i++){
+                  c=substr($0,i,1);
+                  if(c=="(") depth++;
+                  if(c==")") depth--;
+                };
+                if(depth==0 && buf ~ /pensyve_observe\(/){
+                  if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
+                  if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
+                  capture=0;
+                }}' "$rule_file" | while read -r line; do
+    if [ -n "$line" ]; then
+      echo "  FAIL: $line"
+      MISSING_FIELDS=1
+    fi
+  done
+done
+if [ "$MISSING_FIELDS" = "0" ]; then
+  echo "  PASS"
+else
+  EXIT_CODE=1
+fi
+echo ""
+
+# Check 4: provenance tag format — every proactive/auto-capture tag uses [<origin>/<trigger>/<tier>]
+# Format supports both 3-segment [origin/trigger/tier] and 4-segment [origin/trigger/residual/tier]
+# where the third segment may be a literal "residual" qualifier before the tier.
+echo "Check 4: provenance tag format"
+VALID_PROVENANCE_RE='\[(proactive|auto-capture)/(in-flight|stop|pre-compact|curator|user)/(tier-1|tier-2|residual/tier-1|residual/tier-2|open-question)\]'
+if rg -n '\[(proactive|auto-capture)' "$RULES_DIR" | rg -v "$VALID_PROVENANCE_RE"; then
+  echo "  FAIL: some provenance tags do not match [<origin>/<trigger>/<tier>] format"
+  EXIT_CODE=1
+else
+  echo "  PASS"
+fi
+echo ""
+
+# Check 5: procedural memory convention — [procedural] prefix is used in observe content
+echo "Check 5: procedural convention uses [procedural] prefix in pensyve_observe content"
+# Only a warning if no rule mentions [procedural] — may be legitimate if the rule is non-procedural
+if ! rg -q '\[procedural\]' "$RULES_DIR"; then
+  echo "  WARN: no [procedural] prefix usage found across rules. Expected in memory-reflex and flow rules that handle procedural captures."
+else
+  echo "  PASS"
+fi
+echo ""
+
+if [ "$EXIT_CODE" = "0" ]; then
+  echo "All MCP contract checks PASSED."
+else
+  echo "MCP contract checks FAILED. Fix the issues above before committing."
+fi
+
+exit "$EXIT_CODE"

--- a/integrations/windsurf/scripts/lint-mcp-refs.sh
+++ b/integrations/windsurf/scripts/lint-mcp-refs.sh
@@ -34,18 +34,18 @@ for rule_file in "$RULES_DIR"/*.md; do
     FOUND_RELATED=1
   fi
   # Also catch if related_entities appears inside a pensyve_recall( block
-  awk '/pensyve_recall\(/{capture=1; buf=""}
-       capture {buf = buf "\n" $0}
-       capture && /\)/{
-         if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
-           print FILENAME ": related_entities found in pensyve_recall block: " buf;
-         capture=0
-       }' "$rule_file" | while read -r line; do
+  while read -r line; do
     if [ -n "$line" ]; then
       echo "  FAIL: $line"
       FOUND_RELATED=1
     fi
-  done
+  done < <(awk '/pensyve_recall\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+       if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
+       print FILENAME ": related_entities found in pensyve_recall block: " buf;
+       capture=0
+       }' "$rule_file")
 done
 if [ "$FOUND_RELATED" = "0" ]; then
   echo "  PASS"
@@ -59,18 +59,18 @@ echo ""
 echo "Check 2: no unsupported 'continuation_of' on pensyve_episode_start"
 FOUND_CONT=0
 for rule_file in "$RULES_DIR"/*.md; do
-  awk '/pensyve_episode_start\(/{capture=1; buf=""}
-       capture {buf = buf "\n" $0}
-       capture && /\)/{
-         if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
-           print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
-         capture=0
-       }' "$rule_file" | while read -r line; do
+  while read -r line; do
     if [ -n "$line" ]; then
       echo "  FAIL: $line"
       FOUND_CONT=1
     fi
-  done
+  done < <(awk '/pensyve_episode_start\(/{capture=1; buf=""}
+       capture {buf = buf "\n" $0}
+       capture && /\)/{
+       if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
+       print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
+       capture=0
+       }' "$rule_file")
 done
 if [ "$FOUND_CONT" = "0" ]; then
   echo "  PASS"
@@ -85,23 +85,23 @@ echo "Check 3: every pensyve_observe example has source_entity and about_entity"
 MISSING_FIELDS=0
 for rule_file in "$RULES_DIR"/*.md; do
   # Find each pensyve_observe( block (up to the next closing paren within 20 lines)
-  awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
-       capture {buf = buf "\n" $0;
-                for(i=1; i<=length($0); i++){
-                  c=substr($0,i,1);
-                  if(c=="(") depth++;
-                  if(c==")") depth--;
-                };
-                if(depth==0 && buf ~ /pensyve_observe\(/){
-                  if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
-                  if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
-                  capture=0;
-                }}' "$rule_file" | while read -r line; do
+  while read -r line; do
     if [ -n "$line" ]; then
       echo "  FAIL: $line"
       MISSING_FIELDS=1
     fi
-  done
+  done < <(awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
+       capture {buf = buf "\n" $0;
+       for(i=1; i<=length($0); i++){
+       c=substr($0,i,1);
+       if(c=="(") depth++;
+       if(c==")") depth--;
+       };
+       if(depth==0 && buf ~ /pensyve_observe\(/){
+       if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
+       if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
+       capture=0;
+       }}' "$rule_file")
 done
 if [ "$MISSING_FIELDS" = "0" ]; then
   echo "  PASS"


### PR DESCRIPTION
## Summary

Ships the **Pensyve working-memory substrate** to every Pensyve integration in one unified PR. Replaces individual per-integration PRs with a single coordinated rollout per the integration playbook in `pensyve-docs/specs/2026-04-18-pensyve-working-memory-substrate-design.md`.

- **21 integrations** (Claude Code v1.3.0 previously shipped; Cursor + 19 others ship in this PR)
- **33 commits** total on the branch (13 Cursor + 20 other-integration commits)
- **Memory is now the substrate, not a feature** — every Pensyve-integrated agent gets proactive in-flight capture, entity-scoped recall, three-type memory support (semantic/episodic/procedural), and lazy-open episode lifecycle

## Integrations shipped in this PR

**Rules-based IDEs** — port of Cursor's 8-rule substrate adapted to each tool's native rules-file format:

- **Cursor** — `.cursor/rules/*.mdc` (8 files, MDC frontmatter)
- **Cline** — `.clinerules/*.md`
- **Continue** — `.continue/rules/*.md` with YAML frontmatter
- **Windsurf** — `.windsurf/rules/*.md` with MDC-like frontmatter
- **Kiro** — `.kiro/steering/*.md`
- **VS Code Copilot** — consolidated `.github/copilot-instructions.md` (platform constraint: single file)

**CLI plugins** — substrate via single `AGENTS.md` consolidation:

- **Codex plugin** — additive alongside existing hooks/skills
- **opencode plugin** — coexists with native TypeScript plugin
- **openclaw plugin** — additive to existing plugin manifest + src/
- **hermes** — additive to existing Python MemoryProvider

**Editor extensions** — substrate via `instructions/*.md` directory; existing code untouched:

- **VS Code extension** — bumped 1.2.0 → 1.3.0; no .ts changes
- **JetBrains** — stub-to-full integration
- **Neovim** — stub-to-full, with per-plugin guidance for avante.nvim, codecompanion.nvim, MCPHub.nvim

**Library SDKs** — substrate via `SUBSTRATE_PROMPT.md` + framework-specific wiring example:

- **LangChain Python** (`examples/pensyve_agent.py` using `langchain-mcp-adapters` `MultiServerMCPClient`)
- **LangChain TypeScript** (`@langchain/mcp-adapters`, ESM)
- **AutoGen** (`autogen-ext[mcp]` `McpWorkbench` + `StreamableHttpServerParams`)
- **CrewAI** (`crewai-tools MCPServerAdapter`; substrate via `backstory=` per CrewAI idiom)
- **Pydantic AI** (native `MCPServerHTTP` + `agent.run_mcp_servers()` context manager)
- **Google ADK** (`MCPToolset` + `StreamableHTTPConnectionParams`)

**Cloud/other:**

- **Amazon Q** — `.amazonq/rules/*.md` directory
- **Gemini Extension** — consolidated `GEMINI.md`

## Cross-cutting artifacts per integration

- Substrate rule content (adapted to each tool's native format)
- `README.md` rewritten with substrate behavior section + install instructions
- `CHANGELOG.md` with `[1.0.0] - 2026-04-20` entry (or `[1.3.0]` for VS Code)
- MCP config example appropriate to the integration's config surface
- `scripts/lint-mcp-refs.sh` — static MCP-contract linter (all 5 checks passing per integration)
- Consistent `source_entity` naming per platform (`cline`, `continue`, `windsurf`, `langchain`, etc.)

## MCP contract fidelity

Every `pensyve_*` call example across all 21 integrations has been verified against `pensyve-mcp-tools/src/params.rs`:

- No `related_entities` on `pensyve_recall` (use `entity` + fold secondary entities into `query`)
- No `continuation_of` on `pensyve_episode_start` (only `participants`)
- `source_entity` + `about_entity` required on every `pensyve_observe`
- Procedural captures use `[procedural]` content prefix; composition with provenance is `[procedural] [<origin>/<trigger>/<tier>] ...`

## Format-adaptation notes

- **Single-file vs directory** — tools that require a single instructions file (VS Code Copilot, Gemini, Codex, opencode, openclaw, hermes, all library SDKs) consolidate the 8 Cursor rules into one well-sectioned document; tools that support directory-based rules (Cursor, Cline, Continue, Windsurf, Kiro, Amazon Q, VS Code extension, JetBrains, Neovim) use the 8-file layout.
- **MDC frontmatter** — retained on Cursor/Windsurf (which support it); stripped on tools that don't parse it; `description:` kept where meaningful for semantic activation.
- **Lazy-open episode lifecycle** — all integrations share the same model: first `pensyve_observe` call triggers `pensyve_episode_start`; episodes are not explicitly closed; server-side consolidation handles aging.

## Test plan

Merge-time automated checks:
- [ ] CI: Lint, Rust Tests (3 suites), Python/TypeScript/Go/WASM Tests, Gateway Build & Test, Claude Code Review, Seer Code Review

Post-merge validation (opportunistic; organic validation over real use):
- [ ] Rules-based IDEs: spot-check continuity primer, in-flight capture, proactive recall, all three memory types in one session per integration
- [ ] Library SDKs: run the provided example file against Pensyve Cloud or local `pensyve-mcp` binary; verify memories land with correct `source_entity` and `about_entity`

## Follow-ups (sibling specs/plans)

- Automated behavioral eval harness (replays + continuity + noise + cross-integration conformance)
- Per-integration platform-layer upgrades for extensions with existing code (VS Code, JetBrains, Neovim) if users request deeper hook-like features
- New integrations as they appear (not in scope here)

## Spec + documentation references

- **Playbook (cross-integration contract):** `pensyve-docs/specs/2026-04-18-pensyve-working-memory-substrate-design.md`
- **Cursor adapter spec:** `pensyve-docs/specs/2026-04-20-pensyve-cursor-adapter-design.md`
- **Claude Code reference impl:** shipped in `pensyve` v1.3.0 (PR #58, merged 2026-04-20)