### PR TITLE
Phase 23 production hardening: distributed tracing + Redis rate limits + circuit breakers

### DIFF
--- a/pensyve-mcp-gateway/src/auth.rs
+++ b/pensyve-mcp-gateway/src/auth.rs
@@ -311,7 +311,23 @@ impl AuthValidator {
                 return None;
             }
         };
-        if body.get("valid")?.as_bool()? {
+        // Phase 23/C (PR #87 r2): a 2xx response with a missing or
+        // wrong-typed `valid` field is a contract regression on the
+        // validator side, not a revoked key. Treat it as a downstream
+        // failure so the auth circuit can trip on sustained validator
+        // misbehaviour rather than silently looking like a steady stream
+        // of rejections.
+        let Some(valid) = body.get("valid").and_then(serde_json::Value::as_bool) else {
+            if let Some(cb) = &self.circuit_breaker {
+                cb.record_failure().await;
+            }
+            tracing::warn!(
+                payload = %body,
+                "remote validation 2xx with missing or non-bool `valid` field"
+            );
+            return None;
+        };
+        if valid {
             let ctx = AuthContext {
                 key_id: body
                     .get("keyId")

--- a/pensyve-mcp-gateway/src/auth.rs
+++ b/pensyve-mcp-gateway/src/auth.rs
@@ -225,21 +225,12 @@ impl AuthValidator {
                 return None;
             }
 
-            let result = self.validate_remote(url, key, &hash, trace).await;
-            if let Some(cb) = &self.circuit_breaker {
-                // A success here completes the round-trip cleanly — we
-                // record it. Failure recording happens *inside*
-                // `validate_remote` because only there can we distinguish
-                // a genuine transport / 5xx / decode error (which trips
-                // the breaker) from a legitimate 4xx revoked-key response
-                // (which does NOT trip the breaker — a steady stream of
-                // revoked keys must not take the validator offline for
-                // healthy tenants).
-                if result.is_some() {
-                    cb.record_success().await;
-                }
-            }
-            return result;
+            // All breaker bookkeeping (success on any healthy round-trip,
+            // failure on transport / 5xx / decode / contract-regression
+            // errors) lives inside `validate_remote` so HalfOpen recovers
+            // even when the validator returns a healthy 4xx or
+            // `{"valid": false}` rejection (PR #87 r3, CodeRabbit).
+            return self.validate_remote(url, key, &hash, trace).await;
         }
 
         None
@@ -297,7 +288,14 @@ impl AuthValidator {
 
         if !resp.status().is_success() {
             // 4xx — the auth endpoint responded but rejected the key.
-            // This is NOT a circuit-tripping event.
+            // This is NOT a circuit-tripping event; in fact a clean
+            // rejection is positive evidence that the validator is
+            // healthy, so record it as a breaker success (PR #87 r3,
+            // CodeRabbit) to let HalfOpen close on a stream of healthy
+            // rejections after a recovery.
+            if let Some(cb) = &self.circuit_breaker {
+                cb.record_success().await;
+            }
             return None;
         }
 
@@ -321,52 +319,110 @@ impl AuthValidator {
             if let Some(cb) = &self.circuit_breaker {
                 cb.record_failure().await;
             }
+            // PR #87 r3 (CodeRabbit): never log the raw validator payload
+            // at warn level — it can spill `userId`, `stripeCustomerId`
+            // or other unexpected fields into structured logs during a
+            // contract regression. Surface only top-level field names
+            // and JSON types so an operator can diagnose the schema
+            // drift without leaking PII.
             tracing::warn!(
-                payload = %body,
+                payload_shape = %describe_payload_shape(&body),
                 "remote validation 2xx with missing or non-bool `valid` field"
             );
             return None;
         };
-        if valid {
-            let ctx = AuthContext {
-                key_id: body
-                    .get("keyId")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("remote")
-                    .to_string(),
-                user_id: body
-                    .get("userId")
-                    .and_then(|v| v.as_str())
-                    .map(String::from),
-                scope: body
-                    .get("scope")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("mcp")
-                    .to_string(),
-                stripe_customer_id: body
-                    .get("stripeCustomerId")
-                    .and_then(|v| v.as_str())
-                    .map(String::from),
-                plan: body
-                    .get("plan")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("free")
-                    .to_string(),
-            };
-
-            // Cache for 1 hour — remote validation is the #1 latency source.
-            self.remote_cache.insert(
-                hash.to_string(),
-                (
-                    ctx.clone(),
-                    std::time::Instant::now() + std::time::Duration::from_secs(3600),
-                ),
-            );
-
-            return Some(ctx);
+        if !valid {
+            // Healthy `{"valid": false}` rejection — same reasoning as the
+            // 4xx branch above: the validator answered cleanly, so the
+            // round-trip is positive evidence of liveness (PR #87 r3,
+            // CodeRabbit).
+            if let Some(cb) = &self.circuit_breaker {
+                cb.record_success().await;
+            }
+            return None;
         }
 
-        None
+        let ctx = parse_auth_context(&body);
+
+        // Cache for 1 hour — remote validation is the #1 latency source.
+        self.remote_cache.insert(
+            hash.to_string(),
+            (
+                ctx.clone(),
+                std::time::Instant::now() + std::time::Duration::from_secs(3600),
+            ),
+        );
+
+        // Healthy `{"valid": true}` round-trip — record breaker success
+        // here (rather than at the call site) so all healthy-response
+        // paths through `validate_remote` consistently feed the breaker
+        // (PR #87 r3, CodeRabbit).
+        if let Some(cb) = &self.circuit_breaker {
+            cb.record_success().await;
+        }
+
+        Some(ctx)
+    }
+}
+
+/// Build an `AuthContext` from a `{"valid": true, ...}` validator
+/// response. Extracted from `validate_remote` to keep that function
+/// under the clippy line-count cap.
+fn parse_auth_context(body: &serde_json::Value) -> AuthContext {
+    AuthContext {
+        key_id: body
+            .get("keyId")
+            .and_then(|v| v.as_str())
+            .unwrap_or("remote")
+            .to_string(),
+        user_id: body
+            .get("userId")
+            .and_then(|v| v.as_str())
+            .map(String::from),
+        scope: body
+            .get("scope")
+            .and_then(|v| v.as_str())
+            .unwrap_or("mcp")
+            .to_string(),
+        stripe_customer_id: body
+            .get("stripeCustomerId")
+            .and_then(|v| v.as_str())
+            .map(String::from),
+        plan: body
+            .get("plan")
+            .and_then(|v| v.as_str())
+            .unwrap_or("free")
+            .to_string(),
+    }
+}
+
+/// Describe the top-level shape of a JSON payload as a comma-joined
+/// list of `field: type` entries. Used in place of `payload = %body` so
+/// validator contract regressions can be diagnosed without spilling
+/// values like `userId`, `stripeCustomerId`, or arbitrary extension
+/// fields into structured logs.
+fn describe_payload_shape(body: &serde_json::Value) -> String {
+    match body {
+        serde_json::Value::Object(map) => {
+            let mut parts: Vec<String> = map
+                .iter()
+                .map(|(k, v)| format!("{k}: {}", json_type(v)))
+                .collect();
+            parts.sort();
+            format!("{{{}}}", parts.join(", "))
+        }
+        other => format!("<non-object: {}>", json_type(other)),
+    }
+}
+
+fn json_type(v: &serde_json::Value) -> &'static str {
+    match v {
+        serde_json::Value::Null => "null",
+        serde_json::Value::Bool(_) => "bool",
+        serde_json::Value::Number(_) => "number",
+        serde_json::Value::String(_) => "string",
+        serde_json::Value::Array(_) => "array",
+        serde_json::Value::Object(_) => "object",
     }
 }
 

--- a/pensyve-mcp-gateway/src/auth.rs
+++ b/pensyve-mcp-gateway/src/auth.rs
@@ -11,6 +11,7 @@ use sha2::{Digest, Sha256};
 use tower::{Layer, Service};
 
 use crate::AppState;
+use crate::circuit_breaker::CircuitBreaker;
 use crate::config::GatewayConfig;
 use crate::middleware::tracing::TraceContext;
 
@@ -56,6 +57,10 @@ pub struct AuthValidator {
     jwt_decoding_key: Option<DecodingKey>,
     /// Async HTTP client for remote key validation.
     http_client: reqwest::Client,
+    /// Phase 23/C: circuit breaker around `validate_remote`. `None` is
+    /// equivalent to "always closed" — used by unit tests that don't need
+    /// to exercise the breaker logic.
+    circuit_breaker: Option<Arc<CircuitBreaker>>,
 }
 
 impl AuthValidator {
@@ -105,7 +110,17 @@ impl AuthValidator {
             remote_cache: dashmap::DashMap::new(),
             jwt_decoding_key,
             http_client,
+            circuit_breaker: None,
         }
+    }
+
+    /// Attach a circuit breaker that wraps every `validate_remote` call.
+    /// Call this in `main.rs` after constructing the validator and the
+    /// shared breaker.
+    #[must_use]
+    pub fn with_circuit_breaker(mut self, cb: Arc<CircuitBreaker>) -> Self {
+        self.circuit_breaker = Some(cb);
+        self
     }
 
     /// Validate a token. Checks API keys first, then JWT, then remote endpoint.
@@ -164,7 +179,7 @@ impl AuthValidator {
             });
         }
 
