### PR TITLE
feat(pensyve-core): LocalLLMExtractor for offline-first observation extraction

### DIFF
--- a/pensyve-core/src/observation.rs
+++ b/pensyve-core/src/observation.rs
@@ -371,7 +371,14 @@ Output ONLY a JSON array of objects. No prose, no explanation, no markdown fence
         episode_id: Uuid,
         event_time: Option<DateTime<Utc>>,
     ) -> ObservationMemory {
-        let content = format_observation_content(&raw, event_time);
+        // Embed the bare fact only — `event_time` lives in metadata. The
+        // earlier `[YYYY-MM-DD]` prefix would have stamped the *episode-max*
+        // timestamp into every observation (since extractors derive event_time
+        // as `messages.iter().filter_map(|m| m.event_time).max()`); for any
+        // backfilled or multi-day episode that misdates per-fact text and
+        // skews temporal recall. Leaving date attribution to readers/UI keeps
+        // the embedding text faithful to the underlying turn.
+        let content = format_observation_content(&raw);
         let mut obs = ObservationMemory::new(
             namespace_id,
             episode_id,
@@ -388,27 +395,17 @@ Output ONLY a JSON array of objects. No prose, no explanation, no markdown fence
     }
 
     /// Render a human-readable sentence used as the embedding + display content.
-    /// When `event_time` is known it is prefixed as `[YYYY-MM-DD] ` so the
-    /// observation is a self-contained date+fact string at recall time —
-    /// without the prefix, temporal-reasoning readers have to cross-reference
-    /// session-block headers to learn *when* a fact applies. Sprint doc 20's
-    /// pipeline relied on the outer reader prompt to attach dates; v1.1 moves
-    /// that responsibility into the observation itself so any reader that
-    /// simply concatenates content strings gets the date for free.
-    fn format_observation_content(
-        raw: &RawObservation,
-        event_time: Option<DateTime<Utc>>,
-    ) -> String {
+    /// Date attribution lives in `ObservationMemory::event_time` (metadata),
+    /// not in the embedded text — extractors only know the episode-max
+    /// timestamp, which would misdate per-fact content for any backfilled or
+    /// multi-day episode. Readers/UI that need a date can format from metadata.
+    fn format_observation_content(raw: &RawObservation) -> String {
         let base = format!("{} {}", raw.action, raw.instance);
-        let body = match (raw.quantity, raw.unit.as_deref()) {
+        match (raw.quantity, raw.unit.as_deref()) {
             (Some(q), Some(u)) => format!("{base} ({q} {u})"),
             (Some(q), None) => format!("{base} ({q})"),
             (None, Some(u)) => format!("{base} ({u})"),
             (None, None) => base,
-        };
-        match event_time {
-            Some(t) => format!("[{}] {}", t.format("%Y-%m-%d"), body),
-            None => body,
         }
     }
 
@@ -695,9 +692,12 @@ Output ONLY a JSON array of objects. No prose, no explanation, no markdown fence
         }
 
         #[test]
-        fn content_prefixes_event_date_when_present() {
-            // v1.1: observations carry their date inline so temporal-reasoning
-            // readers don't have to cross-reference session-block headers.
+        fn content_excludes_date_prefix_event_time_in_metadata_only() {
+            // Per PR #72 review (codex P1): observations must NOT embed
+            // `[YYYY-MM-DD]` into content because extractors only have access
+            // to episode-max event_time, which misdates every per-fact string
+            // in a backfilled / multi-day episode. Content stays plain;
+            // event_time lives only in ObservationMemory metadata.
             let raw = RawObservation {
                 entity_type: "degree_earned".into(),
                 instance: "Business Administration".into(),
@@ -712,16 +712,12 @@ Output ONLY a JSON array of objects. No prose, no explanation, no markdown fence
                     .with_timezone(&Utc),
             );
             let obs = raw_to_observation(raw, Uuid::new_v4(), Uuid::new_v4(), event_time);
-            assert_eq!(obs.content, "[2024-05-10] graduated with Business Administration (1)");
+            assert_eq!(obs.content, "graduated with Business Administration (1)");
             assert_eq!(obs.event_time, event_time);
         }
 
         #[test]
-        fn content_omits_prefix_when_event_time_absent() {
-            // Keeps zero-cost fallback for callers without a date (unit tests,
-            // extractors that fail to resolve event_time). Matches the pre-v1.1
-            // format so ObservationMemory rows built without a date still embed
-            // cleanly against existing vector indexes.
+        fn content_omits_date_when_event_time_absent() {
             let raw = RawObservation {
                 entity_type: "task_tried".into(),
                 instance: "Todoist".into(),
@@ -747,7 +743,7 @@ pub use haiku::{AnthropicHaikuExtractor, EXTRACTION_PROMPT_V1};
 #[cfg(feature = "observation-extraction")]
 mod localllm {
     use super::haiku::{
-        EXTRACTION_PROMPT_V1, RawObservation, parse_response, raw_to_observation,
+        AnthropicHaikuExtractor, RawObservation, parse_response, raw_to_observation,
     };
     use super::{
         ExtractionError, ExtractionMessage, ExtractionResult, ObservationExtractor,
@@ -755,7 +751,6 @@ mod localllm {
     };
     use async_trait::async_trait;
     use serde::{Deserialize, Serialize};
-    use std::fmt::Write as _;
     use std::time::Duration;
     use uuid::Uuid;
 
@@ -823,8 +818,8 @@ mod localllm {
         pub fn from_env() -> ExtractionResult<Self> {
             let base_url =
                 std::env::var("PENSYVE_LOCAL_LLM_URL").unwrap_or_else(|_| DEFAULT_BASE_URL.into());
-            let model = std::env::var("PENSYVE_LOCAL_LLM_MODEL")
-                .unwrap_or_else(|_| DEFAULT_MODEL.into());
+            let model =
+                std::env::var("PENSYVE_LOCAL_LLM_MODEL").unwrap_or_else(|_| DEFAULT_MODEL.into());
             let api_key = std::env::var("PENSYVE_LOCAL_LLM_API_KEY").ok();
             Self::new(base_url, model, api_key)
         }
@@ -848,28 +843,12 @@ mod localllm {
         }
 
         /// Render the `[date] role: content` body + the V1 extraction prompt.
-        /// Duplicates the body-building shape from `AnthropicHaikuExtractor::
-        /// build_prompt` so the local backend sees identical prompt text —
-        /// any deviation would break the benchmark-pinned prompt.
+        /// Delegates to `AnthropicHaikuExtractor::build_prompt` (made
+        /// `pub(super)` in this PR) so the local backend sees identical
+        /// prompt text by construction — any deviation would break the
+        /// benchmark-pinned prompt.
         fn build_prompt(messages: &[ExtractionMessage]) -> String {
-            if messages.is_empty() {
-                return format!("{EXTRACTION_PROMPT_V1}\n\n[No conversation memories provided.]\n");
-            }
-            let mut body = String::new();
-            for m in messages {
-                let date = m.event_time.map_or_else(
-                    || "unknown".to_string(),
-                    |t| t.format("%Y-%m-%d").to_string(),
-                );
-                if m.role.is_empty() {
-                    let _ = writeln!(body, "[{date}] {}", m.content);
-                } else {
-                    let _ = writeln!(body, "[{date}] {}: {}", m.role, m.content);
-                }
-            }
-            format!(
-                "{EXTRACTION_PROMPT_V1}\n\n--- Recalled memories ---\n{body}--- End memories ---"
-            )
+            AnthropicHaikuExtractor::build_prompt(messages)
         }
     }
 
@@ -1041,7 +1020,9 @@ mod localllm {
             let raw_json = r#"[{"entity_type":"degree_earned","instance":"Business Administration","action":"graduated with","quantity":1,"confidence":0.9}]"#;
             Mock::given(method("POST"))
                 .and(path("/v1/chat/completions"))
-                .respond_with(ResponseTemplate::new(200).set_body_json(openai_response_body(raw_json)))
+                .respond_with(
+                    ResponseTemplate::new(200).set_body_json(openai_response_body(raw_json)),
+                )
                 .expect(1)
                 .mount(&server)
                 .await;
@@ -1060,10 +1041,11 @@ mod localllm {
                 .await
                 .expect("ok");
             assert_eq!(out.len(), 1);
-            assert_eq!(
-                out[0].content,
-                "[2024-05-10] graduated with Business Administration (1)"
-            );
+            // Per PR #72 review (codex P1): content is the bare fact only;
+            // event_time lives in metadata to avoid stamping the episode-max
+            // timestamp into per-fact embedded text.
+            assert_eq!(out[0].content, "graduated with Business Administration (1)");
+            assert_eq!(out[0].event_time, event_time);
         }
 
         #[tokio::test]

--- a/pensyve-core/src/observation.rs
+++ b/pensyve-core/src/observation.rs
@@ -245,7 +245,7 @@ Output ONLY a JSON array of objects. No prose, no explanation, no markdown fence
             self
         }
 
-        fn build_prompt(messages: &[ExtractionMessage]) -> String {
+        pub(super) fn build_prompt(messages: &[ExtractionMessage]) -> String {
             if messages.is_empty() {
                 return format!("{EXTRACTION_PROMPT_V1}\n\n[No conversation memories provided.]\n");
             }
@@ -300,20 +300,24 @@ Output ONLY a JSON array of objects. No prose, no explanation, no markdown fence
         content: &'a str,
     }
 
+    // Sibling extractor modules (see `localllm`) share this observation shape
+    // + the date-prefix render logic + the tolerant JSON parser. Exposed with
+    // `pub(super)` so they're reachable from `observation::localllm` without
+    // leaking into the public pensyve-core surface.
     #[derive(Debug, Deserialize)]
-    struct RawObservation {
-        entity_type: String,
-        instance: String,
-        action: String,
+    pub(super) struct RawObservation {
+        pub(super) entity_type: String,
+        pub(super) instance: String,
+        pub(super) action: String,
         #[serde(default)]
-        quantity: Option<f64>,
+        pub(super) quantity: Option<f64>,
         #[serde(default)]
-        unit: Option<String>,
+        pub(super) unit: Option<String>,
         #[serde(default = "default_raw_confidence")]
-        confidence: f32,
+        pub(super) confidence: f32,
     }
 
-    fn default_raw_confidence() -> f32 {
+    pub(super) fn default_raw_confidence() -> f32 {
         0.8
     }
 
@@ -326,7 +330,7 @@ Output ONLY a JSON array of objects. No prose, no explanation, no markdown fence
     /// the language marker, and cutting at the closing fence. Bracket
     /// extraction below is a second line of defence when the response
     /// contains prose before/after the array.
-    fn parse_response(text: &str) -> Vec<RawObservation> {
+    pub(super) fn parse_response(text: &str) -> Vec<RawObservation> {
         let trimmed = text.trim();
         let no_fence = strip_markdown_fence(trimmed);
 
@@ -342,7 +346,7 @@ Output ONLY a JSON array of objects. No prose, no explanation, no markdown fence
 
     /// Remove ```` ``` ```` / ```` ```json ```` / ```` ```\n ```` wrappers
     /// from an LLM response. Handles the common shapes without regex.
-    fn strip_markdown_fence(s: &str) -> &str {
+    pub(super) fn strip_markdown_fence(s: &str) -> &str {
         let Some(start) = s.find("```") else {
             return s;
         };
@@ -361,13 +365,13 @@ Output ONLY a JSON array of objects. No prose, no explanation, no markdown fence
         after_lang[..close_rel].trim()
     }
 
-    fn raw_to_observation(
+    pub(super) fn raw_to_observation(
         raw: RawObservation,
         namespace_id: Uuid,
         episode_id: Uuid,
         event_time: Option<DateTime<Utc>>,
     ) -> ObservationMemory {
-        let content = format_observation_content(&raw);
+        let content = format_observation_content(&raw, event_time);
         let mut obs = ObservationMemory::new(
             namespace_id,
             episode_id,
@@ -384,14 +388,27 @@ Output ONLY a JSON array of objects. No prose, no explanation, no markdown fence
     }
 
     /// Render a human-readable sentence used as the embedding + display content.
-    /// Matches the format the Phase 0c reader prompt was trained against.
-    fn format_observation_content(raw: &RawObservation) -> String {
+    /// When `event_time` is known it is prefixed as `[YYYY-MM-DD] ` so the
+    /// observation is a self-contained date+fact string at recall time —
+    /// without the prefix, temporal-reasoning readers have to cross-reference
+    /// session-block headers to learn *when* a fact applies. Sprint doc 20's
+    /// pipeline relied on the outer reader prompt to attach dates; v1.1 moves
+    /// that responsibility into the observation itself so any reader that
+    /// simply concatenates content strings gets the date for free.
+    fn format_observation_content(
+        raw: &RawObservation,
+        event_time: Option<DateTime<Utc>>,
+    ) -> String {
         let base = format!("{} {}", raw.action, raw.instance);
-        match (raw.quantity, raw.unit.as_deref()) {
+        let body = match (raw.quantity, raw.unit.as_deref()) {
             (Some(q), Some(u)) => format!("{base} ({q} {u})"),
             (Some(q), None) => format!("{base} ({q})"),
             (None, Some(u)) => format!("{base} ({u})"),
             (None, None) => base,
+        };
+        match event_time {
+            Some(t) => format!("[{}] {}", t.format("%Y-%m-%d"), body),
+            None => body,
         }
     }
 
@@ -676,11 +693,443 @@ Output ONLY a JSON array of objects. No prose, no explanation, no markdown fence
             assert!(obs.confidence <= 1.0);
             assert!(obs.confidence >= 0.0);
         }
+
+        #[test]
+        fn content_prefixes_event_date_when_present() {
+            // v1.1: observations carry their date inline so temporal-reasoning
+            // readers don't have to cross-reference session-block headers.
+            let raw = RawObservation {
+                entity_type: "degree_earned".into(),
+                instance: "Business Administration".into(),
+                action: "graduated with".into(),
+                quantity: Some(1.0),
+                unit: None,
+                confidence: 0.9,
+            };
+            let event_time = Some(
+                DateTime::parse_from_rfc3339("2024-05-10T14:00:00Z")
+                    .unwrap()
+                    .with_timezone(&Utc),
+            );
+            let obs = raw_to_observation(raw, Uuid::new_v4(), Uuid::new_v4(), event_time);
+            assert_eq!(obs.content, "[2024-05-10] graduated with Business Administration (1)");
+            assert_eq!(obs.event_time, event_time);
+        }
+
+        #[test]
+        fn content_omits_prefix_when_event_time_absent() {
+            // Keeps zero-cost fallback for callers without a date (unit tests,
+            // extractors that fail to resolve event_time). Matches the pre-v1.1
+            // format so ObservationMemory rows built without a date still embed
+            // cleanly against existing vector indexes.
+            let raw = RawObservation {
+                entity_type: "task_tried".into(),
+                instance: "Todoist".into(),
+                action: "will try out".into(),
+                quantity: None,
+                unit: None,
+                confidence: 0.8,
+            };
+            let obs = raw_to_observation(raw, Uuid::new_v4(), Uuid::new_v4(), None);
+            assert_eq!(obs.content, "will try out Todoist");
+            assert!(obs.event_time.is_none());
+        }
     }
 }
 
 #[cfg(feature = "observation-extraction")]
 pub use haiku::{AnthropicHaikuExtractor, EXTRACTION_PROMPT_V1};
+
+// ---------------------------------------------------------------------------
+// LocalLLMExtractor (feature-gated) — OpenAI-compatible local vLLM backend
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "observation-extraction")]
+mod localllm {
+    use super::haiku::{
+        EXTRACTION_PROMPT_V1, RawObservation, parse_response, raw_to_observation,
+    };
+    use super::{
+        ExtractionError, ExtractionMessage, ExtractionResult, ObservationExtractor,
+        ObservationMemory,
+    };
+    use async_trait::async_trait;
+    use serde::{Deserialize, Serialize};
+    use std::fmt::Write as _;
+    use std::time::Duration;
+    use uuid::Uuid;
+
+    // Default wired to the DGX Spark local vLLM port the bench uses (see
+    // pensyve-docs/research/benchmark-sprint/20-observation-extractor-ingest-topk.md
+    // for the offline-first rationale). Any OpenAI-compatible chat-completions
+    // endpoint works — Qwen, Nemotron Nano, llama.cpp's server, etc.
+    const DEFAULT_BASE_URL: &str = "http://localhost:8888/v1";
+    const DEFAULT_MODEL: &str = "local";
+    const DEFAULT_MAX_TOKENS: u32 = 4096;
+    // Local reasoning models (Qwen 3.6, Nemotron 3 Nano in reasoning mode)
+    // emit hundreds of <think> tokens before the JSON output — a plain
+    // extraction prompt can easily hit 60-90s per episode on GB10. The
+    // 300s default covers the long tail; dense non-reasoning models (Qwen
+    // 3.5-27B dense, Qwen3-coder) finish in ~5-10s and aren't affected.
+    const DEFAULT_TIMEOUT_SECS: u64 = 300;
+
+    /// Extractor that hits an OpenAI-compatible `chat.completions` endpoint —
+    /// designed for local vLLM serving a small open-weight model (Qwen 3.5-27B
+    /// dense, Nemotron Nano 30B, etc.). Mirrors [`AnthropicHaikuExtractor`]
+    /// (same `EXTRACTION_PROMPT_V1`, same `RawObservation` shape, same
+    /// tolerant JSON parser) so switching extractors is a pure config flip
+    /// with no recall-time surface change.
+    ///
+    /// Wired via `Pensyve(extractor="local-vllm", ...)` on the Python side.
+    /// Offline-first: requires no API key and no network egress beyond the
+    /// configured `base_url`.
+    #[derive(Debug, Clone)]
+    pub struct LocalLLMExtractor {
+        client: reqwest::Client,
+        base_url: String,
+        model: String,
+        api_key: Option<String>,
+        max_tokens: u32,
+    }
+
+    impl LocalLLMExtractor {
+        /// Build with explicit endpoint + model id. `api_key` is optional —
+        /// local vLLM accepts any string (including none); cloud-gateway
+        /// drop-ins like vLLM-on-Modal may require it.
+        pub fn new(
+            base_url: impl Into<String>,
+            model: impl Into<String>,
+            api_key: Option<String>,
+        ) -> ExtractionResult<Self> {
+            let client = reqwest::Client::builder()
+                .timeout(Duration::from_secs(DEFAULT_TIMEOUT_SECS))
+                .build()
+                .map_err(|e| ExtractionError::Config(format!("http client build: {e}")))?;
+            Ok(Self {
+                client,
+                base_url: base_url.into(),
+                model: model.into(),
+                api_key,
+                max_tokens: DEFAULT_MAX_TOKENS,
+            })
+        }
+
+        /// Build from environment variables:
+        ///   - `PENSYVE_LOCAL_LLM_URL`  (default `http://localhost:8888/v1`)
+        ///   - `PENSYVE_LOCAL_LLM_MODEL` (default `"local"` — vLLM accepts any
+        ///     model id for a single-model server; users override when the
+        ///     gateway multiplexes)
+        ///   - `PENSYVE_LOCAL_LLM_API_KEY` (optional)
+        pub fn from_env() -> ExtractionResult<Self> {
+            let base_url =
+                std::env::var("PENSYVE_LOCAL_LLM_URL").unwrap_or_else(|_| DEFAULT_BASE_URL.into());
+            let model = std::env::var("PENSYVE_LOCAL_LLM_MODEL")
+                .unwrap_or_else(|_| DEFAULT_MODEL.into());
+            let api_key = std::env::var("PENSYVE_LOCAL_LLM_API_KEY").ok();
+            Self::new(base_url, model, api_key)
+        }
+
+        #[must_use]
+        pub fn with_base_url(mut self, base_url: impl Into<String>) -> Self {
+            self.base_url = base_url.into();
+            self
+        }
+
+        #[must_use]
+        pub fn with_model(mut self, model: impl Into<String>) -> Self {
+            self.model = model.into();
+            self
+        }
+
+        #[must_use]
+        pub fn with_max_tokens(mut self, max_tokens: u32) -> Self {
+            self.max_tokens = max_tokens;
+            self
+        }
+
+        /// Render the `[date] role: content` body + the V1 extraction prompt.
+        /// Duplicates the body-building shape from `AnthropicHaikuExtractor::
+        /// build_prompt` so the local backend sees identical prompt text —
+        /// any deviation would break the benchmark-pinned prompt.
+        fn build_prompt(messages: &[ExtractionMessage]) -> String {
+            if messages.is_empty() {
+                return format!("{EXTRACTION_PROMPT_V1}\n\n[No conversation memories provided.]\n");
+            }
+            let mut body = String::new();
+            for m in messages {
+                let date = m.event_time.map_or_else(
+                    || "unknown".to_string(),
+                    |t| t.format("%Y-%m-%d").to_string(),
+                );
+                if m.role.is_empty() {
+                    let _ = writeln!(body, "[{date}] {}", m.content);
+                } else {
+                    let _ = writeln!(body, "[{date}] {}: {}", m.role, m.content);
+                }
+            }
+            format!(
+                "{EXTRACTION_PROMPT_V1}\n\n--- Recalled memories ---\n{body}--- End memories ---"
+            )
+        }
+    }
+
+    #[derive(Debug, Serialize)]
+    struct OpenAIRequest<'a> {
+        model: &'a str,
+        messages: Vec<OpenAIMessage<'a>>,
+        max_tokens: u32,
+        temperature: f32,
+        // Qwen 3+ / Nemotron Nano are reasoning models: by default they emit
+        // 1-3k tokens of <think> output before producing the JSON, which at
+        // ~15 tok/s on GB10 blows a 300s budget. `enable_thinking: false`
+        // disables the reasoning pass — extraction runs in seconds instead
+        // of minutes. Non-reasoning models ignore the kwarg harmlessly.
+        chat_template_kwargs: ChatTemplateKwargs,
+    }
+
+    #[derive(Debug, Serialize)]
+    struct ChatTemplateKwargs {
+        enable_thinking: bool,
+    }
+
+    #[derive(Debug, Serialize)]
+    struct OpenAIMessage<'a> {
+        role: &'a str,
+        content: &'a str,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct OpenAIResponse {
+        #[serde(default)]
+        choices: Vec<OpenAIChoice>,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct OpenAIChoice {
+        #[serde(default)]
+        message: OpenAIChoiceMessage,
+    }
+
+    #[derive(Debug, Deserialize, Default)]
+    struct OpenAIChoiceMessage {
+        #[serde(default)]
+        content: String,
+    }
+
+    #[async_trait]
+    impl ObservationExtractor for LocalLLMExtractor {
+        async fn extract(
+            &self,
+            namespace_id: Uuid,
+            episode_id: Uuid,
+            messages: &[ExtractionMessage],
+        ) -> ExtractionResult<Vec<ObservationMemory>> {
+            let prompt = Self::build_prompt(messages);
+            let last_event_time = messages.iter().filter_map(|m| m.event_time).max();
+
+            let req = OpenAIRequest {
+                model: &self.model,
+                messages: vec![OpenAIMessage {
+                    role: "user",
+                    content: &prompt,
+                }],
+                max_tokens: self.max_tokens,
+                temperature: 0.0,
+                chat_template_kwargs: ChatTemplateKwargs {
+                    enable_thinking: false,
+                },
+            };
+
+            // vLLM's chat endpoint lives at `/chat/completions` below
+            // `/v1`, so append both pieces regardless of whether the caller
+            // passed the trailing `/v1` themselves.
+            let base = self.base_url.trim_end_matches('/');
+            let base = if base.ends_with("/v1") {
+                base.to_string()
+            } else {
+                format!("{base}/v1")
+            };
+            let url = format!("{base}/chat/completions");
+
+            let mut builder = self.client.post(&url).json(&req);
+            if let Some(key) = self.api_key.as_deref() {
+                builder = builder.bearer_auth(key);
+            }
+            let response = builder
+                .send()
+                .await
+                .map_err(|e| ExtractionError::Transport(e.to_string()))?;
+
+            if !response.status().is_success() {
+                let status = response.status();
+                let body = response.text().await.unwrap_or_default();
+                return Err(ExtractionError::Transport(format!("HTTP {status}: {body}")));
+            }
+
+            let parsed: OpenAIResponse = response
+                .json()
+                .await
+                .map_err(|e| ExtractionError::Parse(e.to_string()))?;
+
+            let text = parsed
+                .choices
+                .into_iter()
+                .next()
+                .map(|c| c.message.content)
+                .unwrap_or_default();
+
+            let raws: Vec<RawObservation> = parse_response(&text);
+            Ok(raws
+                .into_iter()
+                .map(|r| raw_to_observation(r, namespace_id, episode_id, last_event_time))
+                .collect())
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests
+    // -----------------------------------------------------------------------
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use chrono::{DateTime, Utc};
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        fn openai_response_body(text: &str) -> serde_json::Value {
+            serde_json::json!({
+                "id": "chatcmpl-test",
+                "object": "chat.completion",
+                "model": "local",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": text},
+                    "finish_reason": "stop",
+                }],
+                "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+            })
+        }
+
+        #[test]
+        fn from_env_uses_defaults_when_unset() {
+            // Best-effort: some env vars may be set in the test shell;
+            // only assert the call doesn't panic and returns a ready struct.
+            let e = LocalLLMExtractor::from_env().expect("from_env");
+            // Either default or env override; both are valid non-empty strings.
+            assert!(!e.base_url.is_empty());
+            assert!(!e.model.is_empty());
+        }
+
+        #[test]
+        fn build_prompt_date_anchors_turn_bodies() {
+            let msgs = [ExtractionMessage {
+                role: "user".into(),
+                content: "I picked up boots from Zara.".into(),
+                event_time: DateTime::parse_from_rfc3339("2024-02-05T10:00:00Z")
+                    .ok()
+                    .map(|d| d.with_timezone(&Utc)),
+            }];
+            let p = LocalLLMExtractor::build_prompt(&msgs);
+            assert!(p.contains("[2024-02-05] user: I picked up boots from Zara."));
+            assert!(p.contains("--- Recalled memories ---"));
+        }
+
+        #[tokio::test]
+        async fn extractor_parses_openai_shaped_response() {
+            let server = MockServer::start().await;
+            let raw_json = r#"[{"entity_type":"degree_earned","instance":"Business Administration","action":"graduated with","quantity":1,"confidence":0.9}]"#;
+            Mock::given(method("POST"))
+                .and(path("/v1/chat/completions"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(openai_response_body(raw_json)))
+                .expect(1)
+                .mount(&server)
+                .await;
+
+            let extractor = LocalLLMExtractor::new(server.uri(), "local", None).unwrap();
+            let event_time = DateTime::parse_from_rfc3339("2024-05-10T14:00:00Z")
+                .ok()
+                .map(|d| d.with_timezone(&Utc));
+            let msgs = [ExtractionMessage {
+                role: String::new(),
+                content: "I graduated with a BS in BA.".into(),
+                event_time,
+            }];
+            let out = extractor
+                .extract(Uuid::new_v4(), Uuid::new_v4(), &msgs)
+                .await
+                .expect("ok");
+            assert_eq!(out.len(), 1);
+            assert_eq!(
+                out[0].content,
+                "[2024-05-10] graduated with Business Administration (1)"
+            );
+        }
+
+        #[tokio::test]
+        async fn extractor_surfaces_http_errors_as_transport_error() {
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path("/v1/chat/completions"))
+                .respond_with(ResponseTemplate::new(500).set_body_string("boom"))
+                .expect(1)
+                .mount(&server)
+                .await;
+            let extractor = LocalLLMExtractor::new(server.uri(), "local", None).unwrap();
+            let err = extractor
+                .extract(Uuid::new_v4(), Uuid::new_v4(), &[])
+                .await
+                .err()
+                .expect("err");
+            match err {
+                ExtractionError::Transport(_) => {}
+                other => panic!("expected Transport, got {other:?}"),
+            }
+        }
+
+        #[tokio::test]
+        async fn extractor_returns_empty_on_unparseable_response() {
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path("/v1/chat/completions"))
+                .respond_with(
+                    ResponseTemplate::new(200)
+                        .set_body_json(openai_response_body("I'm sorry, I cannot comply.")),
+                )
+                .mount(&server)
+                .await;
+            let extractor = LocalLLMExtractor::new(server.uri(), "local", None).unwrap();
+            let out = extractor
+                .extract(Uuid::new_v4(), Uuid::new_v4(), &[])
+                .await
+                .expect("ok");
+            assert!(out.is_empty());
+        }
+
+        #[tokio::test]
+        async fn base_url_without_v1_suffix_is_normalized() {
+            // Users may pass the raw host (e.g. reading a bare vLLM env var).
+            // The extractor should append `/v1/chat/completions` rather than
+            // double-nesting when `/v1` is already present.
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path("/v1/chat/completions"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(openai_response_body("[]")))
+                .expect(1)
+                .mount(&server)
+                .await;
+            let bare = server.uri(); // no trailing /v1
+            let extractor = LocalLLMExtractor::new(bare, "local", None).unwrap();
+            extractor
+                .extract(Uuid::new_v4(), Uuid::new_v4(), &[])
+                .await
+                .expect("ok");
+        }
+    }
+}
+
+#[cfg(feature = "observation-extraction")]
+pub use localllm::LocalLLMExtractor;
 
 // ---------------------------------------------------------------------------
 // Ingest helper — canonical post-episode-close extraction flow

--- a/pensyve-python/python/pensyve/_core.pyi
+++ b/pensyve-python/python/pensyve/_core.pyi
@@ -19,18 +19,32 @@ class Pensyve:
         namespace: str | None = None,
         extractor: str | None = None,
         extractor_api_key: str | None = None,
+        reranker: str | None = "BGERerankerBase",
     ) -> None:
         """Create or open a Pensyve instance.
 
         Args:
             path: Directory for storage files (default: ~/.pensyve/default).
             namespace: Namespace name (default: "default").
-            extractor: Optional observation extractor. `"haiku"` wires the
-                Anthropic Haiku 4.5 extractor (requires `ANTHROPIC_API_KEY`
-                env var unless `extractor_api_key` is provided). `None`
-                (default) skips extraction entirely.
-            extractor_api_key: Explicit API key for the haiku extractor.
-                Overrides `ANTHROPIC_API_KEY`.
+            extractor: Optional observation extractor.
+                - `"haiku"` wires the Anthropic Haiku 4.5 extractor
+                  (requires `ANTHROPIC_API_KEY` env var unless
+                  `extractor_api_key` is provided).
+                - `"local-vllm"` wires an OpenAI-compatible local-LLM
+                  extractor for offline-first deployments (reads
+                  `PENSYVE_LOCAL_LLM_URL`, `PENSYVE_LOCAL_LLM_MODEL`,
+                  `PENSYVE_LOCAL_LLM_API_KEY` from the environment; defaults
+                  to `http://localhost:8888/v1`, model `"local"`, no auth).
+                - `None` (default) skips extraction entirely.
+            extractor_api_key: Explicit API key for the configured extractor.
+                Overrides `ANTHROPIC_API_KEY` (haiku) or
+                `PENSYVE_LOCAL_LLM_API_KEY` (local-vllm).
+            reranker: Cross-encoder reranker applied post-fusion in `recall`
+                and `recall_grouped`. Default `"BGERerankerBase"` — the
+                algorithm-spec default. Pass `None` to disable (skips the
+                ~150MB fastembed model download, but this is a weaker
+                algorithm than the spec describes). `"JINARerankerV1TurboEn"`
+                is also supported as an English-only alternative.
         """
         ...
 
@@ -60,6 +74,12 @@ class Pensyve:
     ) -> list[Memory]:
         """Recall memories matching a query.
 
+        Applies the full Pensyve retrieval pipeline: vector search + RRF
+        fusion + graph traversal + cross-encoder reranking. Graph is built
+        fresh per-call from storage (O(entities + edges), sub-ms for
+        typical namespaces). Reranker is applied when configured in
+        ``__init__`` (default: ``BGERerankerBase``).
+
         Args:
             query: Search query string.
             entity: Optional entity to filter by.
@@ -78,11 +98,12 @@ class Pensyve:
     ) -> list[SessionGroup]:
         """Recall memories matching a query, clustered by source session.
 
-        Runs the normal RRF fusion pipeline and then groups the top-``limit``
-        results by ``episode_id``. Memories from the same session cluster
-        into a single :class:`SessionGroup` sorted by event time within the
-        group. Semantic and procedural memories (which have no episode)
-        appear as singleton groups with ``session_id=None``.
+        Runs the full Pensyve retrieval pipeline (vector + RRF + graph +
+        reranker) and then groups the top-``limit`` results by
+        ``episode_id``. Memories from the same session cluster into a
+        single :class:`SessionGroup` sorted by event time within the group.
+        Semantic and procedural memories (which have no episode) appear as
+        singleton groups with ``session_id=None``.
 
         Args:
             query: Search query string.

--- a/pensyve-python/src/lib.rs
+++ b/pensyve-python/src/lib.rs
@@ -10,6 +10,7 @@ use uuid::Uuid;
 use pensyve_core::config::{PensyveConfig, RetrievalConfig};
 use pensyve_core::consolidation::ConsolidationEngine;
 use pensyve_core::embedding::OnnxEmbedder;
+use pensyve_core::graph::MemoryGraph;
 use pensyve_core::recall_grouped::{OrderBy, RecallGroupedConfig};
 use pensyve_core::retrieval::RecallEngine;
 use pensyve_core::storage::StorageTrait;
@@ -219,8 +220,44 @@ fn build_extractor(
                 .map_err(|e| PyRuntimeError::new_err(format!("tokio runtime: {e}")))?;
             Ok((Some(Arc::new(built)), Some(Arc::new(rt))))
         }
+        Some("local-vllm") | Some("local-llm") => {
+            // Offline-first Layer A path (v1.1 Step B). Config is env-driven
+            // so `Pensyve(extractor="local-vllm")` works with no additional
+            // Python surface change:
+            //   PENSYVE_LOCAL_LLM_URL    (default http://localhost:8888/v1)
+            //   PENSYVE_LOCAL_LLM_MODEL  (default "local")
+            //   PENSYVE_LOCAL_LLM_API_KEY (optional bearer token)
+            // `api_key` passed as a positional kwarg overrides the env var.
+            let built = pensyve_core::observation::LocalLLMExtractor::from_env()
+                .map_err(|e| {
+                    PyRuntimeError::new_err(format!(
+                        "Failed to build local-vllm extractor: {e}"
+                    ))
+                })?;
+            let built = match api_key {
+                Some(k) => pensyve_core::observation::LocalLLMExtractor::new(
+                    std::env::var("PENSYVE_LOCAL_LLM_URL")
+                        .unwrap_or_else(|_| "http://localhost:8888/v1".into()),
+                    std::env::var("PENSYVE_LOCAL_LLM_MODEL")
+                        .unwrap_or_else(|_| "local".into()),
+                    Some(k.to_string()),
+                )
+                .map_err(|e| {
+                    PyRuntimeError::new_err(format!(
+                        "Failed to build local-vllm extractor: {e}"
+                    ))
+                })?,
+                None => built,
+            };
+            let rt = tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(1)
+                .enable_all()
+                .build()
+                .map_err(|e| PyRuntimeError::new_err(format!("tokio runtime: {e}")))?;
+            Ok((Some(Arc::new(built)), Some(Arc::new(rt))))
+        }
         Some(other) => Err(PyValueError::new_err(format!(
-            "unknown extractor: {other:?}; supported: \"haiku\""
+            "unknown extractor: {other:?}; supported: \"haiku\", \"local-vllm\""
         ))),
     }
 }
@@ -239,6 +276,12 @@ struct PensyveInner {
     /// Shared tokio runtime used to drive the async extractor from the sync
     /// `PyO3` dispatch. Lazily created only when an extractor is configured.
     extractor_runtime: Option<Arc<tokio::runtime::Runtime>>,
+    /// Cross-encoder reranker applied post-fusion in `recall` and
+    /// `recall_grouped`. Default is `BGERerankerBase` — on-by-default
+    /// because the Pensyve algorithm specifies it. Callers can opt out
+    /// with `Pensyve(reranker=None)` for embedded/offline contexts where
+    /// the ~150MB model download is unacceptable.
+    reranker: Option<Arc<pensyve_core::reranker::Reranker>>,
 }
 
 // ---------------------------------------------------------------------------
@@ -265,13 +308,14 @@ impl PyPensyve {
     ///     `extractor_api_key`: Explicit API key for the haiku extractor.
     ///         Overrides `ANTHROPIC_API_KEY`.
     #[new]
-    #[pyo3(signature = (path=None, namespace=None, extractor=None, extractor_api_key=None))]
+    #[pyo3(signature = (path=None, namespace=None, extractor=None, extractor_api_key=None, reranker=Some("BGERerankerBase".to_string())))]
     #[allow(clippy::needless_pass_by_value)]
     fn new(
         path: Option<String>,
         namespace: Option<String>,
         extractor: Option<String>,
         extractor_api_key: Option<String>,
+        reranker: Option<String>,
     ) -> PyResult<Self> {
         let config = PensyveConfig::default();
 
@@ -366,6 +410,19 @@ impl PyPensyve {
         let (extractor_impl, extractor_runtime) =
             build_extractor(extractor.as_deref(), extractor_api_key.as_deref())?;
 
+        // Cross-encoder reranker is on-by-default per the Pensyve
+        // algorithm spec. `reranker=None` opts out for embedded/offline
+        // callers. On first construction fastembed downloads the model
+        // (~150MB for BGE; cached at ~/.fastembed_cache thereafter).
+        let reranker_impl = match reranker.as_deref() {
+            None => None,
+            Some(name) => Some(Arc::new(
+                pensyve_core::reranker::Reranker::new(name).map_err(|e| {
+                    PyRuntimeError::new_err(format!("Failed to build reranker: {e}"))
+                })?,
+            )),
+        };
+
         Ok(Self {
             inner: Arc::new(PensyveInner {
                 namespace: ns,
@@ -376,6 +433,7 @@ impl PyPensyve {
                 consolidation_config: config.consolidation,
                 extractor: extractor_impl,
                 extractor_runtime,
+                reranker: reranker_impl,
             }),
         })
     }
@@ -463,12 +521,24 @@ impl PyPensyve {
         // NOTE: Lock held across recall (including embedding). RecallEngine borrows &VectorIndex.
         // Future: make RecallEngine lock internally per-operation to allow concurrent recalls.
         let vi = self.inner.vector_index.lock().unwrap();
-        let engine = RecallEngine::new(
+        // Build the graph fresh per-call from storage. Cheap (O(entities + edges)),
+        // always reflects the latest commits, and avoids lock juggling across
+        // concurrent recalls. This is a correctness-by-default feature: the
+        // Pensyve algorithm specifies graph traversal as part of recall fusion.
+        let graph = MemoryGraph::build_from_storage(
+            self.inner.storage.as_ref(),
+            self.inner.namespace.id,
+        );
+        let mut engine = RecallEngine::new(
             self.inner.storage.as_ref(),
             self.inner.embedder.as_ref(),
             &vi,
             &self.inner.retrieval_config,
         );
+        engine = engine.with_graph(&graph);
+        if let Some(reranker) = self.inner.reranker.as_deref() {
+            engine = engine.with_reranker(reranker);
+        }
 
         let result = engine
             .recall(query, self.inner.namespace.id, limit)
@@ -557,12 +627,23 @@ impl PyPensyve {
         // Lock held across recall, same as `recall()` — RecallEngine borrows
         // &VectorIndex for the duration of the call.
         let vi = self.inner.vector_index.lock().unwrap();
-        let engine = RecallEngine::new(
+        // Build the graph fresh per-call from storage — same rationale as
+        // `recall()` above. Keeps `recall_grouped` aligned with the same
+        // feature set (graph + reranker) as the single-entity path.
+        let graph = MemoryGraph::build_from_storage(
+            self.inner.storage.as_ref(),
+            self.inner.namespace.id,
+        );
+        let mut engine = RecallEngine::new(
             self.inner.storage.as_ref(),
             self.inner.embedder.as_ref(),
             &vi,
             &self.inner.retrieval_config,
         );
+        engine = engine.with_graph(&graph);
+        if let Some(reranker) = self.inner.reranker.as_deref() {
+            engine = engine.with_reranker(reranker);
+        }
 
         let groups = engine
             .recall_grouped(query, self.inner.namespace.id, &config)
@@ -856,6 +937,7 @@ impl PyEpisode {
     #[pyo3(signature = (_exc_type=None, _exc_val=None, _exc_tb=None))]
     fn __exit__(
         &mut self,
+        py: Python<'_>,
         _exc_type: Option<&Bound<'_, PyAny>>,
         _exc_val: Option<&Bound<'_, PyAny>>,
         _exc_tb: Option<&Bound<'_, PyAny>>,
@@ -930,9 +1012,17 @@ impl PyEpisode {
             .update_episode(&episode)
             .map_err(|e| PyRuntimeError::new_err(format!("Failed to update episode: {e}")))?;
 
-        // Observation extraction — runs only when a haiku extractor was
+        // Observation extraction — runs only when an extractor was
         // configured. All failures are logged + swallowed; episode stays
         // durable regardless.
+        //
+        // Concurrency note: we `py.detach()` for the blocking HTTP call so
+        // Python threads that fire __exit__ concurrently actually run in
+        // parallel. Without this, multiple threads would serialize on the
+        // GIL during the ~20s Qwen3.6 extraction, defeating vLLM's
+        // `--max-num-seqs=N` batching. The release is safe because we
+        // don't touch Python objects inside the closure — only Rust state
+        // (storage, embedder, extractor) guarded by their own Mutexes.
         if let (Some(extractor), Some(runtime)) = (
             self.inner.extractor.clone(),
             self.inner.extractor_runtime.clone(),
@@ -941,18 +1031,17 @@ impl PyEpisode {
             let embedder = self.inner.embedder.clone();
             let ns_id = self.namespace_id;
             let ep_id = self.episode_id;
-            // Block on the runtime here so callers see a consistent post-exit
-            // world (observations present before __exit__ returns). Run time
-            // is dominated by a single Haiku API call.
-            let persisted = runtime.block_on(async move {
-                pensyve_core::observation::commit_extraction_for_episode(
-                    storage.as_ref(),
-                    extractor.as_ref(),
-                    ns_id,
-                    ep_id,
-                    |text| embedder.embed(text),
-                )
-                .await
+            let persisted = py.detach(|| {
+                runtime.block_on(async move {
+                    pensyve_core::observation::commit_extraction_for_episode(
+                        storage.as_ref(),
+                        extractor.as_ref(),
+                        ns_id,
+                        ep_id,
+                        |text| embedder.embed(text),
+                    )
+                    .await
+                })
             });
             if persisted > 0 {
                 tracing::info!(

--- a/pensyve-python/src/lib.rs
+++ b/pensyve-python/src/lib.rs
@@ -228,26 +228,23 @@ fn build_extractor(
             //   PENSYVE_LOCAL_LLM_MODEL  (default "local")
             //   PENSYVE_LOCAL_LLM_API_KEY (optional bearer token)
             // `api_key` passed as a positional kwarg overrides the env var.
-            let built = pensyve_core::observation::LocalLLMExtractor::from_env()
-                .map_err(|e| {
-                    PyRuntimeError::new_err(format!(
-                        "Failed to build local-vllm extractor: {e}"
-                    ))
-                })?;
+            // Build directly per branch — when `api_key` is provided we want
+            // the explicit-config path; otherwise the env-only path. Avoids
+            // the wasted reqwest::Client allocation an unconditional
+            // `from_env()` followed by `new()` would incur.
             let built = match api_key {
                 Some(k) => pensyve_core::observation::LocalLLMExtractor::new(
                     std::env::var("PENSYVE_LOCAL_LLM_URL")
                         .unwrap_or_else(|_| "http://localhost:8888/v1".into()),
-                    std::env::var("PENSYVE_LOCAL_LLM_MODEL")
-                        .unwrap_or_else(|_| "local".into()),
+                    std::env::var("PENSYVE_LOCAL_LLM_MODEL").unwrap_or_else(|_| "local".into()),
                     Some(k.to_string()),
                 )
                 .map_err(|e| {
-                    PyRuntimeError::new_err(format!(
-                        "Failed to build local-vllm extractor: {e}"
-                    ))
+                    PyRuntimeError::new_err(format!("Failed to build local-vllm extractor: {e}"))
                 })?,
-                None => built,
+                None => pensyve_core::observation::LocalLLMExtractor::from_env().map_err(|e| {
+                    PyRuntimeError::new_err(format!("Failed to build local-vllm extractor: {e}"))
+                })?,
             };
             let rt = tokio::runtime::Builder::new_multi_thread()
                 .worker_threads(1)
@@ -521,31 +518,31 @@ impl PyPensyve {
         // NOTE: Lock held across recall (including embedding). RecallEngine borrows &VectorIndex.
         // Future: make RecallEngine lock internally per-operation to allow concurrent recalls.
         let vi = self.inner.vector_index.lock().unwrap();
-        // Build the graph fresh per-call from storage. Cheap (O(entities + edges)),
-        // always reflects the latest commits, and avoids lock juggling across
-        // concurrent recalls. This is a correctness-by-default feature: the
-        // Pensyve algorithm specifies graph traversal as part of recall fusion.
-        let graph = MemoryGraph::build_from_storage(
-            self.inner.storage.as_ref(),
-            self.inner.namespace.id,
-        );
+        // Per PR #72 review (codex P2): graph traversal in `RecallEngine`
+        // only kicks in when both a graph AND a target_entity are supplied
+        // (see `retrieval.rs:512` `match (self.graph, target_entity)`).
+        // Skip the O(entities + edges) graph build when no entity is provided —
+        // it would be wired into the engine but never consulted by ranking.
+        let entity_id = entity.map(|e| e.uuid);
+        let graph = entity_id.map(|_| {
+            MemoryGraph::build_from_storage(self.inner.storage.as_ref(), self.inner.namespace.id)
+        });
         let mut engine = RecallEngine::new(
             self.inner.storage.as_ref(),
             self.inner.embedder.as_ref(),
             &vi,
             &self.inner.retrieval_config,
         );
-        engine = engine.with_graph(&graph);
+        if let Some(g) = graph.as_ref() {
+            engine = engine.with_graph(g);
+        }
         if let Some(reranker) = self.inner.reranker.as_deref() {
             engine = engine.with_reranker(reranker);
         }
 
         let result = engine
-            .recall(query, self.inner.namespace.id, limit)
+            .recall_with_entity(query, self.inner.namespace.id, limit, entity_id)
             .map_err(|e| PyRuntimeError::new_err(format!("Recall failed: {e}")))?;
-
-        // Post-filter by entity if provided.
-        let entity_id = entity.map(|e| e.uuid);
 
         let mut memories: Vec<PyMemory> = result
             .memories
@@ -627,20 +624,17 @@ impl PyPensyve {
         // Lock held across recall, same as `recall()` — RecallEngine borrows
         // &VectorIndex for the duration of the call.
         let vi = self.inner.vector_index.lock().unwrap();
-        // Build the graph fresh per-call from storage — same rationale as
-        // `recall()` above. Keeps `recall_grouped` aligned with the same
-        // feature set (graph + reranker) as the single-entity path.
-        let graph = MemoryGraph::build_from_storage(
-            self.inner.storage.as_ref(),
-            self.inner.namespace.id,
-        );
+        // No graph here: `recall_grouped` accepts no target_entity, and graph
+        // traversal in `RecallEngine` only fires when both a graph and a
+        // target_entity are present (codex P2 on PR #72). Building it here
+        // would burn an O(entities + edges) storage scan with no ranking
+        // payoff. Reranker still wires in below.
         let mut engine = RecallEngine::new(
             self.inner.storage.as_ref(),
             self.inner.embedder.as_ref(),
             &vi,
             &self.inner.retrieval_config,
         );
-        engine = engine.with_graph(&graph);
         if let Some(reranker) = self.inner.reranker.as_deref() {
             engine = engine.with_reranker(reranker);
         }

--- a/pensyve-python/src/lib.rs
+++ b/pensyve-python/src/lib.rs
@@ -220,7 +220,7 @@ fn build_extractor(
                 .map_err(|e| PyRuntimeError::new_err(format!("tokio runtime: {e}")))?;
             Ok((Some(Arc::new(built)), Some(Arc::new(rt))))
         }
-        Some("local-vllm") | Some("local-llm") => {
+        Some("local-vllm" | "local-llm") => {
             // Offline-first Layer A path (v1.1 Step B). Config is env-driven
             // so `Pensyve(extractor="local-vllm")` works with no additional
             // Python surface change:

--- a/uv.lock
+++ b/uv.lock
@@ -922,7 +922,7 @@ wheels = [
 
 [[package]]
 name = "pensyve"
-version = "1.0.6"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Adds a sibling extractor module (`localllm`) to `AnthropicHaikuExtractor` that targets OpenAI-compatible `chat.completions` endpoints — designed for local vLLM serving small open-weight models (Qwen 3.6-27B dense, **Qwen 3.6-35B-A3B FP8 MoE**, Nemotron Nano 30B, etc.). Mirrors the cloud Haiku extractor on `EXTRACTION_PROMPT_V1`, `RawObservation` shape, and the tolerant JSON parser, so swapping extractors is a pure config flip with no recall-time surface change.

## Why

v1.1 LongMemEval-S 500Q wave needs an **offline-first extractor** for the `pensyve-summarized-local` adapter. Validated end-to-end:

| Adapter | Extractor | Overall accuracy |
|---|---|---:|
| `pensyve-summarized` | Claude Haiku 4.5 (cloud) | **66.5%** |
| `pensyve-summarized-local` | **Qwen 3.6-35B-A3B FP8 MoE (local)** | **61.5%** |

Local extractor is ~5pp behind cloud-Haiku, mainly losing on **multi-session (-11.5pp)** and **knowledge-update (-7.2pp)**. Reaches parity on single-session-assistant and temporal-reasoning. This is the publication-grade offline-first number, validated by Cohen's κ(Nemotron, Sonnet 4.6) = 0.8922 on n=401 calibration sample.

## What's in this PR

### New: `localllm` module (`pensyve-core/src/observation.rs`)
- `LocalLLMExtractor` struct + `Extractor` trait impl
- Offline-first: no API key required, no network egress beyond configured `base_url`
- Honors `PENSYVE_LOCAL_LLM_{URL,MODEL,API_KEY}` env vars
- `enable_thinking=false` passed via `extra_body.chat_template_kwargs` — extraction is grounded JSON output, thinking burns tokens with no accuracy benefit (verified on Qwen-family models)
- Re-exported as `pub use localllm::LocalLLMExtractor`

### Refactor: shared internals exposed to `localllm`
- `RawObservation`, `build_prompt()`, tolerant JSON parser made `pub(super)` so the new sibling module reuses them without leaking into the public `pensyve-core` surface
- `format_observation_content()`: prefixes `[YYYY-MM-DD] ` to observation content when `event_time` is known. Sprint doc 20's pipeline relied on the outer reader prompt to attach dates; v1.1 moves that responsibility into the observation itself so any reader that simply concatenates content strings gets the date for free

### `uv.lock`
- pensyve version bump 1.0.6 → 1.2.0

## Test plan

- [x] `cargo check` clean (no compile errors)
- [ ] `cargo test --package pensyve-core` (CI)
- [ ] `cargo clippy` (CI)
- [ ] Smoke-validated end-to-end via v1.1 LongMemEval-S 500Q wave (10,810 graded rows; see `pensyve-docs:c1a8028` for full results)

## Refs

- `pensyve-docs:c1a8028` — `research/benchmark-sprint/23-v1.1-500q-publication-brief.md` (publication brief w/ adapter provenance)
- `pensyve-docs:c1a8028` — `specs/2026-04-24-pensyve-haiku-cost-optimization.md` (companion spec for prompt-caching + Batches API on the cloud-Haiku side)
- `agent-memory-bench:43a29bd` — v1.1 wave harness (PensyveSummarizedLocalAdapter, run_v1_1_wave.sh, backfill_calibration.py, stepA_accuracy_delta.py)