### PR TITLE
G3 cycle implementation: intent router + supersession summarizer + typed-slot enrichment + MMR diversity

### DIFF
--- a/pensyve-core/src/consolidation/mod.rs
+++ b/pensyve-core/src/consolidation/mod.rs
@@ -3,9 +3,12 @@
 //! ## Per-event gate hooks (G3)
 //!
 //! Pre-reg `pensyve-docs/research/benchmark-sprint/v3/g3/preregistration.md`
-//! §3.4 item 7 + §3.7 + §3.8 add two per-event hooks that fire from
-//! [`ConsolidationEngine::run`] when the appropriate `PENSYVE_RETRIEVAL_CARDS_G3`
-//! env-var arm is active:
+//! §3.4 item 7 + §3.7 + §3.8 add two per-event hooks. They fire from the
+//! ingest path (e.g., `pensyve_core::observation::commit_*` helpers) — NOT
+//! from the legacy [`ConsolidationEngine::run`] periodic pass — when the
+//! appropriate `PENSYVE_RETRIEVAL_CARDS_G3` env-var arm is active. See
+//! the comment block at the hook definitions below for the wiring
+//! rationale.
 //!
 //! 1. **Supersession-chain summarizer** ([`run_supersession_summarizer_hook`])
 //!    — fires on `supersedes`-edge population. Reads chain entries, calls

--- a/pensyve-core/src/consolidation/mod.rs
+++ b/pensyve-core/src/consolidation/mod.rs
@@ -463,6 +463,29 @@ impl ConsolidationEngine {
 /// gate may evolve its trigger criteria independent of the SSU card.
 const TYPED_SLOT_TRIGGER_ACTIONS: &[&str] = &["mentioned", "stated", "is", "has", "lives"];
 
+/// Hard cap on per-event LLM input size. Bounds context overflow + latency
+/// spikes + runaway cost on accidentally-large observations or deep
+/// supersession chains. Per coderabbit Major review on PR #86 +
+/// pre-reg §3.7 design intent (chain summary is bounded by chain depth ≤ 4
+/// and `LIMIT 4` in `lookup_supersession_chain`). Chosen conservatively at
+/// 12 KB to fit comfortably inside any production model's context window
+/// while still admitting realistic observation/chain sizes.
+const MAX_LLM_INPUT_BYTES: usize = 12_000;
+
+/// Truncate a string to at most `max_bytes` while preserving UTF-8
+/// boundaries. Walks back from the byte cap until landing on a char
+/// boundary so we never split a multi-byte codepoint mid-character.
+fn truncate_utf8_safe(s: &str, max_bytes: usize) -> &str {
+    if s.len() <= max_bytes {
+        return s;
+    }
+    let mut end = max_bytes;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    &s[..end]
+}
+
 /// True when the action verb matches the typed-slot extractor's trigger
 /// heuristic. Case-insensitive + trimmed.
 #[must_use]
@@ -572,7 +595,16 @@ pub async fn run_typed_slots_hook<L: TypedSlotLlm + ?Sized>(
         ));
     }
 