-        // 2. Check remote validation cache
+        // 2. Check remote validation cache (fresh entries only).
         if let Some(entry) = self.remote_cache.get(&hash) {
             let (ctx, expires) = entry.value();
             if std::time::Instant::now() < *expires {
@@ -174,9 +189,53 @@ impl AuthValidator {
             self.remote_cache.remove(&hash);
         }
 
-        // 3. Try remote validation
+        // 3. Try remote validation, gated by the circuit breaker.
         if let Some(url) = &self.validation_url {
-            return self.validate_remote(url, key, &hash, trace).await;
+            // Phase 23/C: if the breaker is Open, skip the remote call
+            // entirely. Fall back to a *stale* cache hit if one exists
+            // (entries are kept in the dashmap with their expiry; we
+            // re-read here ignoring the expiry rather than mutating the
+            // remove-on-expiry logic above). Returning a stale-but-known
+            // AuthContext is safer than 403'ing every authenticated user
+            // when pensyve.com is down — cached entries were valid as of
+            // the last successful round-trip.
+            if let Some(cb) = &self.circuit_breaker
+                && let Err(open) = cb.check().await
+            {
+                tracing::warn!(
+                    circuit = open.name,
+                    failures = open.failures,
+                    "auth circuit open; attempting stale cache fallback"
+                );
+                if let Some(entry) = self.remote_cache.get(&hash) {
+                    let (ctx, _expires) = entry.value();
+                    return Some(ctx.clone());
+                }
+                // No cache entry at all → deny. The middleware turns
+                // None into 403 forbidden; we keep the existing API
+                // surface (Option<AuthContext>) rather than introducing
+                // a new AuthError::ServiceUnavailable variant that
+                // would cascade into Service / Tower / response-mapping
+                // changes.
+                return None;
+            }
+
+            let result = self.validate_remote(url, key, &hash, trace).await;
+            if let Some(cb) = &self.circuit_breaker {
+                // A None result here means the remote endpoint either
+                // returned 4xx (key invalid) or failed entirely. We can
+                // distinguish the two paths inside `validate_remote`,
+                // but for circuit-breaker purposes any non-success of
+                // the round-trip counts as a failure — a key being
+                // legitimately revoked still completes the HTTP call
+                // successfully. See validate_remote_with_outcome below.
+                if result.is_some() {
+                    cb.record_success().await;
+                }
+                // Failure recording happens inside validate_remote where
+                // we can distinguish "transport error" from "bad key".
+            }
+            return result;
         }
 
         None
@@ -208,12 +267,46 @@ impl AuthValidator {
             );
         }
 
-        let resp = req.send().await.ok()?;
-        if !resp.status().is_success() {
+        // Phase 23/C: distinguish transport-level failures (network
+        // partitions, 5xx, JSON decode) from auth-level failures (4xx,
+        // valid=false). Only the former trip the circuit; a steady stream
+        // of revoked keys MUST NOT take the validator offline for healthy
+        // tenants.
+        let resp = match req.send().await {
+            Ok(r) => r,
+            Err(e) => {
+                if let Some(cb) = &self.circuit_breaker {
+                    cb.record_failure().await;
+                }
+                tracing::warn!(error = %e, "remote validation transport error");
+                return None;
+            }
+        };
+
+        if resp.status().is_server_error() {
+            if let Some(cb) = &self.circuit_breaker {
+                cb.record_failure().await;
+            }
+            tracing::warn!(status = %resp.status(), "remote validation 5xx");
             return None;
         }
 
-        let body: serde_json::Value = resp.json().await.ok()?;
+        if !resp.status().is_success() {
+            // 4xx — the auth endpoint responded but rejected the key.
+            // This is NOT a circuit-tripping event.
+            return None;
+        }
+
+        let body: serde_json::Value = match resp.json().await {
+            Ok(b) => b,
+            Err(e) => {
+                if let Some(cb) = &self.circuit_breaker {
+                    cb.record_failure().await;
+                }
+                tracing::warn!(error = %e, "remote validation JSON decode failed");
+                return None;
+            }
+        };
         if body.get("valid")?.as_bool()? {
             let ctx = AuthContext {
                 key_id: body

--- a/pensyve-mcp-gateway/src/auth.rs
+++ b/pensyve-mcp-gateway/src/auth.rs
@@ -12,6 +12,7 @@ use tower::{Layer, Service};
 
 use crate::AppState;
 use crate::config::GatewayConfig;
+use crate::middleware::tracing::TraceContext;
 
 /// Validated API key context attached to the request extensions.
 #[derive(Clone, Debug)]
@@ -108,10 +109,15 @@ impl AuthValidator {
     }
 
     /// Validate a token. Checks API keys first, then JWT, then remote endpoint.
-    pub async fn validate(&self, key: &str) -> Option<AuthContext> {
+    ///
+    /// `trace` carries the W3C trace context for the inbound request and
+    /// is propagated as a `traceparent` header on outbound `validate_remote`
+    /// calls. `None` skips propagation (used by unit tests that bypass the
+    /// tracing middleware).
+    pub async fn validate(&self, key: &str, trace: Option<&TraceContext>) -> Option<AuthContext> {
         // 1. API key path (psy_ prefix)
         if key.starts_with("psy_") {
-            return self.validate_api_key(key).await;
+            return self.validate_api_key(key, trace).await;
         }
 
         // 2. JWT path (OAuth access tokens from pensyve.com)
@@ -140,7 +146,11 @@ impl AuthValidator {
         })
     }
 
-    async fn validate_api_key(&self, key: &str) -> Option<AuthContext> {
+    async fn validate_api_key(
+        &self,
+        key: &str,
+        trace: Option<&TraceContext>,
+    ) -> Option<AuthContext> {
         // Check local key list (from PENSYVE_API_KEYS env var)
         let hash = hash_key(key);
         if let Some(prefix) = self.valid_key_hashes.get(&hash) {
@@ -166,13 +176,19 @@ impl AuthValidator {
 
         // 3. Try remote validation
         if let Some(url) = &self.validation_url {
-            return self.validate_remote(url, key, &hash).await;
+            return self.validate_remote(url, key, &hash, trace).await;
         }
 
         None
     }
 
-    async fn validate_remote(&self, url: &str, key: &str, hash: &str) -> Option<AuthContext> {
+    async fn validate_remote(
+        &self,
+        url: &str,
+        key: &str,
+        hash: &str,
+        trace: Option<&TraceContext>,
+    ) -> Option<AuthContext> {
         let mut req = self
             .http_client
             .post(url)
@@ -181,6 +197,15 @@ impl AuthValidator {
 
         if let Some(secret) = &self.gateway_secret {
             req = req.header("x-gateway-secret", secret);
+        }
+
+        // Phase 23/A: propagate W3C trace context to pensyve.com so the
+        // validation endpoint can correlate its logs with the gateway's.
+        if let Some(t) = trace {
+            req = req.header(
+                crate::middleware::tracing::TRACEPARENT_HEADER,
+                t.to_header_value(),
+            );
         }
 
         let resp = req.send().await.ok()?;
@@ -344,7 +369,11 @@ where
                 },
             };
 
-            if let Some(ctx) = state.auth.validate(&token).await {
+            // Pull trace context off the request (set by TracingLayer
+            // upstream) so we can propagate it on the outbound
+            // `validate_remote` POST.
+            let trace = req.extensions().get::<TraceContext>().cloned();
+            if let Some(ctx) = state.auth.validate(&token, trace.as_ref()).await {
                 req.extensions_mut().insert(ctx);
                 inner.call(req).await
             } else {
@@ -396,25 +425,30 @@ mod tests {
     #[tokio::test]
     async fn test_auth_validator_accepts_valid_key() {
         let validator = AuthValidator::new(&test_config(vec!["psy_testkey12345".into()]));
-        assert!(validator.validate("psy_testkey12345").await.is_some());
+        assert!(
+            validator
+                .validate("psy_testkey12345", None)
+                .await
+                .is_some()
+        );
     }
 
     #[tokio::test]
     async fn test_auth_validator_rejects_invalid_key() {
         let validator = AuthValidator::new(&test_config(vec!["psy_testkey12345".into()]));
-        assert!(validator.validate("psy_wrong_key").await.is_none());
+        assert!(validator.validate("psy_wrong_key", None).await.is_none());
     }
 
     #[tokio::test]
     async fn test_auth_validator_rejects_non_psy_prefix() {
         let validator = AuthValidator::new(&test_config(vec!["psy_testkey12345".into()]));
-        assert!(validator.validate("sk_testkey12345").await.is_none());
+        assert!(validator.validate("sk_testkey12345", None).await.is_none());
     }
 
     #[tokio::test]
     async fn test_auth_validator_empty_config_rejects_all() {
         let validator = AuthValidator::new(&test_config(vec![]));
-        assert!(validator.validate("psy_anything").await.is_none());
+        assert!(validator.validate("psy_anything", None).await.is_none());
     }
 
     // Ed25519 test key pair generated for unit tests only — not a real secret.
@@ -480,7 +514,7 @@ mod tests {
         let token = sign_jwt(&valid_claims());
 
         let ctx = validator
-            .validate(&token)
+            .validate(&token, None)
             .await
             .expect("valid JWT should be accepted");
         assert_eq!(ctx.user_id.as_deref(), Some("user_abc123"));
@@ -496,7 +530,7 @@ mod tests {
         let token = sign_jwt(&claims);
 
         assert!(
-            validator.validate(&token).await.is_none(),
+            validator.validate(&token, None).await.is_none(),
             "expired JWT should be rejected"
         );
     }
@@ -509,7 +543,7 @@ mod tests {
         let token = sign_jwt(&claims);
 
         assert!(
-            validator.validate(&token).await.is_none(),
+            validator.validate(&token, None).await.is_none(),
             "JWT with wrong issuer should be rejected"
         );
     }
@@ -522,7 +556,7 @@ mod tests {
         let token = sign_jwt(&claims);
 
         assert!(
-            validator.validate(&token).await.is_none(),
+            validator.validate(&token, None).await.is_none(),
             "JWT with wrong audience should be rejected"
         );
     }
@@ -538,7 +572,7 @@ mod tests {
 
         let token = sign_jwt(&valid_claims());
         assert!(
-            validator.validate(&token).await.is_none(),
+            validator.validate(&token, None).await.is_none(),
             "JWT should not validate when no public key is configured"
         );
     }
@@ -550,7 +584,7 @@ mod tests {
 
         // A psy_ token should go through the API key path, not JWT.
         let ctx = validator
-            .validate("psy_testkey12345")
+            .validate("psy_testkey12345", None)
             .await
             .expect("psy_ key should be validated as API key");
         assert!(
@@ -565,7 +599,10 @@ mod tests {
         // And a psy_ token that is NOT in the valid list should be rejected via
         // the API key path, never falling through to JWT validation.
         assert!(
-            validator.validate("psy_not_a_real_key").await.is_none(),
+            validator
+                .validate("psy_not_a_real_key", None)
+                .await
+                .is_none(),
             "invalid psy_ key should be rejected even with JWT configured"
         );
     }
@@ -574,7 +611,7 @@ mod tests {
     async fn test_local_api_key_gets_default_mcp_scope() {
         let validator = AuthValidator::new(&test_config(vec!["psy_testkey12345".into()]));
         let ctx = validator
-            .validate("psy_testkey12345")
+            .validate("psy_testkey12345", None)
             .await
             .expect("valid key");
         assert_eq!(ctx.scope, "mcp");
@@ -584,7 +621,7 @@ mod tests {
     async fn test_jwt_extracts_scope() {
         let validator = validator_with_jwt(vec![]);
         let token = sign_jwt(&valid_claims());
-        let ctx = validator.validate(&token).await.expect("valid JWT");
+        let ctx = validator.validate(&token, None).await.expect("valid JWT");
         assert_eq!(ctx.scope, "mcp");
     }
 
@@ -594,7 +631,7 @@ mod tests {
         config.key_user_map = vec![("psy_testkey12345".to_string(), "user_abc".to_string())];
         let validator = AuthValidator::new(&config);
         let ctx = validator
-            .validate("psy_testkey12345")
+            .validate("psy_testkey12345", None)
             .await
             .expect("valid key");
         assert_eq!(ctx.user_id.as_deref(), Some("user_abc"));
@@ -605,7 +642,7 @@ mod tests {
         let config = test_config(vec!["psy_testkey12345".into()]);
         let validator = AuthValidator::new(&config);
         let ctx = validator
-            .validate("psy_testkey12345")
+            .validate("psy_testkey12345", None)
             .await
             .expect("valid key");
         assert!(ctx.user_id.is_none());

--- a/pensyve-mcp-gateway/src/auth.rs
+++ b/pensyve-mcp-gateway/src/auth.rs
@@ -180,13 +180,18 @@ impl AuthValidator {
         }
 
         // 2. Check remote validation cache (fresh entries only).
+        //
+        // Note: expired entries are intentionally NOT removed here — they
+        // serve as the stale-cache fallback when the auth circuit breaker
+        // is Open (see step 3 below). They're overwritten on a successful
+        // re-validation. Without this, an outage longer than the 1h TTL
+        // would delete the only known-good context and reject every
+        // authenticated request.
         if let Some(entry) = self.remote_cache.get(&hash) {
             let (ctx, expires) = entry.value();
             if std::time::Instant::now() < *expires {
                 return Some(ctx.clone());
             }
-            drop(entry);
-            self.remote_cache.remove(&hash);
         }
 
         // 3. Try remote validation, gated by the circuit breaker.
@@ -222,18 +227,17 @@ impl AuthValidator {
 
             let result = self.validate_remote(url, key, &hash, trace).await;
             if let Some(cb) = &self.circuit_breaker {
-                // A None result here means the remote endpoint either
-                // returned 4xx (key invalid) or failed entirely. We can
-                // distinguish the two paths inside `validate_remote`,
-                // but for circuit-breaker purposes any non-success of
-                // the round-trip counts as a failure — a key being
-                // legitimately revoked still completes the HTTP call
-                // successfully. See validate_remote_with_outcome below.
+                // A success here completes the round-trip cleanly — we
+                // record it. Failure recording happens *inside*
+                // `validate_remote` because only there can we distinguish
+                // a genuine transport / 5xx / decode error (which trips
+                // the breaker) from a legitimate 4xx revoked-key response
+                // (which does NOT trip the breaker — a steady stream of
+                // revoked keys must not take the validator offline for
+                // healthy tenants).
                 if result.is_some() {
                     cb.record_success().await;
                 }
-                // Failure recording happens inside validate_remote where
-                // we can distinguish "transport error" from "bad key".
             }
             return result;
         }

--- a/pensyve-mcp-gateway/src/auth.rs
+++ b/pensyve-mcp-gateway/src/auth.rs
@@ -518,12 +518,7 @@ mod tests {
     #[tokio::test]
     async fn test_auth_validator_accepts_valid_key() {
         let validator = AuthValidator::new(&test_config(vec!["psy_testkey12345".into()]));
-        assert!(
-            validator
-                .validate("psy_testkey12345", None)
-                .await
-                .is_some()
-        );
+        assert!(validator.validate("psy_testkey12345", None).await.is_some());
     }
 
     #[tokio::test]

--- a/pensyve-mcp-gateway/src/circuit_breaker.rs
+++ b/pensyve-mcp-gateway/src/circuit_breaker.rs
@@ -1,0 +1,725 @@
+//! Circuit breaker for auth validation and Stripe usage reporting.
+//!
+//! Phase 23/C — protects the gateway from cascading failures when downstream
+//! dependencies (pensyve.com `validate-key` endpoint, Stripe `meter_events`
+//! API) become slow or unhealthy. Three-state machine:
+//!
+//! - **Closed** — requests flow normally; failures within `window_secs` are
+//!   counted; if the count reaches `failure_threshold`, the circuit trips
+//!   to **Open**.
+//! - **Open** — requests are short-circuited with [`CircuitOpen`] for the
+//!   `cooldown_secs` window; the caller is expected to use a fallback
+//!   (cached `AuthContext`, bounded event buffer).
+//! - **`HalfOpen`** — after the cooldown elapses, a single probe request is
+//!   allowed through; success → **Closed**, failure → back to **Open** with
+//!   a fresh cooldown.
+//!
+//! The breaker can run in **multi-instance Redis-coordinated** mode or in
+//! **single-instance fallback** mode. When a [`ConnectionManager`] is
+//! supplied, failure counts and state transitions are mirrored into
+//! Redis under `pensyve:cb:<name>:*` keys with `cooldown_secs` TTLs so
+//! sibling gateway pods see the same circuit state. If Redis is
+//! unavailable mid-flight, every breaker call transparently falls back to
+//! the in-memory [`FallbackState`] guarded by a `std::sync::Mutex`.
+//!
+//! Defaults from operator decision (2026-05-07):
+//! - auth: 5 failures / 60s window / 30s cooldown
+//! - stripe: 3 failures / 60s window / 60s cooldown
+//!
+//! All four defaults are env-overridable via `PENSYVE_CB_<NAME>_*` vars.
+
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use redis::AsyncCommands;
+use redis::aio::ConnectionManager;
+
+/// Configuration for a single named circuit breaker.
+#[derive(Debug, Clone)]
+pub struct CircuitBreakerConfig {
+    /// Stable name used as the Redis key prefix and in log lines.
+    /// Convention: `lower_snake_case` matching the upstream system
+    /// (`auth_validation`, `stripe_usage`).
+    pub name: &'static str,
+    /// Number of failures within `window_secs` that trips the circuit.
+    pub failure_threshold: u32,
+    /// Sliding window (seconds) within which failures are counted.
+    /// Failures older than `window_secs` are silently dropped from the
+    /// in-memory ring; in Redis the same effect is achieved via the
+    /// counter key TTL.
+    pub window_secs: u32,
+    /// How long the circuit remains Open before allowing a `HalfOpen`
+    /// probe.
+    pub cooldown_secs: u32,
+}
+
+impl CircuitBreakerConfig {
+    /// Build a config from env overrides, falling back to compile-time
+    /// defaults. The env var names are derived from `name`:
+    /// `PENSYVE_CB_<NAME_UPPER>_FAILURE_THRESHOLD`,
+    /// `PENSYVE_CB_<NAME_UPPER>_WINDOW_SECS`,
+    /// `PENSYVE_CB_<NAME_UPPER>_COOLDOWN_SECS`.
+    ///
+    /// The `name` is uppercased and the leading qualifier stripped to
+    /// produce the env prefix — `auth_validation` → `AUTH`,
+    /// `stripe_usage` → `STRIPE`. We do this rather than `AUTH_VALIDATION`
+    /// to match the operator-locked env var names from the Phase 23 spec.
+    #[must_use]
+    pub fn from_env(name: &'static str, defaults: (u32, u32, u32)) -> Self {
+        let prefix = env_prefix_for(name);
+        let failure_threshold = read_env_u32(&format!("PENSYVE_CB_{prefix}_FAILURE_THRESHOLD"))
+            .unwrap_or(defaults.0);
+        let window_secs =
+            read_env_u32(&format!("PENSYVE_CB_{prefix}_WINDOW_SECS")).unwrap_or(defaults.1);
+        let cooldown_secs =
+            read_env_u32(&format!("PENSYVE_CB_{prefix}_COOLDOWN_SECS")).unwrap_or(defaults.2);
+        Self {
+            name,
+            failure_threshold,
+            window_secs,
+            cooldown_secs,
+        }
+    }
+
+    /// Operator-locked defaults for the auth-validation breaker.
+    #[must_use]
+    pub fn auth_default() -> Self {
+        Self::from_env("auth_validation", (5, 60, 30))
+    }
+
+    /// Operator-locked defaults for the Stripe usage breaker.
+    #[must_use]
+    pub fn stripe_default() -> Self {
+        Self::from_env("stripe_usage", (3, 60, 60))
+    }
+}
+
+/// Map a circuit name to its env-var prefix.
+///
+/// `auth_validation` → `AUTH` (per locked env var name `PENSYVE_CB_AUTH_*`).
+/// `stripe_usage` → `STRIPE`.
+/// Anything else uppercases the entire name as a safe default.
+fn env_prefix_for(name: &'static str) -> String {
+    match name {
+        "auth_validation" => "AUTH".to_string(),
+        "stripe_usage" => "STRIPE".to_string(),
+        other => other.to_uppercase(),
+    }
+}
+
+fn read_env_u32(var: &str) -> Option<u32> {
+    std::env::var(var).ok().and_then(|s| s.parse().ok())
+}
+
+/// Three states of the breaker.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CircuitState {
+    /// Requests flow normally; failures are counted.
+    Closed,
+    /// Requests are rejected immediately with [`CircuitOpen`].
+    Open,
+    /// A single probe is permitted through; outcome decides next state.
+    HalfOpen,
+}
+
+/// Returned by [`CircuitBreaker::check`] when the circuit is Open. The
+/// caller MUST use its fallback path (cache hit, bounded buffer, etc.)
+/// rather than calling the protected operation.
+#[derive(Debug)]
+pub struct CircuitOpen {
+    pub name: &'static str,
+    pub failures: u32,
+    pub window_secs: u32,
+}
+
+impl std::fmt::Display for CircuitOpen {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "circuit '{}' is open; failed {} times in last {}s",
+            self.name, self.failures, self.window_secs
+        )
+    }
+}
+
+impl std::error::Error for CircuitOpen {}
+
+// ---------------------------------------------------------------------------
+// In-memory fallback state — used when Redis is unavailable, or as the
+// authoritative store for single-instance deployments.
+// ---------------------------------------------------------------------------
+
+#[derive(Debug)]
+struct FallbackState {
+    /// Current state. Transitions are guarded by the parent `Mutex`.
+    state: CircuitState,
+    /// Timestamps of recent failures, oldest-first. Pruned to
+    /// `[now - window_secs, now]` on every read/write.
+    failures: Vec<Instant>,
+    /// Set when the circuit transitions to Open. The next `check()`
+    /// after `opened_at + cooldown_secs` is allowed through as a
+    /// `HalfOpen` probe.
+    opened_at: Option<Instant>,
+}
+
+impl FallbackState {
+    const fn new() -> Self {
+        Self {
+            state: CircuitState::Closed,
+            failures: Vec::new(),
+            opened_at: None,
+        }
+    }
+
+    /// Drop failure timestamps older than `now - window`.
+    fn prune(&mut self, now: Instant, window: Duration) {
+        if let Some(cutoff) = now.checked_sub(window) {
+            self.failures.retain(|t| *t >= cutoff);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Redis key layout
+// ---------------------------------------------------------------------------
+//
+// Per breaker `<name>` we use three keys, all TTL'd:
+//   pensyve:cb:<name>:state    -> "closed" | "open" | "halfopen"
+//                                 (TTL = cooldown_secs when "open"; absent in "closed")
+//   pensyve:cb:<name>:failures -> integer counter (TTL = window_secs)
+//   pensyve:cb:<name>:opened_at-> RFC3339 timestamp (TTL = cooldown_secs)
+//
+// State is derived as: if `state` key is "open" → Open; else if
+// `failures >= threshold` → trip to Open inside the breaker; else Closed.
+// HalfOpen is short-lived (one probe) and only ever held in-memory while
+// the probe is in flight, since Redis cannot atomically express "give one
+// caller a probe, block the rest" without Lua scripting that we want to
+// avoid for this initial cut.
+
+fn redis_state_key(name: &str) -> String {
+    format!("pensyve:cb:{name}:state")
+}
+
+fn redis_failures_key(name: &str) -> String {
+    format!("pensyve:cb:{name}:failures")
+}
+
+fn redis_opened_at_key(name: &str) -> String {
+    format!("pensyve:cb:{name}:opened_at")
+}
+
+/// Maximum time we wait on a Redis call inside a breaker check before
+/// giving up and using in-memory state. The breaker is on the hot path of
+/// every authenticated request; if Redis goes catatonic we MUST NOT
+/// inherit its latency.
+const REDIS_TIMEOUT: Duration = Duration::from_millis(100);
+
+// ---------------------------------------------------------------------------
+// Breaker
+// ---------------------------------------------------------------------------
+
+/// Three-state circuit breaker with optional Redis coordination.
+pub struct CircuitBreaker {
+    config: CircuitBreakerConfig,
+    redis: Option<ConnectionManager>,
+    /// In-memory fallback state — authoritative when `redis` is `None`,
+    /// shadow-tracked alongside Redis otherwise so we never block on
+    /// network IO during `check()`.
+    fallback: Arc<Mutex<FallbackState>>,
+}
+
+impl CircuitBreaker {
+    #[must_use]
+    pub fn new(config: CircuitBreakerConfig, redis: Option<ConnectionManager>) -> Self {
+        tracing::info!(
+            name = config.name,
+            failure_threshold = config.failure_threshold,
+            window_secs = config.window_secs,
+            cooldown_secs = config.cooldown_secs,
+            redis = redis.is_some(),
+            "Circuit breaker initialized"
+        );
+        Self {
+            config,
+            redis,
+            fallback: Arc::new(Mutex::new(FallbackState::new())),
+        }
+    }
+
+    /// Check whether the protected operation should proceed.
+    ///
+    /// Returns `Ok(())` if the circuit is Closed (normal flow), Open's
+    /// cooldown has elapsed (the caller becomes a `HalfOpen` probe), or no
+    /// state is recorded yet. Returns `Err(CircuitOpen)` if the circuit is
+    /// currently Open within its cooldown window.
+    ///
+    /// Performance contract: returns within ~1ms when Redis is healthy,
+    /// and never blocks longer than [`REDIS_TIMEOUT`] (100ms). On Redis
+    /// timeout / error, falls back to in-memory state without raising.
+    pub async fn check(&self) -> Result<(), CircuitOpen> {
+        // Fast path: if Redis says Open within cooldown, reject. Otherwise
+        // consult in-memory state (which may have just transitioned to
+        // Open from a record_failure that hasn't reached Redis yet, e.g.
+        // because Redis is slow).
+        if let Some(mut redis) = self.redis.clone() {
+            let result = tokio::time::timeout(REDIS_TIMEOUT, async {
+                let state: Option<String> =
+                    redis.get(redis_state_key(self.config.name)).await.ok().flatten();
+                state
+            })
+            .await;
+            if let Ok(Some(s)) = result
+                && s == "open"
+            {
+                // Mirror to in-memory so HalfOpen probe logic stays consistent.
+                let mut fb = self.fallback.lock().expect("circuit fallback mutex poisoned");
+                fb.state = CircuitState::Open;
+                if fb.opened_at.is_none() {
+                    fb.opened_at = Some(Instant::now());
+                }
+                return Err(CircuitOpen {
+                    name: self.config.name,
+                    failures: self.config.failure_threshold,
+                    window_secs: self.config.window_secs,
+                });
+            }
+            // Redis says not-open OR Redis timed out — fall through to
+            // in-memory check; it will be authoritative.
+        }
+
+        let now = Instant::now();
+        let cooldown = Duration::from_secs(u64::from(self.config.cooldown_secs));
+        let mut fb = self.fallback.lock().expect("circuit fallback mutex poisoned");
+        match fb.state {
+            CircuitState::Closed | CircuitState::HalfOpen => Ok(()),
+            CircuitState::Open => {
+                // If cooldown has elapsed, transition to HalfOpen and let
+                // this caller act as the probe. Subsequent callers in the
+                // same window will also see HalfOpen and pass — record_*
+                // gates the actual transition back to Closed.
+                if let Some(opened) = fb.opened_at
+                    && now.duration_since(opened) >= cooldown
+                {
+                    tracing::info!(
+                        circuit = self.config.name,
+                        "Cooldown elapsed; entering HalfOpen probe"
+                    );
+                    fb.state = CircuitState::HalfOpen;
+                    fb.opened_at = None;
+                    return Ok(());
+                }
+                Err(CircuitOpen {
+                    name: self.config.name,
+                    failures: u32::try_from(fb.failures.len())
+                        .unwrap_or(self.config.failure_threshold),
+                    window_secs: self.config.window_secs,
+                })
+            }
+        }
+    }
+
+    /// Record a successful operation.
+    ///
+    /// In **Closed** state, clears the failure window so transient blips
+    /// don't accumulate toward the threshold across long-lived gateways.
+    /// In **`HalfOpen`** state, the probe succeeded → transition to
+    /// **Closed** and clear all state.
+    pub async fn record_success(&self) {
+        {
+            let mut fb = self.fallback.lock().expect("circuit fallback mutex poisoned");
+            match fb.state {
+                CircuitState::Closed => {
+                    fb.failures.clear();
+                }
+                CircuitState::HalfOpen => {
+                    tracing::info!(
+                        circuit = self.config.name,
+                        "HalfOpen probe succeeded; closing circuit"
+                    );
+                    fb.state = CircuitState::Closed;
+                    fb.failures.clear();
+                    fb.opened_at = None;
+                }
+                CircuitState::Open => {
+                    // Defensive: a success while marked Open shouldn't
+                    // normally happen (check() would have returned Err),
+                    // but if it does we should heal.
+                    fb.state = CircuitState::Closed;
+                    fb.failures.clear();
+                    fb.opened_at = None;
+                }
+            }
+        }
+
+        if let Some(mut redis) = self.redis.clone() {
+            let _ = tokio::time::timeout(REDIS_TIMEOUT, async {
+                // Best-effort cleanup; failures here are non-fatal.
+                let _: Result<(), _> = redis.del::<_, ()>(redis_state_key(self.config.name)).await;
+                let _: Result<(), _> =
+                    redis.del::<_, ()>(redis_failures_key(self.config.name)).await;
+                let _: Result<(), _> =
+                    redis.del::<_, ()>(redis_opened_at_key(self.config.name)).await;
+            })
+            .await;
+        }
+    }
+
+    /// Record a failed operation.
+    ///
+    /// In **Closed** state, increments the failure counter; if the count
+    /// within `window_secs` reaches `failure_threshold`, transitions to
+    /// **Open** and starts the cooldown.
+    /// In **`HalfOpen`** state, the probe failed → transition back to
+    /// **Open** with a fresh cooldown.
+    pub async fn record_failure(&self) {
+        let now = Instant::now();
+        let window = Duration::from_secs(u64::from(self.config.window_secs));
+        let opened_now: bool;
+        {
+            let mut fb = self.fallback.lock().expect("circuit fallback mutex poisoned");
+            match fb.state {
+                CircuitState::Closed => {
+                    fb.failures.push(now);
+                    fb.prune(now, window);
+                    if u32::try_from(fb.failures.len()).unwrap_or(u32::MAX)
+                        >= self.config.failure_threshold
+                    {
+                        tracing::warn!(
+                            circuit = self.config.name,
+                            failures = fb.failures.len(),
+                            threshold = self.config.failure_threshold,
+                            window_secs = self.config.window_secs,
+                            "Failure threshold reached; opening circuit"
+                        );
+                        fb.state = CircuitState::Open;
+                        fb.opened_at = Some(now);
+                        opened_now = true;
+                    } else {
+                        opened_now = false;
+                    }
+                }
+                CircuitState::HalfOpen => {
+                    tracing::warn!(
+                        circuit = self.config.name,
+                        "HalfOpen probe failed; reopening circuit with fresh cooldown"
+                    );
+                    fb.state = CircuitState::Open;
+                    fb.opened_at = Some(now);
+                    // Clear the failure window so the probe failure
+                    // doesn't double-count against the next Closed window.
+                    fb.failures.clear();
+                    opened_now = true;
+                }
+                CircuitState::Open => {
+                    // Already open — refresh opened_at so the cooldown
+                    // window doesn't expire while the downstream remains
+                    // unhealthy. Note: this means a steady stream of
+                    // failures keeps the circuit open indefinitely, which
+                    // is exactly what we want.
+                    fb.opened_at = Some(now);
+                    opened_now = false;
+                }
+            }
+        }
+
+        if let Some(mut redis) = self.redis.clone() {
+            let name = self.config.name;
+            let window_secs = self.config.window_secs;
+            let cooldown_secs = self.config.cooldown_secs;
+            let _ = tokio::time::timeout(REDIS_TIMEOUT, async {
+                // INCR + EXPIRE without WATCH/Lua is racy across
+                // instances but the worst-case effect is a delayed
+                // transition by one request — acceptable. We refresh the
+                // TTL on every increment so a steady failure stream keeps
+                // the counter alive across the window.
+                if let Ok(count) = redis
+                    .incr::<_, _, i64>(redis_failures_key(name), 1)
+                    .await
+                {
+                    let _: Result<(), _> = redis
+                        .expire::<_, ()>(redis_failures_key(name), i64::from(window_secs))
+                        .await;
+                    if opened_now || count >= i64::from(cooldown_secs) {
+                        // Mark Open in Redis with cooldown TTL so sibling
+                        // pods see the same state.
+                    }
+                }
+                if opened_now {
+                    let _: Result<(), _> = redis
+                        .set_ex::<_, _, ()>(
+                            redis_state_key(name),
+                            "open",
+                            u64::from(cooldown_secs),
+                        )
+                        .await;
+                    let _: Result<(), _> = redis
+                        .set_ex::<_, _, ()>(
+                            redis_opened_at_key(name),
+                            chrono::Utc::now().to_rfc3339(),
+                            u64::from(cooldown_secs),
+                        )
+                        .await;
+                }
+            })
+            .await;
+        }
+    }
+
+    /// Inspect the current in-memory state. Useful for tests and the
+    /// future `/metrics` admin endpoint. Synchronous because the
+    /// authoritative source for this view is the in-memory `FallbackState`
+    /// — Redis is only consulted on `check()` to decide whether to short-
+    /// circuit the request.
+    pub fn current_state(&self) -> CircuitState {
+        let fb = self.fallback.lock().expect("circuit fallback mutex poisoned");
+        fb.state
+    }
+
+    /// Number of failures currently held in the in-memory window. Pruning
+    /// is applied lazily in `record_failure`; this method is intended for
+    /// tests and debug logging only.
+    #[cfg(test)]
+    pub fn failure_count(&self) -> usize {
+        let fb = self.fallback.lock().expect("circuit fallback mutex poisoned");
+        fb.failures.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_config() -> CircuitBreakerConfig {
+        CircuitBreakerConfig {
+            name: "test_breaker",
+            failure_threshold: 3,
+            window_secs: 60,
+            cooldown_secs: 1, // short for fast tests
+        }
+    }
+
+    #[tokio::test]
+    async fn closed_initial_state_allows_requests() {
+        let cb = CircuitBreaker::new(test_config(), None);
+        assert_eq!(cb.current_state(), CircuitState::Closed);
+        assert!(cb.check().await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn failures_below_threshold_keep_circuit_closed() {
+        let cb = CircuitBreaker::new(test_config(), None);
+        cb.record_failure().await;
+        cb.record_failure().await;
+        assert_eq!(cb.current_state(), CircuitState::Closed);
+        assert!(cb.check().await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn threshold_failures_open_circuit() {
+        let cb = CircuitBreaker::new(test_config(), None);
+        cb.record_failure().await;
+        cb.record_failure().await;
+        cb.record_failure().await;
+        assert_eq!(cb.current_state(), CircuitState::Open);
+        let err = cb.check().await.expect_err("circuit should be open");
+        assert_eq!(err.name, "test_breaker");
+    }
+
+    #[tokio::test]
+    async fn cooldown_elapses_transitions_to_halfopen() {
+        let cb = CircuitBreaker::new(test_config(), None);
+        for _ in 0..3 {
+            cb.record_failure().await;
+        }
+        assert_eq!(cb.current_state(), CircuitState::Open);
+
+        // Wait past the 1s cooldown.
+        tokio::time::sleep(Duration::from_millis(1100)).await;
+
+        // Next check should pass the caller through as a HalfOpen probe.
+        assert!(cb.check().await.is_ok());
+        assert_eq!(cb.current_state(), CircuitState::HalfOpen);
+    }
+
+    #[tokio::test]
+    async fn halfopen_success_closes_circuit() {
+        let cb = CircuitBreaker::new(test_config(), None);
+        for _ in 0..3 {
+            cb.record_failure().await;
+        }
+        tokio::time::sleep(Duration::from_millis(1100)).await;
+        assert!(cb.check().await.is_ok());
+        assert_eq!(cb.current_state(), CircuitState::HalfOpen);
+
+        cb.record_success().await;
+        assert_eq!(cb.current_state(), CircuitState::Closed);
+        assert_eq!(cb.failure_count(), 0);
+        // And subsequent requests flow normally.
+        assert!(cb.check().await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn halfopen_failure_reopens_circuit_with_fresh_cooldown() {
+        let cb = CircuitBreaker::new(test_config(), None);
+        for _ in 0..3 {
+            cb.record_failure().await;
+        }
+        tokio::time::sleep(Duration::from_millis(1100)).await;
+        assert!(cb.check().await.is_ok());
+        assert_eq!(cb.current_state(), CircuitState::HalfOpen);
+
+        cb.record_failure().await;
+        assert_eq!(cb.current_state(), CircuitState::Open);
+        assert!(cb.check().await.is_err());
+    }
+
+    #[tokio::test]
+    async fn record_success_clears_failure_counter_in_closed() {
+        let cb = CircuitBreaker::new(test_config(), None);
+        cb.record_failure().await;
+        cb.record_failure().await;
+        assert_eq!(cb.failure_count(), 2);
+        cb.record_success().await;
+        assert_eq!(cb.failure_count(), 0);
+        // Now we should be able to take 2 more failures without tripping.
+        cb.record_failure().await;
+        cb.record_failure().await;
+        assert_eq!(cb.current_state(), CircuitState::Closed);
+    }
+
+    #[tokio::test]
+    async fn record_failure_increments_counter() {
+        let cb = CircuitBreaker::new(test_config(), None);
+        assert_eq!(cb.failure_count(), 0);
+        cb.record_failure().await;
+        assert_eq!(cb.failure_count(), 1);
+        cb.record_failure().await;
+        assert_eq!(cb.failure_count(), 2);
+    }
+
+    #[tokio::test]
+    async fn failures_outside_window_dont_count() {
+        // Tight window: 1 second.
+        let config = CircuitBreakerConfig {
+            name: "window_test",
+            failure_threshold: 3,
+            window_secs: 1,
+            cooldown_secs: 30,
+        };
+        let cb = CircuitBreaker::new(config, None);
+
+        // Two failures, then wait for them to age out.
+        cb.record_failure().await;
+        cb.record_failure().await;
+        tokio::time::sleep(Duration::from_millis(1100)).await;
+
+        // A third failure should NOT trip the circuit because the first
+        // two have aged out of the 1s window.
+        cb.record_failure().await;
+        assert_eq!(cb.current_state(), CircuitState::Closed);
+    }
+
+    #[tokio::test]
+    async fn in_memory_fallback_works_without_redis() {
+        // Same as threshold_failures_open_circuit, just makes the
+        // "redis = None" path explicit and visible in test output.
+        let cb = CircuitBreaker::new(test_config(), None);
+        for _ in 0..3 {
+            cb.record_failure().await;
+        }
+        assert_eq!(cb.current_state(), CircuitState::Open);
+        let err = cb.check().await.expect_err("circuit should be open");
+        assert_eq!(err.failures, 3);
+        assert_eq!(err.window_secs, 60);
+    }
+
+    #[test]
+    fn env_prefix_for_known_circuit_names() {
+        // Locked operator decision: PENSYVE_CB_AUTH_*  / PENSYVE_CB_STRIPE_*.
+        assert_eq!(env_prefix_for("auth_validation"), "AUTH");
+        assert_eq!(env_prefix_for("stripe_usage"), "STRIPE");
+        // Fallback: uppercase the full name.
+        assert_eq!(env_prefix_for("custom_thing"), "CUSTOM_THING");
+    }
+
+    #[test]
+    fn auth_default_env_var_names_match_locked_decision() {
+        // Confirms the env-var name template the operator approved.
+        // Bare comparison via env_prefix_for is sufficient — we test the
+        // var-name shape rather than the runtime read, because mutating
+        // env vars in tests requires `unsafe` (Rust 1.88) and the
+        // workspace lints flag unsafe blocks. The runtime read path is
+        // already exercised in production via the `from_env` constructor
+        // chained from `auth_default`.
+        let prefix = env_prefix_for("auth_validation");
+        assert_eq!(format!("PENSYVE_CB_{prefix}_FAILURE_THRESHOLD"),
+                   "PENSYVE_CB_AUTH_FAILURE_THRESHOLD");
+        assert_eq!(format!("PENSYVE_CB_{prefix}_WINDOW_SECS"),
+                   "PENSYVE_CB_AUTH_WINDOW_SECS");
+        assert_eq!(format!("PENSYVE_CB_{prefix}_COOLDOWN_SECS"),
+                   "PENSYVE_CB_AUTH_COOLDOWN_SECS");
+    }
+
+    #[test]
+    fn stripe_default_env_var_names_match_locked_decision() {
+        let prefix = env_prefix_for("stripe_usage");
+        assert_eq!(format!("PENSYVE_CB_{prefix}_FAILURE_THRESHOLD"),
+                   "PENSYVE_CB_STRIPE_FAILURE_THRESHOLD");
+        assert_eq!(format!("PENSYVE_CB_{prefix}_WINDOW_SECS"),
+                   "PENSYVE_CB_STRIPE_WINDOW_SECS");
+        assert_eq!(format!("PENSYVE_CB_{prefix}_COOLDOWN_SECS"),
+                   "PENSYVE_CB_STRIPE_COOLDOWN_SECS");
+    }
+
+    #[test]
+    fn from_env_returns_defaults_when_vars_unset() {
+        // Use an obviously-unique name so it can't collide with anything
+        // in the runtime environment of the test harness.
+        let cfg = CircuitBreakerConfig::from_env(
+            "phase23_test_circuit_unique_xyz",
+            (5, 60, 30),
+        );
+        assert_eq!(cfg.failure_threshold, 5);
+        assert_eq!(cfg.window_secs, 60);
+        assert_eq!(cfg.cooldown_secs, 30);
+        assert_eq!(cfg.name, "phase23_test_circuit_unique_xyz");
+    }
+
+    #[test]
+    fn defaults_match_operator_locked_values_when_env_unset() {
+        // The auth/stripe env vars are not set in the default test env;
+        // we rely on that here. If a developer sets these locally tests
+        // will skip — that's fine, this assertion is primarily a
+        // documentation check of the locked values 5/60/30 and 3/60/60.
+        if std::env::var("PENSYVE_CB_AUTH_FAILURE_THRESHOLD").is_ok()
+            || std::env::var("PENSYVE_CB_STRIPE_FAILURE_THRESHOLD").is_ok()
+        {
+            // Local override active — bail out rather than reporting
+            // a false failure.
+            return;
+        }
+        let auth = CircuitBreakerConfig::auth_default();
+        assert_eq!(auth.failure_threshold, 5);
+        assert_eq!(auth.window_secs, 60);
+        assert_eq!(auth.cooldown_secs, 30);
+
+        let stripe = CircuitBreakerConfig::stripe_default();
+        assert_eq!(stripe.failure_threshold, 3);
+        assert_eq!(stripe.window_secs, 60);
+        assert_eq!(stripe.cooldown_secs, 60);
+    }
+
+    #[tokio::test]
+    async fn check_returns_quickly_when_redis_absent() {
+        let cb = CircuitBreaker::new(test_config(), None);
+        let start = Instant::now();
+        let _ = cb.check().await;
+        let elapsed = start.elapsed();
+        // No Redis = no IO; should be sub-millisecond. Allow 5ms slack
+        // for slow CI machines.
+        assert!(
+            elapsed < Duration::from_millis(5),
+            "check() took {elapsed:?} without Redis"
+        );
+    }
+}

--- a/pensyve-mcp-gateway/src/circuit_breaker.rs
+++ b/pensyve-mcp-gateway/src/circuit_breaker.rs
@@ -67,8 +67,8 @@ impl CircuitBreakerConfig {
     #[must_use]
     pub fn from_env(name: &'static str, defaults: (u32, u32, u32)) -> Self {
         let prefix = env_prefix_for(name);
-        let failure_threshold = read_env_u32(&format!("PENSYVE_CB_{prefix}_FAILURE_THRESHOLD"))
-            .unwrap_or(defaults.0);
+        let failure_threshold =
+            read_env_u32(&format!("PENSYVE_CB_{prefix}_FAILURE_THRESHOLD")).unwrap_or(defaults.0);
         let window_secs =
             read_env_u32(&format!("PENSYVE_CB_{prefix}_WINDOW_SECS")).unwrap_or(defaults.1);
         let cooldown_secs =
@@ -263,8 +263,11 @@ impl CircuitBreaker {
         // because Redis is slow).
         if let Some(mut redis) = self.redis.clone() {
             let result = tokio::time::timeout(REDIS_TIMEOUT, async {
-                let state: Option<String> =
-                    redis.get(redis_state_key(self.config.name)).await.ok().flatten();
+                let state: Option<String> = redis
+                    .get(redis_state_key(self.config.name))
+                    .await
+                    .ok()
+                    .flatten();
                 state
             })
             .await;
@@ -272,7 +275,10 @@ impl CircuitBreaker {
                 && s == "open"
             {
                 // Mirror to in-memory so HalfOpen probe logic stays consistent.
-                let mut fb = self.fallback.lock().expect("circuit fallback mutex poisoned");
+                let mut fb = self
+                    .fallback
+                    .lock()
+                    .expect("circuit fallback mutex poisoned");
                 fb.state = CircuitState::Open;
                 if fb.opened_at.is_none() {
                     fb.opened_at = Some(Instant::now());
@@ -289,7 +295,10 @@ impl CircuitBreaker {
 
         let now = Instant::now();
         let cooldown = Duration::from_secs(u64::from(self.config.cooldown_secs));
-        let mut fb = self.fallback.lock().expect("circuit fallback mutex poisoned");
+        let mut fb = self
+            .fallback
+            .lock()
+            .expect("circuit fallback mutex poisoned");
         match fb.state {
             CircuitState::Closed | CircuitState::HalfOpen => Ok(()),
             CircuitState::Open => {
@@ -326,7 +335,10 @@ impl CircuitBreaker {
     /// **Closed** and clear all state.
     pub async fn record_success(&self) {
         {
-            let mut fb = self.fallback.lock().expect("circuit fallback mutex poisoned");
+            let mut fb = self
+                .fallback
+                .lock()
+                .expect("circuit fallback mutex poisoned");
             match fb.state {
                 CircuitState::Closed => {
                     fb.failures.clear();
@@ -355,10 +367,12 @@ impl CircuitBreaker {
             let _ = tokio::time::timeout(REDIS_TIMEOUT, async {
                 // Best-effort cleanup; failures here are non-fatal.
                 let _: Result<(), _> = redis.del::<_, ()>(redis_state_key(self.config.name)).await;
-                let _: Result<(), _> =
-                    redis.del::<_, ()>(redis_failures_key(self.config.name)).await;
-                let _: Result<(), _> =
-                    redis.del::<_, ()>(redis_opened_at_key(self.config.name)).await;
+                let _: Result<(), _> = redis
+                    .del::<_, ()>(redis_failures_key(self.config.name))
+                    .await;
+                let _: Result<(), _> = redis
+                    .del::<_, ()>(redis_opened_at_key(self.config.name))
+                    .await;
             })
             .await;
         }
@@ -376,7 +390,10 @@ impl CircuitBreaker {
         let window = Duration::from_secs(u64::from(self.config.window_secs));
         let opened_now: bool;
         {
-            let mut fb = self.fallback.lock().expect("circuit fallback mutex poisoned");
+            let mut fb = self
+                .fallback
+                .lock()
+                .expect("circuit fallback mutex poisoned");
             match fb.state {
                 CircuitState::Closed => {
                     fb.failures.push(now);
@@ -432,10 +449,7 @@ impl CircuitBreaker {
                 // transition by one request — acceptable. We refresh the
                 // TTL on every increment so a steady failure stream keeps
                 // the counter alive across the window.
-                if let Ok(count) = redis
-                    .incr::<_, _, i64>(redis_failures_key(name), 1)
-                    .await
-                {
+                if let Ok(count) = redis.incr::<_, _, i64>(redis_failures_key(name), 1).await {
                     let _: Result<(), _> = redis
                         .expire::<_, ()>(redis_failures_key(name), i64::from(window_secs))
                         .await;
@@ -446,11 +460,7 @@ impl CircuitBreaker {
                 }
                 if opened_now {
                     let _: Result<(), _> = redis
-                        .set_ex::<_, _, ()>(
-                            redis_state_key(name),
-                            "open",
-                            u64::from(cooldown_secs),
-                        )
+                        .set_ex::<_, _, ()>(redis_state_key(name), "open", u64::from(cooldown_secs))
                         .await;
                     let _: Result<(), _> = redis
                         .set_ex::<_, _, ()>(
@@ -471,7 +481,10 @@ impl CircuitBreaker {
     /// — Redis is only consulted on `check()` to decide whether to short-
     /// circuit the request.
     pub fn current_state(&self) -> CircuitState {
-        let fb = self.fallback.lock().expect("circuit fallback mutex poisoned");
+        let fb = self
+            .fallback
+            .lock()
+            .expect("circuit fallback mutex poisoned");
         fb.state
     }
 
@@ -480,7 +493,10 @@ impl CircuitBreaker {
     /// tests and debug logging only.
     #[cfg(test)]
     pub fn failure_count(&self) -> usize {
-        let fb = self.fallback.lock().expect("circuit fallback mutex poisoned");
+        let fb = self
+            .fallback
+            .lock()
+            .expect("circuit fallback mutex poisoned");
         fb.failures.len()
     }
 }
@@ -652,33 +668,42 @@ mod tests {
         // already exercised in production via the `from_env` constructor
         // chained from `auth_default`.
         let prefix = env_prefix_for("auth_validation");
-        assert_eq!(format!("PENSYVE_CB_{prefix}_FAILURE_THRESHOLD"),
-                   "PENSYVE_CB_AUTH_FAILURE_THRESHOLD");
-        assert_eq!(format!("PENSYVE_CB_{prefix}_WINDOW_SECS"),
-                   "PENSYVE_CB_AUTH_WINDOW_SECS");
-        assert_eq!(format!("PENSYVE_CB_{prefix}_COOLDOWN_SECS"),
-                   "PENSYVE_CB_AUTH_COOLDOWN_SECS");
+        assert_eq!(
+            format!("PENSYVE_CB_{prefix}_FAILURE_THRESHOLD"),
+            "PENSYVE_CB_AUTH_FAILURE_THRESHOLD"
+        );
+        assert_eq!(
+            format!("PENSYVE_CB_{prefix}_WINDOW_SECS"),
+            "PENSYVE_CB_AUTH_WINDOW_SECS"
+        );
+        assert_eq!(
+            format!("PENSYVE_CB_{prefix}_COOLDOWN_SECS"),
+            "PENSYVE_CB_AUTH_COOLDOWN_SECS"
+        );
     }
 
     #[test]
     fn stripe_default_env_var_names_match_locked_decision() {
         let prefix = env_prefix_for("stripe_usage");
-        assert_eq!(format!("PENSYVE_CB_{prefix}_FAILURE_THRESHOLD"),
-                   "PENSYVE_CB_STRIPE_FAILURE_THRESHOLD");
-        assert_eq!(format!("PENSYVE_CB_{prefix}_WINDOW_SECS"),
-                   "PENSYVE_CB_STRIPE_WINDOW_SECS");
-        assert_eq!(format!("PENSYVE_CB_{prefix}_COOLDOWN_SECS"),
-                   "PENSYVE_CB_STRIPE_COOLDOWN_SECS");
+        assert_eq!(
+            format!("PENSYVE_CB_{prefix}_FAILURE_THRESHOLD"),
+            "PENSYVE_CB_STRIPE_FAILURE_THRESHOLD"
+        );
+        assert_eq!(
+            format!("PENSYVE_CB_{prefix}_WINDOW_SECS"),
+            "PENSYVE_CB_STRIPE_WINDOW_SECS"
+        );
+        assert_eq!(
+            format!("PENSYVE_CB_{prefix}_COOLDOWN_SECS"),
+            "PENSYVE_CB_STRIPE_COOLDOWN_SECS"
+        );
     }
 
     #[test]
     fn from_env_returns_defaults_when_vars_unset() {
         // Use an obviously-unique name so it can't collide with anything
         // in the runtime environment of the test harness.
-        let cfg = CircuitBreakerConfig::from_env(
-            "phase23_test_circuit_unique_xyz",
-            (5, 60, 30),
-        );
+        let cfg = CircuitBreakerConfig::from_env("phase23_test_circuit_unique_xyz", (5, 60, 30));
         assert_eq!(cfg.failure_threshold, 5);
         assert_eq!(cfg.window_secs, 60);
         assert_eq!(cfg.cooldown_secs, 30);

--- a/pensyve-mcp-gateway/src/circuit_breaker.rs
+++ b/pensyve-mcp-gateway/src/circuit_breaker.rs
@@ -443,22 +443,30 @@ impl CircuitBreaker {
             let name = self.config.name;
             let window_secs = self.config.window_secs;
             let cooldown_secs = self.config.cooldown_secs;
+            let failure_threshold = self.config.failure_threshold;
             let _ = tokio::time::timeout(REDIS_TIMEOUT, async {
                 // INCR + EXPIRE without WATCH/Lua is racy across
                 // instances but the worst-case effect is a delayed
                 // transition by one request — acceptable. We refresh the
                 // TTL on every increment so a steady failure stream keeps
                 // the counter alive across the window.
+                let mut should_mark_open = opened_now;
                 if let Ok(count) = redis.incr::<_, _, i64>(redis_failures_key(name), 1).await {
                     let _: Result<(), _> = redis
                         .expire::<_, ()>(redis_failures_key(name), i64::from(window_secs))
                         .await;
-                    if opened_now || count >= i64::from(cooldown_secs) {
-                        // Mark Open in Redis with cooldown TTL so sibling
-                        // pods see the same state.
+                    // Trip the cluster-wide circuit when the *Redis*
+                    // counter crosses the threshold even if this pod's
+                    // local in-memory state hasn't tripped yet — that's
+                    // how sibling gateway instances pick up failures
+                    // distributed across the fleet.
+                    if count >= i64::from(failure_threshold) {
+                        should_mark_open = true;
                     }
                 }
-                if opened_now {
+                if should_mark_open {
+                    // Mark Open in Redis with cooldown TTL so sibling
+                    // pods see the same state.
                     let _: Result<(), _> = redis
                         .set_ex::<_, _, ()>(redis_state_key(name), "open", u64::from(cooldown_secs))
                         .await;

--- a/pensyve-mcp-gateway/src/lib.rs
+++ b/pensyve-mcp-gateway/src/lib.rs
@@ -10,6 +10,7 @@
 pub mod auth;
 pub mod cache;
 pub mod config;
+pub mod middleware;
 pub mod oauth;
 pub mod rate_limit;
 pub mod rest;

--- a/pensyve-mcp-gateway/src/lib.rs
+++ b/pensyve-mcp-gateway/src/lib.rs
@@ -9,6 +9,7 @@
 
 pub mod auth;
 pub mod cache;
+pub mod circuit_breaker;
 pub mod config;
 pub mod middleware;
 pub mod oauth;

--- a/pensyve-mcp-gateway/src/main.rs
+++ b/pensyve-mcp-gateway/src/main.rs
@@ -22,6 +22,7 @@ use pensyve_mcp_tools::PensyveMcpServer;
 use pensyve_mcp_gateway::auth::{self, AuthContext, AuthLayer};
 use pensyve_mcp_gateway::cache;
 use pensyve_mcp_gateway::config::GatewayConfig;
+use pensyve_mcp_gateway::middleware::tracing::TracingLayer;
 use pensyve_mcp_gateway::oauth;
 use pensyve_mcp_gateway::rate_limit::{self, RateLimitLayer};
 use pensyve_mcp_gateway::rest;
@@ -160,11 +161,22 @@ fn init_resources(config: &GatewayConfig) -> Result<InitResources> {
 }
 
 fn main() -> Result<()> {
+    // JSON formatter with span attributes flattened into each event record
+    // (Phase 23/A): the TracingLayer middleware wraps every request handler
+    // in a span carrying `trace_id` + `span_id` fields, and
+    // `with_current_span(true)` emits those fields on every log line under
+    // the span — giving us `trace_id` / `span_id` columns in CloudWatch
+    // Insights without any per-call-site changes.
+    //
+    // `with_span_list(false)` suppresses the redundant `spans` array; the
+    // current span object alone is what downstream log queries key on.
     tracing_subscriber::fmt()
         .with_env_filter(
             EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
         )
         .json()
+        .with_current_span(true)
+        .with_span_list(false)
         .init();
 
     let config = GatewayConfig::from_env();
@@ -333,6 +345,11 @@ async fn async_main(config: GatewayConfig, res: InitResources) -> Result<()> {
         ))
         .layer(RateLimitLayer::new(app_state.clone()))
         .layer(AuthLayer::new(app_state.clone()))
+        // Tracing layer is added LAST so it sits outermost: it observes
+        // every request before auth/rate-limit, so the trace context is
+        // already in request extensions when auth.rs's `validate_remote`
+        // and the tenant_and_usage middleware run.
+        .layer(TracingLayer::new())
         .with_state(app_state.clone());
 
     // Periodic eviction of stale rate-limit entries.
@@ -511,6 +528,11 @@ async fn tenant_and_usage_middleware(
     next: axum::middleware::Next,
 ) -> axum::response::Response {
     let auth_ctx = req.extensions().get::<AuthContext>().cloned();
+    // W3C trace context (Phase 23/A) populated upstream by TracingLayer.
+    let trace_ctx = req
+        .extensions()
+        .get::<pensyve_mcp_gateway::middleware::tracing::TraceContext>()
+        .cloned();
     // Per-tenant agent_id header (G1/P3d). Malformed UUID → ignored, no error
     // returned to the client (backward compatibility with v2.1.0 callers).
     let agent_id = parse_agent_id_header(req.headers());
@@ -561,6 +583,9 @@ async fn tenant_and_usage_middleware(
                 stripe_customer_id: ctx.stripe_customer_id,
                 tier: usage::OperationTier::Standard,
                 count: 1,
+                traceparent: trace_ctx
+                    .as_ref()
+                    .map(pensyve_mcp_gateway::middleware::tracing::TraceContext::to_header_value),
             });
         }
     }

--- a/pensyve-mcp-gateway/src/main.rs
+++ b/pensyve-mcp-gateway/src/main.rs
@@ -21,6 +21,7 @@ use pensyve_mcp_tools::PensyveMcpServer;
 
 use pensyve_mcp_gateway::auth::{self, AuthContext, AuthLayer};
 use pensyve_mcp_gateway::cache;
+use pensyve_mcp_gateway::circuit_breaker::{CircuitBreaker, CircuitBreakerConfig};
 use pensyve_mcp_gateway::config::GatewayConfig;
 use pensyve_mcp_gateway::middleware::tracing::TracingLayer;
 use pensyve_mcp_gateway::oauth;
@@ -240,6 +241,20 @@ async fn async_main(config: GatewayConfig, res: InitResources) -> Result<()> {
 
     let auth_required = !config.api_keys.is_empty();
 
+    // Phase 23/C: shared circuit breakers for the two known-flaky external
+    // dependencies. Both default to operator-locked thresholds:
+    //   auth:    5 failures / 60s / 30s cooldown
+    //   stripe:  3 failures / 60s / 60s cooldown
+    // Override via PENSYVE_CB_AUTH_*  / PENSYVE_CB_STRIPE_* env vars.
+    let auth_cb = Arc::new(CircuitBreaker::new(
+        CircuitBreakerConfig::auth_default(),
+        redis.clone(),
+    ));
+    let stripe_cb = Arc::new(CircuitBreaker::new(
+        CircuitBreakerConfig::stripe_default(),
+        redis.clone(),
+    ));
+
     // Observation extractor — initialized from `LocalLLMExtractor::from_env()`
     // which reads PENSYVE_EXTRACTOR_URL / PENSYVE_EXTRACTOR_MODEL /
     // PENSYVE_EXTRACTOR_API_KEY. Defaults to qwen3.6-35b-a3b on
@@ -265,9 +280,12 @@ async fn async_main(config: GatewayConfig, res: InitResources) -> Result<()> {
         };
 
     let app_state = Arc::new(AppState {
-        auth: auth::AuthValidator::new(&config),
+        auth: auth::AuthValidator::new(&config).with_circuit_breaker(auth_cb.clone()),
         rate_limiter: rate_limit::RateLimiter::new(config.rate_limit_per_minute),
-        usage_reporter: UsageReporter::new(config.stripe_api_key.clone()),
+        usage_reporter: UsageReporter::new_with_circuit_breaker(
+            config.stripe_api_key.clone(),
+            stripe_cb.clone(),
+        ),
         usage_counter,
         tenant_mgr,
         auth_required,

--- a/pensyve-mcp-gateway/src/main.rs
+++ b/pensyve-mcp-gateway/src/main.rs
@@ -254,7 +254,12 @@ async fn async_main(config: GatewayConfig, res: InitResources) -> Result<()> {
 
     let app_state = Arc::new(AppState {
         auth: auth::AuthValidator::new(&config),
-        rate_limiter: rate_limit::RateLimiter::new(config.rate_limit_per_minute),
+        // Phase 23 Track B: rate limiter is now Redis-backed (when REDIS_URL
+        // is set) with plan-aware daily quotas. Falls back to an in-memory
+        // sliding window when Redis is unavailable. The legacy
+        // `rate_limit_per_minute` config is intentionally no longer wired
+        // through here — limits are sourced from the caller's plan tier.
+        rate_limiter: rate_limit::RateLimiter::new(redis.clone()),
         usage_reporter: UsageReporter::new(config.stripe_api_key.clone()),
         usage_counter,
         tenant_mgr,
@@ -335,17 +340,9 @@ async fn async_main(config: GatewayConfig, res: InitResources) -> Result<()> {
         .layer(AuthLayer::new(app_state.clone()))
         .with_state(app_state.clone());
 
-    // Periodic eviction of stale rate-limit entries.
-    tokio::spawn({
-        let state = app_state.clone();
-        async move {
-            let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(60));
-            loop {
-                interval.tick().await;
-                state.rate_limiter.evict_stale();
-            }
-        }
-    });
+    // Phase 23 Track B: the periodic `evict_stale()` task is gone — Redis
+    // TTLs handle window expiry on the primary path, and the in-memory
+    // fallback prunes entries on read inside `RateLimiter::check_fallback`.
 
     // Background consolidation — runs every PENSYVE_CONSOLIDATION_INTERVAL_SECS (default 6h).
     tokio::spawn({

--- a/pensyve-mcp-gateway/src/middleware/mod.rs
+++ b/pensyve-mcp-gateway/src/middleware/mod.rs
@@ -1,0 +1,9 @@
+//! Gateway middleware modules.
+//!
+//! Houses [`tower::Layer`] / [`tower::Service`] implementations that wrap
+//! the axum router with cross-cutting concerns (W3C distributed tracing,
+//! future request-id propagation, etc.). Auth and rate-limit layers
+//! pre-date this module and continue to live at the crate root for
+//! historical reasons; new middleware should land here.
+
+pub mod tracing;

--- a/pensyve-mcp-gateway/src/middleware/tracing.rs
+++ b/pensyve-mcp-gateway/src/middleware/tracing.rs
@@ -1,0 +1,346 @@
+//! W3C Trace Context propagation middleware.
+//!
+//! Implements the W3C Trace Context specification (`traceparent` header)
+//! to enable cross-service distributed tracing across the Pensyve managed
+//! cloud edge. Without this layer, debugging a request that fans out from
+//! the gateway -> pensyve.com (key validation) -> Stripe (usage metering)
+//! requires manual timestamp correlation across `CloudWatch` log groups.
+//!
+//! Behavior:
+//! 1. Extracts the inbound `traceparent` header (W3C v1, version `00`).
+//! 2. If absent or malformed, generates a new [`TraceContext`] with a
+//!    random `trace_id` + `span_id`.
+//! 3. Inserts the [`TraceContext`] into request extensions so downstream
+//!    handlers and outbound clients (`auth.rs` `validate_remote`,
+//!    `usage.rs` Stripe meter events) can echo it.
+//! 4. Sets up a `tracing::info_span!` carrying `trace_id` + `span_id`
+//!    fields so JSON-formatted log lines emitted while handling the
+//!    request automatically include those identifiers.
+//! 5. Echoes the `traceparent` back on the response so end-to-end clients
+//!    see the trace id used by the gateway (matters when the gateway had
+//!    to generate a new id because the inbound header was absent).
+//!
+//! The W3C spec format is:
+//! ```text
+//! traceparent: <version>-<trace-id>-<parent-id>-<flags>
+//!              00       32 hex      16 hex     2 hex
+//! ```
+//! Example: `00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01`
+
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use axum::body::Body;
+use axum::http::{HeaderMap, HeaderValue, Request, Response};
+use tower::{Layer, Service};
+use tracing::Instrument;
+
+/// Header name for W3C Trace Context propagation.
+pub const TRACEPARENT_HEADER: &str = "traceparent";
+
+/// Parsed W3C `traceparent` header value.
+///
+/// Always v1 (version byte `0x00`). Fields are stored as lowercase hex
+/// strings so they round-trip through `to_header_value` byte-for-byte.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TraceContext {
+    /// W3C trace context version. Always `0x00` for v1.
+    pub version: u8,
+    /// 16-byte trace identifier as 32 lowercase hex chars.
+    pub trace_id: String,
+    /// 8-byte span identifier as 16 lowercase hex chars.
+    /// Named `parent_id` in the W3C spec because for an outbound request
+    /// it represents the parent span's id; the receiver creates a fresh
+    /// `span_id` under this `trace_id`.
+    pub parent_id: String,
+    /// Sampling + future flags. `0x01` = sampled, `0x00` = not sampled.
+    pub flags: u8,
+}
+
+impl TraceContext {
+    /// Generate a new `TraceContext` with a random `trace_id` and `span_id`.
+    ///
+    /// Uses two `uuid::Uuid::v4` values for entropy: the first contributes
+    /// all 16 bytes (32 hex chars) of `trace_id`; the second contributes
+    /// its first 8 bytes (16 hex chars) as the `parent_id`. Sampled by
+    /// default (flags = 0x01) so generated traces are always recorded.
+    #[must_use]
+    pub fn generate() -> Self {
+        let trace_uuid = uuid::Uuid::new_v4();
+        let span_uuid = uuid::Uuid::new_v4();
+        let trace_id = hex::encode(trace_uuid.as_bytes());
+        // Take only the first 8 bytes of the 16-byte UUID for span id.
+        let span_bytes: [u8; 8] = span_uuid.as_bytes()[..8]
+            .try_into()
+            .expect("8-byte slice fits in [u8; 8]");
+        let parent_id = hex::encode(span_bytes);
+        Self {
+            version: 0x00,
+            trace_id,
+            parent_id,
+            flags: 0x01,
+        }
+    }
+
+    /// Format as a W3C `traceparent` header value.
+    #[must_use]
+    pub fn to_header_value(&self) -> String {
+        format!(
+            "{:02x}-{}-{}-{:02x}",
+            self.version, self.trace_id, self.parent_id, self.flags
+        )
+    }
+}
+
+/// Parse a W3C v1 `traceparent` header. Returns `None` on any deviation
+/// from the spec (wrong version, wrong field lengths, non-hex characters,
+/// all-zero ids).
+#[must_use]
+pub fn parse_traceparent(header: &str) -> Option<TraceContext> {
+    // Expected: "00-{32 hex}-{16 hex}-{2 hex}" = 55 bytes.
+    if header.len() != 55 {
+        return None;
+    }
+    let parts: Vec<&str> = header.split('-').collect();
+    if parts.len() != 4 {
+        return None;
+    }
+    let (version_s, trace_id, parent_id, flags_s) = (parts[0], parts[1], parts[2], parts[3]);
+
+    if version_s.len() != 2 || trace_id.len() != 32 || parent_id.len() != 16 || flags_s.len() != 2 {
+        return None;
+    }
+
+    let version = u8::from_str_radix(version_s, 16).ok()?;
+    // W3C v1 only — future versions (`ff` is reserved) are rejected.
+    if version != 0x00 {
+        return None;
+    }
+
+    if !is_lower_hex(trace_id) || !is_lower_hex(parent_id) || !is_hex(flags_s) {
+        return None;
+    }
+
+    // Spec: all-zero trace_id or parent_id is invalid.
+    if trace_id.bytes().all(|b| b == b'0') || parent_id.bytes().all(|b| b == b'0') {
+        return None;
+    }
+
+    let flags = u8::from_str_radix(flags_s, 16).ok()?;
+
+    Some(TraceContext {
+        version,
+        trace_id: trace_id.to_string(),
+        parent_id: parent_id.to_string(),
+        flags,
+    })
+}
+
+fn is_hex(s: &str) -> bool {
+    s.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+/// W3C requires lowercase hex for trace-id and parent-id.
+fn is_lower_hex(s: &str) -> bool {
+    s.bytes()
+        .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+}
+
+/// Extract a [`TraceContext`] from request headers, generating a fresh one
+/// if the header is missing or malformed.
+#[must_use]
+pub fn extract_or_generate(headers: &HeaderMap) -> TraceContext {
+    headers
+        .get(TRACEPARENT_HEADER)
+        .and_then(|v| v.to_str().ok())
+        .and_then(parse_traceparent)
+        .unwrap_or_else(TraceContext::generate)
+}
+
+/// Tower [`Layer`] producing a [`TracingMiddleware`].
+#[derive(Clone, Default)]
+pub struct TracingLayer;
+
+impl TracingLayer {
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl<S> Layer<S> for TracingLayer {
+    type Service = TracingMiddleware<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        TracingMiddleware { inner }
+    }
+}
+
+/// Service wrapper that:
+/// 1. Extracts or generates a [`TraceContext`] from the inbound request.
+/// 2. Inserts it into request extensions for downstream handlers.
+/// 3. Wraps the downstream call in a `tracing::info_span!` carrying
+///    `trace_id` + `span_id` fields, so JSON log records emitted under
+///    this span automatically include those identifiers.
+/// 4. Sets the `traceparent` header on the outbound response.
+#[derive(Clone)]
+pub struct TracingMiddleware<S> {
+    inner: S,
+}
+
+impl<S> Service<Request<Body>> for TracingMiddleware<S>
+where
+    S: Service<Request<Body>, Response = Response<Body>> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut req: Request<Body>) -> Self::Future {
+        // Standard tower middleware pattern: clone first, then swap so the
+        // poll_ready'd instance handles this request.
+        let clone = self.inner.clone();
+        let mut inner = std::mem::replace(&mut self.inner, clone);
+
+        let trace_ctx = extract_or_generate(req.headers());
+        let header_value = trace_ctx.to_header_value();
+
+        // Make the trace context available to downstream handlers
+        // (auth.rs validate_remote, usage.rs Stripe meter events).
+        req.extensions_mut().insert(trace_ctx.clone());
+
+        // Build a span carrying the trace identifiers. Anything logged via
+        // `tracing` while this future is polled inside `.instrument(span)`
+        // gets these fields injected into the JSON log line.
+        let span = tracing::info_span!(
+            "request",
+            trace_id = %trace_ctx.trace_id,
+            span_id = %trace_ctx.parent_id,
+            method = %req.method(),
+            path = %req.uri().path(),
+        );
+
+        Box::pin(
+            async move {
+                let mut response = inner.call(req).await?;
+                // Echo traceparent on the response so callers can correlate
+                // end-to-end. If the inbound request already carried a
+                // traceparent we echo back the same value (round-trip).
+                if let Ok(value) = HeaderValue::from_str(&header_value) {
+                    response.headers_mut().insert(TRACEPARENT_HEADER, value);
+                }
+                Ok(response)
+            }
+            .instrument(span),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::HeaderMap;
+
+    const SAMPLE: &str = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+
+    #[test]
+    fn parse_traceparent_accepts_valid_w3c_v1() {
+        let ctx = parse_traceparent(SAMPLE).expect("valid traceparent");
+        assert_eq!(ctx.version, 0x00);
+        assert_eq!(ctx.trace_id, "4bf92f3577b34da6a3ce929d0e0e4736");
+        assert_eq!(ctx.parent_id, "00f067aa0ba902b7");
+        assert_eq!(ctx.flags, 0x01);
+        // Round-trip through the formatter.
+        assert_eq!(ctx.to_header_value(), SAMPLE);
+    }
+
+    #[test]
+    fn parse_traceparent_rejects_wrong_version() {
+        // 01- is reserved; ff- is forbidden by the spec.
+        let bad = "01-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+        assert!(parse_traceparent(bad).is_none());
+        let bad_ff = "ff-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+        assert!(parse_traceparent(bad_ff).is_none());
+    }
+
+    #[test]
+    fn parse_traceparent_rejects_too_short() {
+        assert!(parse_traceparent("00-abc-def-01").is_none());
+        assert!(parse_traceparent("").is_none());
+    }
+
+    #[test]
+    fn parse_traceparent_rejects_non_hex_chars() {
+        // 'z' is not a hex digit.
+        let bad = "00-zbf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+        assert!(parse_traceparent(bad).is_none());
+    }
+
+    #[test]
+    fn parse_traceparent_rejects_uppercase_trace_id() {
+        // W3C v1 requires lowercase hex.
+        let bad = "00-4BF92F3577B34DA6A3CE929D0E0E4736-00f067aa0ba902b7-01";
+        assert!(parse_traceparent(bad).is_none());
+    }
+
+    #[test]
+    fn parse_traceparent_rejects_all_zero_ids() {
+        let bad_trace = "00-00000000000000000000000000000000-00f067aa0ba902b7-01";
+        assert!(parse_traceparent(bad_trace).is_none());
+        let bad_span = "00-4bf92f3577b34da6a3ce929d0e0e4736-0000000000000000-01";
+        assert!(parse_traceparent(bad_span).is_none());
+    }
+
+    #[test]
+    fn generate_produces_valid_hex_lengths() {
+        let ctx = TraceContext::generate();
+        assert_eq!(ctx.version, 0x00);
+        assert_eq!(ctx.trace_id.len(), 32);
+        assert_eq!(ctx.parent_id.len(), 16);
+        assert!(is_lower_hex(&ctx.trace_id));
+        assert!(is_lower_hex(&ctx.parent_id));
+        // Generated traces should round-trip through the parser.
+        let header = ctx.to_header_value();
+        let reparsed = parse_traceparent(&header).expect("generated values round-trip");
+        assert_eq!(ctx, reparsed);
+    }
+
+    #[test]
+    fn generate_produces_unique_ids() {
+        let a = TraceContext::generate();
+        let b = TraceContext::generate();
+        assert_ne!(a.trace_id, b.trace_id);
+        assert_ne!(a.parent_id, b.parent_id);
+    }
+
+    #[test]
+    fn extract_or_generate_preserves_valid_inbound_header() {
+        let mut headers = HeaderMap::new();
+        headers.insert(TRACEPARENT_HEADER, SAMPLE.parse().expect("valid"));
+        let ctx = extract_or_generate(&headers);
+        assert_eq!(ctx.to_header_value(), SAMPLE);
+    }
+
+    #[test]
+    fn extract_or_generate_creates_new_when_missing() {
+        let headers = HeaderMap::new();
+        let ctx = extract_or_generate(&headers);
+        // Generated values must parse cleanly per the spec.
+        let header = ctx.to_header_value();
+        assert!(parse_traceparent(&header).is_some());
+    }
+
+    #[test]
+    fn extract_or_generate_creates_new_when_malformed() {
+        let mut headers = HeaderMap::new();
+        headers.insert(TRACEPARENT_HEADER, "not-a-valid-traceparent".parse().expect("valid"));
+        let ctx = extract_or_generate(&headers);
+        assert_ne!(ctx.to_header_value(), "not-a-valid-traceparent");
+        assert!(parse_traceparent(&ctx.to_header_value()).is_some());
+    }
+}

--- a/pensyve-mcp-gateway/src/middleware/tracing.rs
+++ b/pensyve-mcp-gateway/src/middleware/tracing.rs
@@ -338,7 +338,10 @@ mod tests {
     #[test]
     fn extract_or_generate_creates_new_when_malformed() {
         let mut headers = HeaderMap::new();
-        headers.insert(TRACEPARENT_HEADER, "not-a-valid-traceparent".parse().expect("valid"));
+        headers.insert(
+            TRACEPARENT_HEADER,
+            "not-a-valid-traceparent".parse().expect("valid"),
+        );
         let ctx = extract_or_generate(&headers);
         assert_ne!(ctx.to_header_value(), "not-a-valid-traceparent");
         assert!(parse_traceparent(&ctx.to_header_value()).is_some());

--- a/pensyve-mcp-gateway/src/rate_limit.rs
+++ b/pensyve-mcp-gateway/src/rate_limit.rs
@@ -1,83 +1,359 @@
+//! Plan-aware rate limiting for the Pensyve managed cloud gateway.
+//!
+//! Phase 23 Track B replaces the original DashMap-only sliding-window
+//! limiter with a Redis-backed implementation that scales horizontally
+//! across multiple gateway instances and adds plan-tier-aware daily
+//! operation quotas. A Lua script performs the per-minute window pruning,
+//! quota INCR, and atomic check-and-allow under a single round trip so
+//! concurrent gateway replicas cannot race past their plan limit.
+//!
+//! When `REDIS_URL` is unset or Redis becomes unreachable mid-flight, the
+//! limiter falls back to an in-memory `DashMap` sliding window. The
+//! fallback path enforces only the per-minute RPM check (daily quota is
+//! skipped) and emits a single warning per process so operators are aware
+//! the cluster is running in degraded mode.
+
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::task::{Context, Poll};
 
 use axum::body::Body;
-use axum::http::{Request, Response, StatusCode};
+use axum::http::{HeaderValue, Request, Response, StatusCode};
+use chrono::Utc;
 use dashmap::DashMap;
+use redis::Script;
+use redis::aio::ConnectionManager;
 use tower::{Layer, Service};
 
 use crate::AppState;
 use crate::auth::AuthContext;
 
-/// In-memory sliding window rate limiter per API key.
+/// Plan-tier limits, keyed by the `plan` string returned from auth.
 ///
-/// For production with multiple instances, this would be replaced with
-/// Redis-backed rate limiting (same algorithm as pensyve-cloud's proxy.ts).
+/// Locked operator decision (2026-05-07):
+///   `free`       — 30 RPM,   1 000 daily ops
+///   `business`   — 300 RPM,  50 000 daily ops
+///   `enterprise` — unlimited
+///   unknown plan — most restrictive (free) for safety
+#[derive(Debug, Clone, Copy)]
+pub struct PlanLimits;
+
+impl PlanLimits {
+    #[must_use]
+    pub fn for_plan(plan: &str) -> Limits {
+        // Unknown plan strings collapse to `free` for safety — keeps an
+        // honest bound on consumption if a new plan is introduced
+        // upstream without the gateway being redeployed.
+        match plan {
+            "business" => Limits {
+                rpm: 300,
+                daily: 50_000,
+            },
+            "enterprise" => Limits::unlimited(),
+            // "free" and unknown plan strings.
+            _ => Limits {
+                rpm: 30,
+                daily: 1_000,
+            },
+        }
+    }
+}
+
+/// Resolved per-tenant limit pair.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Limits {
+    pub rpm: u32,
+    pub daily: u32,
+}
+
+impl Limits {
+    /// Sentinel for the `enterprise` tier — never blocks. We use
+    /// `u32::MAX` rather than an `Option<u32>` so the comparison logic
+    /// stays branch-free in the hot path and the Lua script's `tonumber`
+    /// can still read it as an integer.
+    #[must_use]
+    pub const fn unlimited() -> Self {
+        Self {
+            rpm: u32::MAX,
+            daily: u32::MAX,
+        }
+    }
+
+    /// `true` when this tier should bypass enforcement entirely.
+    #[must_use]
+    pub const fn is_unlimited(self) -> bool {
+        self.rpm == u32::MAX && self.daily == u32::MAX
+    }
+}
+
+/// Outcome of a rate-limit check. The middleware copies these fields into
+/// response headers so callers can self-throttle without needing a
+/// follow-up request.
+#[derive(Debug, Clone, Copy)]
+pub struct CheckOutcome {
+    pub allowed: bool,
+    pub rpm_limit: u32,
+    pub rpm_remaining: u32,
+    /// Seconds until the per-minute window rolls over.
+    pub rpm_reset_seconds: u32,
+    pub daily_limit: u32,
+    pub daily_remaining: u32,
+    /// Seconds until the day boundary (UTC midnight) resets the quota.
+    pub daily_reset_seconds: u32,
+    /// `Some(seconds)` only when `allowed == false`. Tracks the more
+    /// pressing of the two windows so clients see a useful Retry-After.
+    pub retry_after_seconds: Option<u32>,
+}
+
+impl CheckOutcome {
+    /// Outcome used for unlimited (enterprise) tenants. Daily/rpm fields
+    /// are populated with `u32::MAX` so middleware can still emit headers
+    /// without special-casing the unlimited path.
+    fn unlimited(now_secs: u64) -> Self {
+        Self {
+            allowed: true,
+            rpm_limit: u32::MAX,
+            rpm_remaining: u32::MAX,
+            rpm_reset_seconds: 60,
+            daily_limit: u32::MAX,
+            daily_remaining: u32::MAX,
+            daily_reset_seconds: seconds_until_utc_midnight(now_secs),
+            retry_after_seconds: None,
+        }
+    }
+}
+
+/// In-memory bucket used by the fallback path. Stored in a `DashMap`
+/// keyed by `tenant_id`. Daily counters are intentionally NOT tracked here —
+/// without Redis there's no shared store across replicas, so daily
+/// quotas would either over- or under-count depending on routing.
+#[derive(Debug, Default)]
+struct FallbackBucket {
+    /// Unix-second timestamps for the sliding minute window.
+    timestamps: Vec<u64>,
+}
+
+/// Plan-aware rate limiter. See module docs for the full contract.
 pub struct RateLimiter {
-    /// Max requests per minute per key.
-    max_rpm: u32,
-    /// Tracks request timestamps per key: `key_id` -> Vec<`timestamp_ms`>.
-    windows: DashMap<String, Vec<u64>>,
+    redis: Option<ConnectionManager>,
+    /// In-memory fallback when Redis is unavailable or fails mid-flight.
+    fallback: Arc<DashMap<String, FallbackBucket>>,
+    /// Compiled Lua script — cached on the server via EVALSHA after the
+    /// first call. The redis crate's `Script` handles NOSCRIPT recovery
+    /// for us, so we just keep a single `Arc<Script>`.
+    script: Arc<Script>,
+    /// One-shot flag so the "Redis unavailable, falling back to memory"
+    /// warning only fires once per process even under sustained failure.
+    fallback_warned: Arc<AtomicBool>,
 }
 
 impl RateLimiter {
-    pub fn new(max_rpm: u32) -> Self {
+    #[must_use]
+    pub fn new(redis: Option<ConnectionManager>) -> Self {
         Self {
-            max_rpm,
-            windows: DashMap::new(),
+            redis,
+            fallback: Arc::new(DashMap::new()),
+            script: Arc::new(Script::new(RATE_LIMIT_LUA)),
+            fallback_warned: Arc::new(AtomicBool::new(false)),
         }
     }
 
-    /// Check if a request is allowed. Returns `true` if under the limit.
-    pub fn check(&self, key_id: &str) -> bool {
-        let now = now_ms();
-        let window_start = now.saturating_sub(60_000);
+    /// Atomic check-and-increment against the tenant's per-minute and
+    /// per-day budget. Returns a populated [`CheckOutcome`] suitable for
+    /// header emission and 429 short-circuiting.
+    pub async fn check(&self, tenant_id: &str, plan: &str) -> CheckOutcome {
+        let limits = PlanLimits::for_plan(plan);
+        let now_secs = unix_seconds();
 
-        let mut entry = self.windows.entry(key_id.to_string()).or_default();
-        let timestamps = entry.value_mut();
-
-        // Prune expired timestamps.
-        timestamps.retain(|&ts| ts > window_start);
-
-        if timestamps.len() >= self.max_rpm as usize {
-            return false;
+        if limits.is_unlimited() {
+            return CheckOutcome::unlimited(now_secs);
         }
 
-        timestamps.push(now);
-        true
-    }
-
-    /// Get remaining requests for a key in the current window.
-    pub fn remaining(&self, key_id: &str) -> u32 {
-        let now = now_ms();
-        let window_start = now.saturating_sub(60_000);
-
-        match self.windows.get_mut(key_id) {
-            Some(mut entry) => {
-                let timestamps = entry.value_mut();
-                // Prune on read too, so counts are accurate and memory is reclaimed.
-                timestamps.retain(|&ts| ts > window_start);
-                self.max_rpm.saturating_sub(timestamps.len() as u32)
+        if let Some(conn) = self.redis.as_ref() {
+            match self.check_redis(conn, tenant_id, limits, now_secs).await {
+                Ok(outcome) => return outcome,
+                Err(e) => {
+                    // Warn once per process, not once per request.
+                    if self.fallback_warned.swap(true, Ordering::Relaxed) {
+                        tracing::debug!(error = %e, "Rate limit Redis call failed; using fallback");
+                    } else {
+                        tracing::warn!(
+                            error = %e,
+                            "Rate limiter falling back to in-memory; daily quota NOT enforced"
+                        );
+                    }
+                    // Fall through to the in-memory path.
+                }
             }
-            None => self.max_rpm,
         }
+
+        self.check_fallback(tenant_id, limits, now_secs)
     }
 
-    /// Remove entries with no recent activity. Call periodically to bound memory.
-    pub fn evict_stale(&self) {
-        let window_start = now_ms().saturating_sub(60_000);
-        self.windows.retain(|_, timestamps| {
-            timestamps.retain(|&ts| ts > window_start);
-            !timestamps.is_empty()
-        });
+    /// Redis-backed path. Single Lua call that prunes the sliding window,
+    /// counts entries, increments the daily counter, and either commits
+    /// or rolls back depending on whether the request is permitted.
+    async fn check_redis(
+        &self,
+        conn: &ConnectionManager,
+        tenant_id: &str,
+        limits: Limits,
+        now_secs: u64,
+    ) -> Result<CheckOutcome, redis::RedisError> {
+        // Per-minute key uses a single rolling key per tenant — the Lua
+        // script prunes by score so we don't need to bucket by minute.
+        let rpm_key = format!("rl:{tenant_id}");
+        let today = Utc::now().format("%Y-%m-%d").to_string();
+        let quota_key = format!("quota:{tenant_id}:{today}");
+
+        // ScriptInvocation is held briefly and consumed by invoke_async.
+        let mut conn = conn.clone();
+        let mut inv = self.script.prepare_invoke();
+        inv.key(&rpm_key)
+            .key(&quota_key)
+            .arg(limits.rpm)
+            .arg(limits.daily)
+            .arg(now_secs);
+
+        // Lua returns: { allowed (0|1), rpm_count, daily_count, retry_after }
+        let result: (i64, i64, i64, i64) = inv.invoke_async(&mut conn).await?;
+        let (allowed, rpm_count, daily_count, retry_after) = result;
+
+        let rpm_count_u = u32::try_from(rpm_count.max(0)).unwrap_or(u32::MAX);
+        let daily_count_u = u32::try_from(daily_count.max(0)).unwrap_or(u32::MAX);
+        let allowed = allowed == 1;
+
+        Ok(CheckOutcome {
+            allowed,
+            rpm_limit: limits.rpm,
+            rpm_remaining: limits.rpm.saturating_sub(rpm_count_u),
+            rpm_reset_seconds: 60,
+            daily_limit: limits.daily,
+            daily_remaining: limits.daily.saturating_sub(daily_count_u),
+            daily_reset_seconds: seconds_until_utc_midnight(now_secs),
+            retry_after_seconds: if allowed {
+                None
+            } else {
+                Some(u32::try_from(retry_after.max(1)).unwrap_or(60))
+            },
+        })
+    }
+
+    /// Pure in-memory path. Implements the same sliding-minute semantics
+    /// as the Redis script, minus the daily quota (see module docs).
+    fn check_fallback(&self, tenant_id: &str, limits: Limits, now_secs: u64) -> CheckOutcome {
+        let mut entry = self.fallback.entry(tenant_id.to_string()).or_default();
+        let bucket = entry.value_mut();
+        let window_start = now_secs.saturating_sub(60);
+        bucket.timestamps.retain(|&ts| ts > window_start);
+
+        let count = bucket.timestamps.len() as u32;
+        let allowed = count < limits.rpm;
+        if allowed {
+            bucket.timestamps.push(now_secs);
+        }
+
+        CheckOutcome {
+            allowed,
+            rpm_limit: limits.rpm,
+            rpm_remaining: limits
+                .rpm
+                .saturating_sub(if allowed { count + 1 } else { count }),
+            rpm_reset_seconds: 60,
+            // Daily quota is not enforced on the fallback path — surface
+            // the configured limit but pretend the full quota remains so
+            // honest clients keep working through a Redis outage.
+            daily_limit: limits.daily,
+            daily_remaining: limits.daily,
+            daily_reset_seconds: seconds_until_utc_midnight(now_secs),
+            retry_after_seconds: if allowed {
+                None
+            } else {
+                // Earliest moment the oldest entry leaves the window.
+                let oldest = bucket.timestamps.first().copied().unwrap_or(now_secs);
+                let wait = (oldest + 60).saturating_sub(now_secs).max(1);
+                Some(u32::try_from(wait).unwrap_or(60))
+            },
+        }
     }
 }
 
-fn now_ms() -> u64 {
+/// Lua script for atomic rate-limit check-and-increment.
+///
+///   `KEYS[1]` = `rl:{tenant_id}`              — sorted set of unix-second
+///                                                timestamps for the rolling
+///                                                minute window.
+///   `KEYS[2]` = `quota:{tenant_id}:{YYYY-MM-DD}` — daily op counter.
+///   `ARGV[1]` = `rpm_limit`
+///   `ARGV[2]` = `daily_limit`
+///   `ARGV[3]` = `current_unix_seconds`
+///
+/// Returns `{ allowed, rpm_count, daily_count, retry_after_seconds }`.
+///
+/// The daily INCR happens unconditionally so the request is "reserved";
+/// if either limit is breached we DECR to roll back. That keeps the
+/// script's three top-level branches symmetric and avoids an extra
+/// ZCARD-then-INCR-then-DECR shuffle. Daily TTL is 48 h so a key never
+/// outlives its UTC day even with clock skew across replicas.
+const RATE_LIMIT_LUA: &str = r"
+local rpm_key = KEYS[1]
+local quota_key = KEYS[2]
+local rpm_limit = tonumber(ARGV[1])
+local daily_limit = tonumber(ARGV[2])
+local now = tonumber(ARGV[3])
+local window_start = now - 60
+
+-- Prune entries outside the rolling minute window.
+redis.call('ZREMRANGEBYSCORE', rpm_key, 0, window_start)
+local rpm_count = tonumber(redis.call('ZCARD', rpm_key))
+
+-- Reserve a slot in the daily counter; we'll roll back if denied.
+local daily_count = tonumber(redis.call('INCR', quota_key))
+redis.call('EXPIRE', quota_key, 172800)
+
+if rpm_count >= rpm_limit then
+    -- Roll back the daily INCR — the request is not permitted.
+    redis.call('DECR', quota_key)
+    -- Retry-After: time until the oldest entry leaves the window.
+    local oldest = redis.call('ZRANGE', rpm_key, 0, 0, 'WITHSCORES')
+    local retry = 60
+    if oldest[2] then
+        retry = math.max(1, math.ceil((tonumber(oldest[2]) + 60) - now))
+    end
+    return {0, rpm_count, daily_count - 1, retry}
+end
+
+if daily_count > daily_limit then
+    -- Roll back so concurrent denials don't drift the counter upward.
+    redis.call('DECR', quota_key)
+    -- Retry-After is time until UTC midnight.
+    local secs_today = now % 86400
+    local retry = math.max(1, 86400 - secs_today)
+    return {0, rpm_count, daily_count - 1, retry}
+end
+
+-- Permitted: stamp the request into the sliding window.
+-- Use a `now:incr` member so duplicate timestamps from concurrent
+-- requests don't collapse into a single ZSET entry.
+local member = tostring(now) .. ':' .. tostring(redis.call('INCR', rpm_key .. ':seq'))
+redis.call('EXPIRE', rpm_key .. ':seq', 120)
+redis.call('ZADD', rpm_key, now, member)
+redis.call('EXPIRE', rpm_key, 120)
+return {1, rpm_count + 1, daily_count, 0}
+";
+
+/// Seconds since the unix epoch.
+fn unix_seconds() -> u64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
-        .as_millis() as u64
+        .as_secs()
+}
+
+/// Seconds remaining until the next UTC midnight from `now_secs`.
+fn seconds_until_utc_midnight(now_secs: u64) -> u32 {
+    let secs_into_day = now_secs % 86_400;
+    u32::try_from(86_400 - secs_into_day).unwrap_or(86_400)
 }
 
 #[derive(Clone)]
@@ -134,26 +410,63 @@ where
                 return inner.call(req).await;
             }
 
-            // Get the authenticated key_id from request extensions.
-            let key_id = req
-                .extensions()
-                .get::<AuthContext>()
-                .map_or_else(|| "anonymous".to_string(), |ctx| ctx.key_id.clone());
+            // Resolve `(tenant_id, plan)` from the auth context attached
+            // upstream by `AuthLayer`. Anonymous traffic (no auth) gets
+            // bucketed under a shared key with the most restrictive
+            // tier — auth-failure paths should already have returned 401
+            // before reaching here, so this is mostly belt-and-suspenders.
+            let (tenant_id, plan) = req.extensions().get::<AuthContext>().map_or_else(
+                || ("anonymous".to_string(), "free".to_string()),
+                |ctx| {
+                    let tenant = ctx.user_id.clone().unwrap_or_else(|| ctx.key_id.clone());
+                    (tenant, ctx.plan.clone())
+                },
+            );
 
-            if !state.rate_limiter.check(&key_id) {
-                let body = Body::from(
-                    r#"{"error":"rate_limited","message":"Too many requests. Please retry later.","retryAfter":60}"#,
-                );
-                return Ok(Response::builder()
-                    .status(StatusCode::TOO_MANY_REQUESTS)
-                    .header("content-type", "application/json")
-                    .header("retry-after", "60")
-                    .body(body)
-                    .expect("valid response"));
+            let outcome = state.rate_limiter.check(&tenant_id, &plan).await;
+
+            if !outcome.allowed {
+                return Ok(deny_response(&outcome));
             }
 
-            inner.call(req).await
+            // Pass the request through, then layer the X-RateLimit-* and
+            // X-Quota-* headers onto the upstream response.
+            let mut response = inner.call(req).await?;
+            apply_headers(response.headers_mut(), &outcome);
+            Ok(response)
         })
+    }
+}
+
+/// Build a 429 response with all rate-limit / retry headers populated.
+fn deny_response(outcome: &CheckOutcome) -> Response<Body> {
+    let retry_after = outcome.retry_after_seconds.unwrap_or(60);
+    let body = Body::from(format!(
+        r#"{{"error":"rate_limited","message":"Too many requests. Please retry later.","retryAfter":{retry_after}}}"#
+    ));
+    let mut resp = Response::builder()
+        .status(StatusCode::TOO_MANY_REQUESTS)
+        .header("content-type", "application/json")
+        .header("retry-after", retry_after.to_string())
+        .body(body)
+        .expect("valid response");
+    apply_headers(resp.headers_mut(), outcome);
+    resp
+}
+
+/// Stamp the standard rate-limit / quota headers onto a response.
+fn apply_headers(headers: &mut axum::http::HeaderMap, outcome: &CheckOutcome) {
+    insert(headers, "x-ratelimit-limit", outcome.rpm_limit);
+    insert(headers, "x-ratelimit-remaining", outcome.rpm_remaining);
+    insert(headers, "x-ratelimit-reset", outcome.rpm_reset_seconds);
+    insert(headers, "x-quota-daily-limit", outcome.daily_limit);
+    insert(headers, "x-quota-daily-remaining", outcome.daily_remaining);
+    insert(headers, "x-quota-daily-reset", outcome.daily_reset_seconds);
+}
+
+fn insert(headers: &mut axum::http::HeaderMap, name: &'static str, value: u32) {
+    if let Ok(v) = HeaderValue::from_str(&value.to_string()) {
+        headers.insert(name, v);
     }
 }
 
@@ -161,40 +474,160 @@ where
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_rate_limiter_allows_under_limit() {
-        let limiter = RateLimiter::new(10);
-        for _ in 0..10 {
-            assert!(limiter.check("key1"));
+    fn limiter() -> RateLimiter {
+        // Redis = None forces the in-memory fallback path for unit tests.
+        RateLimiter::new(None)
+    }
+
+    #[tokio::test]
+    async fn test_rpm_in_memory_fallback() {
+        let rl = limiter();
+        // Free tier — 30 RPM. Issue 30 requests, all allowed.
+        for _ in 0..30 {
+            let outcome = rl.check("tenant_a", "free").await;
+            assert!(outcome.allowed, "in-memory fallback should allow under 30");
+        }
+        // 31st request blocks.
+        let outcome = rl.check("tenant_a", "free").await;
+        assert!(!outcome.allowed, "31st request should be denied");
+        assert!(outcome.retry_after_seconds.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_rpm_respects_plan_limit_free() {
+        let rl = limiter();
+        for i in 0..30 {
+            assert!(
+                rl.check("u_free", "free").await.allowed,
+                "free tier req #{} should pass",
+                i + 1
+            );
+        }
+        assert!(
+            !rl.check("u_free", "free").await.allowed,
+            "free tier req #31 should fail"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_rpm_respects_plan_limit_business() {
+        let rl = limiter();
+        // Business tier has 10x the free RPM (300 vs 30).
+        // Verify the 31st request still passes — this would have failed
+        // under the old single-limit implementation.
+        for i in 0..50 {
+            assert!(
+                rl.check("u_biz", "business").await.allowed,
+                "business tier req #{} should pass",
+                i + 1
+            );
         }
     }
 
-    #[test]
-    fn test_rate_limiter_blocks_over_limit() {
-        let limiter = RateLimiter::new(5);
+    #[tokio::test]
+    async fn test_plan_enterprise_unlimited() {
+        let rl = limiter();
+        // Burst beyond every other tier's RPM limit. Enterprise must
+        // never block, regardless of count.
+        for _ in 0..1_000 {
+            let outcome = rl.check("u_ent", "enterprise").await;
+            assert!(outcome.allowed);
+            assert_eq!(outcome.rpm_limit, u32::MAX);
+            assert_eq!(outcome.daily_limit, u32::MAX);
+            assert!(outcome.retry_after_seconds.is_none());
+        }
+    }
+
+    #[tokio::test]
+    async fn test_response_headers_populated() {
+        let rl = limiter();
+        let outcome = rl.check("u_hdr", "free").await;
+        assert!(outcome.allowed);
+        assert_eq!(outcome.rpm_limit, 30);
+        assert_eq!(outcome.rpm_remaining, 29);
+        assert_eq!(outcome.rpm_reset_seconds, 60);
+        assert_eq!(outcome.daily_limit, 1_000);
+        // Daily quota is not tracked in the fallback path, so remaining
+        // equals limit (we surface "no enforcement" rather than "0 used").
+        assert_eq!(outcome.daily_remaining, 1_000);
+        assert!(outcome.daily_reset_seconds <= 86_400);
+    }
+
+    #[tokio::test]
+    async fn test_429_retry_after_header() {
+        let rl = limiter();
+        for _ in 0..30 {
+            rl.check("u_retry", "free").await;
+        }
+        let outcome = rl.check("u_retry", "free").await;
+        assert!(!outcome.allowed);
+        let retry = outcome.retry_after_seconds.expect("denied → retry_after");
+        assert!(
+            (1..=60).contains(&retry),
+            "retry should be 1..=60, got {retry}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_grace_period_on_redis_failure() {
+        // Redis = None simulates "Redis configured but every call fails".
+        // The limiter must continue serving traffic via the in-memory path
+        // and only emit ONE warning across many requests.
+        let rl = limiter();
         for _ in 0..5 {
-            assert!(limiter.check("key1"));
+            let outcome = rl.check("u_grace", "free").await;
+            assert!(outcome.allowed);
         }
-        assert!(!limiter.check("key1"));
+    }
+
+    #[tokio::test]
+    async fn test_separate_tenants_have_independent_buckets() {
+        let rl = limiter();
+        for _ in 0..30 {
+            assert!(rl.check("tenant_x", "free").await.allowed);
+        }
+        // tenant_x is now exhausted, but tenant_y still has full budget.
+        assert!(!rl.check("tenant_x", "free").await.allowed);
+        assert!(rl.check("tenant_y", "free").await.allowed);
     }
 
     #[test]
-    fn test_rate_limiter_separate_keys() {
-        let limiter = RateLimiter::new(2);
-        assert!(limiter.check("key1"));
-        assert!(limiter.check("key1"));
-        assert!(!limiter.check("key1"));
-        // Different key should still have quota.
-        assert!(limiter.check("key2"));
-        assert!(limiter.check("key2"));
-        assert!(!limiter.check("key2"));
+    fn test_plan_limits_lookup() {
+        assert_eq!(PlanLimits::for_plan("free").rpm, 30);
+        assert_eq!(PlanLimits::for_plan("free").daily, 1_000);
+        assert_eq!(PlanLimits::for_plan("business").rpm, 300);
+        assert_eq!(PlanLimits::for_plan("business").daily, 50_000);
+        assert!(PlanLimits::for_plan("enterprise").is_unlimited());
+        // Unknown plan must collapse to the most restrictive (free).
+        assert_eq!(PlanLimits::for_plan("nonexistent_tier").rpm, 30);
+        assert_eq!(PlanLimits::for_plan("").rpm, 30);
     }
 
     #[test]
-    fn test_rate_limiter_remaining() {
-        let limiter = RateLimiter::new(10);
-        assert_eq!(limiter.remaining("key1"), 10);
-        limiter.check("key1");
-        assert_eq!(limiter.remaining("key1"), 9);
+    fn test_seconds_until_utc_midnight() {
+        // Pin a "now" at 2024-01-01 00:00:00 UTC: full day remains.
+        let new_year = 1_704_067_200;
+        assert_eq!(seconds_until_utc_midnight(new_year), 86_400);
+        // 1 second before midnight: 1 second remains.
+        assert_eq!(seconds_until_utc_midnight(new_year + 86_399), 1);
+        // Halfway through the day: 12 h remains.
+        assert_eq!(seconds_until_utc_midnight(new_year + 43_200), 43_200);
+    }
+
+    #[test]
+    fn test_unlimited_outcome_has_max_remaining() {
+        let outcome = CheckOutcome::unlimited(unix_seconds());
+        assert!(outcome.allowed);
+        assert_eq!(outcome.rpm_remaining, u32::MAX);
+        assert_eq!(outcome.daily_remaining, u32::MAX);
+        assert!(outcome.retry_after_seconds.is_none());
+    }
+
+    #[test]
+    fn test_lua_script_compiles() {
+        // The script string is `const`, but constructing the `Script`
+        // object catches accidental empty/whitespace-only edits.
+        let script = Script::new(RATE_LIMIT_LUA);
+        assert!(!script.get_hash().is_empty());
     }
 }

--- a/pensyve-mcp-gateway/src/rate_limit.rs
+++ b/pensyve-mcp-gateway/src/rate_limit.rs
@@ -174,13 +174,21 @@ impl RateLimiter {
                 Ok(outcome) => return outcome,
                 Err(e) => {
                     // Warn once per process, not once per request.
-                    if self.fallback_warned.swap(true, Ordering::Relaxed) {
-                        tracing::debug!(error = %e, "Rate limit Redis call failed; using fallback");
-                    } else {
+                    // `swap(true, _)` returns the *previous* value: false
+                    // on the very first failure (which is when we want
+                    // the loud warning), true thereafter (when we drop
+                    // to debug-level so we don't flood the logs).
+                    // Reading `if !swap(...)` matches that mental model
+                    // (negate "have we already warned?") even though
+                    // clippy::if_not_else prefers the inverted form.
+                    #[allow(clippy::if_not_else)]
+                    if !self.fallback_warned.swap(true, Ordering::Relaxed) {
                         tracing::warn!(
                             error = %e,
                             "Rate limiter falling back to in-memory; daily quota NOT enforced"
                         );
+                    } else {
+                        tracing::debug!(error = %e, "Rate limit Redis call failed; using fallback");
                     }
                     // Fall through to the in-memory path.
                 }

--- a/pensyve-mcp-gateway/src/usage.rs
+++ b/pensyve-mcp-gateway/src/usage.rs
@@ -46,6 +46,11 @@ pub struct UsageEvent {
     pub stripe_customer_id: Option<String>,
     pub tier: OperationTier,
     pub count: u32,
+    /// W3C `traceparent` header value for the originating request, used
+    /// when this event is forwarded to Stripe's meter events endpoint.
+    /// `None` when no trace context was present (legacy callers, tests,
+    /// or fire-and-forget paths that bypass the tracing middleware).
+    pub traceparent: Option<String>,
 }
 
 /// Asynchronous Stripe usage reporter.
@@ -124,10 +129,20 @@ impl UsageReporter {
         };
 
         // Aggregate by (customer_id, tier) to minimize HTTP calls.
-        let mut aggregated: HashMap<(String, OperationTier), u32> = HashMap::new();
+        // Each bucket keeps a (count, last_traceparent) pair: with batching,
+        // many requests collapse into one Stripe POST, so we keep the most
+        // recent traceparent so at least one trace correlates to the call.
+        let mut aggregated: HashMap<(String, OperationTier), (u32, Option<String>)> =
+            HashMap::new();
         for event in batch.drain(..) {
             if let Some(customer_id) = event.stripe_customer_id {
-                *aggregated.entry((customer_id, event.tier)).or_default() += event.count;
+                let entry = aggregated
+                    .entry((customer_id, event.tier))
+                    .or_insert((0, None));
+                entry.0 += event.count;
+                if event.traceparent.is_some() {
+                    entry.1 = event.traceparent;
+                }
             }
         }
 
@@ -137,27 +152,32 @@ impl UsageReporter {
 
         tracing::info!(
             groups = aggregated.len(),
-            total_ops = aggregated.values().sum::<u32>(),
+            total_ops = aggregated.values().map(|(c, _)| c).sum::<u32>(),
             "Flushing usage to Stripe"
         );
 
-        for ((customer_id, tier), count) in &aggregated {
+        for ((customer_id, tier), (count, traceparent)) in &aggregated {
             let mut success = false;
             for attempt in 0..3 {
                 if attempt > 0 {
                     tokio::time::sleep(tokio::time::Duration::from_millis(500 * 2u64.pow(attempt)))
                         .await;
                 }
-                let result = client
+                let mut req = client
                     .post("https://api.stripe.com/v1/billing/meter_events")
                     .bearer_auth(api_key)
                     .form(&[
                         ("event_name", tier.event_name()),
                         ("payload[stripe_customer_id]", customer_id),
                         ("payload[value]", &count.to_string()),
-                    ])
-                    .send()
-                    .await;
+                    ]);
+                // Phase 23/A: propagate W3C trace context so Stripe's
+                // request logs (and our own egress logs) can be correlated
+                // back to the originating MCP request.
+                if let Some(tp) = traceparent {
+                    req = req.header(crate::middleware::tracing::TRACEPARENT_HEADER, tp);
+                }
+                let result = req.send().await;
 
                 match result {
                     Ok(resp) if resp.status().is_success() => {
@@ -207,6 +227,7 @@ mod tests {
             stripe_customer_id: None,
             tier: OperationTier::Standard,
             count: 1,
+            traceparent: None,
         });
 
         tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
@@ -222,6 +243,7 @@ mod tests {
                 stripe_customer_id: None,
                 tier: OperationTier::Standard,
                 count: 1,
+                traceparent: None,
             });
         }
 
@@ -250,12 +272,14 @@ mod tests {
                 stripe_customer_id: Some("cus_1".into()),
                 tier: OperationTier::Standard,
                 count: 3,
+                traceparent: None,
             },
             UsageEvent {
                 key_id: "k1".into(),
                 stripe_customer_id: Some("cus_1".into()),
                 tier: OperationTier::Standard,
                 count: 7,
+                traceparent: None,
             },
         ];
         // Without a real Stripe key, this just discards.

--- a/pensyve-mcp-gateway/src/usage.rs
+++ b/pensyve-mcp-gateway/src/usage.rs
@@ -332,9 +332,15 @@ impl UsageReporter {
 
         let mut overall_success = true;
         for ((customer_id, tier), (count, traceparent)) in &aggregated {
-            let success =
-                Self::post_meter_event(client, api_key, customer_id, *tier, *count, traceparent.as_deref())
-                    .await;
+            let success = Self::post_meter_event(
+                client,
+                api_key,
+                customer_id,
+                *tier,
+                *count,
+                traceparent.as_deref(),
+            )
+            .await;
             if !success {
                 overall_success = false;
                 tracing::error!(
@@ -375,9 +381,15 @@ impl UsageReporter {
         );
 
         for ((customer_id, tier), (count, traceparent)) in &aggregated {
-            let success =
-                Self::post_meter_event(client, api_key, customer_id, *tier, *count, traceparent.as_deref())
-                    .await;
+            let success = Self::post_meter_event(
+                client,
+                api_key,
+                customer_id,
+                *tier,
+                *count,
+                traceparent.as_deref(),
+            )
+            .await;
             if !success {
                 tracing::error!(
                     customer = customer_id,
@@ -564,8 +576,7 @@ mod tests {
         // Trip the circuit.
         cb.record_failure().await;
 
-        let buffer: Arc<Mutex<VecDeque<UsageEvent>>> =
-            Arc::new(Mutex::new(VecDeque::new()));
+        let buffer: Arc<Mutex<VecDeque<UsageEvent>>> = Arc::new(Mutex::new(VecDeque::new()));
         let client = reqwest::Client::new();
         let mut batch = vec![
             UsageEvent {
@@ -584,15 +595,8 @@ mod tests {
             },
         ];
 
-        UsageReporter::flush_batch_with_buffer(
-            &mut batch,
-            None,
-            &client,
-            Some(&cb),
-            &buffer,
-            10,
-        )
-        .await;
+        UsageReporter::flush_batch_with_buffer(&mut batch, None, &client, Some(&cb), &buffer, 10)
+            .await;
 
         assert!(batch.is_empty(), "batch should be drained into buffer");
         let buf = buffer.lock().expect("lock");
@@ -620,8 +624,7 @@ mod tests {
         ));
         cb.record_failure().await;
 
-        let buffer: Arc<Mutex<VecDeque<UsageEvent>>> =
-            Arc::new(Mutex::new(VecDeque::new()));
+        let buffer: Arc<Mutex<VecDeque<UsageEvent>>> = Arc::new(Mutex::new(VecDeque::new()));
         let client = reqwest::Client::new();
 
         let mut batch: Vec<UsageEvent> = (0..5)
@@ -634,15 +637,8 @@ mod tests {
             })
             .collect();
 
-        UsageReporter::flush_batch_with_buffer(
-            &mut batch,
-            None,
-            &client,
-            Some(&cb),
-            &buffer,
-            3,
-        )
-        .await;
+        UsageReporter::flush_batch_with_buffer(&mut batch, None, &client, Some(&cb), &buffer, 3)
+            .await;
 
         let buf = buffer.lock().expect("lock");
         assert_eq!(buf.len(), 3, "buffer should be capped at 3");

--- a/pensyve-mcp-gateway/src/usage.rs
+++ b/pensyve-mcp-gateway/src/usage.rs
@@ -184,6 +184,20 @@ impl UsageReporter {
                             &buffer,
                             buffer_capacity,
                         ).await;
+                    } else if let Some(cb) = circuit_breaker.as_ref() {
+                        // Idle tick + empty batch: if the breaker has
+                        // recovered, drain any events that piled up while
+                        // the breaker was Open. Without this, low-traffic
+                        // tenants under-report billable usage indefinitely
+                        // after a Stripe outage (the buffer only drains
+                        // on the *next* successful flush of new events).
+                        let has_buffered = {
+                            let buf = buffer.lock().expect("usage buffer mutex poisoned");
+                            !buf.is_empty()
+                        };
+                        if has_buffered && cb.check().await.is_ok() {
+                            Self::drain_buffer(&buffer, stripe_api_key.as_deref(), &client, cb).await;
+                        }
                     }
                 }
             }
@@ -276,17 +290,24 @@ impl UsageReporter {
                 buf.drain(..take).collect()
             };
             let chunk_len = chunk.len();
-            let mut chunk_vec = chunk;
+            // Keep an untouched copy for the requeue path.
+            // `flush_batch_returning_success` calls `aggregate_batch` which
+            // *drains* its input vec, so by the time the !success branch
+            // runs there's nothing left in the borrowed copy to push back.
+            // Without this clone the failed events would be silently lost.
+            let mut working_copy = chunk.clone();
             let success =
-                Self::flush_batch_returning_success(&mut chunk_vec, stripe_api_key, client).await;
+                Self::flush_batch_returning_success(&mut working_copy, stripe_api_key, client)
+                    .await;
             if !success {
-                // Push the un-flushed chunk back to the front so order is
-                // preserved on the next drain attempt. Take care to drop
-                // the MutexGuard before .await — std Mutex guards are
-                // !Send and would un-Send the report_loop future.
+                // Push the original (un-drained) chunk back to the front
+                // so order is preserved on the next drain attempt. Take
+                // care to drop the MutexGuard before .await — std Mutex
+                // guards are !Send and would un-Send the report_loop
+                // future.
                 let remaining = {
                     let mut buf = buffer.lock().expect("usage buffer mutex poisoned");
-                    for event in chunk_vec.into_iter().rev() {
+                    for event in chunk.into_iter().rev() {
                         buf.push_front(event);
                     }
                     buf.len()

--- a/pensyve-mcp-gateway/src/usage.rs
+++ b/pensyve-mcp-gateway/src/usage.rs
@@ -1,6 +1,9 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
+use std::sync::{Arc, Mutex};
 
 use tokio::sync::mpsc;
+
+use crate::circuit_breaker::CircuitBreaker;
 
 /// Operation tier for billing purposes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -40,7 +43,7 @@ impl OperationTier {
 }
 
 /// Usage event sent to the background reporter.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct UsageEvent {
     pub key_id: String,
     pub stripe_customer_id: Option<String>,
@@ -53,20 +56,60 @@ pub struct UsageEvent {
     pub traceparent: Option<String>,
 }
 
+/// Default capacity of the bounded buffer used when the Stripe circuit
+/// breaker is Open. Override via `PENSYVE_STRIPE_BUFFER_SIZE`.
+pub const DEFAULT_STRIPE_BUFFER_SIZE: usize = 5000;
+
+fn buffer_capacity_from_env() -> usize {
+    std::env::var("PENSYVE_STRIPE_BUFFER_SIZE")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_STRIPE_BUFFER_SIZE)
+}
+
 /// Asynchronous Stripe usage reporter.
 ///
 /// Tool calls send events through an mpsc channel. A background task
 /// aggregates by (customer, tier) and batches submissions to Stripe.
 /// Tool call responses are never blocked by billing.
+///
+/// Phase 23/C: Stripe POSTs are gated by a circuit breaker. When the
+/// breaker is Open, events are pushed to a bounded `VecDeque` (default
+/// capacity 5000, drop-oldest on overflow); the buffer is drained on
+/// the first successful POST after the breaker closes.
 pub struct UsageReporter {
     tx: mpsc::Sender<UsageEvent>,
 }
 
 impl UsageReporter {
+    /// Construct a reporter with no circuit breaker. Stripe POSTs always
+    /// proceed; suitable for tests and dev environments without a Redis
+    /// dependency.
     pub fn new(stripe_api_key: Option<String>) -> Self {
         let (tx, rx) = mpsc::channel(1024);
 
-        tokio::spawn(Self::report_loop(rx, stripe_api_key));
+        let buffer_capacity = buffer_capacity_from_env();
+        tokio::spawn(Self::report_loop(rx, stripe_api_key, None, buffer_capacity));
+
+        Self { tx }
+    }
+
+    /// Construct a reporter with an attached circuit breaker. When the
+    /// breaker is Open, events are buffered up to `buffer_capacity` and
+    /// drained after the breaker closes.
+    pub fn new_with_circuit_breaker(
+        stripe_api_key: Option<String>,
+        circuit_breaker: Arc<CircuitBreaker>,
+    ) -> Self {
+        let (tx, rx) = mpsc::channel(1024);
+
+        let buffer_capacity = buffer_capacity_from_env();
+        tokio::spawn(Self::report_loop(
+            rx,
+            stripe_api_key,
+            Some(circuit_breaker),
+            buffer_capacity,
+        ));
 
         Self { tx }
     }
@@ -78,10 +121,22 @@ impl UsageReporter {
         }
     }
 
-    async fn report_loop(mut rx: mpsc::Receiver<UsageEvent>, stripe_api_key: Option<String>) {
+    async fn report_loop(
+        mut rx: mpsc::Receiver<UsageEvent>,
+        stripe_api_key: Option<String>,
+        circuit_breaker: Option<Arc<CircuitBreaker>>,
+        buffer_capacity: usize,
+    ) {
         // Reuse the HTTP client across all flushes for connection pooling.
         let client = reqwest::Client::new();
         let mut batch: Vec<UsageEvent> = Vec::new();
+        // Bounded buffer for events received while the breaker is Open.
+        // Wrapped in std::sync::Mutex so internal drain helpers can take
+        // ownership of the queue without an async lock — the critical
+        // sections are tiny (push/pop_front), and we're already on the
+        // single-threaded report task.
+        let buffer: Arc<Mutex<VecDeque<UsageEvent>>> =
+            Arc::new(Mutex::new(VecDeque::with_capacity(64.min(buffer_capacity))));
         let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(10));
 
         loop {
@@ -92,13 +147,27 @@ impl UsageReporter {
                         Some(e) => {
                             batch.push(e);
                             if batch.len() >= 100 {
-                                Self::flush_batch(&mut batch, stripe_api_key.as_deref(), &client).await;
+                                Self::flush_batch_with_buffer(
+                                    &mut batch,
+                                    stripe_api_key.as_deref(),
+                                    &client,
+                                    circuit_breaker.as_ref(),
+                                    &buffer,
+                                    buffer_capacity,
+                                ).await;
                             }
                         }
                         // Channel closed — flush remaining and exit.
                         None => {
                             if !batch.is_empty() {
-                                Self::flush_batch(&mut batch, stripe_api_key.as_deref(), &client).await;
+                                Self::flush_batch_with_buffer(
+                                    &mut batch,
+                                    stripe_api_key.as_deref(),
+                                    &client,
+                                    circuit_breaker.as_ref(),
+                                    &buffer,
+                                    buffer_capacity,
+                                ).await;
                             }
                             tracing::info!("Usage reporter shutting down");
                             return;
@@ -107,13 +176,179 @@ impl UsageReporter {
                 }
                 _ = interval.tick() => {
                     if !batch.is_empty() {
-                        Self::flush_batch(&mut batch, stripe_api_key.as_deref(), &client).await;
+                        Self::flush_batch_with_buffer(
+                            &mut batch,
+                            stripe_api_key.as_deref(),
+                            &client,
+                            circuit_breaker.as_ref(),
+                            &buffer,
+                            buffer_capacity,
+                        ).await;
                     }
                 }
             }
         }
     }
 
+    /// Flush a batch of usage events to Stripe.
+    ///
+    /// Phase 23/C wrapper: gates the actual POST loop on the circuit
+    /// breaker. When the breaker is Open the batch is enqueued into the
+    /// bounded buffer (drop-oldest on overflow). On a successful POST
+    /// after the breaker reports Closed, any buffered events are drained
+    /// in FIFO order — preserving Track A's per-event traceparent so
+    /// each Stripe call carries the trace id of its originating MCP
+    /// request.
+    async fn flush_batch_with_buffer(
+        batch: &mut Vec<UsageEvent>,
+        stripe_api_key: Option<&str>,
+        client: &reqwest::Client,
+        circuit_breaker: Option<&Arc<CircuitBreaker>>,
+        buffer: &Arc<Mutex<VecDeque<UsageEvent>>>,
+        buffer_capacity: usize,
+    ) {
+        // No circuit breaker = legacy fast path (used by tests and dev).
+        if circuit_breaker.is_none() {
+            Self::flush_batch(batch, stripe_api_key, client).await;
+            return;
+        }
+        let cb = circuit_breaker.expect("just checked Some");
+
+        // Circuit Open: stash the events in the bounded buffer.
+        if cb.check().await.is_err() {
+            let drained = std::mem::take(batch);
+            let mut buf = buffer.lock().expect("usage buffer mutex poisoned");
+            for event in drained {
+                if buf.len() >= buffer_capacity {
+                    // Drop oldest. Older events are lower-value because
+                    // their trace context is already stale and the
+                    // operator's loss tolerance is "newest wins" for
+                    // metering purposes (per locked decision).
+                    let _ = buf.pop_front();
+                }
+                buf.push_back(event);
+            }
+            tracing::warn!(
+                buffered = buf.len(),
+                capacity = buffer_capacity,
+                "stripe circuit open; events buffered"
+            );
+            return;
+        }
+
+        // Circuit Closed (or HalfOpen probe): flush the current batch
+        // through the existing retry loop. Record the outcome on the
+        // breaker so HalfOpen → Closed transition is captured.
+        let success = Self::flush_batch_returning_success(batch, stripe_api_key, client).await;
+        if success {
+            cb.record_success().await;
+            // First successful flush after Open → drain the buffer. We
+            // always attempt to drain whenever there are buffered events,
+            // not just immediately after a state transition: that way a
+            // partial drain (e.g., Stripe came back briefly then died
+            // again) doesn't strand the buffered tail.
+            Self::drain_buffer(buffer, stripe_api_key, client, cb).await;
+        } else {
+            cb.record_failure().await;
+        }
+    }
+
+    /// Drain the bounded buffer one batch at a time. Stops on the first
+    /// failed POST so we never burn through the buffer while Stripe is
+    /// still degraded. Buffered events that fail to post are re-pushed at
+    /// the front so they're tried again on the next drain.
+    async fn drain_buffer(
+        buffer: &Arc<Mutex<VecDeque<UsageEvent>>>,
+        stripe_api_key: Option<&str>,
+        client: &reqwest::Client,
+        circuit_breaker: &Arc<CircuitBreaker>,
+    ) {
+        // Snapshot the current queue contents in chunks to avoid holding
+        // the mutex across awaits.
+        const DRAIN_CHUNK: usize = 100;
+        loop {
+            let chunk: Vec<UsageEvent> = {
+                let mut buf = buffer.lock().expect("usage buffer mutex poisoned");
+                if buf.is_empty() {
+                    return;
+                }
+                let take = buf.len().min(DRAIN_CHUNK);
+                buf.drain(..take).collect()
+            };
+            let chunk_len = chunk.len();
+            let mut chunk_vec = chunk;
+            let success =
+                Self::flush_batch_returning_success(&mut chunk_vec, stripe_api_key, client).await;
+            if !success {
+                // Push the un-flushed chunk back to the front so order is
+                // preserved on the next drain attempt. Take care to drop
+                // the MutexGuard before .await — std Mutex guards are
+                // !Send and would un-Send the report_loop future.
+                let remaining = {
+                    let mut buf = buffer.lock().expect("usage buffer mutex poisoned");
+                    for event in chunk_vec.into_iter().rev() {
+                        buf.push_front(event);
+                    }
+                    buf.len()
+                };
+                circuit_breaker.record_failure().await;
+                tracing::warn!(
+                    remaining,
+                    "stripe drain stalled mid-buffer; circuit reopened"
+                );
+                return;
+            }
+            tracing::info!(drained = chunk_len, "stripe buffer drained chunk");
+            circuit_breaker.record_success().await;
+        }
+    }
+
+    /// Flush a batch and report whether the Stripe call(s) ultimately
+    /// succeeded. Used by the circuit-breaker wrapper so we can classify
+    /// the outcome.
+    async fn flush_batch_returning_success(
+        batch: &mut Vec<UsageEvent>,
+        stripe_api_key: Option<&str>,
+        client: &reqwest::Client,
+    ) -> bool {
+        let Some(api_key) = stripe_api_key else {
+            // No Stripe configured — events are intentionally dropped at
+            // the source (dev mode). Treat as success so we don't trip
+            // the breaker on operator misconfiguration.
+            batch.clear();
+            return true;
+        };
+
+        let aggregated = Self::aggregate_batch(batch);
+        if aggregated.is_empty() {
+            return true;
+        }
+
+        tracing::info!(
+            groups = aggregated.len(),
+            total_ops = aggregated.values().map(|(c, _)| c).sum::<u32>(),
+            "Flushing usage to Stripe"
+        );
+
+        let mut overall_success = true;
+        for ((customer_id, tier), (count, traceparent)) in &aggregated {
+            let success =
+                Self::post_meter_event(client, api_key, customer_id, *tier, *count, traceparent.as_deref())
+                    .await;
+            if !success {
+                overall_success = false;
+                tracing::error!(
+                    customer = customer_id,
+                    count,
+                    "Stripe meter event dropped after 3 retries"
+                );
+            }
+        }
+        overall_success
+    }
+
+    /// Legacy flush path — used only when no circuit breaker is attached.
+    /// Behaviour identical to v2.2.0 pre-Phase 23/C.
     async fn flush_batch(
         batch: &mut Vec<UsageEvent>,
         stripe_api_key: Option<&str>,
@@ -128,10 +363,37 @@ impl UsageReporter {
             return;
         };
 
-        // Aggregate by (customer_id, tier) to minimize HTTP calls.
-        // Each bucket keeps a (count, last_traceparent) pair: with batching,
-        // many requests collapse into one Stripe POST, so we keep the most
-        // recent traceparent so at least one trace correlates to the call.
+        let aggregated = Self::aggregate_batch(batch);
+        if aggregated.is_empty() {
+            return;
+        }
+
+        tracing::info!(
+            groups = aggregated.len(),
+            total_ops = aggregated.values().map(|(c, _)| c).sum::<u32>(),
+            "Flushing usage to Stripe"
+        );
+
+        for ((customer_id, tier), (count, traceparent)) in &aggregated {
+            let success =
+                Self::post_meter_event(client, api_key, customer_id, *tier, *count, traceparent.as_deref())
+                    .await;
+            if !success {
+                tracing::error!(
+                    customer = customer_id,
+                    count,
+                    "Stripe meter event dropped after 3 retries"
+                );
+            }
+        }
+    }
+
+    /// Aggregate batch by (`customer_id`, tier). Each bucket keeps the
+    /// summed count and the most recent non-None traceparent — Track A's
+    /// guarantee that at least one trace correlates per Stripe POST.
+    fn aggregate_batch(
+        batch: &mut Vec<UsageEvent>,
+    ) -> HashMap<(String, OperationTier), (u32, Option<String>)> {
         let mut aggregated: HashMap<(String, OperationTier), (u32, Option<String>)> =
             HashMap::new();
         for event in batch.drain(..) {
@@ -145,78 +407,75 @@ impl UsageReporter {
                 }
             }
         }
+        aggregated
+    }
 
-        if aggregated.is_empty() {
-            return;
-        }
+    /// POST a single (customer, tier, count) bucket to Stripe with
+    /// retries on 5xx / network errors. Returns `true` on success or
+    /// 4xx (client errors are not retryable and still count as "we
+    /// finished trying").
+    async fn post_meter_event(
+        client: &reqwest::Client,
+        api_key: &str,
+        customer_id: &str,
+        tier: OperationTier,
+        count: u32,
+        traceparent: Option<&str>,
+    ) -> bool {
+        for attempt in 0..3 {
+            if attempt > 0 {
+                tokio::time::sleep(tokio::time::Duration::from_millis(500 * 2u64.pow(attempt)))
+                    .await;
+            }
+            let mut req = client
+                .post("https://api.stripe.com/v1/billing/meter_events")
+                .bearer_auth(api_key)
+                .form(&[
+                    ("event_name", tier.event_name()),
+                    ("payload[stripe_customer_id]", customer_id),
+                    ("payload[value]", &count.to_string()),
+                ]);
+            // Phase 23/A: propagate W3C trace context so Stripe's
+            // request logs (and our own egress logs) can be correlated
+            // back to the originating MCP request.
+            if let Some(tp) = traceparent {
+                req = req.header(crate::middleware::tracing::TRACEPARENT_HEADER, tp);
+            }
+            let result = req.send().await;
 
-        tracing::info!(
-            groups = aggregated.len(),
-            total_ops = aggregated.values().map(|(c, _)| c).sum::<u32>(),
-            "Flushing usage to Stripe"
-        );
-
-        for ((customer_id, tier), (count, traceparent)) in &aggregated {
-            let mut success = false;
-            for attempt in 0..3 {
-                if attempt > 0 {
-                    tokio::time::sleep(tokio::time::Duration::from_millis(500 * 2u64.pow(attempt)))
-                        .await;
+            match result {
+                Ok(resp) if resp.status().is_success() => {
+                    tracing::debug!(
+                        customer = customer_id,
+                        tier = tier.event_name(),
+                        "Usage reported"
+                    );
+                    return true;
                 }
-                let mut req = client
-                    .post("https://api.stripe.com/v1/billing/meter_events")
-                    .bearer_auth(api_key)
-                    .form(&[
-                        ("event_name", tier.event_name()),
-                        ("payload[stripe_customer_id]", customer_id),
-                        ("payload[value]", &count.to_string()),
-                    ]);
-                // Phase 23/A: propagate W3C trace context so Stripe's
-                // request logs (and our own egress logs) can be correlated
-                // back to the originating MCP request.
-                if let Some(tp) = traceparent {
-                    req = req.header(crate::middleware::tracing::TRACEPARENT_HEADER, tp);
+                Ok(resp) if resp.status().is_server_error() => {
+                    tracing::warn!(status = %resp.status(), attempt, customer = customer_id, "Stripe meter event failed, retrying");
                 }
-                let result = req.send().await;
-
-                match result {
-                    Ok(resp) if resp.status().is_success() => {
-                        tracing::debug!(
-                            customer = customer_id,
-                            tier = tier.event_name(),
-                            "Usage reported"
-                        );
-                        success = true;
-                        break;
-                    }
-                    Ok(resp) if resp.status().is_server_error() => {
-                        tracing::warn!(status = %resp.status(), attempt, customer = customer_id, "Stripe meter event failed, retrying");
-                    }
-                    Ok(resp) => {
-                        // Client error (4xx) — don't retry.
-                        tracing::warn!(status = %resp.status(), customer = customer_id, "Stripe meter event rejected");
-                        success = true; // Don't retry client errors.
-                        break;
-                    }
-                    Err(e) => {
-                        tracing::warn!(error = %e, attempt, "Stripe API call failed, retrying");
-                    }
+                Ok(resp) => {
+                    // Client error (4xx) — don't retry. We treat this as
+                    // "the call finished, even if billing was rejected"
+                    // so we don't trip the breaker on a misconfigured
+                    // customer. Operator alarms on the warn log.
+                    tracing::warn!(status = %resp.status(), customer = customer_id, "Stripe meter event rejected");
+                    return true;
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, attempt, "Stripe API call failed, retrying");
                 }
             }
-            if !success {
-                tracing::error!(
-                    customer = customer_id,
-                    count,
-                    "Stripe meter event dropped after 3 retries"
-                );
-            }
         }
+        false
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::circuit_breaker::CircuitBreakerConfig;
 
     #[tokio::test]
     async fn test_usage_reporter_does_not_block() {
@@ -285,5 +544,124 @@ mod tests {
         // Without a real Stripe key, this just discards.
         UsageReporter::flush_batch(&mut batch, None, &client).await;
         assert!(batch.is_empty());
+    }
+
+    /// Phase 23/C: when the circuit breaker is Open, events going
+    /// through `flush_batch_with_buffer` should land in the buffer
+    /// rather than being dropped. We force the breaker Open by
+    /// recording threshold failures up front.
+    #[tokio::test]
+    async fn test_flush_buffers_events_when_circuit_open() {
+        let cb = Arc::new(CircuitBreaker::new(
+            CircuitBreakerConfig {
+                name: "stripe_test_open",
+                failure_threshold: 1,
+                window_secs: 60,
+                cooldown_secs: 60,
+            },
+            None,
+        ));
+        // Trip the circuit.
+        cb.record_failure().await;
+
+        let buffer: Arc<Mutex<VecDeque<UsageEvent>>> =
+            Arc::new(Mutex::new(VecDeque::new()));
+        let client = reqwest::Client::new();
+        let mut batch = vec![
+            UsageEvent {
+                key_id: "k1".into(),
+                stripe_customer_id: Some("cus_1".into()),
+                tier: OperationTier::Standard,
+                count: 5,
+                traceparent: Some("00-aaa-bbb-01".into()),
+            },
+            UsageEvent {
+                key_id: "k1".into(),
+                stripe_customer_id: Some("cus_1".into()),
+                tier: OperationTier::Standard,
+                count: 2,
+                traceparent: None,
+            },
+        ];
+
+        UsageReporter::flush_batch_with_buffer(
+            &mut batch,
+            None,
+            &client,
+            Some(&cb),
+            &buffer,
+            10,
+        )
+        .await;
+
+        assert!(batch.is_empty(), "batch should be drained into buffer");
+        let buf = buffer.lock().expect("lock");
+        assert_eq!(buf.len(), 2, "both events should be buffered");
+        assert_eq!(buf[0].count, 5);
+        assert_eq!(
+            buf[0].traceparent.as_deref(),
+            Some("00-aaa-bbb-01"),
+            "traceparent must be preserved through buffering"
+        );
+    }
+
+    /// Phase 23/C: drop-oldest semantics on overflow. Filling a 3-slot
+    /// buffer with 5 events should retain the newest 3.
+    #[tokio::test]
+    async fn test_buffer_drops_oldest_on_overflow() {
+        let cb = Arc::new(CircuitBreaker::new(
+            CircuitBreakerConfig {
+                name: "stripe_test_overflow",
+                failure_threshold: 1,
+                window_secs: 60,
+                cooldown_secs: 60,
+            },
+            None,
+        ));
+        cb.record_failure().await;
+
+        let buffer: Arc<Mutex<VecDeque<UsageEvent>>> =
+            Arc::new(Mutex::new(VecDeque::new()));
+        let client = reqwest::Client::new();
+
+        let mut batch: Vec<UsageEvent> = (0..5)
+            .map(|i| UsageEvent {
+                key_id: format!("k{i}"),
+                stripe_customer_id: Some("cus_1".into()),
+                tier: OperationTier::Standard,
+                count: u32::try_from(i).unwrap_or(0),
+                traceparent: None,
+            })
+            .collect();
+
+        UsageReporter::flush_batch_with_buffer(
+            &mut batch,
+            None,
+            &client,
+            Some(&cb),
+            &buffer,
+            3,
+        )
+        .await;
+
+        let buf = buffer.lock().expect("lock");
+        assert_eq!(buf.len(), 3, "buffer should be capped at 3");
+        // Oldest two (k0, k1) dropped → newest three remain.
+        assert_eq!(buf[0].key_id, "k2");
+        assert_eq!(buf[1].key_id, "k3");
+        assert_eq!(buf[2].key_id, "k4");
+    }
+
+    #[test]
+    fn test_buffer_capacity_default_when_env_unset() {
+        // Mirror of the auth/stripe defaults test: avoid env mutation
+        // (workspace lints flag unsafe blocks in 1.88) and instead
+        // assert the default contract holds when the var is not set.
+        if std::env::var("PENSYVE_STRIPE_BUFFER_SIZE").is_ok() {
+            return;
+        }
+        assert_eq!(buffer_capacity_from_env(), DEFAULT_STRIPE_BUFFER_SIZE);
+        // Also asserts the operator-locked default of 5000.
+        assert_eq!(DEFAULT_STRIPE_BUFFER_SIZE, 5000);
     }
 }

--- a/pensyve-mcp-gateway/src/usage.rs
+++ b/pensyve-mcp-gateway/src/usage.rs
@@ -253,6 +253,14 @@ impl UsageReporter {
         // Circuit Closed (or HalfOpen probe): flush the current batch
         // through the existing retry loop. Record the outcome on the
         // breaker so HalfOpen → Closed transition is captured.
+        //
+        // Phase 23/C (PR #87 r2): `flush_batch_returning_success` drains
+        // `batch` via `aggregate_batch`. If the flush fails BEFORE the
+        // breaker has accumulated enough failures to trip Open, the batch
+        // contents would otherwise be silently lost. Take a defensive
+        // clone so we can requeue on failure into the same bounded
+        // buffer the Open path uses (drop-oldest semantics preserved).
+        let preserved = batch.clone();
         let success = Self::flush_batch_returning_success(batch, stripe_api_key, client).await;
         if success {
             cb.record_success().await;
@@ -263,6 +271,29 @@ impl UsageReporter {
             // again) doesn't strand the buffered tail.
             Self::drain_buffer(buffer, stripe_api_key, client, cb).await;
         } else {
+            // Requeue the in-flight batch into the bounded buffer so we
+            // don't under-bill on the failure runway before the breaker
+            // trips. Drop-oldest matches the locked Phase 23 decision.
+            let requeued_len;
+            let dropped_oldest;
+            {
+                let mut buf = buffer.lock().expect("usage buffer mutex poisoned");
+                let mut dropped = 0usize;
+                for event in preserved {
+                    if buf.len() >= buffer_capacity && buf.pop_front().is_some() {
+                        dropped += 1;
+                    }
+                    buf.push_back(event);
+                }
+                requeued_len = buf.len();
+                dropped_oldest = dropped;
+            }
+            tracing::warn!(
+                buffered = requeued_len,
+                dropped_oldest,
+                capacity = buffer_capacity,
+                "stripe flush failed; batch requeued into bounded buffer"
+            );
             cb.record_failure().await;
         }
     }


### PR DESCRIPTION
## Phase 23 Implementation

Per `specs/2026-04-06-pensyve-phase23-design.md` + `plans/2026-05-07-pensyve-phase23-scoping.md` (operator-locked 2026-05-07). All three production-hardening tracks in one integration PR.

### Track A — Distributed tracing (W3C traceparent)
- New `pensyve-mcp-gateway/src/middleware/tracing.rs`
- TracingLayer at outermost layer position; populates request extensions before auth/rate-limit
- Outbound traceparent propagation through `validate_remote` (auth.rs) + Stripe meter events (usage.rs)
- JSON log span injection via `tracing_subscriber::fmt().json().with_current_span(true)`
- 11 new unit tests; UsageEvent gained `traceparent: Option<String>` field
- Risk: LOW

### Track B — Redis-backed rate limits
- Rewrite of `pensyve-mcp-gateway/src/rate_limit.rs` (~607 LOC)
- Lua script for atomic check-and-increment; plan-aware daily quotas (free 30 RPM/1k daily, business 300 RPM/50k daily, enterprise unlimited)
- Graceful in-memory DashMap fallback when Redis unavailable
- Response headers: X-RateLimit-*, X-Quota-Daily-*, Retry-After
- main.rs eviction task removed (Redis TTL handles cleanup)
- Risk: MEDIUM

### Track C — Circuit breakers (validate-key + Stripe usage)
- New `pensyve-mcp-gateway/src/circuit_breaker.rs` (~725 LOC including 16 tests)
- FSM Closed/Open/HalfOpen with Redis-coordinated state + std::sync::Mutex in-memory fallback
- Auth: 5 fail / 60s window / 30s cooldown; falls back to remote_cache (ignores 1h TTL during open)
- Stripe: 3 fail / 60s / 60s cooldown; bounded VecDeque buffer (5000 events env-configurable, drop-oldest on overflow); always-attempt-drain in 100-event FIFO chunks
- Failure classification: only 5xx/transport/decode trip the breaker; 4xx (revoked keys) does NOT
- Risk: MEDIUM-HIGH

### Locked operator decisions

| Setting | Value | Env override |
|---|---|---|
| Plan: free RPM / daily | 30 / 1k | (compile-time) |
| Plan: business RPM / daily | 300 / 50k | (compile-time) |
| CB Auth: failure / window / cooldown | 5 / 60s / 30s | PENSYVE_CB_AUTH_* |
| CB Stripe: failure / window / cooldown | 3 / 60s / 60s | PENSYVE_CB_STRIPE_* |
| Stripe buffer size | 5000 | PENSYVE_STRIPE_BUFFER_SIZE |
| Redis ops | Lua atomic | (compile-time) |
| Retry-After (RFC 7231) | yes | (compile-time) |
| Observability | structured logs (metrics in Phase 24) | — |

Zero new Cargo deps across all three tracks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * W3C Trace Context propagation: trace headers extracted, echoed on responses, and forwarded to auth validation and Stripe calls.
  * Circuit breakers added for auth validation and Stripe reporting with buffered retry semantics for outbound meter events.
  * Plan-aware, tenant-scoped rate limiting with Redis-backed enforcement and per-response rate/quota headers.

* **Improvements**
  * Structured JSON logs now include trace identifiers.
  * Denied requests return JSON 429 with Retry-After; improved degraded-mode fallbacks and more robust remote validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->