-    match extract_slots(observation_content, extractor, cancel).await {
+    // Bound LLM input size before the network call. Prevents context
+    // overflow + latency spikes + runaway cost on accidentally-large
+    // observations (e.g., a haystack message that includes a full
+    // conversation excerpt). Per coderabbit Major review on PR #86.
+    let bounded_content = truncate_utf8_safe(observation_content, MAX_LLM_INPUT_BYTES);
+    if bounded_content.is_empty() {
+        return Ok(None);
+    }
+
+    match extract_slots(bounded_content, extractor, cancel).await {
         Ok(slots) => {
             // Defer-on-empty: nothing to persist; caller logs to defer
             // log and skips the UPDATE.
@@ -646,7 +678,8 @@ markdown.";
         return Ok(None);
     }
 
-    let trimmed = chain_text.trim();
+    // Bound LLM input — chain text can grow with depth-of-supersession.
+    let trimmed = truncate_utf8_safe(chain_text.trim(), MAX_LLM_INPUT_BYTES);
     if trimmed.is_empty() {
         return Ok(None);
     }

--- a/pensyve-core/src/consolidation/mod.rs
+++ b/pensyve-core/src/consolidation/mod.rs
@@ -1,3 +1,49 @@
+//! Consolidation engine — periodic and per-event memory transformations.
+//!
+//! ## Per-event gate hooks (G3)
+//!
+//! Pre-reg `pensyve-docs/research/benchmark-sprint/v3/g3/preregistration.md`
+//! §3.4 item 7 + §3.7 + §3.8 add two per-event hooks that fire from
+//! [`ConsolidationEngine::run`] when the appropriate `PENSYVE_RETRIEVAL_CARDS_G3`
+//! env-var arm is active:
+//!
+//! 1. **Supersession-chain summarizer** ([`run_supersession_summarizer_hook`])
+//!    — fires on `supersedes`-edge population. Reads chain entries, calls
+//!    Qwen once with chain text, writes 1-2 sentence English-prose summary
+//!    to `chain_summary` column on the head observation. Bounded by
+//!    `#[max_llm_calls(1)]`. Gated on `PENSYVE_RETRIEVAL_CARDS_G3 ∈
+//!    {summarizer, full}` via [`g3_summarizer_enabled`].
+//! 2. **Typed-slot extractor** ([`run_typed_slots_hook`]) — fires on
+//!    observation insertion when the question-type heuristic matches
+//!    (`action ∈ {'mentioned', 'stated', 'is', 'has', 'lives'}` per
+//!    `PeerCard`'s `action_to_kind` mapping). Calls Qwen once with
+//!    observation content, parses 5-slot JSON, writes populated slots to
+//!    typed-slot columns. Bounded by `#[max_llm_calls(1)]` (one call
+//!    extracts all 5 slots per operator-locked (c') 2026-05-06). Gated on
+//!    `PENSYVE_RETRIEVAL_CARDS_G3 ∈ {typed_slots, full}` via
+//!    [`g3_typed_slots_enabled`].
+//!
+//! Both hooks check [`NetworkPolicy::Permissive`] before the LLM call (G1
+//! contract) and respect the [`CancellationToken`] passed through.
+//!
+//! Operator-locked (b') on 2026-05-06: cancellation semantics =
+//! ROLLBACK. If `cancel` triggers mid-LLM-call, partial state is rolled
+//! back — `chain_summary` and typed-slot columns are either fully
+//! populated OR NULL, never partial. Implementation: each hook uses a
+//! defer-write pattern (compute the full LLM result first; persist only
+//! on success) so a cancelled future drops cleanly without touching
+//! `SQLite`. The storage-trait write methods are atomic single-row
+//! UPDATE statements, so the persist step is its own transaction
+//! boundary — no partial column writes are possible by construction.
+//!
+//! ## Submodules
+//!
+//! - [`typed_slots`] — fixed-shape 5-slot LLM extractor used by the
+//!   per-event gate. See its module docs for the prompt and parser
+//!   contract.
+
+pub mod typed_slots;
+
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
@@ -10,7 +56,9 @@ use crate::decay;
 use crate::embedding::{OnnxEmbedder, cosine_similarity};
 use crate::network_policy::{NetworkPolicy, NetworkRequiredError};
 use crate::storage::{StorageError, StorageTrait};
-use crate::types::{EpisodicMemory, Memory, SemanticMemory};
+use crate::types::{EpisodicMemory, Memory, SemanticMemory, SlotKind};
+
+use self::typed_slots::{TypedSlotLlm, TypedSlots, extract_slots};
 
 // ---------------------------------------------------------------------------
 // Error type
@@ -387,6 +435,272 @@ impl ConsolidationEngine {
 
         Ok((decayed, archived))
     }
+}
+
+// ---------------------------------------------------------------------------
+// G3 per-event consolidation gate hooks
+// ---------------------------------------------------------------------------
+//
+// These hook helpers are NOT plumbed into the legacy
+// `ConsolidationEngine::run` periodic pass — they fire from the ingest
+// path (engine entry / observation persist) when an event triggers the
+// associated condition. The pre-reg's "ConsolidationEngine::run is
+// extended with two per-event gate hooks" wording is realised here as
+// `pub fn` helpers callable from any ingest site that already holds a
+// storage handle, an extractor handle, and a cancellation token.
+//
+// Wiring into the actual ingest path (e.g.,
+// `pensyve_core::observation::commit_extraction_for_episode`) is left to
+// the harness adapter on the parallel P5 work; this module ships the
+// callable surface + the env-gate predicates.
+
+/// Action verbs that trigger the typed-slot extractor's question-type
+/// heuristic, per pre-reg §3.8 ("`action ∈ {'mentioned', 'stated', 'is',
+/// 'has', 'lives'}` per `PeerCard`'s `action_to_kind` mapping"). Mirrors
+/// the user-fact verb set in
+/// `pensyve_core::retrieval::cards::single_session_user::USER_FACT_ACTIONS`
+/// — kept as a const here rather than imported because the typed-slot
+/// gate may evolve its trigger criteria independent of the SSU card.
+const TYPED_SLOT_TRIGGER_ACTIONS: &[&str] = &["mentioned", "stated", "is", "has", "lives"];
+
+/// True when the action verb matches the typed-slot extractor's trigger
+/// heuristic. Case-insensitive + trimmed.
+#[must_use]
+pub fn typed_slot_action_triggers(action: &str) -> bool {
+    let normalized = action.trim().to_ascii_lowercase();
+    TYPED_SLOT_TRIGGER_ACTIONS.iter().any(|v| *v == normalized)
+}
+
+/// Read `PENSYVE_RETRIEVAL_CARDS_G3` and return `true` when the
+/// supersession-chain summarizer hook is enabled (`summarizer` or `full`).
+/// All other values (including unset / empty) return `false`.
+#[must_use]
+pub fn g3_summarizer_enabled() -> bool {
+    matches!(
+        std::env::var("PENSYVE_RETRIEVAL_CARDS_G3")
+            .as_deref()
+            .map(str::trim)
+            .map(str::to_ascii_lowercase)
+            .as_deref(),
+        Ok("summarizer" | "full")
+    )
+}
+
+/// Read `PENSYVE_RETRIEVAL_CARDS_G3` and return `true` when the
+/// typed-slot extractor hook is enabled (`typed_slots` or `full`). All
+/// other values (including unset / empty) return `false`.
+#[must_use]
+pub fn g3_typed_slots_enabled() -> bool {
+    matches!(
+        std::env::var("PENSYVE_RETRIEVAL_CARDS_G3")
+            .as_deref()
+            .map(str::trim)
+            .map(str::to_ascii_lowercase)
+            .as_deref(),
+        Ok("typed_slots" | "full")
+    )
+}
+
+/// Per-event gate hook: typed-slot extractor.
+///
+/// Fires on observation insertion when the action verb matches
+/// [`typed_slot_action_triggers`] AND the env-gate
+/// [`g3_typed_slots_enabled`] is on. Calls the LLM once with the
+/// observation content; parses the JSON response into [`TypedSlots`];
+/// returns the slots without persisting (caller persists via
+/// `StorageTrait::update_observation_typed_slots` once that surface
+/// lands — see pre-reg §7 item 7 wiring note).
+///
+/// Bounded by `#[max_llm_calls(1)]` per Rev B §5.4.
+///
+/// ## `NetworkPolicy`
+///
+/// The hook itself does NOT call into the network — it delegates to the
+/// passed-in [`TypedSlotLlm`] which honors its own configured policy
+/// (`Permissive` for managed-service, `LocalOnly` for offline-first
+/// `localhost:8888`, `Disabled` for the air-gap test). The policy
+/// argument here is forwarded for forward-compat: when the trait gains
+/// a policy-aware variant, the hook plumbs it through unchanged.
+///
+/// ## Cancellation (operator-locked (b') ROLLBACK)
+///
+/// On cancel, the LLM call returns
+/// [`typed_slots::SlotExtractionError::Cancelled`] and this hook returns
+/// `Err(_)`. Caller MUST NOT persist on this path — typed-slot columns
+/// stay NULL (rollback semantics). Atomic single-row UPDATE on the
+/// persist side guarantees no partial-column states are possible by
+/// construction.
+///
+/// ## Defer-on-failure
+///
+/// On parse / transport / empty-content failure, returns `Ok(None)` so
+/// the caller can log to the per-event defer log and continue without
+/// typed-slot enrichment for this observation. Distinguished from the
+/// cancel path which returns `Err(_)` so callers can route the two
+/// outcomes to different log streams.
+pub async fn run_typed_slots_hook<L: TypedSlotLlm + ?Sized>(
+    observation_action: &str,
+    observation_content: &str,
+    extractor: &L,
+    policy: &NetworkPolicy,
+    cancel: CancellationToken,
+) -> Result<Option<TypedSlots>, ConsolidationError> {
+    // Env-gate: only fire when arm is on.
+    if !g3_typed_slots_enabled() {
+        return Ok(None);
+    }
+
+    // Action-heuristic gate: pre-reg §3.8 limits the extractor to
+    // user-fact-shaped observations to keep write-time LLM cost bounded.
+    if !typed_slot_action_triggers(observation_action) {
+        return Ok(None);
+    }
+
+    // NetworkPolicy gate: G1 contract requires `Permissive` for any
+    // outbound LLM call. `Disabled` and `LocalOnly` are checked by the
+    // extractor itself (the policy parameter on `LocalLLMExtractor` is
+    // already enforced); we re-check here so the hook fails closed
+    // before attempting the call when the policy is explicitly off.
+    if matches!(policy, NetworkPolicy::Disabled) {
+        return Ok(None);
+    }
+
+    // Pre-flight cancel — cheap short-circuit before the LLM call.
+    if cancel.is_cancelled() {
+        return Err(ConsolidationError::Cancelled(
+            "cancelled before typed-slots LLM call".into(),
+        ));
+    }
+
+    match extract_slots(observation_content, extractor, cancel).await {
+        Ok(slots) => {
+            // Defer-on-empty: nothing to persist; caller logs to defer
+            // log and skips the UPDATE.
+            if slots.is_empty() {
+                return Ok(None);
+            }
+            Ok(Some(slots))
+        }
+        Err(typed_slots::SlotExtractionError::Cancelled(msg)) => {
+            // Operator-locked (b') ROLLBACK path: surface as Cancelled so
+            // the caller does not persist.
+            Err(ConsolidationError::Cancelled(format!("typed-slots: {msg}")))
+        }
+        Err(other) => {
+            // Defer-on-failure: log + skip persist. The typed-slot
+            // columns remain NULL for this observation, which is the
+            // same shape as a v=1 legacy row.
+            tracing::debug!(
+                error = %other,
+                action = observation_action,
+                "typed-slot extractor deferred on this observation"
+            );
+            Ok(None)
+        }
+    }
+}
+
+/// Per-event gate hook: supersession-chain summarizer.
+///
+/// Fires on `supersedes`-edge population (caller decides when to invoke
+/// — typically right after `Edge { edge_type: EdgeType::Supersedes, .. }`
+/// is committed) when the env-gate [`g3_summarizer_enabled`] is on.
+/// Calls the LLM once with the chain entries' concatenated content;
+/// returns the 1-2 sentence English-prose summary string without
+/// persisting. Caller persists into the head observation's
+/// `chain_summary` column via the storage-trait UPDATE.
+///
+/// Bounded by `#[max_llm_calls(1)]` per Rev B §5.4.
+///
+/// ## Cancellation (operator-locked (b') ROLLBACK)
+///
+/// On cancel, the LLM call returns Cancelled and this hook returns
+/// `Err(_)`. Caller MUST NOT persist — `chain_summary` column stays NULL.
+///
+/// ## Defer-on-failure
+///
+/// On any non-cancellation failure, returns `Ok(None)`. Caller logs and
+/// skips the UPDATE; the head observation's `chain_summary` stays NULL.
+///
+/// ## Implementation note
+///
+/// The summarizer is implemented as a thin wrapper around
+/// [`TypedSlotLlm::complete`] with a chain-summary prompt instead of the
+/// 5-slot prompt — the underlying HTTP shape is identical (single
+/// system-prompt + user-content pair), so reusing the trait avoids
+/// duplicating the OpenAI-compatible request plumbing.
+pub async fn run_supersession_summarizer_hook<L: TypedSlotLlm + ?Sized>(
+    chain_text: &str,
+    extractor: &L,
+    policy: &NetworkPolicy,
+    cancel: CancellationToken,
+) -> Result<Option<String>, ConsolidationError> {
+    const SUMMARIZER_PROMPT: &str = "You are a memory-chain summarizer. \
+Given a sequence of related observations describing how a user state \
+evolved over time, produce a 1-2 sentence English-prose summary of the \
+overall evolution. Focus on the FINAL state and the path that got there. \
+Output ONLY the summary text. No prose intro, no bullet points, no \
+markdown.";
+
+    if !g3_summarizer_enabled() {
+        return Ok(None);
+    }
+
+    let trimmed = chain_text.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+
+    if matches!(policy, NetworkPolicy::Disabled) {
+        return Ok(None);
+    }
+
+    if cancel.is_cancelled() {
+        return Err(ConsolidationError::Cancelled(
+            "cancelled before summarizer LLM call".into(),
+        ));
+    }
+
+    match extractor.complete(SUMMARIZER_PROMPT, trimmed, cancel).await {
+        Ok(text) => {
+            let summary = text.trim().to_string();
+            if summary.is_empty() {
+                return Ok(None);
+            }
+            Ok(Some(summary))
+        }
+        Err(typed_slots::SlotExtractionError::Cancelled(msg)) => {
+            Err(ConsolidationError::Cancelled(format!("summarizer: {msg}")))
+        }
+        Err(other) => {
+            tracing::debug!(
+                error = %other,
+                "supersession-chain summarizer deferred on this chain"
+            );
+            Ok(None)
+        }
+    }
+}
+
+/// Apply a [`TypedSlots`] result to the column-name → value mapping the
+/// caller will bind into a SQL UPDATE statement. Centralises the slot-
+/// column naming convention (column = `{kind}_slot`) so SQL sites cannot
+/// drift from the migration's column names.
+#[must_use]
+pub fn typed_slots_to_columns(slots: &TypedSlots) -> Vec<(&'static str, Option<String>)> {
+    SlotKind::all()
+        .iter()
+        .map(|kind| {
+            let col = match kind {
+                SlotKind::Biography => "biography_slot",
+                SlotKind::Preference => "preference_slot",
+                SlotKind::Experience => "experience_slot",
+                SlotKind::Social => "social_slot",
+                SlotKind::Work => "work_slot",
+            };
+            (col, slots.get(*kind).map(str::to_string))
+        })
+        .collect()
 }
 
 // ---------------------------------------------------------------------------

--- a/pensyve-core/src/consolidation/typed_slots.rs
+++ b/pensyve-core/src/consolidation/typed_slots.rs
@@ -1,0 +1,487 @@
+//! Per-event typed-slot extractor — Pensyve v3 G3 implementation per
+//! `pensyve-docs/research/benchmark-sprint/v3/g3/preregistration.md`
+//! §3.4 item 6 + §3.8 + §7 item 7 (locked at `pensyve-docs@64481dc`).
+//!
+//! Operator-locked decision (c) on 2026-05-06: typed-slot enrichment is
+//! implemented as new NULLABLE columns on `observation_memories` (NOT a
+//! separate `typed_slots` table). Schema migration in
+//! `storage::sqlite::run_versioned_migrations` v=2 lands the columns;
+//! this module's [`extract_slots`] populates them at write time.
+//!
+//! Operator-locked decision (c') on 2026-05-06: extraction is FIXED-SHAPE
+//! — a single LLM call always extracts all 5 slots. Non-matching slots
+//! return NULL in the JSON response. Bounded by `#[max_llm_calls(1)]`
+//! per Rev B §5.4 (1 LLM call per write event, non-cumulative).
+//!
+//! Operator-locked decision (b') on 2026-05-06: cancellation semantics =
+//! ROLLBACK. The extractor itself does not write to storage — it returns
+//! a [`TypedSlots`] result; the calling consolidation gate hook in
+//! `super::run_typed_slots_hook` is responsible for the transactional
+//! defer-write pattern that ensures the typed-slot columns are either
+//! fully populated or NULL, never partial. See parent module docs.
+//!
+//! ## Defer-on-failure contract
+//!
+//! Mirrors the existing observation-extraction pattern in
+//! `pensyve-core/src/observation.rs`:
+//!
+//! - Parse failure (LLM returned malformed JSON) → return
+//!   `Err(SlotExtractionError::Parse)`. Caller logs to defer-event log
+//!   and falls back to "no typed-slot enrichment for this event".
+//! - Transport failure (LLM HTTP error) → return
+//!   `Err(SlotExtractionError::Transport)`. Caller behavior identical.
+//! - Cancellation (token signaled mid-call) → return
+//!   `Err(SlotExtractionError::Cancelled)`. Caller rolls back any
+//!   partial state per the `(b')` lock above.
+//!
+//! Errors are intentionally distinct from `observation::ExtractionError`
+//! so the consolidation gate can disambiguate "typed-slot extractor
+//! failed" from "observation extractor failed" in the per-event defer
+//! log without re-encoding the error variant.
+
+use std::collections::HashMap;
+
+use serde::Deserialize;
+use thiserror::Error;
+use tokio_util::sync::CancellationToken;
+
+use crate::types::SlotKind;
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/// Result of a single typed-slot extraction call. Each field is `Option<String>`
+/// because the FIXED-SHAPE prompt always returns all 5 keys; non-matching
+/// slots come back as JSON `null` and decode to `None`.
+///
+/// The consolidation gate hook in `super::run_typed_slots_hook` writes
+/// these into the `biography_slot`, `preference_slot`, `experience_slot`,
+/// `social_slot`, `work_slot` columns on the head observation row at
+/// write time.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TypedSlots {
+    pub biography: Option<String>,
+    pub preference: Option<String>,
+    pub experience: Option<String>,
+    pub social: Option<String>,
+    pub work: Option<String>,
+}
+
+impl TypedSlots {
+    /// Returns `true` when every slot is `None`. The caller may use
+    /// this to skip the persist path entirely when extraction yielded
+    /// nothing useful (defer-on-empty mirrors `PeerCard`'s contract).
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.biography.is_none()
+            && self.preference.is_none()
+            && self.experience.is_none()
+            && self.social.is_none()
+            && self.work.is_none()
+    }
+
+    /// Lookup a slot value by [`SlotKind`]. Returns the borrowed
+    /// `Option<&str>` shape that the SQL bind sites need (NULL when
+    /// `None`, the trimmed string when `Some`).
+    #[must_use]
+    pub fn get(&self, kind: SlotKind) -> Option<&str> {
+        match kind {
+            SlotKind::Biography => self.biography.as_deref(),
+            SlotKind::Preference => self.preference.as_deref(),
+            SlotKind::Experience => self.experience.as_deref(),
+            SlotKind::Social => self.social.as_deref(),
+            SlotKind::Work => self.work.as_deref(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/// Non-fatal errors from typed-slot extraction. The caller (consolidation
+/// gate) logs them to the per-event defer log and continues without slot
+/// enrichment for the failing observation.
+#[derive(Debug, Error)]
+pub enum SlotExtractionError {
+    /// LLM returned malformed JSON or a shape that didn't match the
+    /// fixed-5-slot schema. Caller defers per pre-reg §3.8 hardening.
+    #[error("typed-slot extractor parse error: {0}")]
+    Parse(String),
+
+    /// HTTP / transport layer failure between this process and the local
+    /// vLLM endpoint. Includes timeouts.
+    #[error("typed-slot extractor transport error: {0}")]
+    Transport(String),
+
+    /// Cancellation observed via the [`CancellationToken`] passed into
+    /// [`extract_slots`]. The accompanying string carries a short site
+    /// marker (`"cancelled before HTTP call"` / `"cancelled during HTTP
+    /// call"`) so post-hoc logs can reconstruct where the cancel was
+    /// observed. Per operator-locked (b') 2026-05-06: the consolidation
+    /// gate ROLLS BACK any partial state when this fires.
+    #[error("typed-slot extraction cancelled: {0}")]
+    Cancelled(String),
+}
+
+pub type SlotExtractionResult = Result<TypedSlots, SlotExtractionError>;
+
+// ---------------------------------------------------------------------------
+// Prompt
+// ---------------------------------------------------------------------------
+
+/// FIXED-SHAPE typed-slot extraction prompt per operator-locked (c')
+/// 2026-05-06. The prompt asks the LLM to return a JSON object with
+/// exactly 5 string-or-null keys (one per [`SlotKind`]).
+///
+/// Note: the prompt requires the LLM to honor the JSON schema. Real
+/// production calls use the same `enable_thinking: false` chat template
+/// kwarg as `LocalLLMExtractor` to keep latency on Qwen 3+ / Nemotron
+/// Nano reasoning models bounded; that knob is configured at the
+/// extractor adapter, not in the prompt text.
+pub const TYPED_SLOTS_PROMPT_V1: &str = "You are a structured-fact extractor. \
+Given a single observation about the user, extract the user's standing \
+facts into FIVE typed slots. The 5 slots are:
+
+1. biography  — durable personal facts (name, age, location, family).
+2. preference — durable likes/dislikes/wants (food preferences, hotel preferences, dietary restrictions).
+3. experience — recent or significant life events (trips, projects completed, milestones).
+4. social     — relationships and social context (friends, colleagues, partners, communities).
+5. work       — occupation, professional role, current projects, employer.
+
+Output a JSON object with exactly these 5 keys. Each value is either:
+- A short English-prose string capturing the fact (max ~100 chars), OR
+- null if the observation contains no information for that slot.
+
+Rules:
+- DO NOT make up facts. If the observation does not mention the slot, output null.
+- DO NOT include hedged or hypothetical statements (\"I might move to NY\" → null for biography).
+- DO NOT duplicate the observation verbatim — extract the SLOT-SHAPED FACT.
+- Output ONLY the JSON object. No prose, no explanation, no markdown fences.
+
+Example output:
+{\"biography\": \"User lives in Seattle\", \"preference\": null, \"experience\": null, \"social\": null, \"work\": \"User is a software engineer\"}";
+
+/// JSON shape the prompt asks the LLM to return. Mirrors [`TypedSlots`]
+/// but uses `Option<String>` to map JSON `null` to `None` cleanly.
+#[derive(Debug, Deserialize, Default)]
+struct RawTypedSlots {
+    #[serde(default)]
+    biography: Option<String>,
+    #[serde(default)]
+    preference: Option<String>,
+    #[serde(default)]
+    experience: Option<String>,
+    #[serde(default)]
+    social: Option<String>,
+    #[serde(default)]
+    work: Option<String>,
+}
+
+impl From<RawTypedSlots> for TypedSlots {
+    fn from(raw: RawTypedSlots) -> Self {
+        // Trim and normalize: empty strings become None, non-empty strings
+        // get trimmed. Mirrors the observation extractor's tolerance for
+        // LLM whitespace variation.
+        fn norm(s: Option<String>) -> Option<String> {
+            s.map(|v| v.trim().to_string()).filter(|v| !v.is_empty())
+        }
+        Self {
+            biography: norm(raw.biography),
+            preference: norm(raw.preference),
+            experience: norm(raw.experience),
+            social: norm(raw.social),
+            work: norm(raw.work),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Extractor abstraction
+// ---------------------------------------------------------------------------
+
+/// Minimal LLM-call abstraction: takes the prompt + observation content,
+/// returns the raw response string. Intentionally narrower than
+/// `observation::ObservationExtractor` because typed-slot extraction has
+/// a single-shot prompt-in / string-out shape that doesn't need the
+/// per-message conversation framing.
+///
+/// The production wiring lives at the consolidation gate hook site,
+/// which constructs an adapter wrapping
+/// `observation::LocalLLMExtractor`. Tests use a closure-backed mock
+/// (see `tests/test_typed_slots.rs` for the harness).
+#[async_trait::async_trait]
+pub trait TypedSlotLlm: Send + Sync {
+    /// Single-prompt LLM call. Implementations MUST honor the
+    /// [`CancellationToken`] (race the in-flight HTTP future via
+    /// `tokio::select!` per the G1 contract) and return
+    /// [`SlotExtractionError::Cancelled`] within ≤500ms when the token
+    /// is signaled.
+    async fn complete(
+        &self,
+        system_prompt: &str,
+        user_content: &str,
+        cancel: CancellationToken,
+    ) -> Result<String, SlotExtractionError>;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Extract typed slots from a single observation's content via one LLM
+/// call.
+///
+/// FIXED-SHAPE per operator-locked (c') 2026-05-06: always asks for all
+/// 5 slots; non-matching slots return NULL in the JSON. Bounded by
+/// `#[max_llm_calls(1)]` per Rev B §5.4.
+///
+/// ## Cancellation
+///
+/// Honors `cancel` via the underlying [`TypedSlotLlm`] implementation.
+/// On cancel, returns [`SlotExtractionError::Cancelled`]; the calling
+/// consolidation gate hook in `super::run_typed_slots_hook` rolls back
+/// any partial state (typed-slot columns stay NULL) per the `(b')` lock.
+///
+/// ## Defer-on-failure
+///
+/// On parse failure, transport failure, or empty observation content,
+/// returns the corresponding error. The caller logs to the defer-event
+/// log and skips the persist path — typed-slot columns remain NULL for
+/// this observation.
+///
+/// ## Empty content
+///
+/// Returns `Ok(TypedSlots::default())` (all-None) when the observation
+/// content is empty or whitespace-only. The caller may check
+/// `result.is_empty()` to skip the persist path entirely.
+pub async fn extract_slots<E: TypedSlotLlm + ?Sized>(
+    observation_content: &str,
+    extractor: &E,
+    cancel: CancellationToken,
+) -> SlotExtractionResult {
+    // Pre-flight cancel check. Cheap, deterministic, short-circuits the
+    // prompt build + LLM call below when the caller has already given
+    // up. Pre-reg §5.5 / I5 binds the contract.
+    if cancel.is_cancelled() {
+        return Err(SlotExtractionError::Cancelled(
+            "cancelled before HTTP call".into(),
+        ));
+    }
+
+    let trimmed = observation_content.trim();
+    if trimmed.is_empty() {
+        // Empty content — defer-on-empty path. Returns all-None slots so
+        // the caller can persist NULL across all 5 columns (which is the
+        // same shape as a v=1 legacy row, by design).
+        return Ok(TypedSlots::default());
+    }
+
+    let raw = extractor
+        .complete(TYPED_SLOTS_PROMPT_V1, trimmed, cancel)
+        .await?;
+
+    parse_response(&raw)
+}
+
+// ---------------------------------------------------------------------------
+// Response parsing
+// ---------------------------------------------------------------------------
+
+/// Parse the LLM response into [`TypedSlots`].
+///
+/// Tolerant parser mirroring `observation::prompt_v1::parse_response`:
+/// strips markdown fences and extracts the outermost JSON object before
+/// deserialization. Returns `Err(SlotExtractionError::Parse)` when:
+/// - the response contains no `{` `}` braces, OR
+/// - the JSON inside the braces fails to deserialize as a 5-key object.
+///
+/// Exposed `pub(crate)` so the integration tests in
+/// `tests/test_typed_slots.rs` can exercise the parser without a mock
+/// LLM round-trip.
+pub(crate) fn parse_response(text: &str) -> SlotExtractionResult {
+    fn pick(map: &HashMap<String, serde_json::Value>, key: &str) -> Option<String> {
+        map.get(key).and_then(|v| match v {
+            serde_json::Value::String(s) => {
+                let t = s.trim();
+                if t.is_empty() {
+                    None
+                } else {
+                    Some(t.to_string())
+                }
+            }
+            serde_json::Value::Null => None,
+            // Be tolerant of LLMs that wrap the value in unusual shapes —
+            // stringify non-null primitives as a last-resort fallback.
+            other if !other.is_null() => Some(other.to_string()),
+            _ => None,
+        })
+    }
+
+    let trimmed = text.trim();
+    let no_fence = strip_markdown_fence(trimmed);
+
+    let brace_start = no_fence.find('{');
+    let brace_end = no_fence.rfind('}');
+    let slice = match (brace_start, brace_end) {
+        (Some(s), Some(e)) if e > s => &no_fence[s..=e],
+        _ => {
+            return Err(SlotExtractionError::Parse(format!(
+                "no JSON object braces in response: {trimmed:?}"
+            )));
+        }
+    };
+
+    // First try: strict object deserialization.
+    if let Ok(raw) = serde_json::from_str::<RawTypedSlots>(slice) {
+        return Ok(raw.into());
+    }
+
+    // Resilience fallback: parse as a generic map and pick out the 5
+    // known keys. Lets the caller tolerate extra fields the LLM may
+    // emit (e.g., `"reasoning": "..."`) without rejecting the whole
+    // response.
+    let map: HashMap<String, serde_json::Value> = serde_json::from_str(slice)
+        .map_err(|e| SlotExtractionError::Parse(format!("json deserialize: {e}")))?;
+
+    Ok(TypedSlots {
+        biography: pick(&map, "biography"),
+        preference: pick(&map, "preference"),
+        experience: pick(&map, "experience"),
+        social: pick(&map, "social"),
+        work: pick(&map, "work"),
+    })
+}
+
+/// Strip markdown fences from an LLM response. Mirrors the helper in
+/// `observation::prompt_v1::strip_markdown_fence` but kept local here
+/// to avoid coupling the typed-slot module to the observation extractor's
+/// feature-gated submodule.
+fn strip_markdown_fence(s: &str) -> &str {
+    let Some(start) = s.find("```") else {
+        return s;
+    };
+    let after_open = &s[start + 3..];
+    let after_lang = after_open
+        .strip_prefix("json")
+        .unwrap_or(after_open)
+        .trim_start();
+    let Some(close_rel) = after_lang.rfind("```") else {
+        return after_lang.trim();
+    };
+    after_lang[..close_rel].trim()
+}
+
+// ---------------------------------------------------------------------------
+// Tests (inline; integration fuzz lives in tests/test_typed_slots.rs)
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_response_extracts_all_five_slots() {
+        let text = r#"{
+            "biography": "User lives in Seattle",
+            "preference": "Prefers dark roast coffee",
+            "experience": "Visited Iceland in 2024",
+            "social": "Has a sister named Marie",
+            "work": "Software engineer at Acme Corp"
+        }"#;
+        let slots = parse_response(text).expect("parse");
+        assert_eq!(slots.biography.as_deref(), Some("User lives in Seattle"));
+        assert_eq!(
+            slots.preference.as_deref(),
+            Some("Prefers dark roast coffee")
+        );
+        assert_eq!(slots.experience.as_deref(), Some("Visited Iceland in 2024"));
+        assert_eq!(slots.social.as_deref(), Some("Has a sister named Marie"));
+        assert_eq!(
+            slots.work.as_deref(),
+            Some("Software engineer at Acme Corp")
+        );
+        assert!(!slots.is_empty());
+    }
+
+    #[test]
+    fn parse_response_handles_all_null_slots() {
+        let text = r#"{
+            "biography": null,
+            "preference": null,
+            "experience": null,
+            "social": null,
+            "work": null
+        }"#;
+        let slots = parse_response(text).expect("parse");
+        assert!(slots.is_empty());
+    }
+
+    #[test]
+    fn parse_response_handles_partial_slots() {
+        let text = r#"{"biography": null, "preference": "tea over coffee", "experience": null, "social": null, "work": null}"#;
+        let slots = parse_response(text).expect("parse");
+        assert_eq!(slots.preference.as_deref(), Some("tea over coffee"));
+        assert!(slots.biography.is_none());
+        assert!(slots.work.is_none());
+        assert!(!slots.is_empty());
+    }
+
+    #[test]
+    fn parse_response_strips_markdown_fence() {
+        let text = "```json\n{\"biography\": \"x\", \"preference\": null, \"experience\": null, \"social\": null, \"work\": null}\n```";
+        let slots = parse_response(text).expect("parse");
+        assert_eq!(slots.biography.as_deref(), Some("x"));
+    }
+
+    #[test]
+    fn parse_response_rejects_non_json_response() {
+        let text = "I can't help with that request.";
+        let err = parse_response(text).expect_err("must reject prose");
+        assert!(matches!(err, SlotExtractionError::Parse(_)));
+    }
+
+    #[test]
+    fn parse_response_tolerates_extra_keys() {
+        // LLM emits the 5 expected keys plus an extra "reasoning" field.
+        let text = r#"{
+            "reasoning": "this user mentioned their job",
+            "biography": null,
+            "preference": null,
+            "experience": null,
+            "social": null,
+            "work": "software engineer"
+        }"#;
+        let slots = parse_response(text).expect("parse");
+        assert_eq!(slots.work.as_deref(), Some("software engineer"));
+    }
+
+    #[test]
+    fn parse_response_rejects_truncated_response() {
+        let text = "{\"biography\": \"x";
+        let err = parse_response(text).expect_err("must reject truncated json");
+        assert!(matches!(err, SlotExtractionError::Parse(_)));
+    }
+
+    #[test]
+    fn typed_slots_empty_query_short_circuits() {
+        // The .is_empty() helper returns true on an all-None default.
+        let s = TypedSlots::default();
+        assert!(s.is_empty());
+    }
+
+    #[test]
+    fn typed_slots_get_returns_borrowed_value() {
+        let s = TypedSlots {
+            biography: Some("bio".into()),
+            preference: None,
+            experience: None,
+            social: None,
+            work: Some("work".into()),
+        };
+        assert_eq!(s.get(SlotKind::Biography), Some("bio"));
+        assert_eq!(s.get(SlotKind::Work), Some("work"));
+        assert_eq!(s.get(SlotKind::Preference), None);
+    }
+}

--- a/pensyve-core/src/observation.rs
+++ b/pensyve-core/src/observation.rs
@@ -971,6 +971,19 @@ mod localllm {
             Self::new(base_url, model, api_key, policy)
         }
 
+        /// Configured chat endpoint base URL (without the `/chat/completions`
+        /// suffix). Read by the G3 gate wiring layer so structured log
+        /// markers (`consolidation_gate_fired`, `typed_slots_extracted`,
+        /// `summarizer_gate`) record the actual URL the gate called rather
+        /// than a hardcoded literal — operators with `PENSYVE_EXTRACTOR_URL`
+        /// pointing somewhere other than `localhost:8888` get accurate
+        /// audit evidence. Per coderabbit PR #86 round-3 review on
+        /// observation.rs:2483.
+        #[must_use]
+        pub fn endpoint(&self) -> &str {
+            &self.base_url
+        }
+
         #[must_use]
         pub fn with_base_url(mut self, base_url: impl Into<String>) -> Self {
             self.base_url = base_url.into();
@@ -2433,16 +2446,6 @@ mod gate_wiring {
         Ok(out)
     }
 
-    /// Build a new typed-slot LLM extractor from environment variables.
-    /// Reuses `LocalLLMExtractor::from_env()` so the typed-slot endpoint
-    /// matches the observation extractor's by construction (same
-    /// `PENSYVE_EXTRACTOR_URL` / `PENSYVE_EXTRACTOR_MODEL` / network
-    /// policy). Returns `None` on any configuration error — gate firings
-    /// degrade to no-ops cleanly.
-    fn build_typed_slot_extractor() -> Option<LocalLLMExtractor> {
-        LocalLLMExtractor::from_env().ok()
-    }
-
     /// Fire the typed-slot extractor gate hook and persist the result.
     ///
     /// Pre-reg §3.8 binds the action-verb heuristic + 5-slot extractor
@@ -2462,6 +2465,7 @@ mod gate_wiring {
         observation: &ObservationMemory,
         extractor: &L,
         policy: &NetworkPolicy,
+        endpoint: &str,
         cancel: CancellationToken,
     ) where
         L: TypedSlotLlm + ?Sized,
@@ -2478,8 +2482,9 @@ mod gate_wiring {
         }
 
         tracing::info!(
-            "consolidation_gate_fired event_id={} gate_kind=typed_slots endpoint=localhost:8888 max_llm_calls=1",
-            observation.id
+            "consolidation_gate_fired event_id={} gate_kind=typed_slots endpoint={} max_llm_calls=1",
+            observation.id,
+            endpoint
         );
 
         let result = consolidation::run_typed_slots_hook(
@@ -2504,16 +2509,18 @@ mod gate_wiring {
                 match persist {
                     Ok(()) => {
                         tracing::info!(
-                            "typed_slots_extracted observation_id={} populated_slots=[{}] endpoint=localhost:8888 result=ok",
+                            "typed_slots_extracted observation_id={} populated_slots=[{}] endpoint={} result=ok",
                             observation.id,
-                            populated
+                            populated,
+                            endpoint
                         );
                     }
                     Err(e) => {
                         tracing::warn!(
-                            "typed_slots_extracted observation_id={} populated_slots=[{}] endpoint=localhost:8888 result=deferred error={}",
+                            "typed_slots_extracted observation_id={} populated_slots=[{}] endpoint={} result=deferred error={}",
                             observation.id,
                             populated,
+                            endpoint,
                             e
                         );
                     }
@@ -2523,22 +2530,25 @@ mod gate_wiring {
                 // Defer-on-empty / non-triggering / hook-disabled. NULL
                 // columns are the same shape as a v=1 legacy row.
                 tracing::info!(
-                    "typed_slots_extracted observation_id={} populated_slots=[] endpoint=localhost:8888 result=deferred",
-                    observation.id
+                    "typed_slots_extracted observation_id={} populated_slots=[] endpoint={} result=deferred",
+                    observation.id,
+                    endpoint
                 );
             }
             Err(consolidation::ConsolidationError::Cancelled(_)) => {
                 // Operator-locked (b') ROLLBACK: do NOT persist. Columns
                 // stay NULL.
                 tracing::info!(
-                    "typed_slots_extracted observation_id={} populated_slots=[] endpoint=localhost:8888 result=cancelled",
-                    observation.id
+                    "typed_slots_extracted observation_id={} populated_slots=[] endpoint={} result=cancelled",
+                    observation.id,
+                    endpoint
                 );
             }
             Err(e) => {
                 tracing::warn!(
-                    "typed_slots_extracted observation_id={} populated_slots=[] endpoint=localhost:8888 result=deferred error={}",
+                    "typed_slots_extracted observation_id={} populated_slots=[] endpoint={} result=deferred error={}",
                     observation.id,
+                    endpoint,
                     e
                 );
             }
@@ -2562,6 +2572,7 @@ mod gate_wiring {
         observation: &ObservationMemory,
         extractor: &L,
         policy: &NetworkPolicy,
+        endpoint: &str,
         cancel: CancellationToken,
     ) where
         L: TypedSlotLlm + ?Sized,
@@ -2581,8 +2592,9 @@ mod gate_wiring {
                 Ok(p) => p,
                 Err(e) => {
                     tracing::warn!(
-                        "summarizer_gate observation_id={} endpoint=localhost:8888 result=deferred error=lookup_failed_{}",
+                        "summarizer_gate observation_id={} endpoint={} result=deferred error=lookup_failed_{}",
                         observation.id,
+                        endpoint,
                         e
                     );
                     return;
@@ -2606,8 +2618,9 @@ mod gate_wiring {
         chain_text.push_str(&observation.content);
 
         tracing::info!(
-            "consolidation_gate_fired event_id={} gate_kind=summarizer endpoint=localhost:8888 max_llm_calls=1",
-            observation.id
+            "consolidation_gate_fired event_id={} gate_kind=summarizer endpoint={} max_llm_calls=1",
+            observation.id,
+            endpoint
         );
 
         let result =
@@ -2625,16 +2638,18 @@ mod gate_wiring {
                 match persist {
                     Ok(()) => {
                         tracing::info!(
-                            "summarizer_gate observation_id={} chain_summary_len={} endpoint=localhost:8888 result=ok",
+                            "summarizer_gate observation_id={} chain_summary_len={} endpoint={} result=ok",
                             observation.id,
-                            len
+                            len,
+                            endpoint
                         );
                     }
                     Err(e) => {
                         tracing::warn!(
-                            "summarizer_gate observation_id={} chain_summary_len={} endpoint=localhost:8888 result=deferred error={}",
+                            "summarizer_gate observation_id={} chain_summary_len={} endpoint={} result=deferred error={}",
                             observation.id,
                             len,
+                            endpoint,
                             e
                         );
                     }
@@ -2642,20 +2657,23 @@ mod gate_wiring {
             }
             Ok(None) => {
                 tracing::info!(
-                    "summarizer_gate observation_id={} chain_summary_len=0 endpoint=localhost:8888 result=deferred",
-                    observation.id
+                    "summarizer_gate observation_id={} chain_summary_len=0 endpoint={} result=deferred",
+                    observation.id,
+                    endpoint
                 );
             }
             Err(consolidation::ConsolidationError::Cancelled(_)) => {
                 tracing::info!(
-                    "summarizer_gate observation_id={} chain_summary_len=0 endpoint=localhost:8888 result=cancelled",
-                    observation.id
+                    "summarizer_gate observation_id={} chain_summary_len=0 endpoint={} result=cancelled",
+                    observation.id,
+                    endpoint
                 );
             }
             Err(e) => {
                 tracing::warn!(
-                    "summarizer_gate observation_id={} chain_summary_len=0 endpoint=localhost:8888 result=deferred error={}",
+                    "summarizer_gate observation_id={} chain_summary_len=0 endpoint={} result=deferred error={}",
                     observation.id,
+                    endpoint,
                     e
                 );
             }
@@ -2666,14 +2684,24 @@ mod gate_wiring {
     /// observation. No-op on storage backends without an on-disk path or
     /// when neither gate is enabled.
     ///
-    /// The `extractor` is built lazily (and cached at the call-site) to
-    /// avoid constructing a fresh HTTP client per observation. Returns
-    /// without invoking any LLM call when both env predicates are off.
+    /// `endpoint` is the configured LLM endpoint URL (e.g. read from
+    /// `LocalLLMExtractor::endpoint()`); it's threaded into the
+    /// structured log markers (`consolidation_gate_fired`,
+    /// `typed_slots_extracted`, `summarizer_gate`) so the audit trail
+    /// reflects the actual URL the gate called rather than a hardcoded
+    /// literal — operators with `PENSYVE_EXTRACTOR_URL` pointing
+    /// somewhere other than `localhost:8888` get accurate evidence.
+    ///
+    /// The caller hoists extractor construction once per ingest call
+    /// (see `commit_extraction_for_episode` and
+    /// `commit_extractions_for_episodes`), avoiding the per-observation
+    /// `reqwest::Client` rebuild.
     pub(super) async fn fire_gates_for_observation<L>(
         storage: &(dyn StorageTrait + Send + Sync),
         observation: &ObservationMemory,
         extractor: &L,
         policy: &NetworkPolicy,
+        endpoint: &str,
         cancel: CancellationToken,
     ) where
         L: TypedSlotLlm + ?Sized,
@@ -2687,30 +2715,64 @@ mod gate_wiring {
 
         // Fire typed-slot first (cheaper to short-circuit on action-gate
         // mismatch); summarizer second (does an extra SQL lookup).
-        fire_typed_slots_gate(&db_path, observation, extractor, policy, cancel.clone()).await;
-        fire_summarizer_gate(&db_path, observation, extractor, policy, cancel).await;
+        fire_typed_slots_gate(
+            &db_path,
+            observation,
+            extractor,
+            policy,
+            endpoint,
+            cancel.clone(),
+        )
+        .await;
+        fire_summarizer_gate(&db_path, observation, extractor, policy, endpoint, cancel).await;
     }
 
-    /// Public entry-point for tests + the ingest helpers in this file.
-    /// Builds the typed-slot extractor on-demand; returns immediately if
-    /// neither gate is enabled (zero-cost fast path).
-    pub(super) async fn maybe_fire_gates_with_env_extractor(
+    /// Build the gate extractor IF either G3 gate is enabled. Intended
+    /// to be called once per ingest scope (e.g.
+    /// `commit_extraction_for_episode`) and the resulting handle reused
+    /// across every observation in the call — see
+    /// [`maybe_fire_gates_with_extractor`]. Returns `None` when both
+    /// gates are off (zero-cost) OR when env-based extractor build
+    /// fails (warns once at construction). Per coderabbit PR #86
+    /// round-3 review on observation.rs:2713 — avoids per-observation
+    /// `reqwest::Client` reconstruction and repeated env parsing on
+    /// the hot path.
+    pub(super) fn build_gate_extractor_if_enabled() -> Option<LocalLLMExtractor> {
+        if !consolidation::g3_typed_slots_enabled() && !consolidation::g3_summarizer_enabled() {
+            return None;
+        }
+        match LocalLLMExtractor::from_env() {
+            Ok(ext) => Some(ext),
+            Err(e) => {
+                tracing::warn!(
+                    "G3 gate firing disabled: failed to build typed-slot extractor from env: {}",
+                    e
+                );
+                None
+            }
+        }
+    }
+
+    /// Fire both G3 gate hooks for a single observation using a
+    /// pre-built extractor. When `extractor` is `None` (gates off or
+    /// build failed), this is a zero-cost no-op. The extractor is
+    /// expected to have been hoisted once per ingest call via
+    /// [`build_gate_extractor_if_enabled`] so connection pooling and
+    /// env parsing are reused across every observation persisted in
+    /// the call.
+    pub(super) async fn maybe_fire_gates_with_extractor(
         storage: &(dyn StorageTrait + Send + Sync),
         observation: &ObservationMemory,
+        extractor: Option<&LocalLLMExtractor>,
         cancel: CancellationToken,
     ) {
-        if !consolidation::g3_typed_slots_enabled() && !consolidation::g3_summarizer_enabled() {
-            return;
-        }
-        let Some(extractor) = build_typed_slot_extractor() else {
-            tracing::warn!(
-                observation_id = %observation.id,
-                "G3 gate firing skipped: failed to build typed-slot extractor from env"
-            );
+        let Some(extractor) = extractor else {
             return;
         };
         let policy = extractor.network_policy().clone();
-        fire_gates_for_observation(storage, observation, &extractor, &policy, cancel).await;
+        let endpoint = extractor.endpoint();
+        fire_gates_for_observation(storage, observation, extractor, &policy, endpoint, cancel)
+            .await;
     }
 }
 
@@ -2800,6 +2862,14 @@ where
         }
     };
 
+    // Build the gate extractor ONCE per ingest call (or `None` if both
+    // gates are off / env-build failed). Per coderabbit PR #86 round-3
+    // review on observation.rs:2713 — connection pool + env parsing now
+    // reused across every observation in this episode rather than rebuilt
+    // per `save_observation` call.
+    #[cfg(feature = "observation-extraction")]
+    let gate_extractor = gate_wiring::build_gate_extractor_if_enabled();
+
     let mut persisted = 0usize;
     for mut obs in observations {
         match embed(&obs.content) {
@@ -2826,9 +2896,15 @@ where
         // G3 per-event gate hooks (per pre-reg `pensyve-docs@64481dc` §3.7
         // + §3.8 + addendum_01 `pensyve-docs@dd7c053` Finding 2 mitigation).
         // No-op when both `PENSYVE_RETRIEVAL_CARDS_G3` predicates are off
-        // (zero-cost fast path checked inside `maybe_fire_gates_*`).
+        // (zero-cost fast path: `gate_extractor` is `None`).
         #[cfg(feature = "observation-extraction")]
-        gate_wiring::maybe_fire_gates_with_env_extractor(storage, &obs, cancel.clone()).await;
+        gate_wiring::maybe_fire_gates_with_extractor(
+            storage,
+            &obs,
+            gate_extractor.as_ref(),
+            cancel.clone(),
+        )
+        .await;
         persisted += 1;
     }
     persisted
@@ -2866,6 +2942,7 @@ where
 ///
 /// Returns the total number of observations successfully persisted across
 /// every episode in the batch.
+#[allow(clippy::too_many_lines)]
 pub async fn commit_extractions_for_episodes<F, E>(
     storage: &(dyn crate::storage::StorageTrait + Send + Sync),
     extractor: &dyn ObservationExtractor,
@@ -2956,6 +3033,12 @@ where
         return 0;
     }
 
+    // Hoist gate-extractor construction once for the whole bulk call —
+    // shared across every episode + every observation. Per coderabbit
+    // PR #86 round-3 review on observation.rs:2986 (and 2826).
+    #[cfg(feature = "observation-extraction")]
+    let gate_extractor = gate_wiring::build_gate_extractor_if_enabled();
+
     let mut total_persisted = 0usize;
     for (eid, observations) in surviving_ids.iter().zip(batch_results) {
         let mut episode_persisted = 0usize;
@@ -2984,11 +3067,18 @@ where
                 continue;
             }
             // G3 per-event gate hooks — same wiring as the per-episode
-            // helper. Per-observation cost is bounded by the env-gate
-            // fast-path inside `maybe_fire_gates_with_env_extractor` (no
-            // LLM call when both predicates off).
+            // helper, sharing the hoisted extractor across every
+            // observation in the bulk call. Per-observation cost is
+            // bounded by the `gate_extractor.is_none()` fast-path inside
+            // `maybe_fire_gates_with_extractor` when both predicates off.
             #[cfg(feature = "observation-extraction")]
-            gate_wiring::maybe_fire_gates_with_env_extractor(storage, &obs, cancel.clone()).await;
+            gate_wiring::maybe_fire_gates_with_extractor(
+                storage,
+                &obs,
+                gate_extractor.as_ref(),
+                cancel.clone(),
+            )
+            .await;
             episode_persisted += 1;
         }
         total_persisted += episode_persisted;

--- a/pensyve-core/src/observation.rs
+++ b/pensyve-core/src/observation.rs
@@ -1177,6 +1177,121 @@ mod localllm {
     }
 
     // -----------------------------------------------------------------------
+    // TypedSlotLlm impl — G3 per-event gate hooks (typed-slot extractor +
+    // supersession-chain summarizer) need a thin single-prompt LLM adapter.
+    // Reuses the same `reqwest::Client`, `base_url`, `model`, and policy as
+    // `ObservationExtractor::extract` so the typed-slot endpoint discipline
+    // matches the observation extractor's (audit_arm.sh check 6 verifies
+    // `endpoint=localhost:8888` for both gate kinds — see
+    // `pensyve-docs/research/benchmark-sprint/v3/g3/addendum_01.md`).
+    // -----------------------------------------------------------------------
+
+    use crate::consolidation::typed_slots::{SlotExtractionError, TypedSlotLlm};
+
+    #[async_trait]
+    impl TypedSlotLlm for LocalLLMExtractor {
+        async fn complete(
+            &self,
+            system_prompt: &str,
+            user_content: &str,
+            cancel: CancellationToken,
+        ) -> Result<String, SlotExtractionError> {
+            // Pre-flight cancel check. Cheap, deterministic, short-circuits
+            // before prompt build / URL normalization / policy guard. G1
+            // pre-reg §5.5 / I5 binds the contract.
+            if cancel.is_cancelled() {
+                return Err(SlotExtractionError::Cancelled(
+                    "cancelled before HTTP call".into(),
+                ));
+            }
+
+            let req = OpenAIRequest {
+                model: &self.model,
+                messages: vec![
+                    OpenAIMessage {
+                        role: "system",
+                        content: system_prompt,
+                    },
+                    OpenAIMessage {
+                        role: "user",
+                        content: user_content,
+                    },
+                ],
+                max_tokens: self.max_tokens,
+                temperature: 0.0,
+                chat_template_kwargs: ChatTemplateKwargs {
+                    enable_thinking: false,
+                },
+            };
+
+            // Mirror `extract`'s URL normalization + policy guard. Keeps the
+            // typed-slot adapter on the same `localhost:8888` endpoint as
+            // the observation extractor — required by addendum_01 Finding 2
+            // mitigation (audit_arm.sh check 6 greps for `endpoint=` substring).
+            let base = self.base_url.trim_end_matches('/');
+            let base = if base.ends_with("/v1") {
+                base.to_string()
+            } else {
+                format!("{base}/v1")
+            };
+            let url = format!("{base}/chat/completions");
+
+            self.policy
+                .check(&url)
+                .map_err(|e| SlotExtractionError::Transport(e.to_string()))?;
+
+            let mut builder = self.client.post(&url).json(&req);
+            if let Some(key) = self.api_key.as_deref() {
+                builder = builder.bearer_auth(key);
+            }
+
+            // Mid-flight cancellation: race the HTTP send/recv against the
+            // cancel token. Mirrors the observation extractor's pattern —
+            // see `extract` above for the full rationale on why dropping
+            // the future is safe (no storage write boundary inside the
+            // extractor itself; the calling gate hook owns persistence).
+            let http_future = async {
+                let response = builder
+                    .send()
+                    .await
+                    .map_err(|e| SlotExtractionError::Transport(e.to_string()))?;
+
+                if !response.status().is_success() {
+                    let status = response.status();
+                    let body = response.text().await.unwrap_or_default();
+                    return Err(SlotExtractionError::Transport(format!(
+                        "HTTP {status}: {body}"
+                    )));
+                }
+
+                let parsed: OpenAIResponse = response
+                    .json()
+                    .await
+                    .map_err(|e| SlotExtractionError::Parse(e.to_string()))?;
+                Ok::<OpenAIResponse, SlotExtractionError>(parsed)
+            };
+
+            let parsed = tokio::select! {
+                result = http_future => result?,
+                () = cancel.cancelled() => {
+                    return Err(SlotExtractionError::Cancelled(
+                        "cancelled during HTTP call".into(),
+                    ));
+                }
+            };
+
+            let text = parsed
+                .choices
+                .into_iter()
+                .next()
+                .map(|c| c.message.content)
+                .unwrap_or_default();
+
+            Ok(text)
+        }
+    }
+
+    // -----------------------------------------------------------------------
     // Tests
     // -----------------------------------------------------------------------
 
@@ -2115,6 +2230,479 @@ mod batched_localllm {
 pub use batched_localllm::BatchedLocalLLMExtractor;
 
 // ---------------------------------------------------------------------------
+// G3 per-event consolidation gate wiring
+//
+// Pre-reg `pensyve-docs/research/benchmark-sprint/v3/g3/preregistration.md`
+// §3.4 items 6-7 + §3.7 + §3.8 (LOCKED at `pensyve-docs@64481dc`) bind the
+// per-event gate hook surface that lives in `consolidation::mod`. Agent C
+// (G3 P3+P4) landed the hook fns + env predicates as standalone async fns;
+// this module wires them into the per-event ingest path so ARM-3
+// (SUMMARIZER), ARM-4 (TYPED-SLOTS), and ARM-5 (FULL) actually fire the
+// gates during benchmark runs.
+//
+// Structured log markers per `pensyve-docs/research/benchmark-sprint/v3/g3/
+// addendum_01.md` (`pensyve-docs@dd7c053`) Finding 2 mitigation feed
+// `audit_arm.sh` check 6:
+//   - `consolidation_gate_fired event_id=<id> gate_kind=<...>
+//      endpoint=localhost:8888 max_llm_calls=1`
+//   - `typed_slots_extracted observation_id=<id> populated_slots=[...]
+//      endpoint=localhost:8888 result=<ok|cancelled|deferred>`
+//   - `summarizer_gate observation_id=<id> chain_summary_len=<N>
+//      endpoint=localhost:8888 result=<ok|cancelled|deferred>`
+//
+// Operator-locked (b') 2026-05-06 ROLLBACK semantics: on `Cancelled` the
+// UPDATE is not invoked — typed-slot / chain_summary columns stay NULL.
+// On any non-cancellation defer (parse / transport / empty) the same NULL
+// shape applies (defer-write per agent C's design).
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "observation-extraction")]
+mod gate_wiring {
+    //! Gate-hook caller — fires `run_typed_slots_hook` and
+    //! `run_supersession_summarizer_hook` from the per-event ingest path
+    //! after a single observation has been written to
+    //! `observation_memories`.
+    //!
+    //! The `TypedSlotLlm` adapter is a clone of the `LocalLLMExtractor`
+    //! constructed via `from_env()` — same `localhost:8888` endpoint as
+    //! the observation extractor, so `audit_arm.sh` check 6 sees consistent
+    //! `endpoint=` markers across both gate kinds and the observation
+    //! extraction path. Building lazily (one extractor per ingest call,
+    //! reused across all observations of the call) keeps the wiring
+    //! callable from any storage-aware site without additional plumbing
+    //! through `commit_extraction_for_episode`'s public signature.
+    //!
+    //! Persistence: typed-slot columns and `chain_summary` are written
+    //! via a fresh `rusqlite::Connection` opened from
+    //! `StorageTrait::db_path`. The trait surface today does NOT expose
+    //! `update_observation_typed_slots` / `update_observation_chain_summary`
+    //! methods (G3 P3+P4 wiring note in `consolidation::mod` defers those
+    //! to a follow-up); this module persists side-channel via a single
+    //! atomic UPDATE, matching the existing pattern used by
+    //! `retrieval::cards::supersession::build_from_conn`.
+    //!
+    //! Gate firings are no-ops on backends with no on-disk path
+    //! (`db_path()` returns `None`) — the persist UPDATE has nowhere to
+    //! land. Tests that exercise the wiring use `SqliteBackend` so the
+    //! path is always present.
+    use rusqlite::{Connection, OpenFlags, params};
+    use tokio_util::sync::CancellationToken;
+    use uuid::Uuid;
+
+    use crate::consolidation;
+    use crate::consolidation::typed_slots::{TypedSlotLlm, TypedSlots};
+    use crate::network_policy::NetworkPolicy;
+    use crate::storage::StorageTrait;
+    use crate::types::{ObservationMemory, SlotKind};
+
+    use super::localllm::LocalLLMExtractor;
+
+    /// Render the populated-slot-kinds list as a comma-separated string for
+    /// the `populated_slots=[...]` log marker, matching the format used by
+    /// `audit_arm.sh` check 6.
+    fn format_populated_slots(slots: &TypedSlots) -> String {
+        SlotKind::all()
+            .iter()
+            .filter(|k| slots.get(**k).is_some())
+            .map(SlotKind::as_str)
+            .collect::<Vec<_>>()
+            .join(",")
+    }
+
+    /// Open a writable rusqlite connection at the given on-disk path.
+    /// Returns `None` if the file doesn't exist or the open fails.
+    ///
+    /// The connection uses default flags (read-write) and respects the
+    /// 5-second `busy_timeout` PRAGMA matching `SqliteBackend::open`'s
+    /// configuration. The single UPDATE we issue is atomic at the row
+    /// level so no explicit transaction wrapping is required.
+    ///
+    /// This is opened fresh per gate-firing phase (lookup, persist) so
+    /// the `Connection` (which contains `RefCell<...>` and is therefore
+    /// `!Send`) never spans an `await` boundary. Spawned futures (e.g.
+    /// `pensyve-mcp-gateway`'s post-episode extraction `tokio::spawn`)
+    /// require `Send` futures by `tokio` contract.
+    fn open_writable_conn_at(path: &std::path::Path) -> Option<Connection> {
+        if !path.exists() {
+            return None;
+        }
+        let conn = Connection::open_with_flags(
+            path,
+            OpenFlags::SQLITE_OPEN_READ_WRITE | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+        )
+        .ok()?;
+        // Match the primary backend's busy timeout so we don't bail out
+        // early when the writer is mid-INSERT on the same WAL.
+        conn.busy_timeout(std::time::Duration::from_secs(5)).ok()?;
+        Some(conn)
+    }
+
+    /// Single-row UPDATE persisting typed-slot columns. Atomic at the
+    /// `SQLite` row-level. On error, the columns stay NULL — same shape as
+    /// a v=1 legacy row, which is the design intent (operator-locked (c)
+    /// 2026-05-06 NULLABLE columns).
+    fn persist_typed_slots(
+        conn: &Connection,
+        observation_id: Uuid,
+        slots: &TypedSlots,
+    ) -> rusqlite::Result<()> {
+        conn.execute(
+            "UPDATE observation_memories \
+             SET biography_slot = ?1, \
+                 preference_slot = ?2, \
+                 experience_slot = ?3, \
+                 social_slot = ?4, \
+                 work_slot = ?5 \
+             WHERE id = ?6",
+            params![
+                slots.biography.as_deref(),
+                slots.preference.as_deref(),
+                slots.experience.as_deref(),
+                slots.social.as_deref(),
+                slots.work.as_deref(),
+                observation_id.to_string(),
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Single-row UPDATE persisting `chain_summary`. Atomic at the
+    /// `SQLite` row-level.
+    fn persist_chain_summary(
+        conn: &Connection,
+        observation_id: Uuid,
+        summary: &str,
+    ) -> rusqlite::Result<()> {
+        conn.execute(
+            "UPDATE observation_memories SET chain_summary = ?1 WHERE id = ?2",
+            params![summary, observation_id.to_string()],
+        )?;
+        Ok(())
+    }
+
+    /// Look up prior observations matching the new observation's
+    /// `(namespace_id, agent_id, user_id, entity_type, instance, action)`
+    /// shape. Used as the supersession-detection heuristic at ingest:
+    /// when 1+ priors exist, the new observation supersedes them and the
+    /// summarizer hook fires on the chain.
+    ///
+    /// Bounded at 4 priors so the chain-text stays small (the summarizer
+    /// LLM call is bounded by `#[max_llm_calls(1)]` per Rev B §5.4 — we
+    /// keep the input under ~1k chars to stay inside the model's bounded
+    /// reasoning window).
+    fn lookup_supersession_chain(
+        conn: &Connection,
+        new_obs: &ObservationMemory,
+    ) -> rusqlite::Result<Vec<String>> {
+        let mut stmt = conn.prepare(
+            "SELECT content FROM observation_memories \
+             WHERE namespace_id = ?1 \
+               AND entity_type = ?2 \
+               AND instance = ?3 \
+               AND action = ?4 \
+               AND id != ?5 \
+             ORDER BY event_time DESC, created_at DESC \
+             LIMIT 4",
+        )?;
+        let rows = stmt.query_map(
+            params![
+                new_obs.namespace_id.to_string(),
+                new_obs.entity_type,
+                new_obs.instance,
+                new_obs.action,
+                new_obs.id.to_string(),
+            ],
+            |row| row.get::<_, String>(0),
+        )?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row?);
+        }
+        Ok(out)
+    }
+
+    /// Build a new typed-slot LLM extractor from environment variables.
+    /// Reuses `LocalLLMExtractor::from_env()` so the typed-slot endpoint
+    /// matches the observation extractor's by construction (same
+    /// `PENSYVE_EXTRACTOR_URL` / `PENSYVE_EXTRACTOR_MODEL` / network
+    /// policy). Returns `None` on any configuration error — gate firings
+    /// degrade to no-ops cleanly.
+    fn build_typed_slot_extractor() -> Option<LocalLLMExtractor> {
+        LocalLLMExtractor::from_env().ok()
+    }
+
+    /// Fire the typed-slot extractor gate hook and persist the result.
+    ///
+    /// Pre-reg §3.8 binds the action-verb heuristic + 5-slot extractor
+    /// contract; the hook in `consolidation::run_typed_slots_hook`
+    /// enforces both (env-gate, action verb, network policy) before the
+    /// LLM call. This wiring layer just emits the structured log markers
+    /// before/after and persists on success.
+    ///
+    /// `db_path` is taken by value (not a borrowed `Connection`) because
+    /// the persist UPDATE happens AFTER the LLM `await`; a `Connection`
+    /// held across the await would make the future `!Send` and break
+    /// `tokio::spawn` callers (e.g. `pensyve-mcp-gateway`'s post-episode
+    /// extraction spawn). Opening fresh `Connection`s only when needed
+    /// keeps this future `Send`.
+    pub(super) async fn fire_typed_slots_gate<L>(
+        db_path: &std::path::Path,
+        observation: &ObservationMemory,
+        extractor: &L,
+        policy: &NetworkPolicy,
+        cancel: CancellationToken,
+    ) where
+        L: TypedSlotLlm + ?Sized,
+    {
+        // Action-verb gate is checked inside the hook itself; we still
+        // emit the firing-marker only when the gate is on AND the action
+        // matches, mirroring the addendum_01 binding ("structured markers
+        // for both gate kinds" — markers fire when the gate fires).
+        if !consolidation::g3_typed_slots_enabled() {
+            return;
+        }
+        if !consolidation::typed_slot_action_triggers(&observation.action) {
+            return;
+        }
+
+        tracing::info!(
+            "consolidation_gate_fired event_id={} gate_kind=typed_slots endpoint=localhost:8888 max_llm_calls=1",
+            observation.id
+        );
+
+        let result = consolidation::run_typed_slots_hook(
+            &observation.action,
+            &observation.content,
+            extractor,
+            policy,
+            cancel,
+        )
+        .await;
+
+        // After-await persistence: open a fresh connection (any prior conn
+        // is dropped before the await so the future stays `Send`).
+        match result {
+            Ok(Some(slots)) => {
+                let populated = format_populated_slots(&slots);
+                let persist = open_writable_conn_at(db_path)
+                    .ok_or_else(|| {
+                        rusqlite::Error::InvalidPath(std::path::PathBuf::from("no on-disk path"))
+                    })
+                    .and_then(|conn| persist_typed_slots(&conn, observation.id, &slots));
+                match persist {
+                    Ok(()) => {
+                        tracing::info!(
+                            "typed_slots_extracted observation_id={} populated_slots=[{}] endpoint=localhost:8888 result=ok",
+                            observation.id,
+                            populated
+                        );
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            "typed_slots_extracted observation_id={} populated_slots=[{}] endpoint=localhost:8888 result=deferred error={}",
+                            observation.id,
+                            populated,
+                            e
+                        );
+                    }
+                }
+            }
+            Ok(None) => {
+                // Defer-on-empty / non-triggering / hook-disabled. NULL
+                // columns are the same shape as a v=1 legacy row.
+                tracing::info!(
+                    "typed_slots_extracted observation_id={} populated_slots=[] endpoint=localhost:8888 result=deferred",
+                    observation.id
+                );
+            }
+            Err(consolidation::ConsolidationError::Cancelled(_)) => {
+                // Operator-locked (b') ROLLBACK: do NOT persist. Columns
+                // stay NULL.
+                tracing::info!(
+                    "typed_slots_extracted observation_id={} populated_slots=[] endpoint=localhost:8888 result=cancelled",
+                    observation.id
+                );
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "typed_slots_extracted observation_id={} populated_slots=[] endpoint=localhost:8888 result=deferred error={}",
+                    observation.id,
+                    e
+                );
+            }
+        }
+    }
+
+    /// Fire the supersession-chain summarizer gate hook and persist the
+    /// result.
+    ///
+    /// Detects supersession at ingest via SQL lookup for prior
+    /// observations with the same `(entity_type, instance, action)` shape
+    /// in the same scope. When 1+ priors exist, the new observation
+    /// supersedes them and the summarizer hook fires on the chain text
+    /// (priors + new content).
+    ///
+    /// As with `fire_typed_slots_gate`, the SQL connection is opened
+    /// fresh per phase (lookup, persist) and dropped before the await so
+    /// the resulting future is `Send`.
+    pub(super) async fn fire_summarizer_gate<L>(
+        db_path: &std::path::Path,
+        observation: &ObservationMemory,
+        extractor: &L,
+        policy: &NetworkPolicy,
+        cancel: CancellationToken,
+    ) where
+        L: TypedSlotLlm + ?Sized,
+    {
+        if !consolidation::g3_summarizer_enabled() {
+            return;
+        }
+
+        // Phase 1 (sync, before await): look up priors. Open + close the
+        // connection inside this scope so the connection is not held
+        // when the LLM `await` below runs.
+        let priors = {
+            let Some(conn) = open_writable_conn_at(db_path) else {
+                return;
+            };
+            match lookup_supersession_chain(&conn, observation) {
+                Ok(p) => p,
+                Err(e) => {
+                    tracing::warn!(
+                        "summarizer_gate observation_id={} endpoint=localhost:8888 result=deferred error=lookup_failed_{}",
+                        observation.id,
+                        e
+                    );
+                    return;
+                }
+            }
+            // `conn` drops here at end of scope — out of the future
+            // before the await below.
+        };
+        if priors.is_empty() {
+            return;
+        }
+
+        // Build chain text: priors (most-recent-first) followed by the
+        // new observation. The summarizer prompt already instructs the
+        // model to focus on the FINAL state and the path that got there.
+        let mut chain_text = String::new();
+        for prior in priors.iter().rev() {
+            chain_text.push_str(prior);
+            chain_text.push('\n');
+        }
+        chain_text.push_str(&observation.content);
+
+        tracing::info!(
+            "consolidation_gate_fired event_id={} gate_kind=summarizer endpoint=localhost:8888 max_llm_calls=1",
+            observation.id
+        );
+
+        let result =
+            consolidation::run_supersession_summarizer_hook(&chain_text, extractor, policy, cancel)
+                .await;
+
+        match result {
+            Ok(Some(summary)) => {
+                let len = summary.len();
+                let persist = open_writable_conn_at(db_path)
+                    .ok_or_else(|| {
+                        rusqlite::Error::InvalidPath(std::path::PathBuf::from("no on-disk path"))
+                    })
+                    .and_then(|conn| persist_chain_summary(&conn, observation.id, &summary));
+                match persist {
+                    Ok(()) => {
+                        tracing::info!(
+                            "summarizer_gate observation_id={} chain_summary_len={} endpoint=localhost:8888 result=ok",
+                            observation.id,
+                            len
+                        );
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            "summarizer_gate observation_id={} chain_summary_len={} endpoint=localhost:8888 result=deferred error={}",
+                            observation.id,
+                            len,
+                            e
+                        );
+                    }
+                }
+            }
+            Ok(None) => {
+                tracing::info!(
+                    "summarizer_gate observation_id={} chain_summary_len=0 endpoint=localhost:8888 result=deferred",
+                    observation.id
+                );
+            }
+            Err(consolidation::ConsolidationError::Cancelled(_)) => {
+                tracing::info!(
+                    "summarizer_gate observation_id={} chain_summary_len=0 endpoint=localhost:8888 result=cancelled",
+                    observation.id
+                );
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "summarizer_gate observation_id={} chain_summary_len=0 endpoint=localhost:8888 result=deferred error={}",
+                    observation.id,
+                    e
+                );
+            }
+        }
+    }
+
+    /// Top-level wiring entry: fire both gate hooks for a freshly-saved
+    /// observation. No-op on storage backends without an on-disk path or
+    /// when neither gate is enabled.
+    ///
+    /// The `extractor` is built lazily (and cached at the call-site) to
+    /// avoid constructing a fresh HTTP client per observation. Returns
+    /// without invoking any LLM call when both env predicates are off.
+    pub(super) async fn fire_gates_for_observation<L>(
+        storage: &(dyn StorageTrait + Send + Sync),
+        observation: &ObservationMemory,
+        extractor: &L,
+        policy: &NetworkPolicy,
+        cancel: CancellationToken,
+    ) where
+        L: TypedSlotLlm + ?Sized,
+    {
+        if !consolidation::g3_typed_slots_enabled() && !consolidation::g3_summarizer_enabled() {
+            return;
+        }
+        let Some(db_path) = storage.db_path().map(std::path::Path::to_path_buf) else {
+            return;
+        };
+
+        // Fire typed-slot first (cheaper to short-circuit on action-gate
+        // mismatch); summarizer second (does an extra SQL lookup).
+        fire_typed_slots_gate(&db_path, observation, extractor, policy, cancel.clone()).await;
+        fire_summarizer_gate(&db_path, observation, extractor, policy, cancel).await;
+    }
+
+    /// Public entry-point for tests + the ingest helpers in this file.
+    /// Builds the typed-slot extractor on-demand; returns immediately if
+    /// neither gate is enabled (zero-cost fast path).
+    pub(super) async fn maybe_fire_gates_with_env_extractor(
+        storage: &(dyn StorageTrait + Send + Sync),
+        observation: &ObservationMemory,
+        cancel: CancellationToken,
+    ) {
+        if !consolidation::g3_typed_slots_enabled() && !consolidation::g3_summarizer_enabled() {
+            return;
+        }
+        let Some(extractor) = build_typed_slot_extractor() else {
+            tracing::warn!(
+                observation_id = %observation.id,
+                "G3 gate firing skipped: failed to build typed-slot extractor from env"
+            );
+            return;
+        };
+        let policy = extractor.network_policy().clone();
+        fire_gates_for_observation(storage, observation, &extractor, &policy, cancel).await;
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Ingest helper — canonical post-episode-close extraction flow
 // ---------------------------------------------------------------------------
 
@@ -2180,7 +2768,12 @@ where
         .collect();
 
     let observations = match extractor
-        .extract(namespace_id, episode_id, &extraction_messages, cancel)
+        .extract(
+            namespace_id,
+            episode_id,
+            &extraction_messages,
+            cancel.clone(),
+        )
         .await
     {
         Ok(v) => v,
@@ -2218,6 +2811,12 @@ where
             );
             continue;
         }
+        // G3 per-event gate hooks (per pre-reg `pensyve-docs@64481dc` §3.7
+        // + §3.8 + addendum_01 `pensyve-docs@dd7c053` Finding 2 mitigation).
+        // No-op when both `PENSYVE_RETRIEVAL_CARDS_G3` predicates are off
+        // (zero-cost fast path checked inside `maybe_fire_gates_*`).
+        #[cfg(feature = "observation-extraction")]
+        gate_wiring::maybe_fire_gates_with_env_extractor(storage, &obs, cancel.clone()).await;
         persisted += 1;
     }
     persisted
@@ -2317,7 +2916,7 @@ where
         surviving_messages.iter().map(Vec::as_slice).collect();
 
     let batch_results = match extractor
-        .extract_batch(namespace_id, &surviving_ids, episode_slices, cancel)
+        .extract_batch(namespace_id, &surviving_ids, episode_slices, cancel.clone())
         .await
     {
         Ok(v) => v,
@@ -2372,6 +2971,12 @@ where
                 );
                 continue;
             }
+            // G3 per-event gate hooks — same wiring as the per-episode
+            // helper. Per-observation cost is bounded by the env-gate
+            // fast-path inside `maybe_fire_gates_with_env_extractor` (no
+            // LLM call when both predicates off).
+            #[cfg(feature = "observation-extraction")]
+            gate_wiring::maybe_fire_gates_with_env_extractor(storage, &obs, cancel.clone()).await;
             episode_persisted += 1;
         }
         total_persisted += episode_persisted;

--- a/pensyve-core/src/observation.rs
+++ b/pensyve-core/src/observation.rs
@@ -175,6 +175,24 @@ pub trait ObservationExtractor: Send + Sync + Debug {
         }
         Ok(out)
     }
+
+    /// If this extractor is (or wraps) a [`LocalLLMExtractor`], return a
+    /// reference to it so the G3 per-event gate hooks can reuse the same
+    /// endpoint / network policy / auth credentials as the observation
+    /// extractor itself. Default returns `None` — callers fall back to
+    /// `LocalLLMExtractor::from_env()`.
+    ///
+    /// Per coderabbit PR #86 round-4 review on observation.rs:2754:
+    /// without this, an explicitly-configured extractor (e.g. one
+    /// built via `LocalLLMExtractor::new(custom_url, ...)` rather than
+    /// the env path) would silently split the ingest pipeline — the
+    /// observation extractor would call one endpoint and the gate
+    /// extractor a different env-derived one. Implementations that
+    /// don't speak the typed-slot protocol leave this at the default.
+    #[cfg(feature = "observation-extraction")]
+    fn typed_slot_extractor(&self) -> Option<&LocalLLMExtractor> {
+        None
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1187,6 +1205,16 @@ mod localllm {
                 .map(|r| raw_to_observation(r, namespace_id, episode_id, last_event_time))
                 .collect())
         }
+
+        fn typed_slot_extractor(&self) -> Option<&LocalLLMExtractor> {
+            // The observation extractor IS the typed-slot LLM — same
+            // endpoint, same auth, same network policy. Per coderabbit
+            // PR #86 round-4 review on observation.rs:2754, returning
+            // `Some(self)` here lets the gate path reuse the caller's
+            // configured handle instead of building a separate
+            // env-derived one.
+            Some(self)
+        }
     }
 
     // -----------------------------------------------------------------------
@@ -1884,6 +1912,14 @@ mod batched_localllm {
             let results = futures::future::join_all(futures).await;
             results.into_iter().collect()
         }
+
+        fn typed_slot_extractor(&self) -> Option<&LocalLLMExtractor> {
+            // Forward to the wrapped inner extractor. Per coderabbit
+            // PR #86 round-4 review on observation.rs:2754 — the
+            // `BatchedLocalLLMExtractor` is just a fan-out wrapper, so
+            // the gate path can reuse `self.inner` directly.
+            Some(&self.inner)
+        }
     }
 
     // -----------------------------------------------------------------------
@@ -2302,6 +2338,7 @@ mod gate_wiring {
     use tokio_util::sync::CancellationToken;
     use uuid::Uuid;
 
+    use super::ObservationExtractor;
     use crate::consolidation;
     use crate::consolidation::typed_slots::{TypedSlotLlm, TypedSlots};
     use crate::network_policy::NetworkPolicy;
@@ -2359,7 +2396,7 @@ mod gate_wiring {
         observation_id: Uuid,
         slots: &TypedSlots,
     ) -> rusqlite::Result<()> {
-        conn.execute(
+        let updated = conn.execute(
             "UPDATE observation_memories \
              SET biography_slot = ?1, \
                  preference_slot = ?2, \
@@ -2376,6 +2413,15 @@ mod gate_wiring {
                 observation_id.to_string(),
             ],
         )?;
+        // Per coderabbit PR #86 round-4 review on observation.rs:2392 —
+        // a zero-row UPDATE means the observation row vanished between
+        // `save_observation` and the gate fire (e.g., concurrent delete
+        // or DB scope mismatch); the audit trail must NOT log
+        // `result=ok` in that case. Surface as a query error so the
+        // calling gate logs `result=deferred` with a real reason.
+        if updated != 1 {
+            return Err(rusqlite::Error::QueryReturnedNoRows);
+        }
         Ok(())
     }
 
@@ -2386,10 +2432,15 @@ mod gate_wiring {
         observation_id: Uuid,
         summary: &str,
     ) -> rusqlite::Result<()> {
-        conn.execute(
+        let updated = conn.execute(
             "UPDATE observation_memories SET chain_summary = ?1 WHERE id = ?2",
             params![summary, observation_id.to_string()],
         )?;
+        // Same zero-row guard as `persist_typed_slots` — see comment there
+        // (coderabbit PR #86 round-4 review).
+        if updated != 1 {
+            return Err(rusqlite::Error::QueryReturnedNoRows);
+        }
         Ok(())
     }
 
@@ -2733,13 +2784,30 @@ mod gate_wiring {
     /// across every observation in the call — see
     /// [`maybe_fire_gates_with_extractor`]. Returns `None` when both
     /// gates are off (zero-cost) OR when env-based extractor build
-    /// fails (warns once at construction). Per coderabbit PR #86
-    /// round-3 review on observation.rs:2713 — avoids per-observation
-    /// `reqwest::Client` reconstruction and repeated env parsing on
-    /// the hot path.
-    pub(super) fn build_gate_extractor_if_enabled() -> Option<LocalLLMExtractor> {
+    /// fails (warns once at construction).
+    ///
+    /// `caller` is the observation extractor configured by the ingest
+    /// caller. When it exposes a `LocalLLMExtractor` via
+    /// [`ObservationExtractor::typed_slot_extractor`] (which both the
+    /// `LocalLLMExtractor` itself and the `BatchedLocalLLMExtractor`
+    /// wrapper do), we clone-and-reuse it so the gate calls go to the
+    /// same endpoint / network policy / auth as the observation
+    /// extraction. Without this, an explicitly-configured caller would
+    /// silently split its ingest pipeline across two LLM endpoints —
+    /// the observation extractor running on the configured one and the
+    /// gate path on whatever the env vars happened to point at. Per
+    /// coderabbit PR #86 round-3 review on observation.rs:2713
+    /// (caching) and round-4 review on observation.rs:2754 (caller
+    /// reuse). `LocalLLMExtractor::clone()` is cheap because
+    /// `reqwest::Client` is `Arc`-internally.
+    pub(super) fn build_gate_extractor_if_enabled(
+        caller: Option<&dyn ObservationExtractor>,
+    ) -> Option<LocalLLMExtractor> {
         if !consolidation::g3_typed_slots_enabled() && !consolidation::g3_summarizer_enabled() {
             return None;
+        }
+        if let Some(local) = caller.and_then(ObservationExtractor::typed_slot_extractor) {
+            return Some(local.clone());
         }
         match LocalLLMExtractor::from_env() {
             Ok(ext) => Some(ext),
@@ -2866,9 +2934,11 @@ where
     // gates are off / env-build failed). Per coderabbit PR #86 round-3
     // review on observation.rs:2713 — connection pool + env parsing now
     // reused across every observation in this episode rather than rebuilt
-    // per `save_observation` call.
+    // per `save_observation` call. Round-4 review (observation.rs:2754):
+    // we forward the caller's extractor so the gate reuses its endpoint /
+    // network policy / auth instead of a separate env-derived one.
     #[cfg(feature = "observation-extraction")]
-    let gate_extractor = gate_wiring::build_gate_extractor_if_enabled();
+    let gate_extractor = gate_wiring::build_gate_extractor_if_enabled(Some(extractor));
 
     let mut persisted = 0usize;
     for mut obs in observations {
@@ -3035,9 +3105,11 @@ where
 
     // Hoist gate-extractor construction once for the whole bulk call —
     // shared across every episode + every observation. Per coderabbit
-    // PR #86 round-3 review on observation.rs:2986 (and 2826).
+    // PR #86 round-3 review on observation.rs:2986 (and 2826). Round-4
+    // review (observation.rs:2754): forward the caller's extractor so
+    // the gate reuses its endpoint / network policy / auth.
     #[cfg(feature = "observation-extraction")]
-    let gate_extractor = gate_wiring::build_gate_extractor_if_enabled();
+    let gate_extractor = gate_wiring::build_gate_extractor_if_enabled(Some(extractor));
 
     let mut total_persisted = 0usize;
     for (eid, observations) in surviving_ids.iter().zip(batch_results) {

--- a/pensyve-core/src/observation.rs
+++ b/pensyve-core/src/observation.rs
@@ -1913,7 +1913,7 @@ mod batched_localllm {
         }
 
         #[test]
-        fn batched_default_concurrency_is_eight() {
+        fn batched_default_concurrency_is_four() {
             // Pin the default concurrency. The rationale on the const
             // ties it to vLLM's `--max-num-seqs=20` divided by 4 harness
             // workers (with headroom for ensemble overhead). Any change

--- a/pensyve-core/src/observation.rs
+++ b/pensyve-core/src/observation.rs
@@ -2394,6 +2394,14 @@ mod gate_wiring {
         conn: &Connection,
         new_obs: &ObservationMemory,
     ) -> rusqlite::Result<Vec<String>> {
+        // Multi-tenant scope: filter by (namespace_id, agent_id, user_id) to
+        // prevent cross-tenant leakage into the chain text. NULL-safe `IS`
+        // matches the v2.2.0 scoping convention used by the retrieval cards
+        // (peer_card.rs / multi_session.rs / single_session_user.rs). Without
+        // these predicates, two tenants sharing a namespace would see each
+        // other's prior observations summarized into chain_summary — a
+        // correctness + privacy regression flagged in PR #86 (codex P1 +
+        // claude bot + coderabbit Major).
         let mut stmt = conn.prepare(
             "SELECT content FROM observation_memories \
              WHERE namespace_id = ?1 \
@@ -2401,6 +2409,8 @@ mod gate_wiring {
                AND instance = ?3 \
                AND action = ?4 \
                AND id != ?5 \
+               AND agent_id IS ?6 \
+               AND user_id IS ?7 \
              ORDER BY event_time DESC, created_at DESC \
              LIMIT 4",
         )?;
@@ -2411,6 +2421,8 @@ mod gate_wiring {
                 new_obs.instance,
                 new_obs.action,
                 new_obs.id.to_string(),
+                new_obs.agent_id.as_ref().map(ToString::to_string),
+                new_obs.user_id.as_ref().map(ToString::to_string),
             ],
             |row| row.get::<_, String>(0),
         )?;

--- a/pensyve-core/src/retrieval/cards/composite.rs
+++ b/pensyve-core/src/retrieval/cards/composite.rs
@@ -115,6 +115,9 @@ pub const G2_PEER_CARD_CAP: usize = 40;
 pub const G2_MULTI_SESSION_CARD_CAP: usize = 8;
 /// `SingleSessionUserCard` per-card cap (operator §3.X(a) lock 2026-05-05).
 pub const G2_SINGLE_SESSION_USER_CARD_CAP: usize = 12;
+/// `SupersessionCard` per-card cap (G3 pre-reg §3.4 item 1; matches MS
+/// card budget). 80-entry composite hard cap holds: 40 + 8 + 12 + 8 = 68.
+pub const G3_SUPERSESSION_CARD_CAP: usize = 8;
 
 /// Separator inserted between adjacent surviving card sections. Matches
 /// pre-reg §3.8 ("joined with `\n\n`") and gives the reader prompt a
@@ -183,6 +186,34 @@ impl CompositeCard {
             (peer, G2_PEER_CARD_CAP),
             (multi_session, G2_MULTI_SESSION_CARD_CAP),
             (single_session_user, G2_SINGLE_SESSION_USER_CARD_CAP),
+        ])
+    }
+
+    /// G3 default composite per pre-reg §3.4 item 2 + operator-locked
+    /// (b) on 2026-05-06: extends the G2 chain with a 4th card —
+    /// [`crate::retrieval::cards::SupersessionCard`] — at the end of
+    /// the priority chain. Per-card caps inherited from G2; supersession
+    /// cap (= 8) added per [`G3_SUPERSESSION_CARD_CAP`]. The 80-entry
+    /// composite hard cap holds: 40 + 8 + 12 + 8 = 68.
+    ///
+    /// As with [`g2_default`], concrete card types are passed as
+    /// `Box<dyn RetrievalCard>` so the constructor stays decoupled from
+    /// the sibling card module imports — useful for the harness adapter
+    /// that mixes-and-matches per arm.
+    ///
+    /// [`g2_default`]: CompositeCard::g2_default
+    #[must_use]
+    pub fn g3_default(
+        peer: Box<dyn RetrievalCard>,
+        multi_session: Box<dyn RetrievalCard>,
+        single_session_user: Box<dyn RetrievalCard>,
+        supersession: Box<dyn RetrievalCard>,
+    ) -> Self {
+        Self::new(vec![
+            (peer, G2_PEER_CARD_CAP),
+            (multi_session, G2_MULTI_SESSION_CARD_CAP),
+            (single_session_user, G2_SINGLE_SESSION_USER_CARD_CAP),
+            (supersession, G3_SUPERSESSION_CARD_CAP),
         ])
     }
 }

--- a/pensyve-core/src/retrieval/cards/mod.rs
+++ b/pensyve-core/src/retrieval/cards/mod.rs
@@ -52,11 +52,13 @@ pub mod composite;
 pub mod multi_session;
 pub mod peer_card_adapter;
 pub mod single_session_user;
+pub mod supersession;
 
 pub use composite::CompositeCard;
 pub use multi_session::MultiSessionCard;
 pub use peer_card_adapter::PeerCardAdapter;
 pub use single_session_user::SingleSessionUserCard;
+pub use supersession::SupersessionCard;
 
 /// Retrieval-time card builder.
 ///

--- a/pensyve-core/src/retrieval/cards/multi_session.rs
+++ b/pensyve-core/src/retrieval/cards/multi_session.rs
@@ -74,6 +74,7 @@ use std::path::PathBuf;
 use rusqlite::{Connection, OpenFlags, ToSql};
 use uuid::Uuid;
 
+use crate::retrieval::intent_router;
 use crate::storage::StorageTrait;
 use crate::types::{AgentId, UserId};
 
@@ -101,25 +102,78 @@ pub const MULTI_SESSION_CARD_FOOTER: &str = "--- END CROSS-SESSION ENTITIES ---"
 /// pins this at "~80 chars".
 const SNIPPET_MAX_CHARS: usize = 80;
 
+/// Env-var controlling G3 retrieval-card layering. Recognized values:
+/// `router` (router gate + SQL scope-tighten on; other G3 mechanisms off)
+/// and `full` (all G3 mechanisms on). Any other value (or unset) preserves
+/// G2 baseline behavior. Per pre-reg §3.4 + §3.6 + operator decision (a)
+/// 2026-05-06.
+pub const RETRIEVAL_CARDS_G3_ENV: &str = "PENSYVE_RETRIEVAL_CARDS_G3";
+
+/// G2 baseline cross-session threshold: an entity must surface in ≥2
+/// distinct date-day buckets to count as cross-session.
+const MS_CARD_CROSS_SESSION_THRESHOLD_G2: usize = 2;
+
+/// G3 router-mode cross-session threshold: raise the bar to ≥3 distinct
+/// date-day buckets to suppress marginal cross-session entities that
+/// drove the G2 H4 SSU partial-fail. Per pre-reg §3.6 SQL scope-tighten.
+const MS_CARD_CROSS_SESSION_THRESHOLD_G3: usize = 3;
+
 /// Cross-session entity-link card builder.
 ///
 /// Construct with [`MultiSessionCard::new`] for the default cap of
 /// [`MULTI_SESSION_CARD_MAX_ENTRIES`] (= 40), or
 /// [`MultiSessionCard::with_cap`] when a test or composite-cap override
 /// needs a different limit.
+///
+/// The G3 layering knob (`PENSYVE_RETRIEVAL_CARDS_G3`) is read once at
+/// construction time and cached as `g3_mode`. This avoids a per-`build()`
+/// `std::env::var` syscall on the hot recall path; callers that need to
+/// switch G3 modes mid-process should construct a fresh card.
 #[derive(Debug, Clone)]
 pub struct MultiSessionCard {
     /// Maximum number of entries the card emits before truncating.
     /// Defaults to [`MULTI_SESSION_CARD_MAX_ENTRIES`].
     max_entries: usize,
+    /// G3 layering mode resolved at construction. `Some(_)` enables the
+    /// router gate + SQL scope-tighten; `None` preserves G2 baseline
+    /// behavior. Per pre-reg §3.4 item 5 + §3.6 + operator decision (a)
+    /// 2026-05-06.
+    g3_mode: Option<G3Mode>,
+}
+
+/// G3 layering mode resolved from `PENSYVE_RETRIEVAL_CARDS_G3` at card
+/// construction. Both `Router` and `Full` enable the same MS-card-side
+/// gates; `Full` additionally implies all other G3 mechanisms (handled
+/// by sibling cards / engine, not here).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum G3Mode {
+    /// Router gate + MS SQL scope-tighten on; per-event consolidation,
+    /// MMR diversity, typed-slot extractor, `SupersessionCard` all off.
+    Router,
+    /// All G3 mechanisms on. From `MultiSessionCard`'s perspective this
+    /// is identical to `Router` — the additional G3 mechanisms are
+    /// activated by sibling cards / the recall engine.
+    Full,
+}
+
+/// Resolve the G3 layering mode from the process environment. Returns
+/// `None` for unset / unrecognized values, preserving G2 baseline.
+fn resolve_g3_mode() -> Option<G3Mode> {
+    match std::env::var(RETRIEVAL_CARDS_G3_ENV).ok().as_deref() {
+        Some("router") => Some(G3Mode::Router),
+        Some("full") => Some(G3Mode::Full),
+        _ => None,
+    }
 }
 
 impl MultiSessionCard {
-    /// Construct a card with the default cap (= 40).
+    /// Construct a card with the default cap (= 40). Reads
+    /// `PENSYVE_RETRIEVAL_CARDS_G3` once and caches the resolved mode.
     #[must_use]
     pub fn new() -> Self {
         Self {
             max_entries: MULTI_SESSION_CARD_MAX_ENTRIES,
+            g3_mode: resolve_g3_mode(),
         }
     }
 
@@ -127,9 +181,15 @@ impl MultiSessionCard {
     /// or for a composite dispatcher that wants to allocate a smaller
     /// share of the 80-entry composite budget; production callers
     /// should prefer [`MultiSessionCard::new`].
+    ///
+    /// As with [`MultiSessionCard::new`], the G3 layering mode is read
+    /// from the environment at this point and cached.
     #[must_use]
     pub fn with_cap(max_entries: usize) -> Self {
-        Self { max_entries }
+        Self {
+            max_entries,
+            g3_mode: resolve_g3_mode(),
+        }
     }
 }
 
@@ -147,8 +207,21 @@ impl RetrievalCard for MultiSessionCard {
         namespace_id: Uuid,
         agent_id: Option<AgentId>,
         user_id: Option<UserId>,
-        _question_type: Option<&str>,
+        question_type: Option<&str>,
     ) -> Option<String> {
+        // G3 router gate (pre-reg §3.4 item 5 + §3.6, operator decision
+        // (a) 2026-05-06). Active only when `g3_mode` was resolved at
+        // construction (i.e., `PENSYVE_RETRIEVAL_CARDS_G3 ∈ {router,
+        // full}`) AND a `question_type` was supplied. Baseline (G2)
+        // callers without `question_type` skip the gate so they remain
+        // byte-for-byte compatible with the G2 ARM-1-G3-BASELINE floor.
+        if let (Some(_), Some(qt)) = (self.g3_mode, question_type) {
+            let decision = intent_router::route(qt);
+            if !decision.enable_ms_card {
+                return None;
+            }
+        }
+
         // Defer-on-failure path 1: backend has no on-disk SQLite file
         // (in-memory store, future Postgres backend). Card opens its
         // own short-lived read-only connection, so we need the path.
@@ -167,7 +240,25 @@ impl RetrievalCard for MultiSessionCard {
         )
         .ok()?;
 
-        build_from_conn(&conn, namespace_id, agent_id, user_id, self.max_entries)
+        // G3 SQL scope-tighten (pre-reg §3.6): raise cross-session
+        // threshold from G2's ≥2 to ≥3 distinct date-day buckets when
+        // `g3_mode` is set. The filter is enforced in `build_from_conn`'s
+        // post-aggregation pass (the SQL itself returns all rows; the
+        // session-count check happens against the in-memory aggregate).
+        let cross_session_threshold = if self.g3_mode.is_some() {
+            MS_CARD_CROSS_SESSION_THRESHOLD_G3
+        } else {
+            MS_CARD_CROSS_SESSION_THRESHOLD_G2
+        };
+
+        build_from_conn(
+            &conn,
+            namespace_id,
+            agent_id,
+            user_id,
+            self.max_entries,
+            cross_session_threshold,
+        )
     }
 
     fn name(&self) -> &'static str {
@@ -179,12 +270,18 @@ impl RetrievalCard for MultiSessionCard {
 /// connection. Exposed `pub(super)` rather than `pub` — the public
 /// surface is the trait `build()`. Tests in this crate exercise it
 /// directly to avoid the temp-file-and-backend ceremony.
+///
+/// `cross_session_threshold` is the minimum number of distinct
+/// date-day buckets an entity must surface in to count as cross-
+/// session. G2 baseline = 2; G3 router/full = 3 (§3.6 SQL scope-
+/// tighten).
 pub(crate) fn build_from_conn(
     conn: &Connection,
     namespace_id: Uuid,
     agent_id: Option<AgentId>,
     user_id: Option<UserId>,
     max_entries: usize,
+    cross_session_threshold: usize,
 ) -> Option<String> {
     if max_entries == 0 {
         // A zero cap is a degenerate caller bug; prefer defer-on-failure
@@ -221,8 +318,10 @@ pub(crate) fn build_from_conn(
     let mut entries: Vec<RenderedEntity> = groups
         .into_iter()
         .filter_map(|((etype, instance), agg)| {
-            // The cross-session signal: ≥2 distinct date-day buckets.
-            if agg.days.len() < 2 {
+            // The cross-session signal: ≥`cross_session_threshold`
+            // distinct date-day buckets. G2 baseline = 2; G3
+            // router/full = 3 per pre-reg §3.6 SQL scope-tighten.
+            if agg.days.len() < cross_session_threshold {
                 return None;
             }
             Some(RenderedEntity {

--- a/pensyve-core/src/retrieval/cards/multi_session.rs
+++ b/pensyve-core/src/retrieval/cards/multi_session.rs
@@ -191,6 +191,30 @@ impl MultiSessionCard {
             g3_mode: resolve_g3_mode(),
         }
     }
+
+    /// Override the G3 layering mode explicitly, replacing whatever
+    /// value [`resolve_g3_mode`] picked up from the environment at
+    /// construction. The parameter accepts the same string vocabulary
+    /// as `PENSYVE_RETRIEVAL_CARDS_G3` (`"router"` or `"full"`); any
+    /// other value (including `None`) clears the mode back to G2
+    /// baseline.
+    ///
+    /// Per coderabbit PR #86 round-4 review on
+    /// `pensyve-python/src/lib.rs:160` — the `PyO3` boundary now passes
+    /// the resolved mode here directly instead of mutating
+    /// `PENSYVE_RETRIEVAL_CARDS_G3` for the duration of one call. This
+    /// closes the race window where a parallel unguarded `recall()`
+    /// could read the env var while another caller's `G3EnvGuard` had
+    /// it transiently set.
+    #[must_use]
+    pub fn with_g3_mode(mut self, mode: Option<&str>) -> Self {
+        self.g3_mode = match mode {
+            Some("router") => Some(G3Mode::Router),
+            Some("full") => Some(G3Mode::Full),
+            _ => None,
+        };
+        self
+    }
 }
 
 impl Default for MultiSessionCard {

--- a/pensyve-core/src/retrieval/cards/multi_session.rs
+++ b/pensyve-core/src/retrieval/cards/multi_session.rs
@@ -241,15 +241,23 @@ impl RetrievalCard for MultiSessionCard {
         .ok()?;
 
         // G3 SQL scope-tighten (pre-reg §3.6): raise cross-session
-        // threshold from G2's ≥2 to ≥3 distinct date-day buckets when
-        // `g3_mode` is set. The filter is enforced in `build_from_conn`'s
-        // post-aggregation pass (the SQL itself returns all rows; the
-        // session-count check happens against the in-memory aggregate).
-        let cross_session_threshold = if self.g3_mode.is_some() {
-            MS_CARD_CROSS_SESSION_THRESHOLD_G3
-        } else {
-            MS_CARD_CROSS_SESSION_THRESHOLD_G2
-        };
+        // threshold from G2's ≥2 to ≥3 distinct date-day buckets ONLY when
+        // BOTH (a) `g3_mode` is set AND (b) `question_type` matches a
+        // routed cross-session type (multi-session / temporal-reasoning /
+        // knowledge-update). Coderabbit Major review on PR #86 caught a
+        // regression: the original guard raised the threshold on any
+        // `g3_mode`, which silently dropped 2-session entities for callers
+        // that pass no question_type or non-routed types — contradicting
+        // the baseline-compatible fallback intent of the router gate above.
+        let cross_session_threshold = matches!(
+            (self.g3_mode, question_type),
+            (
+                Some(_),
+                Some("multi-session" | "temporal-reasoning" | "knowledge-update")
+            )
+        )
+        .then_some(MS_CARD_CROSS_SESSION_THRESHOLD_G3)
+        .unwrap_or(MS_CARD_CROSS_SESSION_THRESHOLD_G2);
 
         build_from_conn(
             &conn,

--- a/pensyve-core/src/retrieval/cards/supersession.rs
+++ b/pensyve-core/src/retrieval/cards/supersession.rs
@@ -1,0 +1,497 @@
+//! `SupersessionCard` — surfaces supersession-chain summaries to the
+//! reader at recall time (Pensyve v3 G3, ARM-3-SUMMARIZER).
+//!
+//! ## Why this card exists
+//!
+//! Long-running conversations frequently contain *supersession chains*:
+//! a user state evolves through multiple updates ("I'm at SF" →
+//! "I moved to NY" → "I'm back in SF"). The G3 per-event consolidation
+//! gate's summarizer hook (see `consolidation::run`) writes a 1-2
+//! sentence English-prose summary into the head observation's
+//! `chain_summary` column whenever a `supersedes`-edge is populated at
+//! ingest. This recall-time card surfaces those pre-computed summaries
+//! to the reader so cross-session retrieval doesn't have to rediscover
+//! the chain via top-k recall.
+//!
+//! Literature anchor: arXiv:2601.15495 (TRACK supersession-chain
+//! degradation study). The surface mechanism is standard recall-time
+//! prepend, mirroring `PeerCard`/`MultiSessionCard`/`SingleSessionUserCard`.
+//!
+//! ## Design contract
+//!
+//! Operator-locked (b) on 2026-05-06: implemented as a NEW `RetrievalCard`
+//! impl that composes via the existing `CompositeCard` chain. The reader
+//! sees a distinct `--- SUPERSESSION CHAIN ---` block (English prose,
+//! NOT Markdown header style — preserves the G2 operator §3.X(c) lock).
+//!
+//! ## Algorithm
+//!
+//! 1. Open a short-lived read-only connection to the on-disk `SQLite`
+//!    (or return `None` if the backend has no `db_path`).
+//! 2. SELECT `chain_summary` from `observation_memories` where
+//!    `chain_summary IS NOT NULL`, ordered `event_time DESC NULLS LAST,
+//!    created_at DESC`, scoped by `(namespace_id, agent_id, user_id)`
+//!    (matches the existing card scope-clause pattern).
+//! 3. Cap at [`SUPERSESSION_CARD_MAX_ENTRIES`] (= 8, matches MS card
+//!    budget per pre-reg §3.4 item 1).
+//! 4. Render as a Markdown bullet block with the operator-locked header
+//!    and footer markers.
+//!
+//! ## Defer-on-failure paths
+//!
+//! Returns `None` (cleanly elided by `CompositeCard`) when:
+//! - Backend has no on-disk `SQLite` path (in-memory store).
+//! - `SQLite` connection or query fails (e.g., legacy v=1 store before
+//!   the G3 schema migration ran — `chain_summary` column does not exist).
+//! - No rows have non-NULL `chain_summary` (the explicit defer-on-empty
+//!   path; legacy v=1 rows return NULL per pre-reg §3.7).
+//!
+//! ## Out of scope
+//!
+//! - **No write-time hooks.** Card-build is read-only. The summarizer
+//!   that populates `chain_summary` lives in `consolidation::run` and
+//!   fires at ingest, not here.
+//! - **No LLM calls at recall time.** Pure-`SQLite` read; the binding
+//!   §3.2 boundary requires no localhost:8888 traffic during card
+//!   build.
+
+use std::path::PathBuf;
+
+use rusqlite::{Connection, OpenFlags, ToSql, types::Value as SqlValue};
+use uuid::Uuid;
+
+use crate::storage::StorageTrait;
+use crate::types::{AgentId, UserId};
+
+use super::RetrievalCard;
+
+/// Per-card name string used by [`RetrievalCard::name`]. Stable identifier
+/// — log consumers (`out/g3_card_defer_log.jsonl`) match on this exact
+/// spelling.
+pub const SUPERSESSION_CARD_NAME: &str = "SupersessionCard";
+
+/// Maximum number of chain-summary entries the card emits before
+/// truncating. Locked at 8 by pre-reg §3.4 item 1 (matches MS card budget;
+/// 80-entry composite cap holds with `PeerCard` 40 + MS 8 + SSU 12 +
+/// `Supersession` 8 = 68).
+pub const SUPERSESSION_CARD_MAX_ENTRIES: usize = 8;
+
+/// Marker line opening the card. Stable for log/audit grep.
+pub const SUPERSESSION_CARD_HEADER: &str = "--- SUPERSESSION CHAIN ---";
+
+/// Marker line closing the card. Stable for log/audit grep.
+pub const SUPERSESSION_CARD_FOOTER: &str = "--- END SUPERSESSION CHAIN ---";
+
+/// Recall-time card surfacing pre-computed supersession-chain summaries.
+///
+/// Construct with [`SupersessionCard::new`] for the default cap of
+/// [`SUPERSESSION_CARD_MAX_ENTRIES`] (= 8), or
+/// [`SupersessionCard::with_cap`] when a test or composite-cap override
+/// needs a different limit.
+#[derive(Debug, Clone)]
+pub struct SupersessionCard {
+    /// Maximum number of entries the card emits before truncating.
+    /// Defaults to [`SUPERSESSION_CARD_MAX_ENTRIES`].
+    max_entries: usize,
+}
+
+impl SupersessionCard {
+    /// Construct a card with the default cap (= 8).
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            max_entries: SUPERSESSION_CARD_MAX_ENTRIES,
+        }
+    }
+
+    /// Construct a card with an explicit entry cap. Intended for tests
+    /// or for a composite dispatcher that wants to allocate a smaller
+    /// share of the 80-entry composite budget; production callers
+    /// should prefer [`SupersessionCard::new`].
+    #[must_use]
+    pub fn with_cap(max_entries: usize) -> Self {
+        Self { max_entries }
+    }
+}
+
+impl Default for SupersessionCard {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RetrievalCard for SupersessionCard {
+    fn build(
+        &self,
+        _query: &str,
+        store: &dyn StorageTrait,
+        namespace_id: Uuid,
+        agent_id: Option<AgentId>,
+        user_id: Option<UserId>,
+        _question_type: Option<&str>,
+    ) -> Option<String> {
+        if self.max_entries == 0 {
+            // A zero cap is a degenerate caller bug; prefer defer over
+            // emitting an empty card body.
+            return None;
+        }
+
+        // Defer-on-failure path 1: backend has no on-disk path
+        // (in-memory store, future Postgres backend). The card opens its
+        // own short-lived read-only connection so we need a path.
+        let path: PathBuf = store.db_path()?.to_path_buf();
+        if !path.exists() {
+            return None;
+        }
+
+        // Read-only, no-mutex open mirrors the other G2 cards. The card
+        // MUST NOT mutate the SQLite (no journal-file write into the
+        // harness tempdir) and MUST NOT compete for the backend's
+        // primary connection mutex.
+        let conn = Connection::open_with_flags(
+            &path,
+            OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+        )
+        .ok()?;
+
+        build_from_conn(
+            &conn,
+            namespace_id,
+            agent_id.as_ref(),
+            user_id.as_ref(),
+            self.max_entries,
+        )
+    }
+
+    fn name(&self) -> &'static str {
+        SUPERSESSION_CARD_NAME
+    }
+}
+
+/// Lower-level entry point: build the card from an already-open connection.
+///
+/// Exposed `pub(crate)` so the in-tree integration tests can exercise the
+/// SQL path without going through the full `SqliteBackend` ceremony.
+/// The public production surface is the [`RetrievalCard::build`] trait
+/// method.
+///
+/// ## SQL
+///
+/// ```sql
+/// SELECT chain_summary
+/// FROM observation_memories
+/// WHERE chain_summary IS NOT NULL
+///   AND <scope_clause>
+/// ORDER BY event_time DESC NULLS LAST, created_at DESC
+/// LIMIT ?
+/// ```
+///
+/// The scope clause matches `MultiSessionCard::build_scope_clause` /
+/// `SingleSessionUserCard::build_scope_clause` byte-for-byte (G1 +
+/// `addendum_02` Option 2 semantics on the unscoped `(None, None)` path).
+///
+/// Returns `None` on:
+/// - SQL error (legacy v=1 store before the G3 v=2 migration ran — the
+///   `chain_summary` column does not exist; SELECT fails; we defer).
+/// - Empty result (no rows have populated `chain_summary` — the explicit
+///   defer-on-empty path per pre-reg §3.7).
+pub(crate) fn build_from_conn(
+    conn: &Connection,
+    namespace_id: Uuid,
+    agent_id: Option<&AgentId>,
+    user_id: Option<&UserId>,
+    max_entries: usize,
+) -> Option<String> {
+    if max_entries == 0 {
+        return None;
+    }
+
+    let ns = namespace_id.to_string();
+    let agent_str = agent_id.map(|a| a.as_uuid().to_string());
+    let user_str = user_id.map(|u| u.as_uuid().to_string());
+
+    let (scope_clause, scope_binds) =
+        build_scope_clause(&ns, agent_str.as_deref(), user_str.as_deref());
+
+    // ORDER BY event_time DESC NULLS LAST, created_at DESC mirrors the
+    // PeerCard / SSU ordering so the most-recent chain summaries surface
+    // when the cap truncates.
+    let sql = format!(
+        "SELECT chain_summary \
+         FROM observation_memories \
+         WHERE chain_summary IS NOT NULL \
+           AND {scope_clause} \
+         ORDER BY event_time DESC NULLS LAST, created_at DESC \
+         LIMIT ?{}",
+        scope_binds.len() + 1
+    );
+
+    let mut stmt = conn.prepare(&sql).ok()?;
+    let mut params: Vec<Box<dyn ToSql>> =
+        scope_binds.iter().map(|v| boxed_sql(v.clone())).collect();
+    // SAFETY: max_entries is bounded by the per-card cap (= 8 by default,
+    // never exceeds usize range that fits in i64 on supported targets);
+    // the cast to i64 cannot wrap.
+    #[allow(clippy::cast_possible_wrap)]
+    {
+        params.push(Box::new(max_entries as i64));
+    }
+    let param_refs: Vec<&dyn ToSql> = params.iter().map(std::convert::AsRef::as_ref).collect();
+
+    let rows = stmt
+        .query_map(param_refs.as_slice(), |row| row.get::<_, Option<String>>(0))
+        .ok()?;
+
+    // Dedupe identical chain summaries (a single chain_summary may
+    // duplicate across head observations if ingest replays an event;
+    // the harness's defer-on-failure log catches this so we just elide).
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut entries: Vec<String> = Vec::new();
+    for row in rows.flatten() {
+        let Some(summary) = row else { continue };
+        let trimmed = summary.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let owned = trimmed.to_string();
+        if seen.contains(&owned) {
+            continue;
+        }
+        seen.insert(owned.clone());
+        entries.push(owned);
+        if entries.len() >= max_entries {
+            break;
+        }
+    }
+
+    if entries.is_empty() {
+        return None;
+    }
+
+    // Bullet rendering mirrors `SingleSessionUserCard` so the composite-
+    // level bullet clipper in `composite::clip_bullet_entries_or_passthrough`
+    // recognizes this card as bullet-shaped.
+    let bullets: String = entries
+        .iter()
+        .map(|e| format!("- {e}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    Some(format!(
+        "{SUPERSESSION_CARD_HEADER}\n{bullets}\n{SUPERSESSION_CARD_FOOTER}"
+    ))
+}
+
+/// Build the WHERE-clause fragment and bind values for the
+/// `(namespace_id, agent_id, user_id)` scope filter.
+///
+/// Locked scope semantics per pensyve-docs G2 pre-reg + `addendum_02`
+/// (matches `SingleSessionUserCard::build_scope_clause` byte-for-byte):
+/// - `(None, None)` → `namespace_id = ?1` (legacy unscoped read; sees
+///   all rows in namespace per `addendum_02` Option 2).
+/// - `(Some, Some)` → strict `agent_id = ? AND user_id = ?`.
+/// - `(Some, None)` → strict `agent_id = ? AND user_id IS NULL`.
+/// - `(None, Some)` → strict `agent_id IS NULL AND user_id = ?`.
+///
+/// Returns `(clause, binds)` where `clause` references positional
+/// placeholders `?1`, `?2`, ... in order matching `binds`.
+fn build_scope_clause(
+    namespace_id: &str,
+    agent_id: Option<&str>,
+    user_id: Option<&str>,
+) -> (String, Vec<SqlValue>) {
+    if agent_id.is_none() && user_id.is_none() {
+        return (
+            "namespace_id = ?1".to_string(),
+            vec![SqlValue::Text(namespace_id.to_string())],
+        );
+    }
+
+    let mut clauses = vec!["namespace_id = ?1".to_string()];
+    let mut binds: Vec<SqlValue> = vec![SqlValue::Text(namespace_id.to_string())];
+
+    match agent_id {
+        Some(a) => {
+            binds.push(SqlValue::Text(a.to_string()));
+            clauses.push(format!("agent_id = ?{}", binds.len()));
+        }
+        None => {
+            clauses.push("agent_id IS NULL".to_string());
+        }
+    }
+    match user_id {
+        Some(u) => {
+            binds.push(SqlValue::Text(u.to_string()));
+            clauses.push(format!("user_id = ?{}", binds.len()));
+        }
+        None => {
+            clauses.push("user_id IS NULL".to_string());
+        }
+    }
+
+    (clauses.join(" AND "), binds)
+}
+
+/// Box a [`SqlValue`] into a [`ToSql`] trait object. Helper so the
+/// param-binding sites read cleanly.
+fn boxed_sql(v: SqlValue) -> Box<dyn ToSql> {
+    Box::new(v)
+}
+
+#[cfg(test)]
+mod tests {
+    //! Inline unit tests for the SQL helpers. End-to-end fuzz fixtures
+    //! over a real `SqliteBackend` live in
+    //! `pensyve-core/tests/test_supersession_card.rs`.
+
+    use super::*;
+    use rusqlite::Connection;
+
+    /// Bare-minimum test connection with the columns the
+    /// `SupersessionCard` SELECT touches. Mirrors the in-tree test pattern
+    /// in `peer_card.rs`
+    /// (deliberately lighter than the production schema — we are
+    /// testing the card SQL, not the migration runner).
+    fn make_test_conn() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute(
+            "CREATE TABLE observation_memories (
+                id INTEGER PRIMARY KEY,
+                namespace_id TEXT,
+                agent_id TEXT,
+                user_id TEXT,
+                chain_summary TEXT,
+                event_time TEXT,
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )",
+            [],
+        )
+        .unwrap();
+        conn
+    }
+
+    fn insert(
+        conn: &Connection,
+        namespace_id: &str,
+        chain_summary: Option<&str>,
+        event_time: Option<&str>,
+    ) {
+        conn.execute(
+            "INSERT INTO observation_memories \
+             (namespace_id, chain_summary, event_time) \
+             VALUES (?1, ?2, ?3)",
+            (namespace_id, chain_summary, event_time),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn build_from_conn_empty_returns_none() {
+        let conn = make_test_conn();
+        let ns = Uuid::new_v4();
+        assert!(build_from_conn(&conn, ns, None, None, 8).is_none());
+    }
+
+    #[test]
+    fn build_from_conn_all_null_chain_summaries_returns_none() {
+        let conn = make_test_conn();
+        let ns = Uuid::new_v4().to_string();
+        // Insert rows but with NULL chain_summary — SELECT WHERE
+        // chain_summary IS NOT NULL filters them all out.
+        insert(&conn, &ns, None, Some("2024-01-01"));
+        insert(&conn, &ns, None, Some("2024-01-02"));
+        let card = build_from_conn(&conn, Uuid::parse_str(&ns).unwrap(), None, None, 8);
+        assert!(
+            card.is_none(),
+            "all-null chain_summary store must defer (return None)"
+        );
+    }
+
+    #[test]
+    fn build_from_conn_surfaces_chain_summary_with_markers() {
+        let conn = make_test_conn();
+        let ns = Uuid::new_v4().to_string();
+        insert(
+            &conn,
+            &ns,
+            Some("User moved from SF to NY then back to SF over three sessions."),
+            Some("2024-01-03T10:00:00Z"),
+        );
+        let card = build_from_conn(&conn, Uuid::parse_str(&ns).unwrap(), None, None, 8)
+            .expect("non-empty card");
+        assert!(
+            card.contains(SUPERSESSION_CARD_HEADER),
+            "header marker must be present; got: {card}"
+        );
+        assert!(
+            card.contains(SUPERSESSION_CARD_FOOTER),
+            "footer marker must be present; got: {card}"
+        );
+        assert!(
+            card.contains("User moved from SF to NY then back to SF"),
+            "chain_summary content must surface; got: {card}"
+        );
+    }
+
+    #[test]
+    fn build_from_conn_caps_at_max_entries() {
+        let conn = make_test_conn();
+        let ns = Uuid::new_v4().to_string();
+        // Insert 12 distinct chain summaries; expect cap=4 to keep 4.
+        for i in 0..12 {
+            insert(
+                &conn,
+                &ns,
+                Some(&format!("chain summary number {i}")),
+                Some(&format!("2024-01-{:02}T10:00:00Z", i + 1)),
+            );
+        }
+        let card = build_from_conn(&conn, Uuid::parse_str(&ns).unwrap(), None, None, 4)
+            .expect("non-empty card");
+        // Should contain exactly 4 bullet lines.
+        let bullet_count = card.lines().filter(|l| l.starts_with("- ")).count();
+        assert_eq!(
+            bullet_count, 4,
+            "cap=4 must yield exactly 4 bullets; got {bullet_count} in card:\n{card}"
+        );
+    }
+
+    #[test]
+    fn build_from_conn_dedupes_identical_summaries() {
+        let conn = make_test_conn();
+        let ns = Uuid::new_v4().to_string();
+        // Two rows with the same chain_summary; expect 1 bullet after dedupe.
+        insert(
+            &conn,
+            &ns,
+            Some("identical summary text"),
+            Some("2024-01-01T10:00:00Z"),
+        );
+        insert(
+            &conn,
+            &ns,
+            Some("identical summary text"),
+            Some("2024-01-02T10:00:00Z"),
+        );
+        let card = build_from_conn(&conn, Uuid::parse_str(&ns).unwrap(), None, None, 8)
+            .expect("non-empty card");
+        let occurrences = card.matches("identical summary text").count();
+        assert_eq!(
+            occurrences, 1,
+            "dedupe must collapse identical summaries; got {occurrences} occurrences in:\n{card}"
+        );
+    }
+
+    #[test]
+    fn build_from_conn_skips_empty_strings() {
+        let conn = make_test_conn();
+        let ns = Uuid::new_v4().to_string();
+        insert(&conn, &ns, Some("   "), Some("2024-01-01")); // whitespace
+        insert(&conn, &ns, Some(""), Some("2024-01-02")); // empty
+        let card = build_from_conn(&conn, Uuid::parse_str(&ns).unwrap(), None, None, 8);
+        assert!(
+            card.is_none(),
+            "all-blank chain_summary store must defer; got: {card:?}"
+        );
+    }
+}

--- a/pensyve-core/src/retrieval/cards/supersession.rs
+++ b/pensyve-core/src/retrieval/cards/supersession.rs
@@ -229,13 +229,14 @@ pub(crate) fn build_from_conn(
     let mut stmt = conn.prepare(&sql).ok()?;
     let mut params: Vec<Box<dyn ToSql>> =
         scope_binds.iter().map(|v| boxed_sql(v.clone())).collect();
-    // SAFETY: max_entries is bounded by the per-card cap (= 8 by default,
-    // never exceeds usize range that fits in i64 on supported targets);
-    // the cast to i64 cannot wrap.
-    #[allow(clippy::cast_possible_wrap)]
-    {
-        params.push(Box::new(max_entries as i64));
-    }
+    // coderabbit PR #86 review on supersession.rs:264 — over-fetch by 4×
+    // then cap after dedupe so duplicates/whitespace don't undercap the
+    // result (the SQL LIMIT runs before the Rust-side trim/dedupe below,
+    // so binding `max_entries` directly could yield fewer than the
+    // requested count even when older unique summaries exist).
+    let fetch_limit_usize = max_entries.saturating_mul(4).max(max_entries);
+    let fetch_limit = i64::try_from(fetch_limit_usize).unwrap_or(i64::MAX);
+    params.push(Box::new(fetch_limit));
     let param_refs: Vec<&dyn ToSql> = params.iter().map(std::convert::AsRef::as_ref).collect();
 
     let rows = stmt

--- a/pensyve-core/src/retrieval/diversity.rs
+++ b/pensyve-core/src/retrieval/diversity.rs
@@ -51,12 +51,17 @@ use crate::retrieval::engine::ScoredCandidate;
 ///
 /// Inputs:
 /// - `items`: candidates as produced by `RecallEngine::recall` (already
-///   sorted by RRF score descending). Their order on input determines the
-///   relevance term: position 0 is treated as most relevant, position
-///   N-1 as least. The actual relevance score is computed via cosine
-///   similarity between the candidate's embedding and `query_vec`, NOT
-///   from the input position — so re-ranking results from the reranker
-///   stage are honored.
+///   sorted by `ScoredCandidate.final_score` descending — the RRF +
+///   cross-encoder fused score). MMR does NOT consume `final_score`
+///   directly; the relevance term is recomputed as cosine similarity
+///   between the candidate's embedding and `query_vec` so that relevance
+///   and the redundancy term share a single scale (cosine ∈ [-1, 1]) and
+///   the lambda balance remains well-calibrated. Side effect: with
+///   λ = 1.0 the output order is *not* guaranteed to equal the input
+///   order — MMR will resort by raw cosine, which can disagree with the
+///   reranker's `final_score`. Documented tradeoff per coderabbit/claude
+///   PR #86 review and pre-reg §3.X(a'); G4 may revisit using
+///   normalized `final_score` once a multi-cell λ ablation is run.
 /// - `query_vec`: the query embedding used for the relevance term. Same
 ///   vector the recall engine fed into the vector index.
 /// - `lambda`: balance parameter, clamped into `[0.0, 1.0]`. λ=1.0 is

--- a/pensyve-core/src/retrieval/diversity.rs
+++ b/pensyve-core/src/retrieval/diversity.rs
@@ -1,0 +1,141 @@
+//! MMR (Maximal Marginal Relevance) diversity ranking for G3 recall.
+//!
+//! Per pre-reg @64481dc §3.4 item 4 + operator-locked decision (a') on
+//! 2026-05-06: MMR insertion site is BEFORE card prepend. Recall returns
+//! similarity-ranked items; this module reorders them by MMR before the
+//! harness adapter prepends cards. Cards therefore see the
+//! diversity-reordered observations.
+//!
+//! ## Algorithm
+//!
+//! Standard MMR (Carbonell & Goldstein 1998), greedy selection:
+//!
+//! ```text
+//! score(item) = λ · sim(item, query)
+//!             − (1 − λ) · max_j sim(item, selected[j])
+//! ```
+//!
+//! Each iteration picks the candidate with the highest MMR score, appends
+//! it to the selected list, and removes it from the pool. Stops at `k`
+//! items or when the pool is empty.
+//!
+//! ## Similarity function
+//!
+//! Cosine similarity. Memory embeddings are L2-normalized at insert time
+//! by `pensyve_core::vector::VectorIndex`, but this module does not assume
+//! that — it calls [`crate::embedding::cosine_similarity`] which performs
+//! its own normalization, so unnormalized inputs are still scored
+//! correctly. A candidate with an empty (zero-length) embedding gets
+//! similarity 0.0 and is treated as orthogonal to everything.
+//!
+//! ## Embedding source
+//!
+//! `ScoredCandidate.memory.embedding()` already exposes the embedding
+//! vector for every memory variant (Episodic, Semantic, Procedural,
+//! Observation). The MMR call site in `engine.rs` therefore passes the
+//! existing `Vec<ScoredCandidate>` directly — no signature extension
+//! required.
+//!
+//! ## Default-OFF behavior
+//!
+//! `engine.rs` only invokes [`rerank_mmr`] when the `PENSYVE_MMR_LAMBDA`
+//! env var is set to a value > 0.0. With the env var unset (the production
+//! default), the recall path is byte-for-byte identical to G2. This
+//! preserves the ARM-1-G3-BASELINE through ARM-4-TYPED-SLOTS arms in the
+//! G3 ablation; ARM-5-G3-FULL flips it on with λ=0.5.
+
+use crate::embedding::cosine_similarity;
+use crate::retrieval::engine::ScoredCandidate;
+
+/// Reorder a similarity-ranked candidate list by Maximal Marginal Relevance.
+///
+/// Inputs:
+/// - `items`: candidates as produced by `RecallEngine::recall` (already
+///   sorted by RRF score descending). Their order on input determines the
+///   relevance term: position 0 is treated as most relevant, position
+///   N-1 as least. The actual relevance score is computed via cosine
+///   similarity between the candidate's embedding and `query_vec`, NOT
+///   from the input position — so re-ranking results from the reranker
+///   stage are honored.
+/// - `query_vec`: the query embedding used for the relevance term. Same
+///   vector the recall engine fed into the vector index.
+/// - `lambda`: balance parameter, clamped into `[0.0, 1.0]`. λ=1.0 is
+///   pure relevance (output ≈ input order); λ=0.0 is pure diversity. The
+///   pre-reg §3.9 fixes ARM-5-G3-FULL at λ=0.5.
+/// - `k`: maximum number of items to return. If `k > items.len()`, all
+///   items are returned reordered. If `k == 0`, the result is empty.
+///   No padding occurs.
+///
+/// Returns a new `Vec<ScoredCandidate>` in MMR-selected order. The input
+/// vector is consumed; preserved candidates are moved into the output.
+pub fn rerank_mmr(
+    items: Vec<ScoredCandidate>,
+    query_vec: &[f32],
+    lambda: f32,
+    k: usize,
+) -> Vec<ScoredCandidate> {
+    if k == 0 || items.is_empty() {
+        return Vec::new();
+    }
+
+    let lambda = lambda.clamp(0.0, 1.0);
+    let target = k.min(items.len());
+
+    // Pre-compute relevance (cosine vs. query) once per candidate.
+    // Using indexed access because we'll be removing items from the pool
+    // by index during selection.
+    let relevance: Vec<f32> = items
+        .iter()
+        .map(|c| cosine_similarity(c.memory.embedding(), query_vec))
+        .collect();
+
+    // Pool tracks remaining candidates by their original index. We remove
+    // selected entries via `swap_remove` for O(1) removal; selected stays
+    // ordered by selection turn.
+    let mut pool: Vec<usize> = (0..items.len()).collect();
+    let mut selected_indices: Vec<usize> = Vec::with_capacity(target);
+
+    while selected_indices.len() < target && !pool.is_empty() {
+        let mut best_pool_pos: usize = 0;
+        let mut best_score = f32::NEG_INFINITY;
+
+        for (pool_pos, &cand_idx) in pool.iter().enumerate() {
+            let rel = relevance[cand_idx];
+
+            // Redundancy term: max cosine sim against already-selected.
+            // Empty selected (first iteration) → redundancy = 0, so the
+            // first pick equals the highest-relevance candidate.
+            let mut max_redundancy = 0.0_f32;
+            for &sel_idx in &selected_indices {
+                let sim = cosine_similarity(
+                    items[cand_idx].memory.embedding(),
+                    items[sel_idx].memory.embedding(),
+                );
+                if sim > max_redundancy {
+                    max_redundancy = sim;
+                }
+            }
+
+            let mmr = lambda * rel - (1.0 - lambda) * max_redundancy;
+
+            if mmr > best_score {
+                best_score = mmr;
+                best_pool_pos = pool_pos;
+            }
+        }
+
+        // Move the winner from the pool into the selected list.
+        let winner = pool.swap_remove(best_pool_pos);
+        selected_indices.push(winner);
+    }
+
+    // Materialize the output by moving items in selection order. Because
+    // selected_indices contains each original index at most once, we can
+    // collect items into Option<...> slots and `take()` each one as we
+    // emit it.
+    let mut slots: Vec<Option<ScoredCandidate>> = items.into_iter().map(Some).collect();
+    selected_indices
+        .into_iter()
+        .map(|i| slots[i].take().expect("each selected index is unique"))
+        .collect()
+}

--- a/pensyve-core/src/retrieval/diversity.rs
+++ b/pensyve-core/src/retrieval/diversity.rs
@@ -103,18 +103,28 @@ pub fn rerank_mmr(
             let rel = relevance[cand_idx];
 
             // Redundancy term: max cosine sim against already-selected.
-            // Empty selected (first iteration) → redundancy = 0, so the
+            // First iteration (empty selected) → redundancy = 0, so the
             // first pick equals the highest-relevance candidate.
-            let mut max_redundancy = 0.0_f32;
-            for &sel_idx in &selected_indices {
-                let sim = cosine_similarity(
-                    items[cand_idx].memory.embedding(),
-                    items[sel_idx].memory.embedding(),
-                );
-                if sim > max_redundancy {
-                    max_redundancy = sim;
-                }
-            }
+            //
+            // Use the actual maximum (NEG_INFINITY init) instead of
+            // clamping at 0.0. Negative cosine values represent genuine
+            // dissimilarity and should *boost* the candidate's MMR score —
+            // the previous `0.0` floor flattened all-negative cases to
+            // pure-relevance ordering, defeating the diversity term.
+            // Per coderabbit Major review on PR #86.
+            let max_redundancy = if selected_indices.is_empty() {
+                0.0_f32
+            } else {
+                selected_indices
+                    .iter()
+                    .map(|&sel_idx| {
+                        cosine_similarity(
+                            items[cand_idx].memory.embedding(),
+                            items[sel_idx].memory.embedding(),
+                        )
+                    })
+                    .fold(f32::NEG_INFINITY, f32::max)
+            };
 
             let mmr = lambda * rel - (1.0 - lambda) * max_redundancy;
 

--- a/pensyve-core/src/retrieval/diversity.rs
+++ b/pensyve-core/src/retrieval/diversity.rs
@@ -11,30 +11,36 @@
 //! Standard MMR (Carbonell & Goldstein 1998), greedy selection:
 //!
 //! ```text
-//! score(item) = λ · sim(item, query)
-//!             − (1 − λ) · max_j sim(item, selected[j])
+//! score(item) = λ · rel(item)
+//!             − (1 − λ) · max_j cos(item, selected[j])
 //! ```
+//!
+//! `rel(item)` is the candidate's `ScoredCandidate.final_score` — the
+//! RRF + cross-encoder fused relevance the recall pipeline already
+//! computed. Final-scores are min-max normalized within the candidate
+//! pool to `[0, 1]` so they share a scale with the cosine redundancy
+//! term and the lambda balance stays well-defined. Per coderabbit
+//! PR #86 review on diversity.rs:95.
 //!
 //! Each iteration picks the candidate with the highest MMR score, appends
 //! it to the selected list, and removes it from the pool. Stops at `k`
 //! items or when the pool is empty.
 //!
-//! ## Similarity function
+//! ## Redundancy term
 //!
-//! Cosine similarity. Memory embeddings are L2-normalized at insert time
-//! by `pensyve_core::vector::VectorIndex`, but this module does not assume
-//! that — it calls [`crate::embedding::cosine_similarity`] which performs
-//! its own normalization, so unnormalized inputs are still scored
-//! correctly. A candidate with an empty (zero-length) embedding gets
-//! similarity 0.0 and is treated as orthogonal to everything.
+//! Cosine similarity between candidate embeddings. Memory embeddings are
+//! L2-normalized at insert time by `pensyve_core::vector::VectorIndex`,
+//! but this module does not assume that — it calls
+//! [`crate::embedding::cosine_similarity`] which performs its own
+//! normalization, so unnormalized inputs still score correctly. A
+//! candidate with an empty (zero-length) embedding gets similarity 0.0
+//! and is treated as orthogonal to everything.
 //!
-//! ## Embedding source
+//! ## λ=1.0 honors the reranker
 //!
-//! `ScoredCandidate.memory.embedding()` already exposes the embedding
-//! vector for every memory variant (Episodic, Semantic, Procedural,
-//! Observation). The MMR call site in `engine.rs` therefore passes the
-//! existing `Vec<ScoredCandidate>` directly — no signature extension
-//! required.
+//! Because relevance is the reranker's `final_score` (not a re-derived
+//! cosine-vs-query), `λ = 1.0` reproduces the input order EXACTLY —
+//! MMR adds no resorting, the reranker stage is fully respected.
 //!
 //! ## Default-OFF behavior
 //!
@@ -52,18 +58,12 @@ use crate::retrieval::engine::ScoredCandidate;
 /// Inputs:
 /// - `items`: candidates as produced by `RecallEngine::recall` (already
 ///   sorted by `ScoredCandidate.final_score` descending — the RRF +
-///   cross-encoder fused score). MMR does NOT consume `final_score`
-///   directly; the relevance term is recomputed as cosine similarity
-///   between the candidate's embedding and `query_vec` so that relevance
-///   and the redundancy term share a single scale (cosine ∈ [-1, 1]) and
-///   the lambda balance remains well-calibrated. Side effect: with
-///   λ = 1.0 the output order is *not* guaranteed to equal the input
-///   order — MMR will resort by raw cosine, which can disagree with the
-///   reranker's `final_score`. Documented tradeoff per coderabbit/claude
-///   PR #86 review and pre-reg §3.X(a'); G4 may revisit using
-///   normalized `final_score` once a multi-cell λ ablation is run.
-/// - `query_vec`: the query embedding used for the relevance term. Same
-///   vector the recall engine fed into the vector index.
+///   cross-encoder fused score). MMR uses `final_score` directly as the
+///   relevance term, min-max-normalized within the candidate pool to
+///   `[0, 1]` so it shares a scale with the cosine redundancy term.
+///   This honors the reranker stage: with λ=1.0 the output order
+///   reproduces the input order exactly. Per coderabbit PR #86 review on
+///   diversity.rs:95.
 /// - `lambda`: balance parameter, clamped into `[0.0, 1.0]`. λ=1.0 is
 ///   pure relevance (output ≈ input order); λ=0.0 is pure diversity. The
 ///   pre-reg §3.9 fixes ARM-5-G3-FULL at λ=0.5.
@@ -73,12 +73,7 @@ use crate::retrieval::engine::ScoredCandidate;
 ///
 /// Returns a new `Vec<ScoredCandidate>` in MMR-selected order. The input
 /// vector is consumed; preserved candidates are moved into the output.
-pub fn rerank_mmr(
-    items: Vec<ScoredCandidate>,
-    query_vec: &[f32],
-    lambda: f32,
-    k: usize,
-) -> Vec<ScoredCandidate> {
+pub fn rerank_mmr(items: Vec<ScoredCandidate>, lambda: f32, k: usize) -> Vec<ScoredCandidate> {
     if k == 0 || items.is_empty() {
         return Vec::new();
     }
@@ -86,13 +81,30 @@ pub fn rerank_mmr(
     let lambda = lambda.clamp(0.0, 1.0);
     let target = k.min(items.len());
 
-    // Pre-compute relevance (cosine vs. query) once per candidate.
-    // Using indexed access because we'll be removing items from the pool
-    // by index during selection.
-    let relevance: Vec<f32> = items
+    // Pre-compute relevance from the reranker's fused `final_score`,
+    // min-max normalized within this candidate pool so the magnitude
+    // sits on the same `[0, 1]` scale as the cosine redundancy term.
+    // Per coderabbit PR #86 review on diversity.rs:95 — using
+    // `final_score` here lets λ=1.0 reproduce the reranker's order
+    // exactly. When all scores are equal (`range == 0`) we fall back
+    // to a constant 0.5 so ordering is decided by the diversity term
+    // alone.
+    let raw_relevance: Vec<f32> = items.iter().map(|c| c.final_score).collect();
+    let (min_score, max_score) = raw_relevance
         .iter()
-        .map(|c| cosine_similarity(c.memory.embedding(), query_vec))
-        .collect();
+        .copied()
+        .fold((f32::INFINITY, f32::NEG_INFINITY), |(lo, hi), v| {
+            (lo.min(v), hi.max(v))
+        });
+    let range = max_score - min_score;
+    let relevance: Vec<f32> = if range > f32::EPSILON {
+        raw_relevance
+            .iter()
+            .map(|&v| (v - min_score) / range)
+            .collect()
+    } else {
+        vec![0.5_f32; items.len()]
+    };
 
     // Pool tracks remaining candidates by their original index. We remove
     // selected entries via `swap_remove` for O(1) removal; selected stays

--- a/pensyve-core/src/retrieval/engine.rs
+++ b/pensyve-core/src/retrieval/engine.rs
@@ -308,6 +308,15 @@ pub struct RecallEngine<'a> {
     agent_id: Option<Uuid>,
     user_id: Option<Uuid>,
     agent_only: Option<Uuid>,
+    /// Optional explicit MMR balance parameter. When set, the recall
+    /// pipeline uses this value directly instead of reading
+    /// `PENSYVE_MMR_LAMBDA` from the process env. Per coderabbit PR #86
+    /// round-4 review on `pensyve-python/src/lib.rs:160` — eliminates
+    /// the race window between the `PyO3` boundary's `G3EnvGuard` and
+    /// concurrent unguarded readers. Falls through to the env-var read
+    /// when `None`, preserving the v2.2.0 default-OFF behavior for
+    /// callers that haven't migrated.
+    mmr_lambda: Option<f32>,
 }
 
 /// Maximum number of candidates to pass into the cross-encoder for reranking.
@@ -331,6 +340,7 @@ impl<'a> RecallEngine<'a> {
             agent_id: None,
             user_id: None,
             agent_only: None,
+            mmr_lambda: None,
         }
     }
 
@@ -373,6 +383,21 @@ impl<'a> RecallEngine<'a> {
     #[must_use]
     pub fn with_agent_only(mut self, agent_id_self: Uuid) -> Self {
         self.agent_only = Some(agent_id_self);
+        self
+    }
+
+    /// Override the MMR balance parameter explicitly. Per coderabbit
+    /// PR #86 round-4 review — passing this through the engine boundary
+    /// instead of mutating `PENSYVE_MMR_LAMBDA` eliminates the race
+    /// between concurrent recall callers (`recall_with_diversity` used
+    /// to set the env var transiently while a parallel `recall()` could
+    /// read it). When this setter is not called, the engine falls back
+    /// to reading `PENSYVE_MMR_LAMBDA` from the env (v2.2.0 default-OFF
+    /// behavior preserved for the harness adapter). Values outside
+    /// `[0.0, 1.0]` are clamped, matching the env-var path.
+    #[must_use]
+    pub fn with_mmr_lambda(mut self, lambda: f32) -> Self {
+        self.mmr_lambda = Some(lambda.clamp(0.0, 1.0));
         self
     }
 
@@ -470,13 +495,22 @@ impl<'a> RecallEngine<'a> {
         let timeout = std::time::Duration::from_secs(self.config.recall_timeout_secs);
         let max_candidates = self.config.max_candidates;
 
-        // G3-P5: read MMR lambda once up front so we know whether to retain
-        // the query embedding for diversity reranking. When unset/<=0.0 the
-        // recall path is byte-for-byte identical to G2 (default-OFF).
-        let mmr_lambda: Option<f32> = std::env::var("PENSYVE_MMR_LAMBDA")
-            .ok()
-            .and_then(|v| v.parse::<f32>().ok())
-            .map(|v| v.clamp(0.0, 1.0))
+        // G3-P5: prefer the explicit `with_mmr_lambda(...)` override
+        // when the caller threaded it through (PyO3 binding's
+        // `recall_with_diversity` sets it directly — no env-var
+        // round-trip). Falls back to the `PENSYVE_MMR_LAMBDA` env var
+        // for callers that haven't migrated. Per coderabbit PR #86
+        // round-4 review on pensyve-python/src/lib.rs:160. When
+        // unset/<=0.0 the recall path is byte-for-byte identical to G2
+        // (default-OFF).
+        let mmr_lambda: Option<f32> = self
+            .mmr_lambda
+            .or_else(|| {
+                std::env::var("PENSYVE_MMR_LAMBDA")
+                    .ok()
+                    .and_then(|v| v.parse::<f32>().ok())
+                    .map(|v| v.clamp(0.0, 1.0))
+            })
             .filter(|&v| v > 0.0);
 
         // Steps 1–4: embed, search, merge candidates. We capture the query

--- a/pensyve-core/src/retrieval/engine.rs
+++ b/pensyve-core/src/retrieval/engine.rs
@@ -513,16 +513,12 @@ impl<'a> RecallEngine<'a> {
             })
             .filter(|&v| v > 0.0);
 
-        // Steps 1–4: embed, search, merge candidates. We capture the query
-        // embedding into `query_embedding_owned` only when MMR is active so
-        // the optional rerank at the tail can reuse it without re-embedding.
-        // Capture is gated on `mmr_lambda.is_some()` so default-OFF stays
-        // zero-overhead.
-        let mut query_embedding_owned: Option<Vec<f32>> = None;
+        // Steps 1–4: embed, search, merge candidates. The MMR rerank
+        // at the tail no longer needs the query embedding (it consumes
+        // the reranker's `final_score` for relevance per coderabbit
+        // round-5 review on diversity.rs:95), so the recall path
+        // doesn't have to retain it past the gather step.
         let (candidates, vector_map) = if let Some(emb) = pre_embedding {
-            if mmr_lambda.is_some() {
-                query_embedding_owned = Some(emb.to_vec());
-            }
             if target_entity.is_some() {
                 self.gather_candidates_dual_path(
                     emb,
@@ -536,32 +532,13 @@ impl<'a> RecallEngine<'a> {
             }
         } else if target_entity.is_some() {
             let query_embedding = self.embedder.embed(query)?;
-            let result = self.gather_candidates_dual_path(
+            self.gather_candidates_dual_path(
                 &query_embedding,
                 query,
                 namespace_id,
                 max_candidates,
                 target_entity,
-            )?;
-            if mmr_lambda.is_some() {
-                query_embedding_owned = Some(query_embedding);
-            }
-            result
-        } else if mmr_lambda.is_some() {
-            // Same as gather_candidates(...), inlined here so we can keep
-            // the query embedding around for MMR without changing the
-            // gather_candidates signature. Only taken on the MMR-active
-            // path; default-OFF still routes through gather_candidates and
-            // pays the original cost.
-            let query_embedding = self.embedder.embed(query)?;
-            let result = self.gather_candidates_with_embedding(
-                &query_embedding,
-                query,
-                namespace_id,
-                max_candidates,
-            )?;
-            query_embedding_owned = Some(query_embedding);
-            result
+            )?
         } else {
             self.gather_candidates(query, namespace_id, max_candidates)?
         };
@@ -809,8 +786,8 @@ impl<'a> RecallEngine<'a> {
         // PENSYVE_MMR_LAMBDA is set and > 0.0, preserving G2 byte-for-byte
         // parity for ARM-1-G3-BASELINE through ARM-4-TYPED-SLOTS.
         // ARM-5-G3-FULL sets λ=0.5.
-        if let (Some(lambda), Some(qvec)) = (mmr_lambda, query_embedding_owned.as_deref()) {
-            scored = crate::retrieval::diversity::rerank_mmr(scored, qvec, lambda, limit);
+        if let Some(lambda) = mmr_lambda {
+            scored = crate::retrieval::diversity::rerank_mmr(scored, lambda, limit);
         }
 
         scored.truncate(limit);

--- a/pensyve-core/src/retrieval/engine.rs
+++ b/pensyve-core/src/retrieval/engine.rs
@@ -470,8 +470,25 @@ impl<'a> RecallEngine<'a> {
         let timeout = std::time::Duration::from_secs(self.config.recall_timeout_secs);
         let max_candidates = self.config.max_candidates;
 
-        // Steps 1–4: embed, search, merge candidates.
+        // G3-P5: read MMR lambda once up front so we know whether to retain
+        // the query embedding for diversity reranking. When unset/<=0.0 the
+        // recall path is byte-for-byte identical to G2 (default-OFF).
+        let mmr_lambda: Option<f32> = std::env::var("PENSYVE_MMR_LAMBDA")
+            .ok()
+            .and_then(|v| v.parse::<f32>().ok())
+            .map(|v| v.clamp(0.0, 1.0))
+            .filter(|&v| v > 0.0);
+
+        // Steps 1–4: embed, search, merge candidates. We capture the query
+        // embedding into `query_embedding_owned` only when MMR is active so
+        // the optional rerank at the tail can reuse it without re-embedding.
+        // Capture is gated on `mmr_lambda.is_some()` so default-OFF stays
+        // zero-overhead.
+        let mut query_embedding_owned: Option<Vec<f32>> = None;
         let (candidates, vector_map) = if let Some(emb) = pre_embedding {
+            if mmr_lambda.is_some() {
+                query_embedding_owned = Some(emb.to_vec());
+            }
             if target_entity.is_some() {
                 self.gather_candidates_dual_path(
                     emb,
@@ -483,19 +500,36 @@ impl<'a> RecallEngine<'a> {
             } else {
                 self.gather_candidates_with_embedding(emb, query, namespace_id, max_candidates)?
             }
-        } else {
-            if target_entity.is_some() {
-                let query_embedding = self.embedder.embed(query)?;
-                self.gather_candidates_dual_path(
-                    &query_embedding,
-                    query,
-                    namespace_id,
-                    max_candidates,
-                    target_entity,
-                )?
-            } else {
-                self.gather_candidates(query, namespace_id, max_candidates)?
+        } else if target_entity.is_some() {
+            let query_embedding = self.embedder.embed(query)?;
+            let result = self.gather_candidates_dual_path(
+                &query_embedding,
+                query,
+                namespace_id,
+                max_candidates,
+                target_entity,
+            )?;
+            if mmr_lambda.is_some() {
+                query_embedding_owned = Some(query_embedding);
             }
+            result
+        } else if mmr_lambda.is_some() {
+            // Same as gather_candidates(...), inlined here so we can keep
+            // the query embedding around for MMR without changing the
+            // gather_candidates signature. Only taken on the MMR-active
+            // path; default-OFF still routes through gather_candidates and
+            // pays the original cost.
+            let query_embedding = self.embedder.embed(query)?;
+            let result = self.gather_candidates_with_embedding(
+                &query_embedding,
+                query,
+                namespace_id,
+                max_candidates,
+            )?;
+            query_embedding_owned = Some(query_embedding);
+            result
+        } else {
+            self.gather_candidates(query, namespace_id, max_candidates)?
         };
 
         if candidates.is_empty() {
@@ -729,6 +763,16 @@ impl<'a> RecallEngine<'a> {
         }
 
         scored.truncate(limit);
+
+        // G3-P5: optional MMR diversity rerank, BEFORE card prepend.
+        // Operator-locked decision (a') 2026-05-06: cards see the
+        // diversity-reordered observations, so MMR runs here at the recall
+        // tail. Default-OFF: only fires when PENSYVE_MMR_LAMBDA is set
+        // and > 0.0, preserving G2 byte-for-byte parity for ARM-1-G3-BASELINE
+        // through ARM-4-TYPED-SLOTS. ARM-5-G3-FULL sets λ=0.5.
+        if let (Some(lambda), Some(qvec)) = (mmr_lambda, query_embedding_owned.as_deref()) {
+            scored = crate::retrieval::diversity::rerank_mmr(scored, qvec, lambda, limit);
+        }
 
         // Step 9: Retrieval-induced reinforcement.
         self.apply_reinforcement(&scored);

--- a/pensyve-core/src/retrieval/engine.rs
+++ b/pensyve-core/src/retrieval/engine.rs
@@ -762,17 +762,24 @@ impl<'a> RecallEngine<'a> {
             scored = apply_reranking(scored, reranker, query)?;
         }
 
-        scored.truncate(limit);
-
-        // G3-P5: optional MMR diversity rerank, BEFORE card prepend.
+        // G3-P5: optional MMR diversity rerank, BEFORE card prepend AND
+        // BEFORE limit-truncation. MMR needs the full pool to pick diverse
+        // alternatives from lower-ranked candidates — truncating first
+        // would constrain it to reordering the top-N relevance set, which
+        // defeats the diversity term. Per coderabbit Major review on PR
+        // #86 (engine.rs:775). MMR's internal `target = k.min(items.len())`
+        // ensures the output is bounded to `limit` regardless.
+        //
         // Operator-locked decision (a') 2026-05-06: cards see the
-        // diversity-reordered observations, so MMR runs here at the recall
-        // tail. Default-OFF: only fires when PENSYVE_MMR_LAMBDA is set
-        // and > 0.0, preserving G2 byte-for-byte parity for ARM-1-G3-BASELINE
-        // through ARM-4-TYPED-SLOTS. ARM-5-G3-FULL sets λ=0.5.
+        // diversity-reordered observations. Default-OFF: only fires when
+        // PENSYVE_MMR_LAMBDA is set and > 0.0, preserving G2 byte-for-byte
+        // parity for ARM-1-G3-BASELINE through ARM-4-TYPED-SLOTS.
+        // ARM-5-G3-FULL sets λ=0.5.
         if let (Some(lambda), Some(qvec)) = (mmr_lambda, query_embedding_owned.as_deref()) {
             scored = crate::retrieval::diversity::rerank_mmr(scored, qvec, lambda, limit);
         }
+
+        scored.truncate(limit);
 
         // Step 9: Retrieval-induced reinforcement.
         self.apply_reinforcement(&scored);

--- a/pensyve-core/src/retrieval/intent_router.rs
+++ b/pensyve-core/src/retrieval/intent_router.rs
@@ -1,0 +1,145 @@
+//! Intent router for G3 retrieval-side composition.
+//!
+//! Maps `question_type` -> per-card enable flags. Per pre-reg
+//! `pensyve-docs@64481dc` §3.4 item 5 + §3.6 + operator-locked decision (a)
+//! on 2026-05-06: `MultiSessionCard` activates only on cross-session
+//! `question_type`s; `SingleSessionUserCard` always activates;
+//! `PeerCardAdapter` always activates; `SupersessionCard` activates when
+//! the consolidation gate has populated `chain_summary` entries (Agent C
+//! handles that activation; this router defaults it OFF).
+//!
+//! ## Decision table (binding §3.6 + operator decision (a) 2026-05-06)
+//!
+//! | `question_type`              | MS card | SSU card | Peer card | Supersession |
+//! |------------------------------|---------|----------|-----------|--------------|
+//! | `multi-session`              | ON      | ON       | ON        | OFF          |
+//! | `temporal-reasoning`         | ON      | ON       | ON        | OFF          |
+//! | `knowledge-update`           | ON      | ON       | ON        | OFF          |
+//! | `single-session-preference`  | OFF     | ON       | ON        | OFF          |
+//! | `single-session-user`        | OFF     | ON       | ON        | OFF          |
+//! | `single-session-assistant`   | OFF     | ON       | ON        | OFF          |
+//! | (unknown)                    | ON      | ON       | ON        | OFF          |
+//!
+//! The unknown-type fallback is conservative: G2-equivalent
+//! `[PeerCard, MS, SSU]` composition with Supersession deferred. This
+//! preserves the G2 floor (ARM-1-G3-BASELINE) for any `question_type`
+//! string the harness emits that we have not enumerated.
+//!
+//! ## Out of scope
+//!
+//! - **No I/O.** Pure-function lookup; compile-time decision table.
+//! - **No env-var reads.** Caller (e.g., `MultiSessionCard::build`) decides
+//!   whether to consult this router based on `PENSYVE_RETRIEVAL_CARDS_G3`.
+//! - **No `SupersessionCard` activation.** That is Agent C's territory;
+//!   this router only emits the default-OFF flag for it.
+
+/// Per-card enable flags returned by [`route`].
+///
+/// `Copy + Eq` so callers can stash the decision as a struct field or
+/// compare against expected fixtures in tests without ceremony.
+///
+/// Per pre-reg §3.6 the router emits **one bool per card** — there are
+/// four cards in the G3 composite chain so four bools is the minimum
+/// shape. The `clippy::struct_excessive_bools` lint is allowed for this
+/// reason.
+#[allow(
+    clippy::struct_excessive_bools,
+    reason = "binding pre-reg §3.6 shape: one enable flag per G3 composite card (Peer, MS, SSU, Supersession)"
+)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RouterDecision {
+    /// `PeerCardAdapter` enabled. G2-equivalent default: always ON.
+    pub enable_peer_card: bool,
+    /// `MultiSessionCard` enabled. G3 §3.6: ON only for cross-session
+    /// `question_type`s; OFF for single-session-* types.
+    pub enable_ms_card: bool,
+    /// `SingleSessionUserCard` enabled. G2-equivalent default: always ON.
+    pub enable_ssu_card: bool,
+    /// `SupersessionCard` enabled. Default OFF; Agent C flips this when
+    /// the consolidation gate has populated `chain_summary` entries.
+    pub enable_supersession_card: bool,
+}
+
+/// G2-equivalent decision: Peer + MS + SSU on, Supersession off. Used
+/// for explicit cross-session types AND as the conservative fallback
+/// for unknown / future `question_type` strings.
+const G2_EQUIVALENT: RouterDecision = RouterDecision {
+    enable_peer_card: true,
+    enable_ms_card: true,
+    enable_ssu_card: true,
+    enable_supersession_card: false,
+};
+
+/// Single-session-* decision: Peer + SSU on, MS off (the G2 H4 partial-
+/// fail fix), Supersession off.
+const SINGLE_SESSION_DECISION: RouterDecision = RouterDecision {
+    enable_peer_card: true,
+    enable_ms_card: false,
+    enable_ssu_card: true,
+    enable_supersession_card: false,
+};
+
+/// Map a `question_type` string to its per-card enable decision.
+///
+/// See module docs for the binding decision table. Unknown
+/// `question_type`s fall back to G2-equivalent
+/// `{PeerCard, MS, SSU}` (Supersession OFF).
+#[must_use]
+pub fn route(question_type: &str) -> RouterDecision {
+    match question_type {
+        // Single-session-* types: MS card OFF (the H4 partial-fail fix
+        // from G2 + the SSU-noise fix per operator decision (a)).
+        "single-session-preference" | "single-session-user" | "single-session-assistant" => {
+            SINGLE_SESSION_DECISION
+        }
+        // Cross-session types AND unknown / future types: conservative
+        // G2-equivalent composition. Cross-session is the explicit case
+        // per §3.6; unknown is the safe fallback (preserves
+        // ARM-1-G3-BASELINE behavior for any harness-emitted type the
+        // router has not yet enumerated).
+        _ => G2_EQUIVALENT,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Smoke tests; the binding 6-fixture decision-table fuzz lives in
+    //! `pensyve-core/tests/test_intent_router.rs`.
+
+    use super::*;
+
+    #[test]
+    fn cross_session_types_enable_ms_card() {
+        for qt in ["multi-session", "temporal-reasoning", "knowledge-update"] {
+            let d = route(qt);
+            assert!(d.enable_ms_card, "expected MS card ON for {qt}");
+            assert!(d.enable_peer_card);
+            assert!(d.enable_ssu_card);
+            assert!(!d.enable_supersession_card);
+        }
+    }
+
+    #[test]
+    fn single_session_types_disable_ms_card() {
+        for qt in [
+            "single-session-preference",
+            "single-session-user",
+            "single-session-assistant",
+        ] {
+            let d = route(qt);
+            assert!(!d.enable_ms_card, "expected MS card OFF for {qt}");
+            assert!(d.enable_peer_card);
+            assert!(d.enable_ssu_card);
+            assert!(!d.enable_supersession_card);
+        }
+    }
+
+    #[test]
+    fn unknown_type_falls_back_to_g2_default() {
+        let d = route("unknown-future-type");
+        assert!(d.enable_peer_card);
+        assert!(d.enable_ms_card);
+        assert!(d.enable_ssu_card);
+        assert!(!d.enable_supersession_card);
+    }
+}

--- a/pensyve-core/src/retrieval/mod.rs
+++ b/pensyve-core/src/retrieval/mod.rs
@@ -24,6 +24,7 @@
 //! continue to work unchanged after the directory split.
 
 pub mod cards;
+pub mod diversity;
 pub mod engine;
 
 // Flat re-export keeps the v2.x API surface intact after the

--- a/pensyve-core/src/retrieval/mod.rs
+++ b/pensyve-core/src/retrieval/mod.rs
@@ -25,6 +25,7 @@
 
 pub mod cards;
 pub mod engine;
+pub mod intent_router;
 
 // Flat re-export keeps the v2.x API surface intact after the
 // retrieval.rs -> retrieval/engine.rs refactor. New code introduced by G2

--- a/pensyve-core/src/storage/sqlite.rs
+++ b/pensyve-core/src/storage/sqlite.rs
@@ -322,6 +322,31 @@ impl SqliteBackend {
             .collect::<Result<Vec<_>, _>>()?;
         Ok(times)
     }
+
+    /// Return the first namespace UUID stored in this backend, ordered by
+    /// `created_at` (oldest first) for a deterministic pick. Used as a
+    /// last-resort fallback by external callers (e.g., the `pensyve-python`
+    /// G3 binding) that accept arbitrary `db_path` arguments and need to
+    /// resolve *some* namespace when the well-known names miss. Returns
+    /// `Ok(None)` only when the store is genuinely empty.
+    pub fn first_namespace_id(&self) -> Result<Option<Uuid>, StorageError> {
+        let conn = lock_conn!(self);
+        let result: Option<String> = conn
+            .query_row(
+                "SELECT id FROM namespaces ORDER BY created_at ASC, id ASC LIMIT 1",
+                [],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?;
+        match result {
+            None => Ok(None),
+            Some(id_str) => {
+                let id = Uuid::parse_str(&id_str)
+                    .map_err(|e| StorageError::Context(format!("corrupt UUID: {e}")))?;
+                Ok(Some(id))
+            }
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/pensyve-core/src/storage/sqlite.rs
+++ b/pensyve-core/src/storage/sqlite.rs
@@ -155,6 +155,55 @@ impl SqliteBackend {
             )?;
         }
 
+        // ----- Migration v2: G3 typed-slot + supersession-chain columns. -----
+        //
+        // Adds 6 NULLABLE TEXT columns to `observation_memories` per the
+        // operator-locked decisions (b) + (c) on 2026-05-06:
+        //
+        //   biography_slot   — per-event typed-slot extractor output
+        //   preference_slot  — per-event typed-slot extractor output
+        //   experience_slot  — per-event typed-slot extractor output
+        //   social_slot      — per-event typed-slot extractor output
+        //   work_slot        — per-event typed-slot extractor output
+        //   chain_summary    — supersession-chain summarizer output
+        //
+        // NULLABLE preserves backward compat: legacy v=1 rows return NULL
+        // for the new columns and the recall-time `SupersessionCard` /
+        // typed-slot card SQL skip NULL values per pre-reg §3.7 / §3.8.
+        //
+        // See `research/benchmark-sprint/v3/g3/preregistration.md` §3.4
+        // items 8-9 + §7 items 8-10 + Appendix B (line anchors verified
+        // at draft time). Mirrors the v1 idempotency pattern: each ALTER
+        // is guarded by `column_exists` so re-runs are no-ops.
+        if max_applied < 2 {
+            const V2_OBSERVATION_COLUMNS: &[&str] = &[
+                "biography_slot",
+                "preference_slot",
+                "experience_slot",
+                "social_slot",
+                "work_slot",
+                "chain_summary",
+            ];
+
+            for column in V2_OBSERVATION_COLUMNS {
+                if !Self::column_exists(conn, "observation_memories", column)? {
+                    conn.execute_batch(&format!(
+                        "ALTER TABLE observation_memories ADD COLUMN {column} TEXT;"
+                    ))?;
+                }
+            }
+
+            conn.execute(
+                "INSERT INTO schema_versions (version, applied_at, description)
+                 VALUES (?1, ?2, ?3)",
+                params![
+                    2_i64,
+                    Utc::now().to_rfc3339(),
+                    "G3: add typed-slot + chain_summary NULLABLE columns to observation_memories",
+                ],
+            )?;
+        }
+
         Ok(())
     }
 

--- a/pensyve-core/src/types.rs
+++ b/pensyve-core/src/types.rs
@@ -108,6 +108,72 @@ pub enum EntityKind {
     Tool,
 }
 
+/// Typed-slot kind for per-event observation enrichment (Pensyve v3 G3).
+///
+/// Per `LaceMem` (`arXiv:2604.27695`) `Synthius` typology — a fixed
+/// 5-slot family that the per-event consolidation gate's typed-slot
+/// extractor populates on `observation_memories` write events. The
+/// values land in the corresponding NULLABLE columns added by the
+/// `schema_versions` v=2 migration (`biography_slot`, `preference_slot`,
+/// `experience_slot`, `social_slot`, `work_slot`).
+///
+/// Operator-locked decision (c) on 2026-05-06: typed-slot enrichment is
+/// implemented as new NULLABLE columns on `observation_memories` rather
+/// than a separate `typed_slots` table. The enum here is the typed
+/// dispatch surface used by `consolidation::typed_slots::extract_slots`
+/// when populating the columns; legacy v=1 rows return NULL and are
+/// skipped by recall-time card consumers.
+///
+/// Operator-locked decision (c') on 2026-05-06: extraction is FIXED-SHAPE
+/// — a single LLM call extracts all 5 slots; non-matching slots return
+/// NULL in the JSON response. The enum exists so call sites can refer to
+/// individual slot kinds by type-safe variant rather than by string
+/// constant when wiring the recall-time card SQL extensions.
+///
+/// Pre-reg §3.4 item 9 + §7 item 10 + Appendix B.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SlotKind {
+    Biography,
+    Preference,
+    Experience,
+    Social,
+    Work,
+}
+
+impl SlotKind {
+    /// Stable lowercase string used for the SQL column-name suffix
+    /// (`{kind}_slot`) and for the JSON field name in the typed-slot
+    /// extractor's response shape. Single source of truth so the SQL
+    /// migration in `storage::sqlite::run_versioned_migrations` and the
+    /// extractor's response parser cannot drift.
+    #[must_use]
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Biography => "biography",
+            Self::Preference => "preference",
+            Self::Experience => "experience",
+            Self::Social => "social",
+            Self::Work => "work",
+        }
+    }
+
+    /// Iterator over all slot kinds in canonical extraction order. The
+    /// order matches the JSON-key order in the extractor prompt and the
+    /// column-creation order in the v=2 migration so log diff and
+    /// schema-replay tools can read both sides without reordering.
+    #[must_use]
+    pub fn all() -> &'static [SlotKind] {
+        &[
+            Self::Biography,
+            Self::Preference,
+            Self::Experience,
+            Self::Social,
+            Self::Work,
+        ]
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Outcome {
     Success,

--- a/pensyve-core/tests/test_diversity.rs
+++ b/pensyve-core/tests/test_diversity.rs
@@ -1,0 +1,239 @@
+//! Integration tests for the G3-P5 MMR diversity reranker.
+//!
+//! Per pre-reg @64481dc §7 item 18: MMR ranking unit + λ-sanity tests.
+//!
+//! These tests use synthetic 4-d unit-axis embeddings so the cosine
+//! similarities between candidates are predictable without depending on
+//! the real ONNX embedder. The MMR module is pure (no I/O, no storage),
+//! so the only fixture work is constructing `ScoredCandidate` values
+//! with hand-crafted vectors.
+
+use uuid::Uuid;
+
+use pensyve_core::retrieval::ScoredCandidate;
+use pensyve_core::retrieval::diversity::rerank_mmr;
+use pensyve_core::types::{EpisodicMemory, Memory};
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+/// Build a synthetic `ScoredCandidate` carrying the supplied embedding.
+/// `final_score` is set to `relevance_marker` so call sites can verify
+/// the input ordering is what they expect.
+fn make_candidate(embedding: Vec<f32>, relevance_marker: f32) -> ScoredCandidate {
+    let ns = Uuid::new_v4();
+    let ep = Uuid::new_v4();
+    let ent = Uuid::new_v4();
+    let mut mem = EpisodicMemory::new(ns, ep, ent, ent, "synthetic content");
+    mem.embedding = embedding;
+
+    ScoredCandidate {
+        memory_id: mem.id,
+        memory: Memory::Episodic(mem),
+        vector_score: 0.0,
+        bm25_score: 0.0,
+        graph_score: 0.0,
+        intent_score: 0.0,
+        recency_score: 0.0,
+        access_score: 0.0,
+        confidence_score: 1.0,
+        entity_score: 0.0,
+        type_boost: 1.0,
+        final_score: relevance_marker,
+    }
+}
+
+/// Convenience: build a candidate from a 4-d unit-vector style spec.
+fn unit4(x: f32, y: f32, z: f32, w: f32, marker: f32) -> ScoredCandidate {
+    make_candidate(vec![x, y, z, w], marker)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// λ=1.0 → output order = input order on a pre-sorted list.
+///
+/// With λ=1.0 the redundancy term is zero-weighted, so MMR degenerates
+/// into argmax over relevance. When the relevance vector is monotone
+/// (input position 0 has the highest cosine sim to query, position 1
+/// next, etc.), the output order must match the input order.
+///
+/// This is the binding sanity test from the pre-reg spec for ARM-5
+/// activation: the pre-reg requires λ=1.0 to preserve relevance order
+/// so we can confirm the rerank wiring is correct without confounding
+/// it with the diversity term.
+#[test]
+fn test_lambda_1_preserves_relevance_order() {
+    // Query is aligned with x-axis. Construct candidates with decreasing
+    // cosine sim to query: c0=1.0, c1=0.7, c2=0.4, c3=0.1.
+    let query = vec![1.0_f32, 0.0, 0.0, 0.0];
+    let c0 = unit4(1.0, 0.0, 0.0, 0.0, 1.0);
+    let c1 = unit4(0.7, 0.7, 0.0, 0.0, 0.7);
+    let c2 = unit4(0.4, 0.0, 0.9, 0.0, 0.4);
+    let c3 = unit4(0.1, 0.0, 0.0, 0.99, 0.1);
+    let input_ids: Vec<Uuid> = vec![c0.memory_id, c1.memory_id, c2.memory_id, c3.memory_id];
+
+    let out = rerank_mmr(vec![c0, c1, c2, c3], &query, 1.0, 4);
+
+    assert_eq!(out.len(), 4);
+    for (i, cand) in out.iter().enumerate() {
+        assert_eq!(
+            cand.memory_id, input_ids[i],
+            "λ=1.0 should preserve the relevance-sorted input order at position {i}"
+        );
+    }
+}
+
+/// λ=0.0 → diversity-only. With two near-duplicate candidates and one
+/// distinct candidate, the first pick equals the highest-relevance item;
+/// the second pick is the orthogonal one (minimal redundancy with the
+/// already-selected first item) rather than the duplicate.
+#[test]
+fn test_lambda_0_maximizes_diversity() {
+    let query = vec![1.0_f32, 0.0, 0.0, 0.0];
+    // c0 + c1 are near-duplicates aligned with the x-axis (high sim to
+    // query AND high sim to each other). c2 is orthogonal (y-axis). With
+    // λ=0.0 the first pick has redundancy 0 (no selected yet) so MMR
+    // chooses argmax(-redundancy) which is the same for everyone — but
+    // ties are broken by iteration order, so c0 is picked first. The
+    // second pick must avoid c1 (cos≈1.0 with c0) and prefer c2 (cos=0).
+    let c0 = unit4(1.0, 0.0, 0.0, 0.0, 0.0); // x-axis duplicate A
+    let c1 = unit4(0.95, 0.05, 0.0, 0.0, 0.0); // x-axis duplicate B
+    let c2 = unit4(0.0, 1.0, 0.0, 0.0, 0.0); // y-axis (orthogonal)
+
+    let c0_id = c0.memory_id;
+    let c2_id = c2.memory_id;
+
+    let out = rerank_mmr(vec![c0, c1, c2], &query, 0.0, 3);
+
+    assert_eq!(out.len(), 3);
+    assert_eq!(out[0].memory_id, c0_id, "λ=0.0 first pick = first item");
+    assert_eq!(
+        out[1].memory_id, c2_id,
+        "λ=0.0 second pick should be the orthogonal item, not the duplicate"
+    );
+}
+
+/// λ=0.5 — hand-checked balanced case on 3 candidates.
+///
+/// Setup: query aligned with x-axis. We pick c0 / c1 / c2 such that c0
+/// and c1 are *exact duplicates* and c2 is moderately diverse but with
+/// the same relevance score as c0/c1. With λ=0.5 the formula is
+/// `0.5 * rel − 0.5 * max_redundancy`.
+///
+/// First iteration (no items selected yet, redundancy = 0 for all):
+///   score(c0) = score(c1) = score(c2) = 0.5 * 0.7071 = 0.354
+/// Tie on relevance → iteration order wins → c0 selected first.
+///
+/// Second iteration (c0 selected):
+///   redundancy(c1, c0) = 1.0 (exact duplicate) → score(c1) = -0.146
+///   redundancy(c2, c0) = 0.5 (diverse)         → score(c2) = +0.104
+/// c2 wins clearly. This demonstrates that MMR with λ=0.5 demotes a
+/// near-duplicate even when its raw relevance equals a more diverse
+/// candidate's — the binding behavior the diversity rerank exists to
+/// produce.
+///
+/// The numeric expectations:
+///   |c0| = |c1| = √(0.49+0+0.49+0) = √0.98 ≈ 0.99
+///   |c2| = √(0.49+0.49+0+0)        = √0.98 ≈ 0.99
+///   rel(c0) = rel(c1) = rel(c2) = 0.7/0.99 ≈ 0.7071
+///   cos(c1, c0) = 1.0  (identical)
+///   cos(c2, c0) = (0.49 + 0 + 0 + 0) / (0.99 · 0.99) ≈ 0.5
+#[test]
+fn test_lambda_05_balanced() {
+    let query = vec![1.0_f32, 0.0, 0.0, 0.0];
+    let c0 = unit4(0.7, 0.0, 0.7, 0.0, 0.7071);
+    let c1 = unit4(0.7, 0.0, 0.7, 0.0, 0.7071); // exact duplicate of c0
+    let c2 = unit4(0.7, 0.7, 0.0, 0.0, 0.7071); // shares dim 0 with c0, diverges on dim 1
+
+    let c0_id = c0.memory_id;
+    let c1_id = c1.memory_id;
+    let c2_id = c2.memory_id;
+
+    let out = rerank_mmr(vec![c0, c1, c2], &query, 0.5, 3);
+
+    assert_eq!(out.len(), 3);
+    assert_eq!(
+        out[0].memory_id, c0_id,
+        "First pick must be c0 (relevance ties broken by iteration order)"
+    );
+
+    // Second pick: c2 wins over c1 because c1's full duplicate redundancy
+    // (1.0 with c0) overwhelms its relevance, while c2's diverse 0.5
+    // redundancy lets its relevance dominate.
+    assert_eq!(
+        out[1].memory_id, c2_id,
+        "Second pick must be c2 (diverse) — full-duplicate c1 must be demoted"
+    );
+
+    // Last slot is c1 (the demoted duplicate).
+    assert_eq!(
+        out[2].memory_id, c1_id,
+        "Last pick must be the demoted duplicate c1"
+    );
+}
+
+/// k > input.len() — return all items reordered (no padding).
+#[test]
+fn test_k_larger_than_input() {
+    let query = vec![1.0_f32, 0.0, 0.0, 0.0];
+    let c0 = unit4(1.0, 0.0, 0.0, 0.0, 1.0);
+    let c1 = unit4(0.0, 1.0, 0.0, 0.0, 0.5);
+    let c2 = unit4(0.0, 0.0, 1.0, 0.0, 0.2);
+
+    let out = rerank_mmr(vec![c0, c1, c2], &query, 0.5, 10);
+
+    assert_eq!(
+        out.len(),
+        3,
+        "k > input.len() must return exactly input.len() items, not pad"
+    );
+}
+
+/// k=0 → empty output.
+#[test]
+fn test_k_zero_returns_empty() {
+    let query = vec![1.0_f32, 0.0, 0.0, 0.0];
+    let c0 = unit4(1.0, 0.0, 0.0, 0.0, 1.0);
+    let c1 = unit4(0.0, 1.0, 0.0, 0.0, 0.5);
+
+    let out = rerank_mmr(vec![c0, c1], &query, 0.5, 0);
+
+    assert!(out.is_empty(), "k=0 must return empty output");
+}
+
+/// Empty input → empty output, no panic.
+#[test]
+fn test_empty_input_no_panic() {
+    let query = vec![1.0_f32, 0.0, 0.0, 0.0];
+
+    let out = rerank_mmr(Vec::new(), &query, 0.5, 5);
+
+    assert!(out.is_empty(), "Empty input must yield empty output");
+}
+
+/// Unnormalized vectors — cosine similarity normalizes internally, so
+/// magnitude doesn't matter and no NaN should leak into scoring.
+#[test]
+fn test_unnormalized_vectors() {
+    let query = vec![10.0_f32, 0.0, 0.0, 0.0];
+    // Same directions as the basic test, but with arbitrary magnitudes.
+    let c0 = make_candidate(vec![100.0, 0.0, 0.0, 0.0], 1.0);
+    let c1 = make_candidate(vec![0.001, 0.001, 0.0, 0.0], 0.5);
+    let c2 = make_candidate(vec![0.0, 0.0, 1e6, 0.0], 0.2);
+    let c3 = make_candidate(vec![3.0, 4.0, 0.0, 0.0], 0.6); // magnitude 5
+
+    let out = rerank_mmr(vec![c0, c1, c2, c3], &query, 0.5, 4);
+
+    assert_eq!(out.len(), 4);
+    for cand in &out {
+        // The MMR module only reorders existing candidates. We didn't
+        // mutate `final_score` so it should still be the marker we set.
+        assert!(
+            !cand.final_score.is_nan(),
+            "MMR rerank must not emit NaN scores even for wildly unnormalized vectors"
+        );
+    }
+}

--- a/pensyve-core/tests/test_diversity.rs
+++ b/pensyve-core/tests/test_diversity.rs
@@ -15,6 +15,7 @@
 
 use uuid::Uuid;
 
+use pensyve_core::embedding::cosine_similarity;
 use pensyve_core::retrieval::ScoredCandidate;
 use pensyve_core::retrieval::diversity::rerank_mmr;
 use pensyve_core::types::{EpisodicMemory, Memory};
@@ -220,7 +221,10 @@ fn test_empty_input_no_panic() {
 }
 
 /// Unnormalized vectors — cosine similarity normalizes internally, so
-/// magnitude doesn't matter and no NaN should leak into scoring.
+/// magnitude doesn't matter and no NaN should leak into scoring. Also
+/// covers the degenerate all-zero embedding: `cosine_similarity` returns
+/// 0.0 for zero-norm inputs (per the embedding module doc), so MMR must
+/// never propagate NaN from such candidates.
 #[test]
 fn test_unnormalized_vectors() {
     let query = vec![10.0_f32, 0.0, 0.0, 0.0];
@@ -229,16 +233,32 @@ fn test_unnormalized_vectors() {
     let c1 = make_candidate(vec![0.001, 0.001, 0.0, 0.0], 0.5);
     let c2 = make_candidate(vec![0.0, 0.0, 1e6, 0.0], 0.2);
     let c3 = make_candidate(vec![3.0, 4.0, 0.0, 0.0], 0.6); // magnitude 5
+    // Degenerate all-zero embedding — would produce NaN if normalization
+    // weren't handled (0 / 0). Sized 768 to mirror real embedder output.
+    let c4 = make_candidate(vec![0.0; 768], 0.4);
 
-    let out = rerank_mmr(vec![c0, c1, c2, c3], &query, 0.5, 4);
+    let out = rerank_mmr(vec![c0, c1, c2, c3, c4], &query, 0.5, 5);
 
-    assert_eq!(out.len(), 4);
+    assert_eq!(out.len(), 5);
     for cand in &out {
         // The MMR module only reorders existing candidates. We didn't
         // mutate `final_score` so it should still be the marker we set.
         assert!(
             !cand.final_score.is_nan(),
             "MMR rerank must not emit NaN scores even for wildly unnormalized vectors"
+        );
+
+        // coderabbit PR #86 review on test_diversity.rs:243 — assertion
+        // now exercises actual cosine math, not just the seeded fixture
+        // marker. `cosine_similarity` is the same function MMR uses
+        // internally; computing it on the returned candidate's embedding
+        // would surface any NaN regression in the normalization pipeline
+        // (e.g., regressing to dot/(|a|*|b|) without the zero-norm guard).
+        let sim = cosine_similarity(cand.memory.embedding(), &query);
+        assert!(
+            !sim.is_nan(),
+            "Cosine similarity against query must not be NaN for any returned candidate \
+             (degenerate inputs included)"
         );
     }
 }

--- a/pensyve-core/tests/test_diversity.rs
+++ b/pensyve-core/tests/test_diversity.rs
@@ -72,16 +72,18 @@ fn unit4(x: f32, y: f32, z: f32, w: f32, marker: f32) -> ScoredCandidate {
 /// it with the diversity term.
 #[test]
 fn test_lambda_1_preserves_relevance_order() {
-    // Query is aligned with x-axis. Construct candidates with decreasing
-    // cosine sim to query: c0=1.0, c1=0.7, c2=0.4, c3=0.1.
-    let query = vec![1.0_f32, 0.0, 0.0, 0.0];
+    // Per round-5 update — relevance now derives from `final_score`
+    // (min-max normalized) rather than cosine vs. query, so the query
+    // vector is no longer needed by `rerank_mmr`. Final-scores are
+    // monotonically decreasing in the markers `(1.0, 0.7, 0.4, 0.1)`,
+    // so λ=1.0 must reproduce that order exactly.
     let c0 = unit4(1.0, 0.0, 0.0, 0.0, 1.0);
     let c1 = unit4(0.7, 0.7, 0.0, 0.0, 0.7);
     let c2 = unit4(0.4, 0.0, 0.9, 0.0, 0.4);
     let c3 = unit4(0.1, 0.0, 0.0, 0.99, 0.1);
     let input_ids: Vec<Uuid> = vec![c0.memory_id, c1.memory_id, c2.memory_id, c3.memory_id];
 
-    let out = rerank_mmr(vec![c0, c1, c2, c3], &query, 1.0, 4);
+    let out = rerank_mmr(vec![c0, c1, c2, c3], 1.0, 4);
 
     assert_eq!(out.len(), 4);
     for (i, cand) in out.iter().enumerate() {
@@ -98,10 +100,9 @@ fn test_lambda_1_preserves_relevance_order() {
 /// already-selected first item) rather than the duplicate.
 #[test]
 fn test_lambda_0_maximizes_diversity() {
-    let query = vec![1.0_f32, 0.0, 0.0, 0.0];
-    // c0 + c1 are near-duplicates aligned with the x-axis (high sim to
-    // query AND high sim to each other). c2 is orthogonal (y-axis). With
-    // λ=0.0 the first pick has redundancy 0 (no selected yet) so MMR
+    // c0 + c1 are near-duplicates aligned with the x-axis. c2 is
+    // orthogonal (y-axis). With λ=0.0 the first pick has redundancy 0
+    // (no selected yet) so MMR
     // chooses argmax(-redundancy) which is the same for everyone — but
     // ties are broken by iteration order, so c0 is picked first. The
     // second pick must avoid c1 (cos≈1.0 with c0) and prefer c2 (cos=0).
@@ -112,7 +113,7 @@ fn test_lambda_0_maximizes_diversity() {
     let c0_id = c0.memory_id;
     let c2_id = c2.memory_id;
 
-    let out = rerank_mmr(vec![c0, c1, c2], &query, 0.0, 3);
+    let out = rerank_mmr(vec![c0, c1, c2], 0.0, 3);
 
     assert_eq!(out.len(), 3);
     assert_eq!(out[0].memory_id, c0_id, "λ=0.0 first pick = first item");
@@ -149,7 +150,6 @@ fn test_lambda_0_maximizes_diversity() {
 ///   cos(c2, c0) = (0.49 + 0 + 0 + 0) / (0.99 · 0.99) ≈ 0.5
 #[test]
 fn test_lambda_05_balanced() {
-    let query = vec![1.0_f32, 0.0, 0.0, 0.0];
     let c0 = unit4(0.7, 0.0, 0.7, 0.0, 0.7071);
     let c1 = unit4(0.7, 0.0, 0.7, 0.0, 0.7071); // exact duplicate of c0
     let c2 = unit4(0.7, 0.7, 0.0, 0.0, 0.7071); // shares dim 0 with c0, diverges on dim 1
@@ -158,7 +158,7 @@ fn test_lambda_05_balanced() {
     let c1_id = c1.memory_id;
     let c2_id = c2.memory_id;
 
-    let out = rerank_mmr(vec![c0, c1, c2], &query, 0.5, 3);
+    let out = rerank_mmr(vec![c0, c1, c2], 0.5, 3);
 
     assert_eq!(out.len(), 3);
     assert_eq!(
@@ -184,12 +184,11 @@ fn test_lambda_05_balanced() {
 /// `k > input.len()` — return all items reordered (no padding).
 #[test]
 fn test_k_larger_than_input() {
-    let query = vec![1.0_f32, 0.0, 0.0, 0.0];
     let c0 = unit4(1.0, 0.0, 0.0, 0.0, 1.0);
     let c1 = unit4(0.0, 1.0, 0.0, 0.0, 0.5);
     let c2 = unit4(0.0, 0.0, 1.0, 0.0, 0.2);
 
-    let out = rerank_mmr(vec![c0, c1, c2], &query, 0.5, 10);
+    let out = rerank_mmr(vec![c0, c1, c2], 0.5, 10);
 
     assert_eq!(
         out.len(),
@@ -201,11 +200,10 @@ fn test_k_larger_than_input() {
 /// k=0 → empty output.
 #[test]
 fn test_k_zero_returns_empty() {
-    let query = vec![1.0_f32, 0.0, 0.0, 0.0];
     let c0 = unit4(1.0, 0.0, 0.0, 0.0, 1.0);
     let c1 = unit4(0.0, 1.0, 0.0, 0.0, 0.5);
 
-    let out = rerank_mmr(vec![c0, c1], &query, 0.5, 0);
+    let out = rerank_mmr(vec![c0, c1], 0.5, 0);
 
     assert!(out.is_empty(), "k=0 must return empty output");
 }
@@ -213,9 +211,7 @@ fn test_k_zero_returns_empty() {
 /// Empty input → empty output, no panic.
 #[test]
 fn test_empty_input_no_panic() {
-    let query = vec![1.0_f32, 0.0, 0.0, 0.0];
-
-    let out = rerank_mmr(Vec::new(), &query, 0.5, 5);
+    let out = rerank_mmr(Vec::new(), 0.5, 5);
 
     assert!(out.is_empty(), "Empty input must yield empty output");
 }
@@ -227,7 +223,7 @@ fn test_empty_input_no_panic() {
 /// never propagate NaN from such candidates.
 #[test]
 fn test_unnormalized_vectors() {
-    let query = vec![10.0_f32, 0.0, 0.0, 0.0];
+    let query = [10.0_f32, 0.0, 0.0, 0.0];
     // Same directions as the basic test, but with arbitrary magnitudes.
     let c0 = make_candidate(vec![100.0, 0.0, 0.0, 0.0], 1.0);
     let c1 = make_candidate(vec![0.001, 0.001, 0.0, 0.0], 0.5);
@@ -237,7 +233,7 @@ fn test_unnormalized_vectors() {
     // weren't handled (0 / 0). Sized 768 to mirror real embedder output.
     let c4 = make_candidate(vec![0.0; 768], 0.4);
 
-    let out = rerank_mmr(vec![c0, c1, c2, c3, c4], &query, 0.5, 5);
+    let out = rerank_mmr(vec![c0, c1, c2, c3, c4], 0.5, 5);
 
     assert_eq!(out.len(), 5);
     for cand in &out {

--- a/pensyve-core/tests/test_diversity.rs
+++ b/pensyve-core/tests/test_diversity.rs
@@ -8,6 +8,11 @@
 //! so the only fixture work is constructing `ScoredCandidate` values
 //! with hand-crafted vectors.
 
+// 0.7071 literals below are intentional 4-decimal-precision fixture values
+// for the rounding shown in the inline test math; not approximations of
+// `std::f32::consts::FRAC_1_SQRT_2`.
+#![allow(clippy::approx_constant)]
+
 use uuid::Uuid;
 
 use pensyve_core::retrieval::ScoredCandidate;
@@ -175,7 +180,7 @@ fn test_lambda_05_balanced() {
     );
 }
 
-/// k > input.len() — return all items reordered (no padding).
+/// `k > input.len()` — return all items reordered (no padding).
 #[test]
 fn test_k_larger_than_input() {
     let query = vec![1.0_f32, 0.0, 0.0, 0.0];

--- a/pensyve-core/tests/test_gate_wiring.rs
+++ b/pensyve-core/tests/test_gate_wiring.rs
@@ -1,0 +1,583 @@
+#![cfg(feature = "observation-extraction")]
+#![allow(
+    clippy::doc_markdown,
+    reason = "test-only doc strings reference bare identifiers in prose; backticking every occurrence harms readability for the small marginal lint benefit"
+)]
+#![allow(
+    unsafe_code,
+    reason = "tests serialize env-var mutation through ENV_LOCK; std::env::set_var is unsafe in Rust 2024 edition by language design but is safe under our serialization"
+)]
+#![allow(
+    clippy::await_holding_lock,
+    reason = "test serialization: ENV_LOCK is a std::sync::Mutex acquired at test entry to serialize env-var mutation across the suite; the await points inside the locked region are intentional — async test bodies cannot use std::sync::Mutex with the lock dropped before await without losing the serialization invariant. Replacing with tokio::sync::Mutex would require !const construction; the tradeoff favors keeping the simpler shape."
+)]
+//! Integration tests for the G3 gate-hook wiring in
+//! `pensyve_core::observation::commit_extraction_for_episode`.
+//!
+//! Pre-reg `pensyve-docs/research/benchmark-sprint/v3/g3/preregistration.md`
+//! §3.4 items 6-7 + §3.7 + §3.8 (LOCKED at `pensyve-docs@64481dc`) bind the
+//! per-event consolidation gate hooks. Addendum 01 (`pensyve-docs@dd7c053`)
+//! Finding 2 mitigation binds the structured log markers verified here.
+//!
+//! Coverage:
+//!
+//! 1. **Gate disabled when env unset** — no `PENSYVE_RETRIEVAL_CARDS_G3`
+//!    set; ingest writes the observation but emits zero gate-firing log
+//!    lines and leaves typed-slot / `chain_summary` columns NULL.
+//! 2. **Typed-slot gate fires on `summarizer` value** — a bug in the
+//!    env-predicate would surface as cross-arm contamination; this test
+//!    pins the strict matrix from `consolidation::g3_*_enabled`.
+//! 3. **Summarizer fires only when supersession chain detected** — fresh
+//!    observation with no prior counterpart: no summarizer log line. New
+//!    observation matching a prior `(entity_type, instance, action)`
+//!    tuple: summarizer fires, `chain_summary` populated.
+//! 4. **`full` value fires both gates** — verifies ARM-5 (FULL) wiring.
+//! 5. **Cancellation results in NULL columns** — operator-locked (b')
+//!    2026-05-06 ROLLBACK semantic. The hook returns Cancelled BEFORE
+//!    the persist UPDATE; columns stay NULL.
+//!
+//! ## Why this lives in `tests/` instead of inline
+//!
+//! The wiring's structural log markers feed `audit_arm.sh` check 6 (per
+//! addendum_01) so they need an integration-test harness that exercises
+//! the full `commit_extraction_for_episode` ingest path with a real
+//! `SqliteBackend` and the v=2 schema migration applied. Inline tests in
+//! `observation.rs` would duplicate the SqliteBackend setup; this file
+//! consolidates the wiring fixtures.
+
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+use chrono::Utc;
+use pensyve_core::observation::{
+    ExtractionMessage, ExtractionResult, NoopExtractor, ObservationExtractor,
+    commit_extraction_for_episode,
+};
+use pensyve_core::storage::StorageTrait;
+use pensyve_core::storage::sqlite::SqliteBackend;
+use pensyve_core::types::{Episode, EpisodicMemory, Namespace, ObservationMemory};
+use rusqlite::Connection;
+use tempfile::TempDir;
+use tokio_util::sync::CancellationToken;
+use uuid::Uuid;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+// ---------------------------------------------------------------------------
+// Env-var serialization
+//
+// `PENSYVE_RETRIEVAL_CARDS_G3` and `PENSYVE_EXTRACTOR_URL` are process-wide
+// env vars. Tests that mutate them must run serially or they will race the
+// `g3_*_enabled` predicate inside the gate-firing path. Cargo runs tests in
+// parallel by default; we use a single mutex to serialize all env-mutating
+// tests in this file. The wiring's structured-log markers themselves are
+// not asserted here (they're verified at the integration level by
+// `audit_arm.sh` check 6 per addendum_01); this suite asserts the column
+// state, which is the primary fail-loud surface.
+// ---------------------------------------------------------------------------
+
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+// ---------------------------------------------------------------------------
+// Mock extractor
+//
+// Returns a single observation with the test-specified `(entity_type,
+// instance, action)` tuple. `commit_extraction_for_episode` calls this
+// extractor's `extract` method; the gate-wiring then fires on the
+// resulting observation.
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+struct CannedExtractor {
+    obs: ObservationMemory,
+}
+
+#[async_trait]
+impl ObservationExtractor for CannedExtractor {
+    async fn extract(
+        &self,
+        _namespace_id: Uuid,
+        _episode_id: Uuid,
+        _messages: &[ExtractionMessage],
+        _cancel: CancellationToken,
+    ) -> ExtractionResult<Vec<ObservationMemory>> {
+        Ok(vec![self.obs.clone()])
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+/// Build a fresh SqliteBackend in a temp dir and seed an episode + a
+/// participating episodic message so the extraction path has something to
+/// process. Returns the backend, namespace_id, and episode_id.
+fn setup_backend() -> (TempDir, SqliteBackend, Uuid, Uuid) {
+    let tmp = tempfile::tempdir().unwrap();
+    let backend = SqliteBackend::open(tmp.path()).unwrap();
+    let ns = Namespace::new("g3-gate-wiring-test");
+    backend.save_namespace(&ns).unwrap();
+
+    let entity_id = Uuid::new_v4();
+    let source_entity = Uuid::new_v4();
+    let episode = Episode::new(ns.id, vec![source_entity, entity_id]);
+    backend.save_episode(&episode).unwrap();
+
+    let mut em = EpisodicMemory::new(
+        ns.id,
+        episode.id,
+        source_entity,
+        entity_id,
+        "user said hello",
+    );
+    em.timestamp = Utc::now();
+    em.event_time = Some(em.timestamp);
+    backend.save_episodic(&em).unwrap();
+
+    (tmp, backend, ns.id, episode.id)
+}
+
+/// Construct an `ObservationMemory` with a fixed shape used by the
+/// triggering tests. The action verb is `"mentioned"` which matches
+/// `consolidation::typed_slot_action_triggers`.
+fn make_obs(
+    namespace_id: Uuid,
+    episode_id: Uuid,
+    entity_type: &str,
+    instance: &str,
+    action: &str,
+    content: &str,
+) -> ObservationMemory {
+    let mut obs = ObservationMemory::new(
+        namespace_id,
+        episode_id,
+        entity_type,
+        instance,
+        action,
+        content,
+    );
+    obs.event_time = Some(Utc::now());
+    obs
+}
+
+/// Insert an observation directly via the backend. Used to seed prior
+/// observations so the supersession chain lookup has something to match.
+fn seed_observation(backend: &SqliteBackend, obs: &ObservationMemory) {
+    backend.save_observation(obs).unwrap();
+}
+
+/// 6-tuple of NULLABLE string columns the v=2 schema migration adds:
+/// (biography, preference, experience, social, work, chain_summary).
+/// Read together via a single `SELECT` so the per-test fixture only does
+/// one round-trip.
+type G3Columns = (
+    Option<String>,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+);
+
+/// Read typed-slot + chain_summary columns for a given observation.
+fn read_g3_columns(db_path: &std::path::Path, observation_id: Uuid) -> G3Columns {
+    let conn = Connection::open(db_path).unwrap();
+    conn.query_row(
+        "SELECT biography_slot, preference_slot, experience_slot, social_slot, \
+                work_slot, chain_summary \
+         FROM observation_memories WHERE id = ?1",
+        rusqlite::params![observation_id.to_string()],
+        |row| {
+            Ok((
+                row.get::<_, Option<String>>(0)?,
+                row.get::<_, Option<String>>(1)?,
+                row.get::<_, Option<String>>(2)?,
+                row.get::<_, Option<String>>(3)?,
+                row.get::<_, Option<String>>(4)?,
+                row.get::<_, Option<String>>(5)?,
+            ))
+        },
+    )
+    .unwrap()
+}
+
+/// Spin up a wiremock server that responds to `POST /v1/chat/completions`
+/// with the given canned text. Returns the `MockServer` (kept alive by
+/// the test scope) and its base URL with `/v1` trailing.
+async fn spin_up_mock_llm(canned: &str) -> (MockServer, String) {
+    let server = MockServer::start().await;
+    let body = serde_json::json!({
+        "id": "chatcmpl-test",
+        "object": "chat.completion",
+        "model": "test-model",
+        "choices": [{
+            "index": 0,
+            "message": {"role": "assistant", "content": canned},
+            "finish_reason": "stop"
+        }],
+        "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+    });
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(body))
+        .mount(&server)
+        .await;
+    let url = format!("{}/v1", server.uri());
+    (server, url)
+}
+
+/// Configure the env vars the gate-firing path reads:
+///   - `PENSYVE_RETRIEVAL_CARDS_G3` — gate value
+///   - `PENSYVE_EXTRACTOR_URL` — typed-slot LLM endpoint (mock)
+///   - `PENSYVE_NETWORK_POLICY` — `permissive` so the mock URL is reachable
+///   - `PENSYVE_EXTRACTOR_MODEL` — any string; mock ignores it
+fn set_g3_env(arm_value: Option<&str>, mock_url: Option<&str>) {
+    match arm_value {
+        Some(v) => unsafe { std::env::set_var("PENSYVE_RETRIEVAL_CARDS_G3", v) },
+        None => unsafe { std::env::remove_var("PENSYVE_RETRIEVAL_CARDS_G3") },
+    }
+    match mock_url {
+        Some(u) => unsafe { std::env::set_var("PENSYVE_EXTRACTOR_URL", u) },
+        None => unsafe { std::env::remove_var("PENSYVE_EXTRACTOR_URL") },
+    }
+    unsafe { std::env::set_var("PENSYVE_NETWORK_POLICY", "permissive") };
+    unsafe { std::env::set_var("PENSYVE_EXTRACTOR_MODEL", "test-model") };
+}
+
+/// Reset env vars after a test so other tests start clean.
+fn clear_g3_env() {
+    unsafe {
+        std::env::remove_var("PENSYVE_RETRIEVAL_CARDS_G3");
+        std::env::remove_var("PENSYVE_EXTRACTOR_URL");
+        std::env::remove_var("PENSYVE_NETWORK_POLICY");
+        std::env::remove_var("PENSYVE_EXTRACTOR_MODEL");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// Fixture #1: env unset — gate predicates are off, no LLM call, no log
+/// markers, columns stay NULL.
+#[tokio::test]
+async fn test_gate_disabled_when_env_unset() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    clear_g3_env();
+
+    let (_tmp, backend, ns_id, ep_id) = setup_backend();
+    let db_path = backend.db_path().unwrap().to_path_buf();
+
+    let obs = make_obs(ns_id, ep_id, "biography", "user", "mentioned", "I'm Alice");
+    let extractor = CannedExtractor { obs: obs.clone() };
+
+    let persisted = commit_extraction_for_episode(
+        &backend,
+        &extractor,
+        ns_id,
+        ep_id,
+        CancellationToken::new(),
+        |_text| Ok::<Vec<f32>, &'static str>(Vec::new()),
+    )
+    .await;
+
+    assert_eq!(persisted, 1, "the canned observation should persist");
+
+    // Columns must all be NULL since neither gate fired.
+    let (bio, pref, exp, soc, work, chain) = read_g3_columns(&db_path, obs.id);
+    assert!(
+        bio.is_none(),
+        "biography_slot must be NULL when gate is off"
+    );
+    assert!(pref.is_none());
+    assert!(exp.is_none());
+    assert!(soc.is_none());
+    assert!(work.is_none());
+    assert!(
+        chain.is_none(),
+        "chain_summary must be NULL when gate is off"
+    );
+}
+
+/// Fixture #2: `PENSYVE_RETRIEVAL_CARDS_G3=typed_slots` — typed-slot gate
+/// fires; mock LLM returns valid JSON; populated_slot_kinds match.
+#[tokio::test]
+async fn test_typed_slots_gate_fires_and_populates_columns() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    clear_g3_env();
+
+    let canned_response = r#"{"biography": "User is named Alice", "preference": null, "experience": null, "social": null, "work": "User is a software engineer"}"#;
+    let (_server, mock_url) = spin_up_mock_llm(canned_response).await;
+    set_g3_env(Some("typed_slots"), Some(&mock_url));
+
+    let (_tmp, backend, ns_id, ep_id) = setup_backend();
+    let db_path = backend.db_path().unwrap().to_path_buf();
+
+    let obs = make_obs(
+        ns_id,
+        ep_id,
+        "biography",
+        "user",
+        "mentioned",
+        "I'm Alice, a software engineer",
+    );
+    let extractor = CannedExtractor { obs: obs.clone() };
+
+    let persisted = commit_extraction_for_episode(
+        &backend,
+        &extractor,
+        ns_id,
+        ep_id,
+        CancellationToken::new(),
+        |_text| Ok::<Vec<f32>, &'static str>(Vec::new()),
+    )
+    .await;
+
+    assert_eq!(persisted, 1);
+
+    let (bio, pref, exp, soc, work, chain) = read_g3_columns(&db_path, obs.id);
+    assert_eq!(bio.as_deref(), Some("User is named Alice"));
+    assert_eq!(pref, None);
+    assert_eq!(exp, None);
+    assert_eq!(soc, None);
+    assert_eq!(work.as_deref(), Some("User is a software engineer"));
+    // chain_summary stays NULL when only typed_slots is enabled.
+    assert!(
+        chain.is_none(),
+        "chain_summary must be NULL when only typed_slots is enabled"
+    );
+
+    clear_g3_env();
+}
+
+/// Fixture #3a: `PENSYVE_RETRIEVAL_CARDS_G3=summarizer`, no prior matching
+/// observation — supersession chain lookup returns empty; summarizer does
+/// NOT fire; chain_summary stays NULL.
+#[tokio::test]
+async fn test_summarizer_gate_no_supersession_does_not_fire() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    clear_g3_env();
+
+    let (_server, mock_url) = spin_up_mock_llm("This summary should not be persisted.").await;
+    set_g3_env(Some("summarizer"), Some(&mock_url));
+
+    let (_tmp, backend, ns_id, ep_id) = setup_backend();
+    let db_path = backend.db_path().unwrap().to_path_buf();
+
+    let obs = make_obs(
+        ns_id,
+        ep_id,
+        "biography",
+        "user",
+        "mentioned",
+        "I live in Seattle",
+    );
+    let extractor = CannedExtractor { obs: obs.clone() };
+
+    let _ = commit_extraction_for_episode(
+        &backend,
+        &extractor,
+        ns_id,
+        ep_id,
+        CancellationToken::new(),
+        |_text| Ok::<Vec<f32>, &'static str>(Vec::new()),
+    )
+    .await;
+
+    let (_bio, _pref, _exp, _soc, _work, chain) = read_g3_columns(&db_path, obs.id);
+    assert!(
+        chain.is_none(),
+        "chain_summary must be NULL when no supersession chain exists"
+    );
+
+    clear_g3_env();
+}
+
+/// Fixture #3b: same env as #3a but a prior observation with the same
+/// `(entity_type, instance, action)` shape exists — supersession lookup
+/// finds the prior; summarizer fires; chain_summary is populated.
+#[tokio::test]
+async fn test_summarizer_gate_fires_on_supersession_chain() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    clear_g3_env();
+
+    let canned_summary = "User moved from SF to NY.";
+    let (_server, mock_url) = spin_up_mock_llm(canned_summary).await;
+    set_g3_env(Some("summarizer"), Some(&mock_url));
+
+    let (_tmp, backend, ns_id, ep_id) = setup_backend();
+    let db_path = backend.db_path().unwrap().to_path_buf();
+
+    // Seed a prior observation with the SAME (entity_type, instance, action)
+    // tuple. The wiring's supersession-chain lookup should find this prior
+    // and treat the new observation as the head of a supersession chain.
+    // Use action=`"is"` which is on the typed-slot trigger list but is
+    // semantically irrelevant to the summarizer gate (the gate fires on
+    // chain detection, not action verbs).
+    let prior = make_obs(ns_id, ep_id, "location", "user", "is", "User lives in SF");
+    seed_observation(&backend, &prior);
+
+    let new_obs = make_obs(ns_id, ep_id, "location", "user", "is", "User lives in NY");
+    let extractor = CannedExtractor {
+        obs: new_obs.clone(),
+    };
+
+    let _ = commit_extraction_for_episode(
+        &backend,
+        &extractor,
+        ns_id,
+        ep_id,
+        CancellationToken::new(),
+        |_text| Ok::<Vec<f32>, &'static str>(Vec::new()),
+    )
+    .await;
+
+    let (_bio, _pref, _exp, _soc, _work, chain) = read_g3_columns(&db_path, new_obs.id);
+    assert_eq!(
+        chain.as_deref(),
+        Some(canned_summary),
+        "chain_summary must be populated with the canned LLM response"
+    );
+
+    clear_g3_env();
+}
+
+/// Fixture #4: `PENSYVE_RETRIEVAL_CARDS_G3=full` — both gates fire on a
+/// supersession-eligible observation with typed-slot-eligible action.
+#[tokio::test]
+async fn test_full_value_fires_both_gates() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    clear_g3_env();
+
+    // Mock returns a JSON typed-slot response; the same string also serves
+    // as the summarizer output (the parser is tolerant of either shape:
+    // `parse_response` for typed_slots, raw text for summarizer). Since
+    // both hooks call `complete()` against the same mock endpoint, the
+    // mock must produce a response that's valid for the path the hook
+    // takes. We canned the typed-slot JSON shape; the summarizer just
+    // takes the raw text including the JSON, which the consumer trims.
+    let canned = r#"{"biography": "User in Seattle", "preference": null, "experience": null, "social": null, "work": null}"#;
+    let (_server, mock_url) = spin_up_mock_llm(canned).await;
+    set_g3_env(Some("full"), Some(&mock_url));
+
+    let (_tmp, backend, ns_id, ep_id) = setup_backend();
+    let db_path = backend.db_path().unwrap().to_path_buf();
+
+    // Seed a prior so the summarizer sees a chain.
+    let prior = make_obs(
+        ns_id,
+        ep_id,
+        "biography",
+        "user",
+        "mentioned",
+        "I live in NY",
+    );
+    seed_observation(&backend, &prior);
+
+    let new_obs = make_obs(
+        ns_id,
+        ep_id,
+        "biography",
+        "user",
+        "mentioned",
+        "I live in Seattle",
+    );
+    let extractor = CannedExtractor {
+        obs: new_obs.clone(),
+    };
+
+    let _ = commit_extraction_for_episode(
+        &backend,
+        &extractor,
+        ns_id,
+        ep_id,
+        CancellationToken::new(),
+        |_text| Ok::<Vec<f32>, &'static str>(Vec::new()),
+    )
+    .await;
+
+    let (bio, _pref, _exp, _soc, _work, chain) = read_g3_columns(&db_path, new_obs.id);
+    assert_eq!(
+        bio.as_deref(),
+        Some("User in Seattle"),
+        "typed-slot column must populate when full is enabled"
+    );
+    assert!(
+        chain.is_some(),
+        "chain_summary must populate when full is enabled and a chain exists; got NULL"
+    );
+
+    clear_g3_env();
+}
+
+/// Fixture #5: pre-cancelled token — the typed-slot hook returns
+/// `Cancelled` before the LLM call returns; the persist UPDATE is NOT
+/// invoked; columns stay NULL per operator-locked (b') ROLLBACK.
+#[tokio::test]
+async fn test_cancellation_results_in_null_columns() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    clear_g3_env();
+
+    // The pre-flight cancel check inside the hook short-circuits before
+    // the HTTP call lands; the mock would never be invoked, so its body
+    // doesn't matter.
+    let (_server, mock_url) = spin_up_mock_llm(r#"{"biography": "should not persist"}"#).await;
+    set_g3_env(Some("typed_slots"), Some(&mock_url));
+
+    let (_tmp, backend, ns_id, ep_id) = setup_backend();
+    let db_path = backend.db_path().unwrap().to_path_buf();
+
+    let obs = make_obs(ns_id, ep_id, "biography", "user", "mentioned", "I'm Alice");
+    let extractor = CannedExtractor { obs: obs.clone() };
+
+    // Pre-cancel the token: the hook's pre-flight cancel check short-
+    // circuits with `Cancelled` BEFORE the LLM call. The wiring's
+    // persist UPDATE is gated behind `Ok(Some(_))`, so a Cancelled error
+    // means typed-slot columns stay NULL.
+    let cancel = CancellationToken::new();
+    cancel.cancel();
+
+    let _ = commit_extraction_for_episode(&backend, &extractor, ns_id, ep_id, cancel, |_text| {
+        Ok::<Vec<f32>, &'static str>(Vec::new())
+    })
+    .await;
+
+    let (bio, pref, exp, soc, work, _chain) = read_g3_columns(&db_path, obs.id);
+    assert!(
+        bio.is_none() && pref.is_none() && exp.is_none() && soc.is_none() && work.is_none(),
+        "all typed-slot columns must stay NULL when cancellation rolls back persist"
+    );
+
+    clear_g3_env();
+}
+
+/// Fixture #6: NoopExtractor produces no observations — the gate-firing
+/// loop never executes. This exercises the per-observation loop's
+/// no-op path under the gate-on env.
+#[tokio::test]
+async fn test_noop_extractor_produces_no_gate_firings() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    clear_g3_env();
+
+    let (_server, mock_url) = spin_up_mock_llm("anything").await;
+    set_g3_env(Some("full"), Some(&mock_url));
+
+    let (_tmp, backend, ns_id, ep_id) = setup_backend();
+
+    let persisted = commit_extraction_for_episode(
+        &backend,
+        &NoopExtractor,
+        ns_id,
+        ep_id,
+        CancellationToken::new(),
+        |_text| Ok::<Vec<f32>, &'static str>(Vec::new()),
+    )
+    .await;
+
+    assert_eq!(
+        persisted, 0,
+        "NoopExtractor produces no observations, so no gate firings"
+    );
+
+    clear_g3_env();
+}

--- a/pensyve-core/tests/test_intent_router.rs
+++ b/pensyve-core/tests/test_intent_router.rs
@@ -1,0 +1,403 @@
+//! Integration tests for the G3-P2 intent router + `MultiSessionCard`
+//! router gate. Coverage matches pre-reg `pensyve-docs@64481dc` §3.6
+//! hardening:
+//!
+//! 1. **6-fixture decision-table fuzz** — hand-fuzz `route()` against
+//!    all six known `question_type`s + one unknown sentinel.
+//! 2. **End-to-end router gate** — under `PENSYVE_RETRIEVAL_CARDS_G3=
+//!    router`, `MultiSessionCard::build` returns `None` for
+//!    `single-session-user` and `Some(_)` for `multi-session` (when
+//!    the underlying SQL would have produced cross-session results).
+//! 3. **G2 baseline preserved** — without the env var the card behaves
+//!    byte-for-byte as G2 (e.g., a 2-session entity surfaces).
+//! 4. **G3 SQL scope-tighten** — under `PENSYVE_RETRIEVAL_CARDS_G3=
+//!    router`, an entity surfacing in only 2 distinct date-day buckets
+//!    is dropped (G3 raises threshold to ≥3).
+//!
+//! Test fixture pattern mirrors `tests/test_multi_session_card.rs`.
+
+use std::sync::{Mutex, OnceLock};
+
+use uuid::Uuid;
+
+use pensyve_core::retrieval::cards::{MultiSessionCard, RetrievalCard};
+use pensyve_core::retrieval::intent_router::{RouterDecision, route};
+use pensyve_core::storage::StorageTrait;
+use pensyve_core::storage::sqlite::SqliteBackend;
+
+use rusqlite::Connection;
+use tempfile::TempDir;
+
+// ---------------------------------------------------------------------------
+// Env-var serialization
+// ---------------------------------------------------------------------------
+
+const G3_ENV_KEY: &str = "PENSYVE_RETRIEVAL_CARDS_G3";
+
+/// `MultiSessionCard` reads `PENSYVE_RETRIEVAL_CARDS_G3` at construction;
+/// tests that mutate that variable must run serially or the cached
+/// `g3_mode` will race across threads. The mutex is process-wide.
+fn router_env_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+/// RAII guard that holds the process-wide `router_env_lock` AND mutates
+/// `PENSYVE_RETRIEVAL_CARDS_G3` for the lifetime of the guard. The
+/// previous value is captured at construction and restored on drop.
+///
+/// `# Safety`: `std::env::set_var` / `remove_var` are flagged unsafe in
+/// modern Rust because env mutation is process-global and not thread-
+/// safe. This guard serializes all writers/readers behind
+/// [`router_env_lock`] for one `cargo test` binary. Mirrors the
+/// `SsuEnvGuard` pattern in `tests/test_single_session_user_card.rs`.
+struct RouterEnvGuard {
+    _serial: std::sync::MutexGuard<'static, ()>,
+    previous: Option<String>,
+}
+
+#[allow(
+    unsafe_code,
+    reason = "test-only env-var guard; std::env::set_var/remove_var require unsafe in modern Rust because env mutation is process-global. The struct holds the process-wide router_env_lock for its lifetime so concurrent test threads cannot race."
+)]
+impl RouterEnvGuard {
+    fn set(value: &str) -> Self {
+        let serial = router_env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let previous = std::env::var(G3_ENV_KEY).ok();
+        // SAFETY: see struct doc; serialized via the mutex in `serial`.
+        unsafe {
+            std::env::set_var(G3_ENV_KEY, value);
+        }
+        Self {
+            _serial: serial,
+            previous,
+        }
+    }
+
+    fn unset() -> Self {
+        let serial = router_env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let previous = std::env::var(G3_ENV_KEY).ok();
+        // SAFETY: see struct doc.
+        unsafe {
+            std::env::remove_var(G3_ENV_KEY);
+        }
+        Self {
+            _serial: serial,
+            previous,
+        }
+    }
+}
+
+#[allow(
+    unsafe_code,
+    reason = "test-only env-var guard; see RouterEnvGuard::set for justification"
+)]
+impl Drop for RouterEnvGuard {
+    fn drop(&mut self) {
+        // SAFETY: drop runs while we still hold the serialization lock.
+        unsafe {
+            match &self.previous {
+                Some(v) => std::env::set_var(G3_ENV_KEY, v),
+                None => std::env::remove_var(G3_ENV_KEY),
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: 6-fixture decision-table fuzz on `route()`
+// ---------------------------------------------------------------------------
+
+/// Pre-reg §3.6 hardening: hand-fuzz the router decision table against
+/// all six `question_type` strings listed in the spec, plus one unknown
+/// sentinel covering the conservative G2-equivalent fallback.
+#[test]
+fn router_decision_table_matches_spec_for_all_six_question_types() {
+    // Cross-session types: MS card ON.
+    let cross_session = ["multi-session", "temporal-reasoning", "knowledge-update"];
+    for qt in cross_session {
+        assert_eq!(
+            route(qt),
+            RouterDecision {
+                enable_peer_card: true,
+                enable_ms_card: true,
+                enable_ssu_card: true,
+                enable_supersession_card: false,
+            },
+            "decision-table mismatch for {qt}",
+        );
+    }
+
+    // Single-session-* types: MS card OFF.
+    let single_session = [
+        "single-session-preference",
+        "single-session-user",
+        "single-session-assistant",
+    ];
+    for qt in single_session {
+        assert_eq!(
+            route(qt),
+            RouterDecision {
+                enable_peer_card: true,
+                enable_ms_card: false,
+                enable_ssu_card: true,
+                enable_supersession_card: false,
+            },
+            "decision-table mismatch for {qt}",
+        );
+    }
+}
+
+/// Unknown `question_type` falls back to the conservative G2-equivalent
+/// composition (Peer + MS + SSU; Supersession deferred). This preserves
+/// ARM-1-G3-BASELINE behavior for any harness-emitted type the router
+/// has not yet enumerated.
+#[test]
+fn router_unknown_question_type_falls_back_to_g2_default() {
+    let d = route("future-unspecified-type-xyz");
+    assert!(d.enable_peer_card);
+    assert!(d.enable_ms_card);
+    assert!(d.enable_ssu_card);
+    assert!(!d.enable_supersession_card);
+}
+
+/// Empty-string `question_type` (a degenerate harness emission) also
+/// falls back to G2-equivalent. Defensive: the router must never panic
+/// on caller input.
+#[test]
+fn router_empty_question_type_falls_back_to_g2_default() {
+    let d = route("");
+    assert!(d.enable_peer_card);
+    assert!(d.enable_ms_card);
+    assert!(d.enable_ssu_card);
+    assert!(!d.enable_supersession_card);
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: end-to-end router gate via MultiSessionCard
+// ---------------------------------------------------------------------------
+
+/// Build a `SqliteBackend` in a fresh temp dir. Mirrors the fixture
+/// pattern in `tests/test_multi_session_card.rs`.
+fn open_backend() -> (TempDir, std::path::PathBuf, Box<dyn StorageTrait>) {
+    let dir = tempfile::tempdir().unwrap();
+    let backend: Box<dyn StorageTrait> = Box::new(SqliteBackend::open(dir.path()).unwrap());
+    let db_path = backend
+        .db_path()
+        .expect("SqliteBackend must expose its disk path")
+        .to_path_buf();
+    (dir, db_path, backend)
+}
+
+/// Side-channel insert into `observation_memories`. Mirrors the helper
+/// in `tests/test_multi_session_card.rs` (production schema; all NOT
+/// NULL columns supplied).
+#[allow(clippy::too_many_arguments)]
+fn insert_obs(
+    conn: &Connection,
+    namespace_id: &str,
+    entity_type: &str,
+    instance: &str,
+    action: &str,
+    content: &str,
+    event_time: Option<&str>,
+) {
+    conn.execute(
+        "INSERT INTO observation_memories \
+         (id, namespace_id, episode_id, entity_type, instance, action, \
+          content, event_time, created_at, agent_id, user_id) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+        rusqlite::params![
+            Uuid::new_v4().to_string(),
+            namespace_id,
+            Uuid::new_v4().to_string(),
+            entity_type,
+            instance,
+            action,
+            content,
+            event_time,
+            "2023-01-01T00:00:00Z",
+            None::<String>,
+            None::<String>,
+        ],
+    )
+    .unwrap();
+}
+
+/// Seed an entity with N distinct date-day buckets so the
+/// `MultiSessionCard` SQL would surface it on the G2 / unrouted path.
+fn seed_cross_session_entity(conn: &Connection, ns: &str, instance: &str, n_days: usize) {
+    for d in 0..n_days {
+        insert_obs(
+            conn,
+            ns,
+            "person",
+            instance,
+            "discussed",
+            "session content",
+            Some(&format!("2024-01-{:02}T10:00:00Z", d + 1)),
+        );
+    }
+}
+
+/// **Router gate end-to-end.** With `PENSYVE_RETRIEVAL_CARDS_G3=router`
+/// the card returns `None` for `single-session-user` regardless of how
+/// many cross-session entities the store contains, and surfaces the
+/// entities for `multi-session`.
+#[test]
+fn router_gate_blocks_ms_card_on_single_session_user() {
+    let _env = RouterEnvGuard::set("router");
+
+    let (_dir, db_path, backend) = open_backend();
+    let ns = Uuid::new_v4();
+    let ns_str = ns.to_string();
+    let seed = Connection::open(&db_path).unwrap();
+    // 3 distinct date-days → passes G3 ≥3 threshold so the MS-card path
+    // would otherwise surface this entity. The router gate must
+    // suppress it on `single-session-user`.
+    seed_cross_session_entity(&seed, &ns_str, "Marie Curie", 3);
+    drop(seed);
+
+    let card = MultiSessionCard::new();
+
+    // Single-session-user: router gate forces None.
+    let blocked = card.build(
+        "any",
+        backend.as_ref(),
+        ns,
+        None,
+        None,
+        Some("single-session-user"),
+    );
+    assert!(
+        blocked.is_none(),
+        "router=router + question_type=single-session-user must yield None; got: {blocked:?}",
+    );
+
+    // Multi-session: router lets the card through, and the entity is
+    // present (3 distinct dates ≥ G3 threshold of 3).
+    let allowed = card
+        .build(
+            "any",
+            backend.as_ref(),
+            ns,
+            None,
+            None,
+            Some("multi-session"),
+        )
+        .expect("multi-session must surface a card when cross-session entity is present");
+    assert!(
+        allowed.contains("Marie Curie"),
+        "multi-session card must include the cross-session entity; got:\n{allowed}",
+    );
+}
+
+/// **G2 baseline preserved when env var is unset.** Without the G3
+/// env var, the card behaves identically to G2: cross-session entity
+/// with 2 distinct dates surfaces and `question_type` is ignored.
+#[test]
+fn g2_baseline_preserved_when_env_var_unset() {
+    let _env = RouterEnvGuard::unset();
+
+    let (_dir, db_path, backend) = open_backend();
+    let ns = Uuid::new_v4();
+    let ns_str = ns.to_string();
+    let seed = Connection::open(&db_path).unwrap();
+    // Exactly 2 distinct date-days — passes G2 threshold of 2 but
+    // would fail G3 threshold of 3.
+    seed_cross_session_entity(&seed, &ns_str, "Bob", 2);
+    drop(seed);
+
+    let card = MultiSessionCard::new();
+
+    // G2 mode: question_type is irrelevant; entity surfaces.
+    let out = card
+        .build(
+            "any",
+            backend.as_ref(),
+            ns,
+            None,
+            None,
+            Some("single-session-user"),
+        )
+        .expect("G2 baseline must surface 2-session entity regardless of question_type");
+    assert!(
+        out.contains("Bob"),
+        "G2 baseline card must include Bob; got:\n{out}"
+    );
+}
+
+/// **G3 SQL scope-tighten dropped 2-session entities.** Under
+/// `PENSYVE_RETRIEVAL_CARDS_G3=router`, an entity surfacing in only
+/// 2 distinct date-day buckets must be dropped (threshold raised
+/// from G2's ≥2 to G3's ≥3). The `question_type` is `multi-session` so
+/// the router gate doesn't suppress the card; the threshold raise is
+/// what eliminates the entity.
+#[test]
+fn g3_router_mode_raises_cross_session_threshold_to_three() {
+    let _env = RouterEnvGuard::set("router");
+
+    let (_dir, db_path, backend) = open_backend();
+    let ns = Uuid::new_v4();
+    let ns_str = ns.to_string();
+    let seed = Connection::open(&db_path).unwrap();
+    // Exactly 2 distinct date-days for "Carol" — fails G3 threshold.
+    seed_cross_session_entity(&seed, &ns_str, "Carol", 2);
+    // 3 distinct date-days for "Dave" — passes G3 threshold.
+    seed_cross_session_entity(&seed, &ns_str, "Dave", 3);
+    drop(seed);
+
+    let card = MultiSessionCard::new();
+    let out = card
+        .build(
+            "any",
+            backend.as_ref(),
+            ns,
+            None,
+            None,
+            Some("multi-session"),
+        )
+        .expect("3-session Dave must produce a card under G3 router mode");
+
+    assert!(
+        out.contains("Dave"),
+        "Dave (3 sessions) must surface under G3; got:\n{out}"
+    );
+    assert!(
+        !out.contains("Carol"),
+        "Carol (2 sessions) must NOT surface under G3 ≥3 threshold; got:\n{out}",
+    );
+}
+
+/// **`full` mode behaves like `router` mode for MS card.** Per spec,
+/// both `router` and `full` enable the MS-card-side gates; the router
+/// gate + scope-tighten apply identically.
+#[test]
+fn g3_full_mode_also_activates_router_gate() {
+    let _env = RouterEnvGuard::set("full");
+
+    let (_dir, db_path, backend) = open_backend();
+    let ns = Uuid::new_v4();
+    let ns_str = ns.to_string();
+    let seed = Connection::open(&db_path).unwrap();
+    seed_cross_session_entity(&seed, &ns_str, "Eve", 3);
+    drop(seed);
+
+    let card = MultiSessionCard::new();
+    let blocked = card.build(
+        "any",
+        backend.as_ref(),
+        ns,
+        None,
+        None,
+        Some("single-session-user"),
+    );
+    assert!(
+        blocked.is_none(),
+        "full mode must also suppress MS card on single-session-user; got: {blocked:?}",
+    );
+}

--- a/pensyve-core/tests/test_migration_idempotency.rs
+++ b/pensyve-core/tests/test_migration_idempotency.rs
@@ -104,12 +104,16 @@ fn fresh_store_migration_is_idempotent() {
         let conn = open_raw(tmp.path());
 
         let rows = schema_version_rows(&conn);
+        // G3 added v=2 (typed-slot + chain_summary NULLABLE columns on
+        // observation_memories). Fresh-store open lands BOTH v=1 and
+        // v=2 in one pass.
         assert_eq!(
             rows.len(),
-            1,
-            "expected exactly one migration row, got {rows:?}"
+            2,
+            "expected v=1 AND v=2 migration rows after G3, got {rows:?}"
         );
         assert_eq!(rows[0].0, 1, "expected version=1");
+        assert_eq!(rows[1].0, 2, "expected version=2");
 
         assert_migration_v1_landed(&conn);
     }
@@ -147,10 +151,11 @@ fn fresh_store_migration_is_idempotent() {
             rows, versions_first,
             "schema_versions changed on re-open: {rows:?} vs {versions_first:?}"
         );
+        // G3: 2 rows (v=1 + v=2); both must remain stable across reopens.
         assert_eq!(
             rows.len(),
-            1,
-            "duplicate schema_versions row inserted on re-run"
+            2,
+            "duplicate schema_versions row inserted on re-run; expected 2 (v=1+v=2), got {rows:?}"
         );
 
         for (i, table) in PROJECTION_TABLES.iter().enumerate() {
@@ -327,14 +332,17 @@ fn v2_1_fixture_upgrade_lands_alters_and_preserves_rows() {
     // Schema landed.
     assert_migration_v1_landed(&conn);
 
-    // schema_versions registered exactly one row at version=1.
+    // schema_versions registered TWO rows: v=1 (G1) and v=2 (G3).
+    // The v2.1 fixture starts pre-G1, so the upgrade open lands BOTH
+    // migrations in one pass.
     let rows = schema_version_rows(&conn);
     assert_eq!(
         rows.len(),
-        1,
-        "expected one schema_versions row, got {rows:?}"
+        2,
+        "expected v=1 + v=2 schema_versions rows, got {rows:?}"
     );
     assert_eq!(rows[0].0, 1);
+    assert_eq!(rows[1].0, 2);
 
     // Existing rows preserved with NULL agent_id + user_id (the locked
     // NULL-default design).
@@ -369,7 +377,7 @@ fn v2_1_fixture_upgrade_lands_alters_and_preserves_rows() {
     let rows = schema_version_rows(&conn);
     assert_eq!(
         rows.len(),
-        1,
-        "duplicate schema_versions row on re-run against fixture"
+        2,
+        "duplicate schema_versions row on re-run against fixture; expected 2 (v=1+v=2), got {rows:?}"
     );
 }

--- a/pensyve-core/tests/test_schema_v2_migration.rs
+++ b/pensyve-core/tests/test_schema_v2_migration.rs
@@ -1,0 +1,403 @@
+#![allow(
+    clippy::doc_markdown,
+    reason = "test-only doc strings reference SQL column names and bare identifiers in prose; backticking every occurrence harms readability for the small marginal lint benefit"
+)]
+//! G3/v=2 schema migration idempotency + backward-compat tests.
+//!
+//! Verifies the storage substrate's versioned migration runner against
+//! the invariants in
+//! `pensyve-docs/research/benchmark-sprint/v3/g3/preregistration.md`
+//! §3.4 item 8 + §7 item 22:
+//!
+//! 1. **Fresh-store v=2 lands** — opening a fresh `SqliteBackend` runs
+//!    both v=1 and v=2 migrations; `schema_versions` has rows for
+//!    both versions; `observation_memories` has the 6 new NULLABLE
+//!    columns.
+//! 2. **v=1-only fixture upgrades to v=2** — boot a store that
+//!    pre-registered v=1 (no G3 columns); reopen; v=2 migration adds
+//!    the columns; `schema_versions` gains the v=2 row; legacy data
+//!    survives with NULL across all 6 new columns.
+//! 3. **v=2 idempotency** — running open twice on the same v=2 store
+//!    is a no-op: no duplicate ALTER TABLEs, no duplicate
+//!    schema_versions row, no duplicate-column errors.
+//! 4. **NULL-default backward compat** — legacy v=1 rows return NULL
+//!    for the new columns; INSERT with new columns populated returns
+//!    the values intact via SELECT.
+//!
+//! These tests use only the public `SqliteBackend::open` API — they
+//! exercise the migration runner the same way production callers do.
+
+use std::path::Path;
+
+use rusqlite::{Connection, params};
+use tempfile::TempDir;
+use uuid::Uuid;
+
+use pensyve_core::storage::sqlite::SqliteBackend;
+
+/// Six new NULLABLE columns added by the v=2 migration.
+const V2_NEW_COLUMNS: &[&str] = &[
+    "biography_slot",
+    "preference_slot",
+    "experience_slot",
+    "social_slot",
+    "work_slot",
+    "chain_summary",
+];
+
+/// Tuple of the 6 new v=2 columns selected back from a row. Aliased to
+/// keep the SELECT call sites readable + appease clippy's type-complexity
+/// check.
+type V2ColumnRow = (
+    Option<String>,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+);
+
+fn open_raw(dir: &Path) -> Connection {
+    Connection::open(dir.join("memories.db")).expect("open raw connection to memories.db")
+}
+
+fn column_names(conn: &Connection, table: &str) -> Vec<String> {
+    let mut stmt = conn
+        .prepare(&format!("PRAGMA table_info({table})"))
+        .expect("prepare table_info");
+    let rows = stmt
+        .query_map([], |row| row.get::<_, String>(1))
+        .expect("query table_info");
+    rows.collect::<Result<Vec<_>, _>>()
+        .expect("collect column names")
+}
+
+fn schema_version_rows(conn: &Connection) -> Vec<(i64, String)> {
+    let mut stmt = conn
+        .prepare("SELECT version, description FROM schema_versions ORDER BY version")
+        .expect("prepare schema_versions select");
+    let rows = stmt
+        .query_map([], |row| {
+            Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
+        })
+        .expect("query schema_versions");
+    rows.collect::<Result<Vec<_>, _>>()
+        .expect("collect schema_versions")
+}
+
+fn assert_v2_columns_present(conn: &Connection) {
+    let cols = column_names(conn, "observation_memories");
+    for new_col in V2_NEW_COLUMNS {
+        assert!(
+            cols.iter().any(|c| c == new_col),
+            "observation_memories missing v=2 column {new_col}; have {cols:?}"
+        );
+    }
+}
+
+#[test]
+fn fresh_store_lands_v2_migration() {
+    let tmp = TempDir::new().expect("tempdir");
+
+    {
+        let _backend = SqliteBackend::open(tmp.path()).expect("first open");
+    }
+
+    let conn = open_raw(tmp.path());
+
+    // schema_versions has v=1 AND v=2.
+    let versions = schema_version_rows(&conn);
+    assert_eq!(
+        versions.len(),
+        2,
+        "expected v=1 and v=2 migration rows, got {versions:?}"
+    );
+    assert_eq!(versions[0].0, 1);
+    assert_eq!(versions[1].0, 2);
+
+    // observation_memories has the new columns.
+    assert_v2_columns_present(&conn);
+}
+
+#[test]
+fn v2_migration_idempotent_on_reopen() {
+    let tmp = TempDir::new().expect("tempdir");
+
+    // First open lands v=1 + v=2.
+    {
+        let _backend = SqliteBackend::open(tmp.path()).expect("first open");
+    }
+
+    // Snapshot column + version sets.
+    let cols_first = {
+        let conn = open_raw(tmp.path());
+        column_names(&conn, "observation_memories")
+    };
+    let versions_first = {
+        let conn = open_raw(tmp.path());
+        schema_version_rows(&conn)
+    };
+
+    // Second open MUST be a no-op. No duplicate ALTER TABLEs (would
+    // error on rusqlite duplicate-column), no duplicate schema_versions
+    // INSERTs.
+    {
+        let _backend = SqliteBackend::open(tmp.path()).expect("second open is idempotent");
+    }
+
+    let conn = open_raw(tmp.path());
+
+    let versions_now = schema_version_rows(&conn);
+    assert_eq!(
+        versions_now, versions_first,
+        "schema_versions changed on re-open: {versions_now:?} vs {versions_first:?}"
+    );
+
+    let cols_now = column_names(&conn, "observation_memories");
+    assert_eq!(
+        cols_now, cols_first,
+        "observation_memories columns drifted across re-open"
+    );
+}
+
+#[test]
+fn v2_migration_idempotent_on_third_open() {
+    // Pin: a third open beyond the second one stays idempotent.
+    // (Original v=1 idempotency test only covered 2 opens.)
+    let tmp = TempDir::new().expect("tempdir");
+
+    for _ in 0..3 {
+        let _backend = SqliteBackend::open(tmp.path()).expect("repeated open is idempotent");
+    }
+
+    let conn = open_raw(tmp.path());
+    let versions = schema_version_rows(&conn);
+    assert_eq!(
+        versions.len(),
+        2,
+        "exactly 2 schema_versions rows after 3 opens; got {versions:?}"
+    );
+    assert_v2_columns_present(&conn);
+}
+
+#[test]
+fn v2_columns_default_to_null_for_legacy_rows() {
+    let tmp = TempDir::new().expect("tempdir");
+
+    // First open lands the schema with v=1 + v=2 columns.
+    {
+        let _backend = SqliteBackend::open(tmp.path()).expect("first open");
+    }
+
+    // INSERT a row WITHOUT specifying the new columns (simulates a
+    // legacy ingest path that hasn't been updated to populate them).
+    let conn = open_raw(tmp.path());
+    let id = Uuid::new_v4().to_string();
+    let ns = Uuid::new_v4().to_string();
+    let episode = Uuid::new_v4().to_string();
+    conn.execute(
+        "INSERT INTO observation_memories \
+         (id, namespace_id, episode_id, entity_type, instance, action, \
+          content, created_at) \
+         VALUES (?1, ?2, ?3, 'food', 'pizza', 'ate', 'legacy obs', ?4)",
+        params![id, ns, episode, "2024-01-01T00:00:00Z"],
+    )
+    .expect("insert legacy obs row");
+
+    // SELECT the new columns; expect NULL for all 6.
+    let row: V2ColumnRow = conn
+        .query_row(
+            "SELECT biography_slot, preference_slot, experience_slot, \
+                    social_slot, work_slot, chain_summary \
+             FROM observation_memories WHERE id = ?1",
+            params![id],
+            |r| {
+                Ok((
+                    r.get(0)?,
+                    r.get(1)?,
+                    r.get(2)?,
+                    r.get(3)?,
+                    r.get(4)?,
+                    r.get(5)?,
+                ))
+            },
+        )
+        .expect("select new columns from legacy row");
+
+    assert!(row.0.is_none(), "biography_slot should default to NULL");
+    assert!(row.1.is_none(), "preference_slot should default to NULL");
+    assert!(row.2.is_none(), "experience_slot should default to NULL");
+    assert!(row.3.is_none(), "social_slot should default to NULL");
+    assert!(row.4.is_none(), "work_slot should default to NULL");
+    assert!(row.5.is_none(), "chain_summary should default to NULL");
+}
+
+#[test]
+fn v2_columns_populated_via_explicit_insert_round_trip() {
+    let tmp = TempDir::new().expect("tempdir");
+    {
+        let _backend = SqliteBackend::open(tmp.path()).expect("first open");
+    }
+
+    let conn = open_raw(tmp.path());
+    let id = Uuid::new_v4().to_string();
+    let ns = Uuid::new_v4().to_string();
+    let episode = Uuid::new_v4().to_string();
+
+    // Populate every new column.
+    conn.execute(
+        "INSERT INTO observation_memories \
+         (id, namespace_id, episode_id, entity_type, instance, action, \
+          content, created_at, \
+          biography_slot, preference_slot, experience_slot, \
+          social_slot, work_slot, chain_summary) \
+         VALUES (?1, ?2, ?3, 'person', 'me', 'mentioned', 'obs', ?4, \
+                 ?5, ?6, ?7, ?8, ?9, ?10)",
+        params![
+            id,
+            ns,
+            episode,
+            "2024-01-01T00:00:00Z",
+            "User lives in Seattle",
+            "Prefers tea over coffee",
+            "Visited Iceland in 2024",
+            "Has a sister Marie",
+            "Software engineer at Acme",
+            "User moved from SF to NY then back to SF",
+        ],
+    )
+    .expect("insert with all v=2 columns populated");
+
+    let row: V2ColumnRow = conn
+        .query_row(
+            "SELECT biography_slot, preference_slot, experience_slot, \
+                    social_slot, work_slot, chain_summary \
+             FROM observation_memories WHERE id = ?1",
+            params![id],
+            |r| {
+                Ok((
+                    r.get(0)?,
+                    r.get(1)?,
+                    r.get(2)?,
+                    r.get(3)?,
+                    r.get(4)?,
+                    r.get(5)?,
+                ))
+            },
+        )
+        .expect("select populated columns");
+
+    assert_eq!(row.0.as_deref(), Some("User lives in Seattle"));
+    assert_eq!(row.1.as_deref(), Some("Prefers tea over coffee"));
+    assert_eq!(row.2.as_deref(), Some("Visited Iceland in 2024"));
+    assert_eq!(row.3.as_deref(), Some("Has a sister Marie"));
+    assert_eq!(row.4.as_deref(), Some("Software engineer at Acme"));
+    assert_eq!(
+        row.5.as_deref(),
+        Some("User moved from SF to NY then back to SF")
+    );
+}
+
+/// Pin: v=1 fixture (legacy schema before v=2 ran) upgrades cleanly.
+///
+/// Mirrors `test_migration_idempotency.rs::v2_1_fixture_upgrade_*` but
+/// for the v=2 boundary. We synthesize a "v=1-only" store inline:
+///   1. Open via SqliteBackend (lands BOTH v=1 and v=2).
+///   2. Manually drop the v=2 columns and remove the v=2 schema_versions
+///      row, simulating a store written before the v=2 migration code
+///      existed.
+///   3. Re-open; the v=2 migration must land cleanly and add the columns.
+///
+/// SQLite ALTER TABLE DROP COLUMN is supported in 3.35+ which is the
+/// rusqlite bundled minimum; if it isn't available the fallback is
+/// rebuild-via-CREATE-TABLE-AS, but that's unnecessary on the supported
+/// versions.
+#[test]
+fn v1_only_fixture_upgrades_to_v2() {
+    let tmp = TempDir::new().expect("tempdir");
+
+    // Step 1: Open lands v=1 AND v=2.
+    {
+        let _backend = SqliteBackend::open(tmp.path()).expect("initial open");
+    }
+
+    // Step 2: Manually roll back to a v=1-only state.
+    {
+        let conn = open_raw(tmp.path());
+        for col in V2_NEW_COLUMNS {
+            conn.execute(
+                &format!("ALTER TABLE observation_memories DROP COLUMN {col}"),
+                [],
+            )
+            .unwrap_or_else(|e| panic!("drop column {col}: {e}"));
+        }
+        conn.execute("DELETE FROM schema_versions WHERE version = 2", [])
+            .expect("delete v=2 schema_versions row");
+    }
+
+    // Insert a row in the v=1 schema (no new columns yet).
+    let id_legacy = Uuid::new_v4().to_string();
+    {
+        let conn = open_raw(tmp.path());
+        conn.execute(
+            "INSERT INTO observation_memories \
+             (id, namespace_id, episode_id, entity_type, instance, action, \
+              content, created_at) \
+             VALUES (?1, ?2, ?3, 'food', 'pizza', 'ate', 'legacy', ?4)",
+            params![
+                id_legacy,
+                Uuid::new_v4().to_string(),
+                Uuid::new_v4().to_string(),
+                "2024-01-01T00:00:00Z",
+            ],
+        )
+        .expect("insert v=1-shape row");
+    }
+
+    // Step 3: Re-open. The v=2 migration must run.
+    {
+        let _backend = SqliteBackend::open(tmp.path()).expect("upgrade open");
+    }
+
+    let conn = open_raw(tmp.path());
+
+    // v=2 columns now present.
+    assert_v2_columns_present(&conn);
+
+    // schema_versions has both v=1 and v=2 again.
+    let versions = schema_version_rows(&conn);
+    assert_eq!(
+        versions.len(),
+        2,
+        "expected v=1 + v=2 after upgrade; got {versions:?}"
+    );
+
+    // The legacy row survived with NULL across all new columns.
+    let row: V2ColumnRow = conn
+        .query_row(
+            "SELECT biography_slot, preference_slot, experience_slot, \
+                    social_slot, work_slot, chain_summary \
+             FROM observation_memories WHERE id = ?1",
+            params![id_legacy],
+            |r| {
+                Ok((
+                    r.get(0)?,
+                    r.get(1)?,
+                    r.get(2)?,
+                    r.get(3)?,
+                    r.get(4)?,
+                    r.get(5)?,
+                ))
+            },
+        )
+        .expect("legacy row survived migration");
+    assert!(
+        row.0.is_none()
+            && row.1.is_none()
+            && row.2.is_none()
+            && row.3.is_none()
+            && row.4.is_none()
+            && row.5.is_none(),
+        "legacy v=1 row must have NULL in all 6 new columns; got {row:?}"
+    );
+}

--- a/pensyve-core/tests/test_supersession_card.rs
+++ b/pensyve-core/tests/test_supersession_card.rs
@@ -1,0 +1,317 @@
+#![allow(
+    clippy::doc_markdown,
+    reason = "test-only doc strings reference SQL column names and bare identifiers in prose; backticking every occurrence harms readability for the small marginal lint benefit"
+)]
+//! Integration tests for the G3-P3 `SupersessionCard`.
+//!
+//! Coverage mirrors the pre-reg §3.7 hardening fuzz fixtures:
+//!
+//! 1. **Empty store** — fresh backend with zero observation rows;
+//!    `build()` returns `None` (defer-on-empty).
+//! 2. **Store with 0 supersedes-edges (no chain_summary populated)** —
+//!    backend has rows but every `chain_summary` is NULL; `build()`
+//!    returns `None`.
+//! 3. **Store with 1 supersedes-edge but `chain_summary IS NULL`** —
+//!    pre-reg phrasing for the case where the summarizer hook never
+//!    fired (or deferred); identical behavior to fixture #2 since the
+//!    card SQL only filters on `chain_summary IS NOT NULL`.
+//! 4. **Store with 5 chain_summary rows** — verifies English-prose
+//!    output format: header, footer, bullet-shaped body, all 5
+//!    summaries surface in order.
+//! 5. **Cap enforcement** — store with 12 chain_summary rows; default
+//!    cap (= 8) emits exactly 8 bullets; `with_cap(3)` emits exactly 3.
+
+use uuid::Uuid;
+
+use pensyve_core::retrieval::cards::RetrievalCard;
+use pensyve_core::retrieval::cards::supersession::{
+    SUPERSESSION_CARD_FOOTER, SUPERSESSION_CARD_HEADER, SUPERSESSION_CARD_MAX_ENTRIES,
+    SUPERSESSION_CARD_NAME, SupersessionCard,
+};
+use pensyve_core::storage::StorageTrait;
+use pensyve_core::storage::sqlite::SqliteBackend;
+
+use rusqlite::Connection;
+use tempfile::TempDir;
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+/// Build a `SqliteBackend` in a fresh temp dir. The backend's `open`
+/// path runs the v=2 migration, so the `chain_summary` column will be
+/// present on `observation_memories`.
+fn open_backend() -> (TempDir, std::path::PathBuf, Box<dyn StorageTrait>) {
+    let dir = tempfile::tempdir().unwrap();
+    let backend: Box<dyn StorageTrait> = Box::new(SqliteBackend::open(dir.path()).unwrap());
+    let db_path = backend
+        .db_path()
+        .expect("SqliteBackend must expose its disk path")
+        .to_path_buf();
+    (dir, db_path, backend)
+}
+
+/// Side-channel insert into `observation_memories` mirroring the
+/// production schema (all NOT NULL columns supplied + the v=2 chain_summary).
+#[allow(clippy::too_many_arguments)]
+fn insert_obs(
+    conn: &Connection,
+    namespace_id: &str,
+    chain_summary: Option<&str>,
+    event_time: Option<&str>,
+) {
+    conn.execute(
+        "INSERT INTO observation_memories \
+         (id, namespace_id, episode_id, entity_type, instance, action, \
+          content, event_time, created_at, chain_summary) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+        rusqlite::params![
+            Uuid::new_v4().to_string(),
+            namespace_id,
+            Uuid::new_v4().to_string(), // episode_id
+            "person",
+            "marie-curie",
+            "stated",
+            "obs content",
+            event_time,
+            "2024-01-01T00:00:00Z", // created_at
+            chain_summary,
+        ],
+    )
+    .unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// Fixture #1: empty store → `None`.
+#[test]
+fn empty_store_returns_none() {
+    let (_dir, _db_path, backend) = open_backend();
+    let ns = Uuid::new_v4();
+    let card = SupersessionCard::new();
+    let out = card.build("any query", backend.as_ref(), ns, None, None, None);
+    assert!(out.is_none(), "empty store must defer; got: {out:?}");
+}
+
+/// Fixture #2: store has rows but every chain_summary is NULL → `None`.
+///
+/// Mirrors the case where the per-event summarizer hook never fired
+/// (e.g., G3 arm OFF) or every fire deferred (parse failure / cancel /
+/// rollback).
+#[test]
+fn no_chain_summary_populated_returns_none() {
+    let (_dir, db_path, backend) = open_backend();
+    let ns = Uuid::new_v4().to_string();
+    let conn = Connection::open(&db_path).unwrap();
+    insert_obs(&conn, &ns, None, Some("2024-01-01T10:00:00Z"));
+    insert_obs(&conn, &ns, None, Some("2024-02-01T10:00:00Z"));
+    insert_obs(&conn, &ns, None, Some("2024-03-01T10:00:00Z"));
+    drop(conn);
+
+    let card = SupersessionCard::new();
+    let out = card.build(
+        "q",
+        backend.as_ref(),
+        Uuid::parse_str(&ns).unwrap(),
+        None,
+        None,
+        None,
+    );
+    assert!(
+        out.is_none(),
+        "all-NULL chain_summary store must defer; got: {out:?}"
+    );
+}
+
+/// Fixture #3 (combined with #2 by SQL semantics): 1 supersedes-edge
+/// would have populated chain_summary IF the hook ran, but the row
+/// has chain_summary IS NULL. Same defer behavior as fixture #2.
+///
+/// This test pins that the card does NOT surface the underlying
+/// observation content in lieu of the chain_summary — the only signal
+/// the card consumes is the `chain_summary` column itself.
+#[test]
+fn supersedes_edge_without_chain_summary_returns_none() {
+    let (_dir, db_path, backend) = open_backend();
+    let ns = Uuid::new_v4().to_string();
+    let conn = Connection::open(&db_path).unwrap();
+    // Insert a row whose content describes a supersession but whose
+    // chain_summary column is NULL (summarizer hook never fired).
+    conn.execute(
+        "INSERT INTO observation_memories \
+         (id, namespace_id, episode_id, entity_type, instance, action, \
+          content, event_time, created_at) \
+         VALUES (?1, ?2, ?3, 'person', 'me', 'mentioned', \
+                 'I moved from SF to NY', ?4, ?5)",
+        rusqlite::params![
+            Uuid::new_v4().to_string(),
+            ns,
+            Uuid::new_v4().to_string(),
+            "2024-02-01T10:00:00Z",
+            "2024-01-01T00:00:00Z",
+        ],
+    )
+    .unwrap();
+    drop(conn);
+
+    let card = SupersessionCard::new();
+    let out = card.build(
+        "q",
+        backend.as_ref(),
+        Uuid::parse_str(&ns).unwrap(),
+        None,
+        None,
+        None,
+    );
+    assert!(
+        out.is_none(),
+        "card must NOT fall back to observation content when chain_summary is NULL; got: {out:?}"
+    );
+}
+
+/// Fixture #4: 5 distinct chain_summary rows; verify English-prose
+/// surface format and all 5 summaries are present.
+#[test]
+fn five_chain_summaries_surface_with_correct_format() {
+    let (_dir, db_path, backend) = open_backend();
+    let ns = Uuid::new_v4().to_string();
+    let conn = Connection::open(&db_path).unwrap();
+    let summaries = [
+        "User moved from SF to NY then back to SF",
+        "User changed jobs from Acme to Globex",
+        "User upgraded from gas car to EV",
+        "User shifted from oat milk to almond milk preferences",
+        "User transitioned from contract to FTE role",
+    ];
+    for (i, summary) in summaries.iter().enumerate() {
+        insert_obs(
+            &conn,
+            &ns,
+            Some(summary),
+            Some(&format!("2024-01-{:02}T10:00:00Z", i + 1)),
+        );
+    }
+    drop(conn);
+
+    let card = SupersessionCard::new();
+    let out = card
+        .build(
+            "what does the store know about the user's history?",
+            backend.as_ref(),
+            Uuid::parse_str(&ns).unwrap(),
+            None,
+            None,
+            None,
+        )
+        .expect("non-empty card");
+
+    // Header / footer markers present
+    assert!(
+        out.contains(SUPERSESSION_CARD_HEADER),
+        "header marker missing; got: {out}"
+    );
+    assert!(
+        out.contains(SUPERSESSION_CARD_FOOTER),
+        "footer marker missing; got: {out}"
+    );
+    // All 5 summaries surface
+    for s in &summaries {
+        assert!(
+            out.contains(s),
+            "summary missing from card: {s}\ncard: {out}"
+        );
+    }
+    // Bullet-shape verified (CompositeCard's clipper recognizes "- " lines)
+    let bullet_count = out.lines().filter(|l| l.starts_with("- ")).count();
+    assert_eq!(
+        bullet_count, 5,
+        "expected 5 bullet lines; got {bullet_count} in:\n{out}"
+    );
+}
+
+/// Fixture #5: 12 chain_summary rows; default cap (= 8) keeps 8;
+/// `with_cap(3)` keeps 3.
+#[test]
+fn cap_enforcement_truncates_excess_summaries() {
+    let (_dir, db_path, backend) = open_backend();
+    let ns = Uuid::new_v4().to_string();
+    let conn = Connection::open(&db_path).unwrap();
+    for i in 0..12 {
+        insert_obs(
+            &conn,
+            &ns,
+            Some(&format!("chain summary number {i}")),
+            // Spread across distinct days so ordering is stable.
+            Some(&format!("2024-{:02}-15T10:00:00Z", i + 1)),
+        );
+    }
+    drop(conn);
+
+    let ns_uuid = Uuid::parse_str(&ns).unwrap();
+
+    // Default cap = 8.
+    let default_card = SupersessionCard::new();
+    let default_out = default_card
+        .build("q", backend.as_ref(), ns_uuid, None, None, None)
+        .expect("non-empty card with default cap");
+    let default_bullets = default_out.lines().filter(|l| l.starts_with("- ")).count();
+    assert_eq!(
+        default_bullets, SUPERSESSION_CARD_MAX_ENTRIES,
+        "default cap = {SUPERSESSION_CARD_MAX_ENTRIES} but card has {default_bullets} bullets:\n{default_out}"
+    );
+
+    // Custom cap = 3.
+    let small_card = SupersessionCard::with_cap(3);
+    let small_out = small_card
+        .build("q", backend.as_ref(), ns_uuid, None, None, None)
+        .expect("non-empty card with cap=3");
+    let small_bullets = small_out.lines().filter(|l| l.starts_with("- ")).count();
+    assert_eq!(
+        small_bullets, 3,
+        "custom cap=3 must yield 3 bullets; got {small_bullets} in:\n{small_out}"
+    );
+}
+
+/// Bonus: `name()` returns the pinned identifier.
+#[test]
+fn card_name_is_pinned() {
+    assert_eq!(SupersessionCard::new().name(), SUPERSESSION_CARD_NAME);
+    assert_eq!(SUPERSESSION_CARD_NAME, "SupersessionCard");
+}
+
+/// Bonus: ordering — when summaries have distinct `event_time`, the
+/// most-recent surfaces first (matches the SQL `ORDER BY event_time DESC
+/// NULLS LAST`).
+#[test]
+fn most_recent_summary_surfaces_first() {
+    let (_dir, db_path, backend) = open_backend();
+    let ns = Uuid::new_v4().to_string();
+    let conn = Connection::open(&db_path).unwrap();
+    insert_obs(&conn, &ns, Some("oldest"), Some("2024-01-01T10:00:00Z"));
+    insert_obs(&conn, &ns, Some("middle"), Some("2024-06-01T10:00:00Z"));
+    insert_obs(&conn, &ns, Some("newest"), Some("2024-12-01T10:00:00Z"));
+    drop(conn);
+
+    let card = SupersessionCard::new();
+    let out = card
+        .build(
+            "q",
+            backend.as_ref(),
+            Uuid::parse_str(&ns).unwrap(),
+            None,
+            None,
+            None,
+        )
+        .expect("non-empty card");
+
+    // Find the position of each summary in the rendered text.
+    let pos_newest = out.find("newest").unwrap();
+    let pos_middle = out.find("middle").unwrap();
+    let pos_oldest = out.find("oldest").unwrap();
+    assert!(
+        pos_newest < pos_middle && pos_middle < pos_oldest,
+        "expected newest → middle → oldest ordering; got:\n{out}"
+    );
+}

--- a/pensyve-core/tests/test_typed_slots.rs
+++ b/pensyve-core/tests/test_typed_slots.rs
@@ -1,0 +1,322 @@
+#![allow(
+    clippy::doc_markdown,
+    reason = "test-only doc strings reference bare identifiers in prose; backticking every occurrence harms readability for the small marginal lint benefit"
+)]
+//! Integration tests for the G3-P4 typed-slot extractor.
+//!
+//! Coverage mirrors the pre-reg §3.8 hardening fuzz fixtures:
+//!
+//! 1. **Empty observation content** — extractor returns
+//!    `Ok(TypedSlots::default())` (all-None); caller may skip persist.
+//! 2. **Observation with no extractable slot content** — LLM responds
+//!    with all-null JSON; `is_empty()` is true.
+//! 3. **Observation with all 5 slot kinds present** — LLM responds
+//!    with all 5 fields populated; every slot decodes.
+//! 4. **Malformed LLM response (parse-failure path)** — extractor
+//!    surfaces `SlotExtractionError::Parse`; caller defers and logs.
+//! 5. **Cancellation mid-extraction** — token signals before the
+//!    LLM call returns; extractor surfaces
+//!    `SlotExtractionError::Cancelled`; the consolidation gate's
+//!    operator-locked (b') ROLLBACK semantic is upheld at the API
+//!    surface (caller sees Cancelled before any persist call).
+//!
+//! Bonus coverage:
+//!
+//! 6. **Pre-flight cancel** — token already cancelled before the
+//!    `extract_slots` call; extractor short-circuits without invoking
+//!    the LLM (the mock would panic if it were invoked, pinning
+//!    short-circuit semantics).
+//! 7. **Partial-slots response** — LLM populates some slots only;
+//!    decodes correctly, `is_empty()` is false.
+
+use std::sync::{Arc, Mutex};
+
+use pensyve_core::consolidation::typed_slots::{
+    SlotExtractionError, TypedSlotLlm, TypedSlots, extract_slots,
+};
+use pensyve_core::types::SlotKind;
+
+use async_trait::async_trait;
+use tokio_util::sync::CancellationToken;
+
+// ---------------------------------------------------------------------------
+// Mock LLM
+// ---------------------------------------------------------------------------
+
+/// Minimal mock implementing [`TypedSlotLlm`]. Returns a pre-canned
+/// response (or error) on each `complete` call. The mock records the
+/// number of times it was invoked so tests can pin invocation counts
+/// (e.g., the pre-flight-cancel test asserts the mock was NEVER
+/// called).
+#[derive(Clone)]
+struct MockLlm {
+    response: Arc<Mutex<MockBehavior>>,
+    invocations: Arc<Mutex<u32>>,
+}
+
+#[derive(Clone)]
+#[allow(
+    dead_code,
+    reason = "Parse variant is reserved for future tests that exercise LLM-side parse-error paths; the current test surface tickles parse failures through Ok(malformed_text) instead, which exercises the extract_slots parser. Keeping the variant lets future tests opt into the explicit error-channel path without re-adding the enum branch."
+)]
+enum MockBehavior {
+    /// Return the canned response string verbatim.
+    Ok(String),
+    /// Return a parse error.
+    Parse(String),
+    /// Return a transport error.
+    Transport(String),
+    /// Return a cancellation error (simulates mid-call cancel).
+    Cancelled(String),
+    /// Panic if invoked — used by the pre-flight-cancel test to pin
+    /// that the extractor short-circuits.
+    PanicOnInvoke,
+}
+
+impl MockLlm {
+    fn new(behavior: MockBehavior) -> Self {
+        Self {
+            response: Arc::new(Mutex::new(behavior)),
+            invocations: Arc::new(Mutex::new(0)),
+        }
+    }
+
+    fn invocation_count(&self) -> u32 {
+        *self.invocations.lock().unwrap()
+    }
+}
+
+#[async_trait]
+impl TypedSlotLlm for MockLlm {
+    async fn complete(
+        &self,
+        _system_prompt: &str,
+        _user_content: &str,
+        _cancel: CancellationToken,
+    ) -> Result<String, SlotExtractionError> {
+        *self.invocations.lock().unwrap() += 1;
+        let behavior = self.response.lock().unwrap().clone();
+        match behavior {
+            MockBehavior::Ok(s) => Ok(s),
+            MockBehavior::Parse(msg) => Err(SlotExtractionError::Parse(msg)),
+            MockBehavior::Transport(msg) => Err(SlotExtractionError::Transport(msg)),
+            MockBehavior::Cancelled(msg) => Err(SlotExtractionError::Cancelled(msg)),
+            MockBehavior::PanicOnInvoke => {
+                panic!("MockLlm::complete invoked when it should have short-circuited")
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// Fixture #1: empty observation content → all-None result, no LLM call.
+#[tokio::test]
+async fn empty_observation_returns_all_none() {
+    let mock = MockLlm::new(MockBehavior::PanicOnInvoke);
+    let cancel = CancellationToken::new();
+    let slots = extract_slots("", &mock, cancel)
+        .await
+        .expect("empty content must defer-on-empty, not error");
+    assert!(
+        slots.is_empty(),
+        "empty observation must yield all-None slots"
+    );
+    assert_eq!(
+        mock.invocation_count(),
+        0,
+        "extractor must short-circuit on empty content; LLM was invoked"
+    );
+}
+
+/// Fixture #1b: whitespace-only observation content → all-None result.
+#[tokio::test]
+async fn whitespace_only_observation_returns_all_none() {
+    let mock = MockLlm::new(MockBehavior::PanicOnInvoke);
+    let cancel = CancellationToken::new();
+    let slots = extract_slots("   \n\t  ", &mock, cancel)
+        .await
+        .expect("whitespace-only content must defer-on-empty");
+    assert!(slots.is_empty());
+    assert_eq!(mock.invocation_count(), 0);
+}
+
+/// Fixture #2: LLM responds with all-null JSON; result is all-None.
+#[tokio::test]
+async fn all_null_llm_response_yields_empty_slots() {
+    let response = r#"{"biography": null, "preference": null, "experience": null, "social": null, "work": null}"#;
+    let mock = MockLlm::new(MockBehavior::Ok(response.to_string()));
+    let cancel = CancellationToken::new();
+    let slots = extract_slots("user said hello", &mock, cancel)
+        .await
+        .expect("all-null is a valid response shape");
+    assert!(
+        slots.is_empty(),
+        "all-null JSON must decode to all-None slots"
+    );
+    assert_eq!(mock.invocation_count(), 1);
+}
+
+/// Fixture #3: LLM responds with all 5 slots populated.
+#[tokio::test]
+async fn all_five_slots_populated_response_decodes() {
+    let response = r#"{
+        "biography": "User lives in Seattle",
+        "preference": "Prefers dark roast coffee",
+        "experience": "Visited Iceland in 2024",
+        "social": "Has a sister named Marie",
+        "work": "Software engineer at Acme Corp"
+    }"#;
+    let mock = MockLlm::new(MockBehavior::Ok(response.to_string()));
+    let cancel = CancellationToken::new();
+    let slots = extract_slots("user is a Seattle-based software engineer", &mock, cancel)
+        .await
+        .expect("valid JSON must decode");
+
+    assert_eq!(
+        slots.get(SlotKind::Biography),
+        Some("User lives in Seattle")
+    );
+    assert_eq!(
+        slots.get(SlotKind::Preference),
+        Some("Prefers dark roast coffee")
+    );
+    assert_eq!(
+        slots.get(SlotKind::Experience),
+        Some("Visited Iceland in 2024")
+    );
+    assert_eq!(
+        slots.get(SlotKind::Social),
+        Some("Has a sister named Marie")
+    );
+    assert_eq!(
+        slots.get(SlotKind::Work),
+        Some("Software engineer at Acme Corp")
+    );
+    assert!(!slots.is_empty());
+}
+
+/// Fixture #4: malformed LLM response (not JSON) → Parse error.
+#[tokio::test]
+async fn malformed_llm_response_surfaces_parse_error() {
+    let mock = MockLlm::new(MockBehavior::Ok(
+        "I cannot extract slots for this request.".to_string(),
+    ));
+    let cancel = CancellationToken::new();
+    let err = extract_slots("user content", &mock, cancel)
+        .await
+        .expect_err("non-JSON response must surface as Parse error");
+    assert!(
+        matches!(err, SlotExtractionError::Parse(_)),
+        "expected Parse error; got {err:?}"
+    );
+}
+
+/// Fixture #4b: LLM emits truncated JSON.
+#[tokio::test]
+async fn truncated_json_response_surfaces_parse_error() {
+    let mock = MockLlm::new(MockBehavior::Ok("{\"biography\": \"x".to_string()));
+    let cancel = CancellationToken::new();
+    let err = extract_slots("user content", &mock, cancel)
+        .await
+        .expect_err("truncated JSON must surface as Parse error");
+    assert!(
+        matches!(err, SlotExtractionError::Parse(_)),
+        "expected Parse error; got {err:?}"
+    );
+}
+
+/// Fixture #5: cancellation mid-extraction. The mock returns
+/// `Cancelled(...)` simulating the LLM noticing cancel mid-HTTP-call;
+/// the extractor surfaces the error so the caller (consolidation gate)
+/// can apply ROLLBACK semantics per operator-locked (b') 2026-05-06.
+#[tokio::test]
+async fn cancellation_mid_extraction_returns_cancelled_error() {
+    let mock = MockLlm::new(MockBehavior::Cancelled("cancelled during HTTP call".into()));
+    let cancel = CancellationToken::new();
+    let err = extract_slots("some user content", &mock, cancel)
+        .await
+        .expect_err("mid-call cancel must surface as Cancelled");
+    match err {
+        SlotExtractionError::Cancelled(msg) => {
+            assert!(
+                msg.contains("cancelled"),
+                "Cancelled error message should reflect cancel site; got: {msg}"
+            );
+        }
+        other => panic!("expected Cancelled; got {other:?}"),
+    }
+}
+
+/// Fixture #6 (bonus): pre-flight cancel — token already cancelled
+/// before `extract_slots` is invoked. Extractor short-circuits without
+/// calling the LLM (the mock panics if invoked).
+#[tokio::test]
+async fn preflight_cancelled_token_short_circuits_without_llm_call() {
+    let mock = MockLlm::new(MockBehavior::PanicOnInvoke);
+    let cancel = CancellationToken::new();
+    cancel.cancel(); // signal BEFORE the call
+
+    let err = extract_slots("user content here", &mock, cancel)
+        .await
+        .expect_err("pre-flight-cancelled token must surface Cancelled");
+    assert!(
+        matches!(err, SlotExtractionError::Cancelled(_)),
+        "expected Cancelled; got {err:?}"
+    );
+    assert_eq!(
+        mock.invocation_count(),
+        0,
+        "LLM must NOT be invoked when token is pre-cancelled"
+    );
+}
+
+/// Fixture #7 (bonus): partial slots — LLM emits valid JSON with some
+/// slots populated and some null. Result decodes; only populated slots
+/// are present; `is_empty()` is false.
+#[tokio::test]
+async fn partial_slots_response_decodes_correctly() {
+    let response = r#"{
+        "biography": null,
+        "preference": "tea over coffee",
+        "experience": null,
+        "social": null,
+        "work": "remote backend engineer"
+    }"#;
+    let mock = MockLlm::new(MockBehavior::Ok(response.to_string()));
+    let cancel = CancellationToken::new();
+    let slots = extract_slots("user briefly mentions job and drink choice", &mock, cancel)
+        .await
+        .expect("partial response is valid");
+
+    assert_eq!(slots.get(SlotKind::Preference), Some("tea over coffee"));
+    assert_eq!(slots.get(SlotKind::Work), Some("remote backend engineer"));
+    assert_eq!(slots.get(SlotKind::Biography), None);
+    assert_eq!(slots.get(SlotKind::Experience), None);
+    assert_eq!(slots.get(SlotKind::Social), None);
+    assert!(!slots.is_empty(), "at least one populated slot — not empty");
+}
+
+/// Fixture #7b (bonus): transport error from LLM (simulates network
+/// glitch). Extractor surfaces Transport error; caller defers.
+#[tokio::test]
+async fn transport_error_surfaces_unchanged() {
+    let mock = MockLlm::new(MockBehavior::Transport("connection reset by peer".into()));
+    let cancel = CancellationToken::new();
+    let err = extract_slots("user content", &mock, cancel)
+        .await
+        .expect_err("transport failure must surface");
+    assert!(
+        matches!(err, SlotExtractionError::Transport(_)),
+        "expected Transport; got {err:?}"
+    );
+}
+
+/// `TypedSlots::is_empty` honors the all-None contract.
+#[tokio::test]
+async fn typed_slots_default_is_empty() {
+    let s = TypedSlots::default();
+    assert!(s.is_empty());
+}

--- a/pensyve-python/python/pensyve/_core.pyi
+++ b/pensyve-python/python/pensyve/_core.pyi
@@ -186,6 +186,66 @@ class Pensyve:
         """
         ...
 
+    def build_retrieval_card_g3(
+        self,
+        db_path: str,
+        question_type: str,
+        g2_cards: list[str],
+        g3_features: list[str],
+    ) -> str | None:
+        """G3 retrieval-card composition (binding pre-reg
+        ``pensyve-docs@64481dc`` §3.4 item 11 + §7 item 11).
+
+        Builds the G3 ``CompositeCard`` against an external SQLite store
+        and returns the synthesized card text (English prose, possibly
+        multi-section joined with ``\\n\\n``), or ``None`` when every
+        selected card defers.
+
+        Args:
+            db_path: Path to a Pensyve SQLite store. May be the directory
+                containing ``memories.db`` OR the file itself; both shapes
+                are normalized to the directory before opening.
+            question_type: LongMemEval question_type string (e.g.
+                ``"single-session-preference"``, ``"multi-session"``).
+                Threaded into each card's ``build()`` call.
+            g2_cards: G2 base composition; subset of
+                ``["peer", "ms", "ssu"]``. Order does not matter (the G2
+                priority order is fixed).
+            g3_features: G3 layering knobs; subset of
+                ``["router", "summarizer", "typed_slots", "diversity"]``.
+                Translated to the ``PENSYVE_RETRIEVAL_CARDS_G3`` env-var
+                value: ``[]`` → unset (G2-equivalent baseline), single
+                feature → that feature's name, all four → ``"full"``.
+                ``"summarizer"`` additionally pulls ``SupersessionCard``
+                into the composite chain.
+        """
+        ...
+
+    def recall_with_diversity(
+        self,
+        query: str,
+        k: int = 22,
+        lambda_: float = 0.5,
+    ) -> list[Memory]:
+        """Recall with MMR diversity reorder (binding pre-reg
+        ``pensyve-docs@64481dc`` §3.4 item 11 + §7 item 11).
+
+        Sets ``PENSYVE_MMR_LAMBDA`` for the duration of this call so the
+        existing diversity reorder in ``RecallEngine`` activates, then
+        restores the prior env-var value on return (including panic /
+        exception unwind). Behaviorally identical to :meth:`recall` when
+        ``lambda_ <= 0.0``; reorders by ``lambda_·sim − (1−lambda_)·max_j sim``
+        otherwise.
+
+        Args:
+            query: Search query string.
+            k: Maximum number of results (default: 22).
+            lambda_: MMR balance, clamped to ``[0.0, 1.0]`` by the engine.
+                The Python kwarg uses a trailing underscore because
+                ``lambda`` is a reserved word.
+        """
+        ...
+
     def forget(
         self,
         entity: Entity,

--- a/pensyve-python/python/pensyve/_core.pyi
+++ b/pensyve-python/python/pensyve/_core.pyi
@@ -230,12 +230,11 @@ class Pensyve:
         """Recall with MMR diversity reorder (binding pre-reg
         ``pensyve-docs@64481dc`` §3.4 item 11 + §7 item 11).
 
-        Sets ``PENSYVE_MMR_LAMBDA`` for the duration of this call so the
-        existing diversity reorder in ``RecallEngine`` activates, then
-        restores the prior env-var value on return (including panic /
-        exception unwind). Behaviorally identical to :meth:`recall` when
-        ``lambda_ <= 0.0``; reorders by ``lambda_·sim − (1−lambda_)·max_j sim``
-        otherwise.
+        Passes ``lambda_`` directly to
+        :py:meth:`RecallEngine.with_mmr_lambda` so the diversity reorder
+        activates without process-env mutation (round-4 fix).
+        Behaviorally identical to :meth:`recall` when ``lambda_ <= 0.0``;
+        reorders by ``lambda_·sim − (1−lambda_)·max_j sim`` otherwise.
 
         Args:
             query: Search query string.

--- a/pensyve-python/src/lib.rs
+++ b/pensyve-python/src/lib.rs
@@ -13,6 +13,14 @@ use pensyve_core::embedding::OnnxEmbedder;
 use pensyve_core::graph::MemoryGraph;
 use pensyve_core::recall_grouped::{OrderBy, RecallGroupedConfig};
 use pensyve_core::retrieval::RecallEngine;
+use pensyve_core::retrieval::cards::composite::{
+    G2_MULTI_SESSION_CARD_CAP, G2_PEER_CARD_CAP, G2_SINGLE_SESSION_USER_CARD_CAP,
+    G3_SUPERSESSION_CARD_CAP,
+};
+use pensyve_core::retrieval::cards::{
+    CompositeCard, MultiSessionCard, PeerCardAdapter, RetrievalCard, SingleSessionUserCard,
+    SupersessionCard,
+};
 use pensyve_core::storage::StorageTrait;
 use pensyve_core::storage::sqlite::SqliteBackend;
 use pensyve_core::types::{self, EntityKind, EpisodicMemory, Namespace, Outcome, SemanticMemory};
@@ -63,6 +71,93 @@ fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PySessionGroup>()?;
     m.add_function(wrap_pyfunction!(embedding_info, m)?)?;
     Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// G3 env-var guards
+// ---------------------------------------------------------------------------
+
+/// Process-wide mutex serializing writes to `PENSYVE_RETRIEVAL_CARDS_G3` and
+/// `PENSYVE_MMR_LAMBDA`. Both env vars are read by retrieval-card and recall
+/// engine code at call time; the G3 `PyO3` bindings (`build_retrieval_card_g3`,
+/// `recall_with_diversity`) mutate them transiently for the duration of one
+/// call. Mirrors the `RouterEnvGuard` / `SsuEnvGuard` patterns already used in
+/// `pensyve-core/tests/test_intent_router.rs` + `tests/test_single_session_user_card.rs`.
+fn g3_env_lock() -> &'static std::sync::Mutex<()> {
+    static LOCK: OnceLock<std::sync::Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| std::sync::Mutex::new(()))
+}
+
+/// RAII guard that holds [`g3_env_lock`] for its lifetime, mutates a single
+/// env var to a target value (or removes it), and restores the prior value
+/// on drop — including on Rust panic / Python exception unwind paths.
+///
+/// `# Safety`: `std::env::set_var` / `remove_var` are flagged unsafe in
+/// modern Rust because env mutation is process-global and not thread-safe.
+/// This guard serializes all writers/readers behind [`g3_env_lock`] for the
+/// `pensyve-python` cdylib lifetime; concurrent G3 `PyO3` calls cannot race.
+struct G3EnvGuard {
+    _serial: std::sync::MutexGuard<'static, ()>,
+    key: &'static str,
+    previous: Option<String>,
+}
+
+#[allow(
+    unsafe_code,
+    reason = "G3 PyO3 binding scoped env-var guard; std::env::set_var / remove_var require unsafe in modern Rust because env mutation is process-global. The struct holds the process-wide g3_env_lock for its lifetime so concurrent calls cannot race."
+)]
+impl G3EnvGuard {
+    /// Acquire the lock, capture the previous value of `key`, set it to
+    /// `value`. The guard restores `previous` on drop.
+    fn set(key: &'static str, value: &str) -> Self {
+        let serial = g3_env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let previous = std::env::var(key).ok();
+        // SAFETY: see struct doc; serialized via the mutex in `serial`.
+        unsafe {
+            std::env::set_var(key, value);
+        }
+        Self {
+            _serial: serial,
+            key,
+            previous,
+        }
+    }
+
+    /// Acquire the lock, capture the previous value of `key`, remove it.
+    /// The guard restores `previous` on drop.
+    fn unset(key: &'static str) -> Self {
+        let serial = g3_env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let previous = std::env::var(key).ok();
+        // SAFETY: see struct doc.
+        unsafe {
+            std::env::remove_var(key);
+        }
+        Self {
+            _serial: serial,
+            key,
+            previous,
+        }
+    }
+}
+
+#[allow(
+    unsafe_code,
+    reason = "G3 PyO3 binding scoped env-var guard; see G3EnvGuard::set for justification"
+)]
+impl Drop for G3EnvGuard {
+    fn drop(&mut self) {
+        // SAFETY: drop runs while we still hold the serialization lock.
+        unsafe {
+            match &self.previous {
+                Some(v) => std::env::set_var(self.key, v),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -934,6 +1029,278 @@ impl PyPensyve {
                     .collect(),
                 group_score: g.group_score,
             })
+            .collect())
+    }
+
+    /// G3 retrieval-card composition (binding pre-reg `pensyve-docs@64481dc`
+    /// §3.4 item 11 + §7 item 11).
+    ///
+    /// Builds the G3 [`CompositeCard`] against an external `SQLite` store
+    /// (the harness's per-question DB lives in a `TemporaryDirectory`).
+    /// `g3_features` is translated to the
+    /// [`pensyve_core::retrieval::cards::multi_session::RETRIEVAL_CARDS_G3_ENV`]
+    /// env-var value for the duration of this call; the env-var is restored
+    /// to its prior value on return (including panic / exception unwind).
+    ///
+    /// Args:
+    ///     `db_path`: Path to a Pensyve `SQLite` store. May be the directory
+    ///         containing `memories.db` OR the file itself; both shapes are
+    ///         normalized to the directory before opening
+    ///         [`SqliteBackend`].
+    ///     `question_type`: `LongMemEval` `question_type` string (e.g.
+    ///         `"single-session-preference"`, `"multi-session"`). Threaded
+    ///         to each card's `build()` call so the intent router and any
+    ///         future per-question-type cards can dispatch on it.
+    ///     `g2_cards`: G2 base composition. Subset of
+    ///         `["peer", "ms", "ssu"]`; the order does not matter (G2
+    ///         priority order is fixed). An empty list disables every G2
+    ///         card; the result is supersession-only (or `None` when the
+    ///         supersession card defers).
+    ///     `g3_features`: G3 layering knobs. Subset of
+    ///         `["router", "summarizer", "typed_slots", "diversity"]`.
+    ///         Translated to the env-var value:
+    ///         - `[]` → unset (G2-equivalent baseline; engine sees no env var)
+    ///         - `["router"]` → `"router"`
+    ///         - `["summarizer"]` → `"summarizer"`
+    ///         - `["typed_slots"]` → `"typed_slots"`
+    ///         - any superset of `{router, summarizer, typed_slots, diversity}`
+    ///           covering all four → `"full"` (operator-locked single-string
+    ///           encoding per §3.1).
+    ///         The `summarizer` feature additionally pulls
+    ///         [`SupersessionCard`] into the composite chain
+    ///         (otherwise it is omitted).
+    ///
+    /// Returns:
+    ///     The synthesized card text (English prose, possibly multi-section
+    ///     joined with `\n\n`), or `None` when every selected card defers.
+    #[pyo3(signature = (db_path, question_type, g2_cards, g3_features))]
+    #[allow(clippy::needless_pass_by_value, clippy::too_many_lines)]
+    fn build_retrieval_card_g3(
+        &self,
+        db_path: String,
+        question_type: String,
+        g2_cards: Vec<String>,
+        g3_features: Vec<String>,
+    ) -> PyResult<Option<String>> {
+        // Validate g2_cards membership.
+        for card in &g2_cards {
+            match card.as_str() {
+                "peer" | "ms" | "ssu" => {}
+                other => {
+                    return Err(PyValueError::new_err(format!(
+                        "g2_cards element {other:?} is not recognized; expected subset of \
+                         [\"peer\", \"ms\", \"ssu\"]"
+                    )));
+                }
+            }
+        }
+        // Validate g3_features membership.
+        for feat in &g3_features {
+            match feat.as_str() {
+                "router" | "summarizer" | "typed_slots" | "diversity" => {}
+                other => {
+                    return Err(PyValueError::new_err(format!(
+                        "g3_features element {other:?} is not recognized; expected subset of \
+                         [\"router\", \"summarizer\", \"typed_slots\", \"diversity\"]"
+                    )));
+                }
+            }
+        }
+
+        // Translate g3_features to PENSYVE_RETRIEVAL_CARDS_G3 env-var value
+        // per pre-reg §3.1 (single-string encoding). Any subset covering all
+        // four flags collapses to "full"; otherwise we emit the singleton
+        // value when exactly one feature is requested. Empty → unset.
+        let env_var_key = pensyve_core::retrieval::cards::multi_session::RETRIEVAL_CARDS_G3_ENV;
+        let env_value: Option<&str> = if g3_features.is_empty() {
+            None
+        } else {
+            let has_router = g3_features.iter().any(|f| f == "router");
+            let has_summ = g3_features.iter().any(|f| f == "summarizer");
+            let has_typed = g3_features.iter().any(|f| f == "typed_slots");
+            let has_div = g3_features.iter().any(|f| f == "diversity");
+            if has_router && has_summ && has_typed && has_div {
+                Some("full")
+            } else if has_router && !has_summ && !has_typed && !has_div {
+                Some("router")
+            } else if has_summ && !has_router && !has_typed && !has_div {
+                Some("summarizer")
+            } else if has_typed && !has_router && !has_summ && !has_div {
+                Some("typed_slots")
+            } else if has_div && !has_router && !has_summ && !has_typed {
+                // `diversity` alone has no card-side env-gate (MMR is wired
+                // via PENSYVE_MMR_LAMBDA in `recall_with_diversity`), so we
+                // leave the cards env-var unset for this combo. Caller
+                // typically pairs `diversity` with `recall_with_diversity`.
+                None
+            } else {
+                return Err(PyValueError::new_err(format!(
+                    "g3_features={g3_features:?} is not a recognized G3 layer combination; \
+                     expected one of: [], [\"router\"], [\"summarizer\"], [\"typed_slots\"], \
+                     [\"diversity\"], or [\"router\", \"summarizer\", \"typed_slots\", \"diversity\"] (full)"
+                )));
+            }
+        };
+
+        // Acquire the env-var guard. `_guard` keeps the env var set + the
+        // process-wide lock held for the full card-build call; `Drop`
+        // restores the prior value on every exit path.
+        let _guard = match env_value {
+            Some(v) => G3EnvGuard::set(env_var_key, v),
+            None => G3EnvGuard::unset(env_var_key),
+        };
+
+        // Normalize `db_path` into the directory expected by
+        // `SqliteBackend::open`. The harness sometimes passes the file path
+        // (`{tmp}/memories.db`); other callers pass the parent directory
+        // directly. Both shapes work.
+        let raw = PathBuf::from(&db_path);
+        let dir = if raw.is_file() || raw.extension().and_then(|s| s.to_str()) == Some("db") {
+            raw.parent()
+                .map(std::path::Path::to_path_buf)
+                .unwrap_or(raw)
+        } else {
+            raw
+        };
+
+        let backend = SqliteBackend::open(&dir).map_err(|e| {
+            PyRuntimeError::new_err(format!(
+                "Failed to open SQLite backend at {}: {e}",
+                dir.display()
+            ))
+        })?;
+
+        // Resolve the namespace. Prefer the same namespace the harness
+        // adapter uses ("longmemeval"); fall back to the handle's own
+        // namespace name; ultimately scan storage and use the first hit.
+        // Defer-on-failure: when no namespace exists we simply return None
+        // (every card would have nothing to scope by).
+        let ns_id_opt: Option<Uuid> = backend
+            .get_namespace_by_name("longmemeval")
+            .ok()
+            .flatten()
+            .map(|ns| ns.id)
+            .or_else(|| {
+                let handle_name = self.inner.namespace.name.clone();
+                backend
+                    .get_namespace_by_name(&handle_name)
+                    .ok()
+                    .flatten()
+                    .map(|ns| ns.id)
+            });
+
+        let Some(ns_id) = ns_id_opt else {
+            return Ok(None);
+        };
+
+        // Build the composite card chain. `g2_cards` chooses which G2 cards
+        // are present; `g3_features` containing "summarizer" pulls in the
+        // SupersessionCard. The G2 priority order (Peer → MS → SSU) is
+        // preserved regardless of the input list ordering — matches Rev C
+        // §3.1 + the operator §3.X(a) per-card cap layout.
+        let want_peer = g2_cards.iter().any(|c| c == "peer");
+        let want_ms = g2_cards.iter().any(|c| c == "ms");
+        let want_ssu = g2_cards.iter().any(|c| c == "ssu");
+        let want_supersession = g3_features.iter().any(|f| f == "summarizer");
+
+        let mut cards: Vec<(Box<dyn RetrievalCard>, usize)> = Vec::with_capacity(4);
+        if want_peer {
+            cards.push((Box::new(PeerCardAdapter::new()), G2_PEER_CARD_CAP));
+        }
+        if want_ms {
+            cards.push((Box::new(MultiSessionCard::new()), G2_MULTI_SESSION_CARD_CAP));
+        }
+        if want_ssu {
+            cards.push((
+                Box::new(SingleSessionUserCard::new()),
+                G2_SINGLE_SESSION_USER_CARD_CAP,
+            ));
+        }
+        if want_supersession {
+            cards.push((Box::new(SupersessionCard::new()), G3_SUPERSESSION_CARD_CAP));
+        }
+
+        if cards.is_empty() {
+            // No cards selected → no composition to build. Defer cleanly.
+            return Ok(None);
+        }
+
+        let composite = CompositeCard::new(cards);
+        // `query` is reserved for future per-card relevance scoring; G2/G3
+        // cards ignore it (see `RetrievalCard` trait docs). Empty string is
+        // explicitly allowed and matches the harness adapter's call
+        // pattern.
+        let qt: Option<&str> = if question_type.is_empty() {
+            None
+        } else {
+            Some(question_type.as_str())
+        };
+        Ok(composite.build(
+            "",
+            &backend as &dyn StorageTrait,
+            ns_id,
+            self.inner.agent_id.map(pensyve_core::types::AgentId::from),
+            self.inner.user_id.map(pensyve_core::types::UserId::from),
+            qt,
+        ))
+    }
+
+    /// Recall with MMR diversity reorder (binding pre-reg
+    /// `pensyve-docs@64481dc` §3.4 item 11 + §7 item 11).
+    ///
+    /// Sets `PENSYVE_MMR_LAMBDA` for the duration of this call so the
+    /// existing diversity reorder in `RecallEngine::recall_inner` activates,
+    /// then restores the prior env-var value on return (including panic /
+    /// exception unwind). Behaviorally identical to [`recall`] when
+    /// `lambda_ == 0.0` (engine treats `lambda <= 0.0` as MMR-OFF) and
+    /// reorders the result by `λ·sim − (1−λ)·max_j sim` when `lambda_ > 0.0`.
+    ///
+    /// Args:
+    ///     query: Search query string.
+    ///     k: Maximum number of results (default: 22).
+    ///     `lambda_`: MMR balance. Clamped to `[0.0, 1.0]` by the engine.
+    ///         `1.0` is pure relevance (output ≈ unreordered recall).
+    ///         `0.0` (or unset) is MMR-OFF. The pre-reg §3.9 fixes
+    ///         ARM-5-G3-FULL at `0.5`. The Python kwarg uses a trailing
+    ///         underscore because `lambda` is a reserved word.
+    #[pyo3(signature = (query, k=22, lambda_=0.5))]
+    fn recall_with_diversity(
+        &self,
+        query: &str,
+        k: usize,
+        lambda_: f32,
+    ) -> PyResult<Vec<PyMemory>> {
+        if query.is_empty() {
+            return Err(PyRuntimeError::new_err("query must not be empty"));
+        }
+
+        // Acquire the env-var guard. The engine reads PENSYVE_MMR_LAMBDA
+        // once at the top of `recall_inner`, so we just need it set when
+        // `engine.recall(...)` runs. Drop restores on every exit path
+        // (including the embedding-failure / SQL-failure unwind paths).
+        let clamped = lambda_.clamp(0.0, 1.0);
+        let _guard = G3EnvGuard::set("PENSYVE_MMR_LAMBDA", &format!("{clamped}"));
+
+        let vi = self.inner.vector_index.lock().unwrap();
+        let mut engine = RecallEngine::new(
+            self.inner.storage.as_ref(),
+            self.inner.embedder.as_ref(),
+            &vi,
+            &self.inner.retrieval_config,
+        );
+        if let Some(reranker) = self.inner.reranker.as_deref() {
+            engine = engine.with_reranker(reranker);
+        }
+        engine = engine.with_scope(self.inner.agent_id, self.inner.user_id);
+
+        let result = engine
+            .recall(query, self.inner.namespace.id, k)
+            .map_err(|e| PyRuntimeError::new_err(format!("Recall failed: {e}")))?;
+
+        Ok(result
+            .memories
+            .into_iter()
+            .map(|c| py_memory_from(&c.memory, c.final_score))
             .collect())
     }
 

--- a/pensyve-python/src/lib.rs
+++ b/pensyve-python/src/lib.rs
@@ -1029,35 +1029,27 @@ impl PyPensyve {
         // round-4 review on pensyve-python/src/lib.rs:160 — passing the
         // mode explicitly here instead of mutating env eliminates the
         // race window with parallel unguarded `recall()` callers.
-        let g3_mode_value: Option<&str> = if g3_features.is_empty() {
-            None
+        //
+        // Per coderabbit PR #86 round-5 review on lib.rs:1060: the
+        // mode mapping accepts arbitrary subsets rather than rejecting
+        // mixed combinations. The `MultiSessionCard`'s G3 mode (the
+        // only thing this value influences) only distinguishes
+        // `Some("full")` (all four flags) from `Some("router")` (any
+        // subset that includes router) from `None` (everything else);
+        // the other features (`summarizer`, `typed_slots`, `diversity`)
+        // are wired through their own paths (`want_supersession` below
+        // for the `SupersessionCard`, `recall_with_diversity` for MMR)
+        // and don't need to be encoded into the card-side mode at all.
+        let has_router = g3_features.iter().any(|f| f == "router");
+        let has_summ = g3_features.iter().any(|f| f == "summarizer");
+        let has_typed = g3_features.iter().any(|f| f == "typed_slots");
+        let has_div = g3_features.iter().any(|f| f == "diversity");
+        let g3_mode_value: Option<&str> = if has_router && has_summ && has_typed && has_div {
+            Some("full")
+        } else if has_router {
+            Some("router")
         } else {
-            let has_router = g3_features.iter().any(|f| f == "router");
-            let has_summ = g3_features.iter().any(|f| f == "summarizer");
-            let has_typed = g3_features.iter().any(|f| f == "typed_slots");
-            let has_div = g3_features.iter().any(|f| f == "diversity");
-            if has_router && has_summ && has_typed && has_div {
-                Some("full")
-            } else if has_router && !has_summ && !has_typed && !has_div {
-                Some("router")
-            } else if has_summ && !has_router && !has_typed && !has_div {
-                Some("summarizer")
-            } else if has_typed && !has_router && !has_summ && !has_div {
-                Some("typed_slots")
-            } else if has_div && !has_router && !has_summ && !has_typed {
-                // `diversity` alone has no card-side mode (MMR is wired
-                // via `engine.with_mmr_lambda(...)` in
-                // `recall_with_diversity`), so we leave the card mode
-                // unset for this combo. Caller typically pairs
-                // `diversity` with `recall_with_diversity`.
-                None
-            } else {
-                return Err(PyValueError::new_err(format!(
-                    "g3_features={g3_features:?} is not a recognized G3 layer combination; \
-                     expected one of: [], [\"router\"], [\"summarizer\"], [\"typed_slots\"], \
-                     [\"diversity\"], or [\"router\", \"summarizer\", \"typed_slots\", \"diversity\"] (full)"
-                )));
-            }
+            None
         };
 
         // Normalize `db_path` into the directory expected by
@@ -1169,12 +1161,12 @@ impl PyPensyve {
     /// Recall with MMR diversity reorder (binding pre-reg
     /// `pensyve-docs@64481dc` §3.4 item 11 + §7 item 11).
     ///
-    /// Sets `PENSYVE_MMR_LAMBDA` for the duration of this call so the
-    /// existing diversity reorder in `RecallEngine::recall_inner` activates,
-    /// then restores the prior env-var value on return (including panic /
-    /// exception unwind). Behaviorally identical to [`recall`] when
-    /// `lambda_ == 0.0` (engine treats `lambda <= 0.0` as MMR-OFF) and
-    /// reorders the result by `λ·sim − (1−λ)·max_j sim` when `lambda_ > 0.0`.
+    /// Passes `lambda_` directly to
+    /// [`RecallEngine::with_mmr_lambda`](pensyve_core::retrieval::engine::RecallEngine::with_mmr_lambda)
+    /// so the diversity reorder activates without process-env mutation
+    /// (round-4 fix). Behaviorally identical to [`recall`] when
+    /// `lambda_ <= 0.0` (engine treats those as MMR-OFF); reorders by
+    /// `λ·sim − (1−λ)·max_j sim` otherwise.
     ///
     /// Args:
     ///     query: Search query string.

--- a/pensyve-python/src/lib.rs
+++ b/pensyve-python/src/lib.rs
@@ -1187,7 +1187,11 @@ impl PyPensyve {
                     .ok()
                     .flatten()
                     .map(|ns| ns.id)
-            });
+            })
+            // Fallback: pick the first existing namespace before giving up —
+            // handles external DBs created under arbitrary namespace names.
+            // Per coderabbit PR #86 review on lib.rs:1194.
+            .or_else(|| backend.first_namespace_id().ok().flatten());
 
         let Some(ns_id) = ns_id_opt else {
             return Ok(None);

--- a/pensyve-python/src/lib.rs
+++ b/pensyve-python/src/lib.rs
@@ -76,91 +76,6 @@ fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
 // ---------------------------------------------------------------------------
 // G3 env-var guards
 // ---------------------------------------------------------------------------
-
-/// Process-wide mutex serializing writes to `PENSYVE_RETRIEVAL_CARDS_G3` and
-/// `PENSYVE_MMR_LAMBDA`. Both env vars are read by retrieval-card and recall
-/// engine code at call time; the G3 `PyO3` bindings (`build_retrieval_card_g3`,
-/// `recall_with_diversity`) mutate them transiently for the duration of one
-/// call. Mirrors the `RouterEnvGuard` / `SsuEnvGuard` patterns already used in
-/// `pensyve-core/tests/test_intent_router.rs` + `tests/test_single_session_user_card.rs`.
-fn g3_env_lock() -> &'static std::sync::Mutex<()> {
-    static LOCK: OnceLock<std::sync::Mutex<()>> = OnceLock::new();
-    LOCK.get_or_init(|| std::sync::Mutex::new(()))
-}
-
-/// RAII guard that holds [`g3_env_lock`] for its lifetime, mutates a single
-/// env var to a target value (or removes it), and restores the prior value
-/// on drop — including on Rust panic / Python exception unwind paths.
-///
-/// `# Safety`: `std::env::set_var` / `remove_var` are flagged unsafe in
-/// modern Rust because env mutation is process-global and not thread-safe.
-/// This guard serializes all writers/readers behind [`g3_env_lock`] for the
-/// `pensyve-python` cdylib lifetime; concurrent G3 `PyO3` calls cannot race.
-struct G3EnvGuard {
-    _serial: std::sync::MutexGuard<'static, ()>,
-    key: &'static str,
-    previous: Option<String>,
-}
-
-#[allow(
-    unsafe_code,
-    reason = "G3 PyO3 binding scoped env-var guard; std::env::set_var / remove_var require unsafe in modern Rust because env mutation is process-global. The struct holds the process-wide g3_env_lock for its lifetime so concurrent calls cannot race."
-)]
-impl G3EnvGuard {
-    /// Acquire the lock, capture the previous value of `key`, set it to
-    /// `value`. The guard restores `previous` on drop.
-    fn set(key: &'static str, value: &str) -> Self {
-        let serial = g3_env_lock()
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let previous = std::env::var(key).ok();
-        // SAFETY: see struct doc; serialized via the mutex in `serial`.
-        unsafe {
-            std::env::set_var(key, value);
-        }
-        Self {
-            _serial: serial,
-            key,
-            previous,
-        }
-    }
-
-    /// Acquire the lock, capture the previous value of `key`, remove it.
-    /// The guard restores `previous` on drop.
-    fn unset(key: &'static str) -> Self {
-        let serial = g3_env_lock()
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let previous = std::env::var(key).ok();
-        // SAFETY: see struct doc.
-        unsafe {
-            std::env::remove_var(key);
-        }
-        Self {
-            _serial: serial,
-            key,
-            previous,
-        }
-    }
-}
-
-#[allow(
-    unsafe_code,
-    reason = "G3 PyO3 binding scoped env-var guard; see G3EnvGuard::set for justification"
-)]
-impl Drop for G3EnvGuard {
-    fn drop(&mut self) {
-        // SAFETY: drop runs while we still hold the serialization lock.
-        unsafe {
-            match &self.previous {
-                Some(v) => std::env::set_var(self.key, v),
-                None => std::env::remove_var(self.key),
-            }
-        }
-    }
-}
-
-// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
@@ -1107,12 +1022,14 @@ impl PyPensyve {
             }
         }
 
-        // Translate g3_features to PENSYVE_RETRIEVAL_CARDS_G3 env-var value
-        // per pre-reg §3.1 (single-string encoding). Any subset covering all
-        // four flags collapses to "full"; otherwise we emit the singleton
-        // value when exactly one feature is requested. Empty → unset.
-        let env_var_key = pensyve_core::retrieval::cards::multi_session::RETRIEVAL_CARDS_G3_ENV;
-        let env_value: Option<&str> = if g3_features.is_empty() {
+        // Translate g3_features into the G3 layering mode value passed
+        // to `MultiSessionCard::with_g3_mode(...)`. The vocabulary
+        // matches `PENSYVE_RETRIEVAL_CARDS_G3` (`"router"`, `"full"`,
+        // or unset / unrecognized → G2 baseline). Per coderabbit PR #86
+        // round-4 review on pensyve-python/src/lib.rs:160 — passing the
+        // mode explicitly here instead of mutating env eliminates the
+        // race window with parallel unguarded `recall()` callers.
+        let g3_mode_value: Option<&str> = if g3_features.is_empty() {
             None
         } else {
             let has_router = g3_features.iter().any(|f| f == "router");
@@ -1128,10 +1045,11 @@ impl PyPensyve {
             } else if has_typed && !has_router && !has_summ && !has_div {
                 Some("typed_slots")
             } else if has_div && !has_router && !has_summ && !has_typed {
-                // `diversity` alone has no card-side env-gate (MMR is wired
-                // via PENSYVE_MMR_LAMBDA in `recall_with_diversity`), so we
-                // leave the cards env-var unset for this combo. Caller
-                // typically pairs `diversity` with `recall_with_diversity`.
+                // `diversity` alone has no card-side mode (MMR is wired
+                // via `engine.with_mmr_lambda(...)` in
+                // `recall_with_diversity`), so we leave the card mode
+                // unset for this combo. Caller typically pairs
+                // `diversity` with `recall_with_diversity`.
                 None
             } else {
                 return Err(PyValueError::new_err(format!(
@@ -1140,14 +1058,6 @@ impl PyPensyve {
                      [\"diversity\"], or [\"router\", \"summarizer\", \"typed_slots\", \"diversity\"] (full)"
                 )));
             }
-        };
-
-        // Acquire the env-var guard. `_guard` keeps the env var set + the
-        // process-wide lock held for the full card-build call; `Drop`
-        // restores the prior value on every exit path.
-        let _guard = match env_value {
-            Some(v) => G3EnvGuard::set(env_var_key, v),
-            None => G3EnvGuard::unset(env_var_key),
         };
 
         // Normalize `db_path` into the directory expected by
@@ -1212,7 +1122,14 @@ impl PyPensyve {
             cards.push((Box::new(PeerCardAdapter::new()), G2_PEER_CARD_CAP));
         }
         if want_ms {
-            cards.push((Box::new(MultiSessionCard::new()), G2_MULTI_SESSION_CARD_CAP));
+            // Pass `g3_mode_value` explicitly so the card sees the
+            // intended mode without relying on a process-env mutation
+            // (round-4 fix; see comment block above the
+            // `g3_mode_value` computation).
+            cards.push((
+                Box::new(MultiSessionCard::new().with_g3_mode(g3_mode_value)),
+                G2_MULTI_SESSION_CARD_CAP,
+            ));
         }
         if want_ssu {
             cards.push((
@@ -1278,12 +1195,13 @@ impl PyPensyve {
             return Err(PyRuntimeError::new_err("query must not be empty"));
         }
 
-        // Acquire the env-var guard. The engine reads PENSYVE_MMR_LAMBDA
-        // once at the top of `recall_inner`, so we just need it set when
-        // `engine.recall(...)` runs. Drop restores on every exit path
-        // (including the embedding-failure / SQL-failure unwind paths).
+        // Per coderabbit PR #86 round-4 review on
+        // pensyve-python/src/lib.rs:160 — thread the MMR lambda through
+        // the engine boundary explicitly via `with_mmr_lambda` instead
+        // of mutating `PENSYVE_MMR_LAMBDA` via `G3EnvGuard`. Closes the
+        // race where a parallel unguarded `recall()` could read the env
+        // var while another caller had it transiently set.
         let clamped = lambda_.clamp(0.0, 1.0);
-        let _guard = G3EnvGuard::set("PENSYVE_MMR_LAMBDA", &format!("{clamped}"));
 
         let vi = self.inner.vector_index.lock().unwrap();
         let mut engine = RecallEngine::new(
@@ -1296,6 +1214,7 @@ impl PyPensyve {
             engine = engine.with_reranker(reranker);
         }
         engine = engine.with_scope(self.inner.agent_id, self.inner.user_id);
+        engine = engine.with_mmr_lambda(clamped);
 
         let result = engine
             .recall(query, self.inner.namespace.id, k)

--- a/pensyve-python/tests/test_g3_pyo3.py
+++ b/pensyve-python/tests/test_g3_pyo3.py
@@ -1,0 +1,336 @@
+"""G3 PyO3 binding integration tests.
+
+Pre-reg anchor: ``pensyve-docs/research/benchmark-sprint/v3/g3/preregistration.md``
+§3.4 item 11 + §7 item 11. Verifies the two new methods on
+:class:`pensyve.Pensyve`:
+
+* :meth:`Pensyve.build_retrieval_card_g3` — translates the Python
+  ``g3_features`` list into the
+  ``PENSYVE_RETRIEVAL_CARDS_G3`` env var (operator-locked single-string
+  encoding per §3.1) and dispatches through ``CompositeCard::g3_default``.
+* :meth:`Pensyve.recall_with_diversity` — wraps the standard recall path
+  with a scoped ``PENSYVE_MMR_LAMBDA`` env var so the engine's MMR
+  reorder activates without leaking the env var to subsequent calls.
+
+The tests run against a fresh Pensyve store. The G3 cards (PeerCard, MS,
+SSU, Supersession) all read from ``observation_memories``, which the
+default ingest path leaves empty (extraction is gated by an LLM
+extractor). To keep the tests self-contained without a real LLM, we
+seed observation rows directly via ``sqlite3`` after constructing the
+store. This mirrors the pattern used by the harness's per-question
+tempdir + manual fixture flow.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import tempfile
+import uuid
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pensyve
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def _env_snapshot(*keys):
+    """Capture and restore env vars for the listed keys.
+
+    Used to assert that the G3 PyO3 methods do not leak their scoped env
+    var mutations onto subsequent calls.
+    """
+    saved = {k: os.environ.get(k) for k in keys}
+    try:
+        yield saved
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+def _store_db_path(store_dir: str) -> Path:
+    """Return the single .db file inside the Pensyve store directory."""
+    db = Path(store_dir) / "memories.db"
+    assert db.exists(), f"expected memories.db inside {store_dir}, found: {list(Path(store_dir).iterdir())}"
+    return db
+
+
+def _seed_observations(
+    db_path: Path,
+    namespace_id: str,
+    *,
+    days: int = 3,
+    rows_per_day: int = 4,
+) -> int:
+    """Insert observation rows directly so the G3 cards have data to scan.
+
+    Mirrors the schema in
+    ``pensyve-core/src/storage/sqlite.rs:408`` (CREATE TABLE
+    ``observation_memories``). The G1 migration adds NULLABLE
+    ``agent_id`` / ``user_id`` columns; we leave them NULL so the
+    cards' unscoped read path matches.
+    """
+    base = datetime(2026, 4, 1, 9, 0, 0, tzinfo=timezone.utc)
+    inserted = 0
+    with sqlite3.connect(str(db_path)) as con:
+        cur = con.cursor()
+        for day in range(days):
+            day_ts = base + timedelta(days=day)
+            episode_id = str(uuid.uuid4())
+            for row in range(rows_per_day):
+                obs_id = str(uuid.uuid4())
+                # Two distinct entities × two days each → cross-session
+                # entities (the MS card filter requires ≥2 distinct days).
+                entity_type = "game_played" if row % 2 == 0 else "place_lived"
+                instance = "Hades" if row % 2 == 0 else "Portland"
+                action = "played" if row % 2 == 0 else "lives"
+                content = (
+                    f"User {action} {instance} during session on day {day}, row {row}"
+                )
+                event_time = (day_ts + timedelta(hours=row)).isoformat()
+                cur.execute(
+                    "INSERT INTO observation_memories ("
+                    "  id, namespace_id, episode_id, entity_type, instance, action, "
+                    "  quantity, unit, content, embedding, confidence, event_time, "
+                    "  created_at, stability, retrievability) "
+                    "VALUES (?, ?, ?, ?, ?, ?, NULL, NULL, ?, NULL, ?, ?, ?, 1.0, 1.0)",
+                    (
+                        obs_id,
+                        namespace_id,
+                        episode_id,
+                        entity_type,
+                        instance,
+                        action,
+                        content,
+                        0.85,
+                        event_time,
+                        event_time,
+                    ),
+                )
+                inserted += 1
+        con.commit()
+    return inserted
+
+
+def _namespace_id(db_path: Path, name: str) -> str:
+    """Look up the namespace UUID created at Pensyve construction."""
+    with sqlite3.connect(str(db_path)) as con:
+        row = con.execute(
+            "SELECT id FROM namespaces WHERE name = ? LIMIT 1", (name,)
+        ).fetchone()
+    assert row is not None, f"namespace {name!r} missing from {db_path}"
+    return row[0]
+
+
+def _ingest_for_recall(p: pensyve.Pensyve) -> None:
+    """Ingest a small corpus so ``recall_with_diversity`` has rows to rerank."""
+    user = p.entity("alice", kind="user")
+    agent = p.entity("agent", kind="agent")
+    contents = [
+        "I love drinking oat milk lattes every morning",
+        "Switched from coffee to matcha for the L-theanine",
+        "Pad thai with extra peanuts is my weekend dinner",
+        "Ramen on cold weekends, salads when it's hot",
+        "Rust has become my main programming language for systems work",
+        "TypeScript at work but rust on every personal project",
+        "Played Hades during my evening sessions in April",
+        "Hades runs are a perfect 30-minute break",
+    ]
+    for content in contents:
+        with p.episode(agent, user) as ep:
+            ep.message("user", content)
+
+
+# ---------------------------------------------------------------------------
+# build_retrieval_card_g3 — defer-on-empty
+# ---------------------------------------------------------------------------
+
+
+def test_build_retrieval_card_g3_returns_none_on_empty_store():
+    """Empty observation_memories → every card defers → composite returns None."""
+    with tempfile.TemporaryDirectory() as tmp:
+        p = pensyve.Pensyve(path=tmp, namespace="g3-empty")
+        # No ingest, no manual seed: observation_memories is empty.
+        result = p.build_retrieval_card_g3(
+            db_path=str(_store_db_path(tmp)),
+            question_type="multi-session",
+            g2_cards=["peer", "ms", "ssu"],
+            g3_features=[],
+        )
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# build_retrieval_card_g3 — happy path
+# ---------------------------------------------------------------------------
+
+
+def test_build_retrieval_card_g3_with_seeded_observations_returns_card_text():
+    """Cross-session entities seeded → MS card emits content (G2-equivalent)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        p = pensyve.Pensyve(path=tmp, namespace="g3-happy")
+        db = _store_db_path(tmp)
+        ns_id = _namespace_id(db, "g3-happy")
+        inserted = _seed_observations(db, ns_id, days=3, rows_per_day=4)
+        assert inserted > 0
+
+        # G2-equivalent baseline: peer + ms + ssu, no G3 layering.
+        result = p.build_retrieval_card_g3(
+            db_path=str(db),
+            question_type="multi-session",
+            g2_cards=["peer", "ms", "ssu"],
+            g3_features=[],
+        )
+        assert result is not None
+        # MultiSessionCard surface form check — at least one cross-session
+        # entity should be reported.
+        assert "CROSS-SESSION ENTITIES" in result, (
+            f"expected MS card header in composite output; got:\n{result}"
+        )
+
+
+def test_build_retrieval_card_g3_router_feature_sets_env_var_correctly():
+    """g3_features=['router'] → env-var = 'router'; restored on return."""
+    env_key = "PENSYVE_RETRIEVAL_CARDS_G3"
+    with tempfile.TemporaryDirectory() as tmp:
+        p = pensyve.Pensyve(path=tmp, namespace="g3-router")
+        db = _store_db_path(tmp)
+        ns_id = _namespace_id(db, "g3-router")
+        _seed_observations(db, ns_id, days=3, rows_per_day=4)
+
+        # Ensure env-var is unset BEFORE the call so we can assert
+        # restoration works.
+        with _env_snapshot(env_key) as saved:
+            os.environ.pop(env_key, None)
+
+            # `single-session-preference` is one of the question types where
+            # the G3 router gate disables MS. With the router on, MS should
+            # defer (single-session type) → output is peer + ssu only (no
+            # CROSS-SESSION ENTITIES block). With g3_features=[] the same
+            # call should still produce a card (G2-equivalent path).
+            with_router = p.build_retrieval_card_g3(
+                db_path=str(db),
+                question_type="single-session-preference",
+                g2_cards=["peer", "ms", "ssu"],
+                g3_features=["router"],
+            )
+            # Env-var must be restored (i.e., still unset) after return.
+            assert env_key not in os.environ, (
+                f"{env_key} leaked after build_retrieval_card_g3 returned: "
+                f"{os.environ.get(env_key)!r}"
+            )
+
+            # Without the router gate, MS card stays ON for the same
+            # question type (G2-equivalent baseline).
+            without_router = p.build_retrieval_card_g3(
+                db_path=str(db),
+                question_type="single-session-preference",
+                g2_cards=["peer", "ms", "ssu"],
+                g3_features=[],
+            )
+            assert env_key not in os.environ
+            # Both calls run defensively even if their content matches —
+            # the binding contract is the env-var lifecycle, not the card
+            # content per se. The router gate's behavioral effect is
+            # covered by pensyve-core/tests/test_intent_router.rs.
+            del with_router, without_router  # consumed
+            del saved  # silence pyright
+
+
+def test_build_retrieval_card_g3_rejects_unknown_features():
+    """Bogus g3_features values raise ValueError before opening the store."""
+    with tempfile.TemporaryDirectory() as tmp:
+        p = pensyve.Pensyve(path=tmp, namespace="g3-bogus")
+        try:
+            p.build_retrieval_card_g3(
+                db_path=str(_store_db_path(tmp)),
+                question_type="multi-session",
+                g2_cards=["peer"],
+                g3_features=["nonsense"],
+            )
+        except ValueError as exc:
+            assert "g3_features" in str(exc), str(exc)
+        else:
+            raise AssertionError("expected ValueError for bogus g3_features")
+
+
+# ---------------------------------------------------------------------------
+# recall_with_diversity — env-var lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_recall_with_diversity_lambda_one_preserves_recall_shape():
+    """λ=1.0 is pure relevance; result matches a regular recall."""
+    with tempfile.TemporaryDirectory() as tmp:
+        p = pensyve.Pensyve(
+            path=tmp, namespace="div-one", reranker=None
+        )
+        _ingest_for_recall(p)
+
+        env_key = "PENSYVE_MMR_LAMBDA"
+        with _env_snapshot(env_key):
+            os.environ.pop(env_key, None)
+            results = p.recall_with_diversity(
+                "what does the user drink", k=5, lambda_=1.0
+            )
+            # Env var must be restored (i.e., unset) afterward.
+            assert env_key not in os.environ, (
+                f"{env_key} leaked after recall_with_diversity: "
+                f"{os.environ.get(env_key)!r}"
+            )
+
+        assert isinstance(results, list)
+        # Recall against a freshly-ingested store should return at least
+        # the top-1 candidate; the corpus has multiple beverage-related
+        # observations.
+        assert len(results) >= 1
+        # Memory shape: returns same Memory class as `recall`.
+        assert all(hasattr(m, "id") and hasattr(m, "score") for m in results)
+
+
+def test_recall_with_diversity_restores_prior_lambda_value():
+    """Pre-existing PENSYVE_MMR_LAMBDA value is restored after the call."""
+    with tempfile.TemporaryDirectory() as tmp:
+        p = pensyve.Pensyve(
+            path=tmp, namespace="div-restore", reranker=None
+        )
+        _ingest_for_recall(p)
+
+        env_key = "PENSYVE_MMR_LAMBDA"
+        sentinel = "0.7"
+        with _env_snapshot(env_key):
+            os.environ[env_key] = sentinel
+            _ = p.recall_with_diversity(
+                "preferred programming language", k=3, lambda_=0.5
+            )
+            # Inner call's transient mutation must be undone; the prior
+            # sentinel value is what callers expect to see again.
+            assert os.environ.get(env_key) == sentinel, (
+                f"recall_with_diversity did not restore prior {env_key} value; "
+                f"saw {os.environ.get(env_key)!r}, expected {sentinel!r}"
+            )
+
+
+def test_recall_with_diversity_lambda_half_returns_results():
+    """λ=0.5 is the pre-reg ARM-5-G3-FULL setting; engine must accept it."""
+    with tempfile.TemporaryDirectory() as tmp:
+        p = pensyve.Pensyve(
+            path=tmp, namespace="div-half", reranker=None
+        )
+        _ingest_for_recall(p)
+
+        results = p.recall_with_diversity(
+            "what video games does the user play", k=5, lambda_=0.5
+        )
+        assert isinstance(results, list)
+        # Result count is bounded by k; semantic content is exercised by
+        # pensyve-core's diversity unit tests.
+        assert len(results) <= 5


### PR DESCRIPTION
## Summary

- **G3 cycle implementation** integrating 5 phases of the pre-reg @ `pensyve-docs@64481dc`: P2 intent router + MS scope-tighten, P3 SupersessionCard + summarizer gate, P4 schema_versions v=2 + typed-slot extractor, P5 MMR λ=0.5 diversity, plus gate-hook wiring + PyO3 bindings.
- **486 tests pass** with `cargo test -p pensyve-core --features observation-extraction`; **445 baseline preserved** without the feature flag (no behavior change for callers that don't opt in).
- **Cargo clippy + fmt clean** on both `pensyve-core` and `pensyve-python` with `--all-targets -- -D warnings`.

## Companion docs PR

pensyve-docs#TBD — pre-reg + 3 addenda + results.md + per-arm run artifacts. Verdict: GATE-FAIL but NOT FALL-BACK; H1 PRIMARY PASS via SS-Pref +13.3pp and SSU +10pp simultaneously; H5 composition additivity PASS on all 3 cells.

## What's in this branch

5 merge commits + 1 clippy fix:
- `aa1f52b` P2: intent router + MultiSessionCard SQL scope-tighten (4 files, 654/-6 LOC; +10 tests)
- `a3ee45f` P5: MMR diversity ranking module (4 files, 438/-13 LOC; +7 tests)
- `ec04fde` P3+P4: SupersessionCard + summarizer gate + schema_versions v=2 + typed-slot extractor + SlotKind enum (11 files, 2506/-10 LOC; +41 tests)
- `34efc5d` Foreground clippy fix (`approx_constant` + `doc_markdown` on test_diversity.rs from `--all-targets`)
- `52e5249` Gate-hook wiring (observation.rs commit_extraction_for_episode + commit_extractions_for_episodes; 2 files, 1190/-2 LOC; +7 tests)
- `4c82e13` PyO3 bindings (PyPensyve.build_retrieval_card_g3 + recall_with_diversity; 3 files, 763/-0 LOC; +7 tests)

## Operator-locked design choices (per pre-reg §1.4 + §3.X)

- (a) **BOTH** intent router + MS SQL scope-tighten (≥3 cross-session days)
- (b) NEW `SupersessionCard` impl of `RetrievalCard` trait
- (c) Typed-slot columns on `observation_memories` (schema_versions v=2 NULLABLE columns)
- (d) MMR λ=0.5 single value, no ablation
- (e) 30-Q × 3 cells inherited byte-for-byte from G2 subsets
- (f) v2.3.0 if G3 ships (NOT this cycle — G3 GATE-FAIL means hold)
- (a') MMR insertion site = BEFORE card prepend
- (b') ROLLBACK on cancel (defer-write pattern)
- (c') Fixed-shape 5-slot prompt (1 LLM call/event)

## Test plan

- [x] `cargo test -p pensyve-core --lib --tests` (445 pass; no feature flag)
- [x] `cargo test -p pensyve-core --features observation-extraction --lib --tests` (486 pass)
- [x] `cargo test -p pensyve-python --tests` (full pensyve-python suite passes)
- [x] `cargo clippy -p pensyve-core --all-targets --features observation-extraction -- -D warnings` clean
- [x] `cargo clippy -p pensyve-python --all-targets -- -D warnings` clean
- [x] `cargo fmt -p pensyve-core --check` clean
- [x] `cargo fmt -p pensyve-python --check` clean
- [x] Real-data run validation: pensyve-docs@dcaf421 commits 15 per-combo run artifacts; all 6/6 audits PASS; zero extractor failures

## Implementation notes

Per `pensyve-docs@c7f4514` (addendum_02), some implementation choices deviate from pre-reg literal wording:

- **MS SQL "scope-tighten"** (pre-reg §3.6 wording: `GROUP BY ... HAVING COUNT(DISTINCT date(event_time)) >= 3`) actually lands as **Rust-side aggregation** (the G2 code uses `aggregate_rows()` post-SQL, not SQL `GROUP BY`). Behavior identical; implementation site shifted.
- **Per-event consolidation gate hooks** (pre-reg §3.4 item 7 wording: `ConsolidationEngine::run` extension) actually land as **module-level public async fns** in `consolidation/mod.rs` because `ConsolidationEngine::run` is a periodic batch entry, not an event-driven hook surface. Functionally equivalent.
- **ROLLBACK on cancel** (operator-locked (b')) implemented as **defer-write pattern** rather than SQLite `BEGIN/COMMIT/ROLLBACK` — atomic single-row UPDATE makes partial-column states impossible by SQLite atomicity.

## Operator decision required

Tag decision: HOLD v2.3.0. Per operator-locked (f), v2.3.0 ships on G3 PASS verdict; G3 GATE-FAIL means bundle G3 surface into v2.4.0 or v3.0.0 with G4 mechanisms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-event typed-slot extraction (biography, preference, experience, social, work) persisted on observations.
  * Supersession-chain summarization persisted and a new Supersession retrieval card; default G3 retrieval composition and intent-based routing.
  * Recall diversity: configurable MMR reranking with improved handling of negative-similarity embeddings.
  * Python API additions: build_retrieval_card_g3() and recall_with_diversity().

* **Tests**
  * Extensive unit/integration tests for extraction, summarization, routing, MMR, migrations, and cards.

* **Chores**
  * Schema migration adds nullable slot and chain_summary columns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->