### PR TITLE
G4 cycle implementation: k-budget per question_type + MS-card-v2 + PyO3 kwargs

### DIFF
--- a/pensyve-core/src/retrieval/cards/composite.rs
+++ b/pensyve-core/src/retrieval/cards/composite.rs
@@ -391,7 +391,12 @@ fn clip_bullet_entries_or_passthrough(card_output: &str, n: usize) -> String {
     // Walk inclusive from the line after the header up to and including
     // the last kept bullet.
     let walk_start = usize::from(header_idx != usize::MAX);
-    for (i, l) in lines.iter().enumerate().take(last_bullet + 1).skip(walk_start) {
+    for (i, l) in lines
+        .iter()
+        .enumerate()
+        .take(last_bullet + 1)
+        .skip(walk_start)
+    {
         if bullet_set.contains(&i) {
             out.push(l);
         } else if !l.starts_with("- ") && is_section_marker(l) {

--- a/pensyve-core/src/retrieval/cards/composite.rs
+++ b/pensyve-core/src/retrieval/cards/composite.rs
@@ -216,6 +216,53 @@ impl CompositeCard {
             (supersession, G3_SUPERSESSION_CARD_CAP),
         ])
     }
+
+    /// G4 default composite per pre-reg lock @ pensyve-docs@8930c4a:
+    /// inherits the G3 four-card chain
+    /// (`Peer + MultiSession + SingleSessionUser + Supersession`) but
+    /// expects the `multi_session` slot to be a
+    /// [`crate::retrieval::cards::MultiSessionCard`] constructed via
+    /// `MultiSessionCard::v2()` /
+    /// `MultiSessionCard::v2_with_cap()` with an attached
+    /// `with_supersession_chain(...)` handle.
+    ///
+    /// Wiring rationale (Approach A output-merge):
+    ///
+    /// - The MS-card-v2 reads the supersession chain at recall time
+    ///   and **prepends** a chain block to its own output under the
+    ///   `--- SUPERSESSION CHAIN (MS) ---` markers (distinct from the
+    ///   standalone SSC markers).
+    /// - The 4th-slot standalone `SupersessionCard` continues to emit
+    ///   its own `--- SUPERSESSION CHAIN ---` block; both surfaces
+    ///   coexist in the composite output.
+    /// - The merge sits inside `MultiSessionCard::build()` (not in
+    ///   `CompositeCard::build()`) so the composite stays object-safe
+    ///   and `cards: Vec<(Box<dyn RetrievalCard>, usize)>` does not
+    ///   need card-specific dispatch logic. The output-level join here
+    ///   is composition-only.
+    ///
+    /// The caller is responsible for constructing the `multi_session`
+    /// arg via the v2 path with the supersession-chain handle attached;
+    /// this constructor's signature is identical to
+    /// [`g3_default`] so the harness adapter / Python bindings can swap
+    /// G3 → G4 by changing only the `multi_session` builder, not the
+    /// composite assembly.
+    ///
+    /// [`g3_default`]: CompositeCard::g3_default
+    #[must_use]
+    pub fn g4_default(
+        peer: Box<dyn RetrievalCard>,
+        multi_session: Box<dyn RetrievalCard>,
+        single_session_user: Box<dyn RetrievalCard>,
+        supersession: Box<dyn RetrievalCard>,
+    ) -> Self {
+        Self::new(vec![
+            (peer, G2_PEER_CARD_CAP),
+            (multi_session, G2_MULTI_SESSION_CARD_CAP),
+            (single_session_user, G2_SINGLE_SESSION_USER_CARD_CAP),
+            (supersession, G3_SUPERSESSION_CARD_CAP),
+        ])
+    }
 }
 
 impl RetrievalCard for CompositeCard {
@@ -291,7 +338,14 @@ impl RetrievalCard for CompositeCard {
 /// - The first `n` bullet lines are kept.
 /// - Any non-bullet lines AFTER the last kept bullet are preserved
 ///   verbatim as a footer (e.g., `--- END USER FACTS ---` markers).
-///   Non-bullet lines BETWEEN bullets are dropped.
+/// - **Marker-style** non-bullet lines BETWEEN bullets — lines that
+///   start with `"--- "` and end with `" ---"` — are preserved in
+///   document order. This supports the G4 MS-card-v2 + supersession
+///   output-merge surface, where the merged output may contain inner
+///   `--- SUPERSESSION CHAIN (MS) ---` / `--- END SUPERSESSION CHAIN
+///   (MS) ---` boundaries between the chain bullets and the
+///   cross-session bullets. Non-marker non-bullet lines between
+///   bullets are still dropped.
 /// - If `n == 0` or there are zero bullets, the empty string is
 ///   returned (composite treats this as a defer).
 fn clip_bullet_entries_or_passthrough(card_output: &str, n: usize) -> String {
@@ -323,22 +377,47 @@ fn clip_bullet_entries_or_passthrough(card_output: &str, n: usize) -> String {
         return String::new();
     }
 
-    // Footer = any non-bullet lines after the last kept bullet.
+    // Build the output in document order: header (if any), then walk
+    // from line 0..=last_bullet keeping bullets in `bullet_indices` and
+    // marker-style non-bullet lines (`--- ... ---`) between them, then
+    // append the footer (any non-bullet lines after the last kept bullet).
     let last_bullet = *bullet_indices.last().unwrap();
-    let footer: Vec<&str> = lines[last_bullet + 1..]
-        .iter()
-        .filter(|l| !l.starts_with("- "))
-        .copied()
-        .collect();
+    let bullet_set: std::collections::HashSet<usize> = bullet_indices.iter().copied().collect();
 
-    let bullets: Vec<&str> = bullet_indices.iter().map(|&i| lines[i]).collect();
-    let mut out = Vec::with_capacity(1 + bullets.len() + footer.len());
+    let mut out: Vec<&str> = Vec::with_capacity(lines.len());
     if !header.is_empty() {
         out.push(header);
     }
-    out.extend(&bullets);
-    out.extend(&footer);
+    // Walk inclusive from the line after the header up to and including
+    // the last kept bullet.
+    let walk_start = usize::from(header_idx != usize::MAX);
+    for (i, l) in lines.iter().enumerate().take(last_bullet + 1).skip(walk_start) {
+        if bullet_set.contains(&i) {
+            out.push(l);
+        } else if !l.starts_with("- ") && is_section_marker(l) {
+            // Marker-style line between bullets — preserved.
+            out.push(l);
+        }
+        // Other non-bullet lines between bullets: dropped (preserves
+        // the original clipper contract for non-marker noise).
+    }
+    // Footer = any non-bullet lines after the last kept bullet (existing
+    // behavior; markers and prose alike pass through).
+    for l in &lines[last_bullet + 1..] {
+        if !l.starts_with("- ") {
+            out.push(l);
+        }
+    }
     out.join("\n")
+}
+
+/// Is `line` a section-marker line (starts with `"--- "` and ends with
+/// `" ---"`)? Used by `clip_bullet_entries_or_passthrough` to preserve
+/// inner section boundaries (e.g., the MS-card-v2 +
+/// supersession-chain merged surface) instead of dropping them as noise.
+fn is_section_marker(line: &str) -> bool {
+    let t = line.trim();
+    t.starts_with("--- ") && t.ends_with(" ---") && t.len() >= "--- X ---".len()
 }
 
 #[cfg(test)]

--- a/pensyve-core/src/retrieval/cards/multi_session.rs
+++ b/pensyve-core/src/retrieval/cards/multi_session.rs
@@ -447,12 +447,7 @@ impl RetrievalCard for MultiSessionCard {
         // contract.
         if self.supersession_chain.is_some() {
             let chain_output = self.supersession_chain.as_ref().and_then(|sc| {
-                sc.build_chain_only(
-                    &conn,
-                    namespace_id,
-                    agent_id.as_ref(),
-                    user_id.as_ref(),
-                )
+                sc.build_chain_only(&conn, namespace_id, agent_id.as_ref(), user_id.as_ref())
             });
             self.merge_supersession_chain(chain_output.as_deref(), base)
         } else {
@@ -497,11 +492,7 @@ impl MultiSessionCard {
         let chain_clean = chain_output
             .map(str::trim)
             .filter(|s| !s.is_empty())
-            .map(|s| {
-                format!(
-                    "{MS_CARD_SUPERSESSION_HEADER}\n{s}\n{MS_CARD_SUPERSESSION_FOOTER}"
-                )
-            });
+            .map(|s| format!("{MS_CARD_SUPERSESSION_HEADER}\n{s}\n{MS_CARD_SUPERSESSION_FOOTER}"));
 
         match (chain_clean, base_output) {
             (Some(chain), Some(base)) => Some(format!("{chain}\n\n{base}")),

--- a/pensyve-core/src/retrieval/cards/multi_session.rs
+++ b/pensyve-core/src/retrieval/cards/multi_session.rs
@@ -79,6 +79,7 @@ use crate::storage::StorageTrait;
 use crate::types::{AgentId, UserId};
 
 use super::RetrievalCard;
+use super::supersession::SupersessionCard;
 
 /// Per-card name string used by [`RetrievalCard::name`]. Stable
 /// identifier — log consumers (`out/g2_card_defer_log.jsonl`) match on
@@ -118,6 +119,23 @@ const MS_CARD_CROSS_SESSION_THRESHOLD_G2: usize = 2;
 /// drove the G2 H4 SSU partial-fail. Per pre-reg §3.6 SQL scope-tighten.
 const MS_CARD_CROSS_SESSION_THRESHOLD_G3: usize = 3;
 
+/// G4 MS-card-v2 cross-session threshold default: relaxed back to ≥2
+/// distinct date-day buckets (G4 pre-reg lock @ pensyve-docs@8930c4a).
+/// G3 raised the bar to 3 to suppress marginal cross-session entities
+/// at the cost of recall on legitimate 2-session cross-session entities.
+/// G4 trades recall back in. The threshold is env-toggleable via
+/// [`MS_CARD_DAYS_ENV`] (`PENSYVE_MS_CARD_DAYS`).
+pub const MS_CARD_CROSS_SESSION_THRESHOLD_G4: usize = 2;
+
+/// Env-var controlling the G4 MS-card-v2 cross-session day threshold.
+/// Recognized values: any unsigned integer string (e.g., `"2"`, `"3"`,
+/// `"4"`). Unset / unparseable values fall back to
+/// [`MS_CARD_CROSS_SESSION_THRESHOLD_G4`] (= 2) when the v2 path is
+/// active. Read once at construction (`MultiSessionCard::v2` /
+/// `MultiSessionCard::v2_with_cap`) and cached as `ms_days` so the
+/// recall hot path does not re-read the environment.
+pub const MS_CARD_DAYS_ENV: &str = "PENSYVE_MS_CARD_DAYS";
+
 /// Cross-session entity-link card builder.
 ///
 /// Construct with [`MultiSessionCard::new`] for the default cap of
@@ -139,6 +157,25 @@ pub struct MultiSessionCard {
     /// behavior. Per pre-reg §3.4 item 5 + §3.6 + operator decision (a)
     /// 2026-05-06.
     g3_mode: Option<G3Mode>,
+    /// G4 MS-card-v2 cross-session day threshold, resolved at
+    /// construction time. `Some(n)` activates the v2 path (≥`n` distinct
+    /// date-day buckets, env-toggleable via `PENSYVE_MS_CARD_DAYS`,
+    /// default = 2). `None` preserves the G2/G3 dispatch on `g3_mode` +
+    /// `question_type`. Per G4 pre-reg lock @ pensyve-docs@8930c4a.
+    ///
+    /// Cached at construction (mirrors `g3_mode`) so the recall hot path
+    /// does not re-read `PENSYVE_MS_CARD_DAYS` on every `build()`.
+    ms_days: Option<usize>,
+    /// Optional supersession-chain side-input. When `Some`, MS-card-v2
+    /// queries the supersession card's chain-only output at recall time
+    /// and prepends a chain-summary block onto its own output (G4
+    /// Approach A output-merge per pre-reg lock @ pensyve-docs@8930c4a).
+    /// When `None`, MS-card emits its standard output unchanged.
+    ///
+    /// The standalone [`SupersessionCard`] in the composite chain is
+    /// unaffected; this field carries a separate (typically
+    /// freshly-constructed) handle used solely for the merge path.
+    supersession_chain: Option<SupersessionCard>,
 }
 
 /// G3 layering mode resolved from `PENSYVE_RETRIEVAL_CARDS_G3` at card
@@ -166,14 +203,36 @@ fn resolve_g3_mode() -> Option<G3Mode> {
     }
 }
 
+/// Resolve the G4 MS-card-v2 cross-session day threshold from
+/// [`MS_CARD_DAYS_ENV`]. Returns the parsed value when set to a valid
+/// non-zero unsigned integer, otherwise the v2 default
+/// ([`MS_CARD_CROSS_SESSION_THRESHOLD_G4`] = 2).
+///
+/// Zero is treated as unparseable: a 0-day threshold would surface
+/// every entity (no cross-session signal at all), which is never useful.
+fn resolve_ms_days() -> usize {
+    std::env::var(MS_CARD_DAYS_ENV)
+        .ok()
+        .and_then(|s| s.trim().parse::<usize>().ok())
+        .filter(|&n| n > 0)
+        .unwrap_or(MS_CARD_CROSS_SESSION_THRESHOLD_G4)
+}
+
 impl MultiSessionCard {
     /// Construct a card with the default cap (= 40). Reads
     /// `PENSYVE_RETRIEVAL_CARDS_G3` once and caches the resolved mode.
+    ///
+    /// This is the **G2/G3 entry path**: `ms_days` is `None`, so the
+    /// cross-session threshold is dispatched on `g3_mode` +
+    /// `question_type` (G2 baseline = 2, G3 routed-cross-session = 3).
+    /// The G4 MS-card-v2 path is reached via [`MultiSessionCard::v2`].
     #[must_use]
     pub fn new() -> Self {
         Self {
             max_entries: MULTI_SESSION_CARD_MAX_ENTRIES,
             g3_mode: resolve_g3_mode(),
+            ms_days: None,
+            supersession_chain: None,
         }
     }
 
@@ -183,13 +242,72 @@ impl MultiSessionCard {
     /// should prefer [`MultiSessionCard::new`].
     ///
     /// As with [`MultiSessionCard::new`], the G3 layering mode is read
-    /// from the environment at this point and cached.
+    /// from the environment at this point and cached. This is the
+    /// **G2/G3 entry path**; `ms_days` is `None`.
     #[must_use]
     pub fn with_cap(max_entries: usize) -> Self {
         Self {
             max_entries,
             g3_mode: resolve_g3_mode(),
+            ms_days: None,
+            supersession_chain: None,
         }
+    }
+
+    /// Construct a **G4 MS-card-v2** card with the default cap (= 40).
+    /// Reads both `PENSYVE_RETRIEVAL_CARDS_G3` and
+    /// [`MS_CARD_DAYS_ENV`] (`PENSYVE_MS_CARD_DAYS`) once at
+    /// construction and caches the resolved values.
+    ///
+    /// The v2 path takes precedence over the G2/G3 dispatch when
+    /// active: the cross-session threshold is **always**
+    /// `ms_days` regardless of `question_type`. The default v2
+    /// threshold is [`MS_CARD_CROSS_SESSION_THRESHOLD_G4`] (= 2),
+    /// relaxed back from G3's 3 to recover legitimate 2-session
+    /// cross-session entities suppressed by the G3 SQL scope-tighten.
+    ///
+    /// Use [`MultiSessionCard::v2_with_supersession`] / the builder
+    /// [`MultiSessionCard::with_supersession_chain`] to also wire in
+    /// the supersession-chain output-merge (G4 Approach A).
+    #[must_use]
+    pub fn v2() -> Self {
+        Self {
+            max_entries: MULTI_SESSION_CARD_MAX_ENTRIES,
+            g3_mode: resolve_g3_mode(),
+            ms_days: Some(resolve_ms_days()),
+            supersession_chain: None,
+        }
+    }
+
+    /// Construct a **G4 MS-card-v2** card with an explicit entry cap.
+    /// Reads both env vars once and caches the resolved values, as in
+    /// [`MultiSessionCard::v2`].
+    #[must_use]
+    pub fn v2_with_cap(max_entries: usize) -> Self {
+        Self {
+            max_entries,
+            g3_mode: resolve_g3_mode(),
+            ms_days: Some(resolve_ms_days()),
+            supersession_chain: None,
+        }
+    }
+
+    /// Builder method: attach a [`SupersessionCard`] handle for the G4
+    /// Approach A output-merge. When attached, MS-card builds its
+    /// standard output then prepends a chain-summary block produced by
+    /// [`SupersessionCard::build_chain_only`]. Pass any
+    /// `SupersessionCard` instance — it is consumed for its chain-only
+    /// query, never rendered with its own header/footer scaffolding by
+    /// this card.
+    ///
+    /// Standalone `SupersessionCard` consumers (including the separate
+    /// `SupersessionCard` slot in `CompositeCard::g3_default` /
+    /// `CompositeCard::g4_default`) are unaffected — the chain handle
+    /// here is independent and is never published as the SSC block.
+    #[must_use]
+    pub fn with_supersession_chain(mut self, chain: SupersessionCard) -> Self {
+        self.supersession_chain = Some(chain);
+        self
     }
 
     /// Override the G3 layering mode explicitly, replacing whatever
@@ -213,6 +331,24 @@ impl MultiSessionCard {
             Some("full") => Some(G3Mode::Full),
             _ => None,
         };
+        self
+    }
+
+    /// Override the G4 MS-card-v2 day threshold explicitly, replacing
+    /// whatever value [`resolve_ms_days`] picked up from
+    /// [`MS_CARD_DAYS_ENV`] at construction. `Some(n)` (with `n > 0`)
+    /// activates the v2 path with threshold `n`; `None` reverts to the
+    /// G2/G3 dispatch (`new()` / `with_cap()` semantics).
+    ///
+    /// Mirrors the pattern of [`with_g3_mode`] — gives the `PyO3`
+    /// boundary a way to pass a per-call threshold without mutating
+    /// `PENSYVE_MS_CARD_DAYS` (closes the same env-mutation race that
+    /// motivated `with_g3_mode`).
+    ///
+    /// [`with_g3_mode`]: MultiSessionCard::with_g3_mode
+    #[must_use]
+    pub fn with_ms_days(mut self, days: Option<usize>) -> Self {
+        self.ms_days = days.filter(|&n| n > 0);
         self
     }
 }
@@ -264,39 +400,128 @@ impl RetrievalCard for MultiSessionCard {
         )
         .ok()?;
 
-        // G3 SQL scope-tighten (pre-reg §3.6): raise cross-session
-        // threshold from G2's ≥2 to ≥3 distinct date-day buckets ONLY when
-        // BOTH (a) `g3_mode` is set AND (b) `question_type` matches a
-        // routed cross-session type (multi-session / temporal-reasoning /
-        // knowledge-update). Coderabbit Major review on PR #86 caught a
-        // regression: the original guard raised the threshold on any
-        // `g3_mode`, which silently dropped 2-session entities for callers
-        // that pass no question_type or non-routed types — contradicting
-        // the baseline-compatible fallback intent of the router gate above.
-        let cross_session_threshold = matches!(
+        // Cross-session threshold dispatch:
+        //
+        // - **G4 MS-card-v2 path** (`ms_days = Some(n)`): use `n`
+        //   directly. Default = 2 (relaxed back from G3's 3). The v2
+        //   threshold is question-type-agnostic — the router gate above
+        //   has already filtered out non-cross-session question types.
+        //
+        // - **G3 SQL scope-tighten** (`ms_days = None`,
+        //   `g3_mode = Some(_)`, `question_type` matches routed
+        //   cross-session): raise to G3's 3.
+        //
+        // - **G2 baseline** (everything else): use 2.
+        //
+        // Coderabbit Major review on PR #86 pinned the `g3_mode` +
+        // `question_type` AND-guard for the G3 path; the v2 short-circuit
+        // sits ahead of that guard so v2 callers do not need to pass a
+        // question_type to get the relaxed threshold.
+        let cross_session_threshold = if let Some(n) = self.ms_days {
+            n
+        } else if matches!(
             (self.g3_mode, question_type),
             (
                 Some(_),
                 Some("multi-session" | "temporal-reasoning" | "knowledge-update")
             )
-        )
-        .then_some(MS_CARD_CROSS_SESSION_THRESHOLD_G3)
-        .unwrap_or(MS_CARD_CROSS_SESSION_THRESHOLD_G2);
+        ) {
+            MS_CARD_CROSS_SESSION_THRESHOLD_G3
+        } else {
+            MS_CARD_CROSS_SESSION_THRESHOLD_G2
+        };
 
-        build_from_conn(
+        let base = build_from_conn(
             &conn,
             namespace_id,
             agent_id,
             user_id,
             self.max_entries,
             cross_session_threshold,
-        )
+        );
+
+        // G4 Approach A output-merge: prepend supersession-chain entries
+        // when the chain handle is attached. The merge runs only if
+        // either the base MS-card or the chain produced content; if both
+        // are empty the card defers (returns `None`) per the standard
+        // contract.
+        if self.supersession_chain.is_some() {
+            let chain_output = self.supersession_chain.as_ref().and_then(|sc| {
+                sc.build_chain_only(
+                    &conn,
+                    namespace_id,
+                    agent_id.as_ref(),
+                    user_id.as_ref(),
+                )
+            });
+            self.merge_supersession_chain(chain_output.as_deref(), base)
+        } else {
+            base
+        }
     }
 
     fn name(&self) -> &'static str {
         MULTI_SESSION_CARD_NAME
     }
 }
+
+impl MultiSessionCard {
+    /// G4 Approach A output-merge helper. Combines a supersession-chain
+    /// summary block (typically produced by
+    /// [`SupersessionCard::build_chain_only`]) with the MS-card's own
+    /// base output, prepending the chain block under a stable
+    /// `--- SUPERSESSION CHAIN (MS) ---` / `--- END SUPERSESSION CHAIN
+    /// (MS) ---` marker pair. The marker pair is **distinct** from the
+    /// standalone `SupersessionCard` block markers so log-grep
+    /// consumers and the composite-level bullet clipper can tell the
+    /// two surfaces apart.
+    ///
+    /// Merge semantics (full truth table):
+    ///
+    /// | `chain_output`      | `base_output`     | result                          |
+    /// |---------------------|-------------------|---------------------------------|
+    /// | `Some(non-empty)`   | `Some(non-empty)` | chain block + `\n\n` + base     |
+    /// | `Some(non-empty)`   | `None`            | chain block alone               |
+    /// | `None` / empty      | `Some(non-empty)` | base alone                      |
+    /// | `None` / empty      | `None`            | `None` (defer-on-failure)       |
+    ///
+    /// `\n\n` matches `CompositeCard`'s section separator so the
+    /// composite-level join sees the merged output as one cohesive
+    /// section.
+    #[must_use]
+    pub fn merge_supersession_chain(
+        &self,
+        chain_output: Option<&str>,
+        base_output: Option<String>,
+    ) -> Option<String> {
+        let chain_clean = chain_output
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(|s| {
+                format!(
+                    "{MS_CARD_SUPERSESSION_HEADER}\n{s}\n{MS_CARD_SUPERSESSION_FOOTER}"
+                )
+            });
+
+        match (chain_clean, base_output) {
+            (Some(chain), Some(base)) => Some(format!("{chain}\n\n{base}")),
+            (Some(chain), None) => Some(chain),
+            (None, Some(base)) => Some(base),
+            (None, None) => None,
+        }
+    }
+}
+
+/// Marker line opening the supersession-chain block prepended by
+/// MS-card-v2 (G4 Approach A output-merge). Distinct from the
+/// standalone `SupersessionCard`'s `--- SUPERSESSION CHAIN ---` so
+/// log-grep tools and the composite-level bullet clipper can
+/// distinguish the two surfaces.
+pub const MS_CARD_SUPERSESSION_HEADER: &str = "--- SUPERSESSION CHAIN (MS) ---";
+
+/// Marker line closing the MS-card supersession-chain block. See
+/// [`MS_CARD_SUPERSESSION_HEADER`].
+pub const MS_CARD_SUPERSESSION_FOOTER: &str = "--- END SUPERSESSION CHAIN (MS) ---";
 
 /// Lower-level entry point: build the card from an already-open
 /// connection. Exposed `pub(super)` rather than `pub` — the public

--- a/pensyve-core/src/retrieval/cards/supersession.rs
+++ b/pensyve-core/src/retrieval/cards/supersession.rs
@@ -112,6 +112,40 @@ impl SupersessionCard {
     pub fn with_cap(max_entries: usize) -> Self {
         Self { max_entries }
     }
+
+    /// Build a chain-only string (G4 Approach A output-merge): the
+    /// dedupe + cap + bullet-render passes run as in [`build_from_conn`]
+    /// but the [`SUPERSESSION_CARD_HEADER`] / [`SUPERSESSION_CARD_FOOTER`]
+    /// scaffolding is **omitted**. Returns the bullet block (one
+    /// `- <summary>` line per chain) or `None` when no chain summaries
+    /// surface.
+    ///
+    /// Intended consumer: [`crate::retrieval::cards::MultiSessionCard`]
+    /// when constructed via `with_supersession_chain()`. The MS-card
+    /// wraps the returned bullet block in its own
+    /// `--- SUPERSESSION CHAIN (MS) ---` markers
+    /// (see `MS_CARD_SUPERSESSION_HEADER`) so the composite-level bullet
+    /// clipper still recognizes the merged surface as bullet-shaped and
+    /// the standalone `SupersessionCard` block remains
+    /// byte-for-byte unchanged for callers that consume it directly.
+    ///
+    /// Connection-borrow form (no `db_path` / `OpenFlags` ceremony) so
+    /// the caller can reuse a connection it already opened — saves an
+    /// extra read-only `SQLite` open on the recall hot path when both
+    /// cards run in the same composite.
+    #[must_use]
+    pub fn build_chain_only(
+        &self,
+        conn: &Connection,
+        namespace_id: Uuid,
+        agent_id: Option<&AgentId>,
+        user_id: Option<&UserId>,
+    ) -> Option<String> {
+        if self.max_entries == 0 {
+            return None;
+        }
+        build_chain_only_from_conn(conn, namespace_id, agent_id, user_id, self.max_entries)
+    }
 }
 
 impl Default for SupersessionCard {
@@ -202,6 +236,31 @@ pub(crate) fn build_from_conn(
     user_id: Option<&UserId>,
     max_entries: usize,
 ) -> Option<String> {
+    let bullets = build_chain_only_from_conn(conn, namespace_id, agent_id, user_id, max_entries)?;
+    Some(format!(
+        "{SUPERSESSION_CARD_HEADER}\n{bullets}\n{SUPERSESSION_CARD_FOOTER}"
+    ))
+}
+
+/// Internal: query, dedupe, cap, and bullet-render the chain summaries
+/// **without** the surrounding card scaffolding. Powers both
+/// [`build_from_conn`] (which adds the
+/// [`SUPERSESSION_CARD_HEADER`]/[`SUPERSESSION_CARD_FOOTER`]) and
+/// [`SupersessionCard::build_chain_only`] (which leaves the wrapping
+/// to the caller — typically [`crate::retrieval::cards::MultiSessionCard`]
+/// for the G4 Approach A output-merge).
+///
+/// Returns `None` when (a) `max_entries` is zero, (b) the SQL prepare
+/// fails (legacy v=1 store before the v=2 migration ran — `chain_summary`
+/// column does not exist), or (c) no rows have non-NULL non-empty
+/// `chain_summary`.
+fn build_chain_only_from_conn(
+    conn: &Connection,
+    namespace_id: Uuid,
+    agent_id: Option<&AgentId>,
+    user_id: Option<&UserId>,
+    max_entries: usize,
+) -> Option<String> {
     if max_entries == 0 {
         return None;
     }
@@ -277,10 +336,7 @@ pub(crate) fn build_from_conn(
         .map(|e| format!("- {e}"))
         .collect::<Vec<_>>()
         .join("\n");
-
-    Some(format!(
-        "{SUPERSESSION_CARD_HEADER}\n{bullets}\n{SUPERSESSION_CARD_FOOTER}"
-    ))
+    Some(bullets)
 }
 
 /// Build the WHERE-clause fragment and bind values for the

--- a/pensyve-core/src/retrieval/engine.rs
+++ b/pensyve-core/src/retrieval/engine.rs
@@ -469,6 +469,43 @@ impl<'a> RecallEngine<'a> {
         ))
     }
 
+    /// G4 P2: variant of [`recall_grouped`](Self::recall_grouped) that
+    /// resolves the candidate-pool `limit` from a per-question-type
+    /// k-budget instead of the caller-supplied `config.limit`.
+    ///
+    /// `router.k_for_type(question_type)` is **authoritative**: any
+    /// `config.limit` value is ignored and overridden. This mirrors the
+    /// G3 `MultiSessionCard::with_g3_mode` + `g3_mode` cache pattern —
+    /// the router is the single source of truth for retrieval-side
+    /// composition decisions; the caller is not expected to also
+    /// hand-tune `limit` for the same `question_type`.
+    ///
+    /// Defaults from G4 pre-reg `pensyve-docs@8930c4a`:
+    /// `SS-Pref=22`, `MS=50`, `SSU=12`. Unknown / future
+    /// `question_type` strings fall back to the SS-Pref bucket (22),
+    /// which matches the v2.0 baseline `k`.
+    ///
+    /// Public surface of [`recall_grouped`](Self::recall_grouped) is
+    /// unchanged — this is a strictly additive method.
+    pub fn recall_grouped_with_router(
+        &self,
+        router: &crate::retrieval::intent_router::IntentRouter,
+        query: &str,
+        namespace_id: Uuid,
+        question_type: &str,
+        config: &crate::recall_grouped::RecallGroupedConfig,
+    ) -> Result<Vec<crate::recall_grouped::SessionGroup>, RecallError> {
+        // Router-resolved k-budget overrides any caller-supplied
+        // `config.limit`. Clone the config so we don't mutate the
+        // caller's struct in place — RecallGroupedConfig is small
+        // (a few words + an Option<Vec<String>>) and not on the hot
+        // critical path; the clone cost is dominated by the recall
+        // pipeline itself.
+        let mut overridden = config.clone();
+        overridden.limit = router.k_for_type(question_type);
+        self.recall_grouped(query, namespace_id, &overridden)
+    }
+
     /// Like `recall`, but allows specifying a `target_entity` for graph BFS.
     #[allow(clippy::too_many_lines)]
     #[tracing::instrument(skip_all, fields(query, namespace_id = %namespace_id, limit))]
@@ -1573,5 +1610,112 @@ mod tests {
                 cand.final_score
             );
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // G4 P2: recall_grouped_with_router — k-budget override
+    // -----------------------------------------------------------------------
+
+    /// G4 P2: `recall_grouped_with_router` must override
+    /// `config.limit` with the router's per-question-type k-budget,
+    /// regardless of what the caller passed in `config.limit`.
+    ///
+    /// Verification strategy: seed N>budget memories, call the router
+    /// path with a question_type whose budget is < N, and assert the
+    /// candidate pool size equals the router's k. The caller's
+    /// `config.limit` is set deliberately HIGH (well above N) so a
+    /// bug that forwards `config.limit` through unchanged would
+    /// surface as the full N being returned.
+    #[test]
+    fn recall_grouped_with_router_overrides_caller_limit() {
+        use crate::recall_grouped::{OrderBy, RecallGroupedConfig};
+        use crate::retrieval::intent_router::{IntentRouter, KBudget};
+
+        let dir = tempfile::tempdir().unwrap();
+        let storage = SqliteBackend::open(dir.path()).unwrap();
+        let embedder = OnnxEmbedder::new_mock(64);
+        let mut vector_index = VectorIndex::new(64, 16);
+        let config = test_config();
+
+        let ns = Namespace::new("g4-k-budget-ns");
+        storage.save_namespace(&ns).unwrap();
+
+        // Seed 7 distinct memories — more than the SSU budget (3) but
+        // less than the SS-Pref budget (5) we'll dial in below. Each
+        // memory is in its own episode so it produces a distinct
+        // SessionGroup.
+        let n_seed = 7usize;
+        for i in 0..n_seed {
+            let content = format!("topic-{i} content for k-budget test");
+            let mem = setup_episodic(&storage, &embedder, &ns, &content);
+            vector_index.add(mem.id, &mem.embedding).unwrap();
+        }
+
+        let engine = RecallEngine::new(&storage, &embedder, &vector_index, &config);
+
+        // Hand-tuned budget: SSU=3 forces a small cap; SS-Pref=5 is
+        // the unknown-fallback bucket. Distinct values across buckets
+        // ensure we can attribute the cap to the right one.
+        let router = IntentRouter::with_budget(KBudget {
+            ss_pref: 5,
+            ms: 50,
+            ssu: 3,
+        });
+
+        // Caller passes a *very* high `config.limit` to expose any
+        // bug that lets the caller's value win over the router.
+        let cfg = RecallGroupedConfig {
+            limit: 999,
+            order: OrderBy::Relevance,
+            max_groups: None,
+            types: None,
+        };
+
+        let groups_ssu = engine
+            .recall_grouped_with_router(
+                &router,
+                "topic content",
+                ns.id,
+                "single-session-user",
+                &cfg,
+            )
+            .unwrap();
+        assert!(
+            groups_ssu.len() <= 3,
+            "SSU bucket caps at 3; got {} groups",
+            groups_ssu.len()
+        );
+
+        let groups_ms = engine
+            .recall_grouped_with_router(&router, "topic content", ns.id, "multi-session", &cfg)
+            .unwrap();
+        // MS budget (50) is above n_seed (7) so all distinct memories
+        // surface. The point is that the caller's 999 is NOT what
+        // dictates the candidate pool — the router does.
+        assert!(
+            groups_ms.len() <= 50,
+            "MS bucket caps at 50; got {} groups",
+            groups_ms.len()
+        );
+        assert!(
+            groups_ms.len() >= groups_ssu.len(),
+            "MS budget (50) must surface at least as many groups as SSU budget (3)",
+        );
+
+        // Unknown question_type → SS-Pref bucket = 5.
+        let groups_unknown = engine
+            .recall_grouped_with_router(
+                &router,
+                "topic content",
+                ns.id,
+                "future-unspecified-type",
+                &cfg,
+            )
+            .unwrap();
+        assert!(
+            groups_unknown.len() <= 5,
+            "unknown type falls back to SS-Pref bucket (5); got {} groups",
+            groups_unknown.len()
+        );
     }
 }

--- a/pensyve-core/src/retrieval/intent_router.rs
+++ b/pensyve-core/src/retrieval/intent_router.rs
@@ -1,12 +1,29 @@
-//! Intent router for G3 retrieval-side composition.
+//! Intent router for G3/G4 retrieval-side composition.
 //!
-//! Maps `question_type` -> per-card enable flags. Per pre-reg
-//! `pensyve-docs@64481dc` §3.4 item 5 + §3.6 + operator-locked decision (a)
-//! on 2026-05-06: `MultiSessionCard` activates only on cross-session
-//! `question_type`s; `SingleSessionUserCard` always activates;
-//! `PeerCardAdapter` always activates; `SupersessionCard` activates when
-//! the consolidation gate has populated `chain_summary` entries (Agent C
-//! handles that activation; this router defaults it OFF).
+//! Maps `question_type` -> per-card enable flags AND per-question-type
+//! `k`-budget. Per G3 pre-reg `pensyve-docs@64481dc` §3.4 item 5 + §3.6 +
+//! operator-locked decision (a) on 2026-05-06: `MultiSessionCard` activates
+//! only on cross-session `question_type`s; `SingleSessionUserCard` always
+//! activates; `PeerCardAdapter` always activates; `SupersessionCard`
+//! activates when the consolidation gate has populated `chain_summary`
+//! entries (Agent C handles that activation; this router defaults it OFF).
+//!
+//! ## G4 k-budget extension (`pensyve-docs@8930c4a`)
+//!
+//! G4 introduces a per-question-type retrieval `k` cap in addition to the
+//! per-card enable flags. Defaults locked at:
+//!
+//! | bucket   | default `k` | env var                       | applies to                                                  |
+//! |----------|-------------|-------------------------------|-------------------------------------------------------------|
+//! | SS-Pref  | 22          | `PENSYVE_K_BUDGET_SS_PREF`    | `single-session-preference`                                 |
+//! | MS       | 50          | `PENSYVE_K_BUDGET_MS`         | `multi-session`, `temporal-reasoning`, `knowledge-update`   |
+//! | SSU      | 12          | `PENSYVE_K_BUDGET_SSU`        | `single-session-user`, `single-session-assistant`           |
+//!
+//! Unknown `question_type` strings fall back to the SS-Pref budget (22),
+//! which matches the v2.0 baseline `k`. The env vars are read once at
+//! [`IntentRouter`] construction (mirrors the G3 `g3_mode` cache pattern in
+//! `MultiSessionCard`) so the recall hot path never pays a per-build
+//! `std::env::var` syscall.
 //!
 //! ## Decision table (binding §3.6 + operator decision (a) 2026-05-06)
 //!
@@ -101,6 +118,175 @@ pub fn route(question_type: &str) -> RouterDecision {
     }
 }
 
+// ---------------------------------------------------------------------------
+// G4: per-question-type k-budget
+// ---------------------------------------------------------------------------
+
+/// Env-var names for the G4 k-budget knobs. Stable identifiers — log
+/// consumers and harness scripts grep on these exact spellings.
+pub const K_BUDGET_SS_PREF_ENV: &str = "PENSYVE_K_BUDGET_SS_PREF";
+/// Env-var name for the multi-session / cross-session k-budget bucket.
+pub const K_BUDGET_MS_ENV: &str = "PENSYVE_K_BUDGET_MS";
+/// Env-var name for the single-session-user / single-session-assistant
+/// k-budget bucket.
+pub const K_BUDGET_SSU_ENV: &str = "PENSYVE_K_BUDGET_SSU";
+
+/// G4 default k-budget for the SS-Pref bucket (`single-session-preference`).
+/// Per G4 pre-reg `pensyve-docs@8930c4a`.
+pub const K_BUDGET_SS_PREF_DEFAULT: usize = 22;
+/// G4 default k-budget for the MS bucket (`multi-session`,
+/// `temporal-reasoning`, `knowledge-update`). Per G4 pre-reg.
+pub const K_BUDGET_MS_DEFAULT: usize = 50;
+/// G4 default k-budget for the SSU bucket (`single-session-user`,
+/// `single-session-assistant`). Per G4 pre-reg.
+pub const K_BUDGET_SSU_DEFAULT: usize = 12;
+
+/// Resolved per-question-type `k`-budget. Three buckets — `SS-Pref`,
+/// `MS`, `SSU` — sized per G4 pre-reg `pensyve-docs@8930c4a` and
+/// overridable via `PENSYVE_K_BUDGET_*` env vars at [`IntentRouter`]
+/// construction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct KBudget {
+    /// `single-session-preference` budget. Default 22.
+    pub ss_pref: usize,
+    /// Multi-session / cross-session budget. Default 50. Shared by
+    /// `multi-session`, `temporal-reasoning`, `knowledge-update`.
+    pub ms: usize,
+    /// Single-session-user / -assistant budget. Default 12. Shared by
+    /// `single-session-user` and `single-session-assistant`.
+    pub ssu: usize,
+}
+
+impl Default for KBudget {
+    fn default() -> Self {
+        Self {
+            ss_pref: K_BUDGET_SS_PREF_DEFAULT,
+            ms: K_BUDGET_MS_DEFAULT,
+            ssu: K_BUDGET_SSU_DEFAULT,
+        }
+    }
+}
+
+impl KBudget {
+    /// Resolve a [`KBudget`] from the process environment. Each bucket
+    /// reads its dedicated env var (`PENSYVE_K_BUDGET_SS_PREF`, `_MS`,
+    /// `_SSU`). Unset / unparseable / zero values fall back to the
+    /// locked G4 defaults.
+    ///
+    /// `0` is treated as unset because a zero k-budget would short-
+    /// circuit the entire recall pipeline — defensive: any operator
+    /// sweep that explicitly wants to suppress recall should use a
+    /// dedicated kill-switch, not `K_BUDGET_*=0`.
+    #[must_use]
+    pub fn from_env() -> Self {
+        let parse = |key: &str, default: usize| -> usize {
+            std::env::var(key)
+                .ok()
+                .and_then(|s| s.parse::<usize>().ok())
+                .filter(|v| *v > 0)
+                .unwrap_or(default)
+        };
+        Self {
+            ss_pref: parse(K_BUDGET_SS_PREF_ENV, K_BUDGET_SS_PREF_DEFAULT),
+            ms: parse(K_BUDGET_MS_ENV, K_BUDGET_MS_DEFAULT),
+            ssu: parse(K_BUDGET_SSU_ENV, K_BUDGET_SSU_DEFAULT),
+        }
+    }
+}
+
+/// Stateful intent router that caches the per-question-type `k`-budget
+/// resolved from the process environment at construction.
+///
+/// Mirrors the G3 `MultiSessionCard::g3_mode` resolution pattern:
+/// env-var read happens **once**, never on the per-`build()` recall
+/// path. Callers wanting to switch buckets mid-process should construct
+/// a fresh [`IntentRouter`].
+///
+/// [`IntentRouter::route`] forwards to the free [`route`] function so
+/// existing callers can migrate without changing the per-card flag
+/// semantics. New G4 callers use [`IntentRouter::k_for_type`] to obtain
+/// the per-question-type retrieval cap.
+#[derive(Debug, Clone, Copy)]
+pub struct IntentRouter {
+    /// k-budget cached at construction. Use [`IntentRouter::k_for_type`]
+    /// to map a `question_type` string to the bucket value.
+    k_budget: KBudget,
+}
+
+impl Default for IntentRouter {
+    fn default() -> Self {
+        Self::from_env()
+    }
+}
+
+impl IntentRouter {
+    /// Construct a router with explicit `k`-budget. Intended for tests
+    /// that need deterministic budgets without touching process env.
+    #[must_use]
+    pub fn with_budget(k_budget: KBudget) -> Self {
+        Self { k_budget }
+    }
+
+    /// Construct a router by resolving [`KBudget::from_env`] once.
+    ///
+    /// Env-var unset / unparseable → locked G4 defaults
+    /// (`SS-Pref=22, MS=50, SSU=12`).
+    #[must_use]
+    pub fn from_env() -> Self {
+        Self {
+            k_budget: KBudget::from_env(),
+        }
+    }
+
+    /// Return the cached [`KBudget`] (e.g., for logging / diagnostics).
+    #[must_use]
+    pub fn k_budget(&self) -> KBudget {
+        self.k_budget
+    }
+
+    /// Forward to the free [`route`] function for per-card enable flags.
+    /// Provided so callers can hold a single `IntentRouter` handle and
+    /// dispatch both flag and k-budget queries through it.
+    #[must_use]
+    pub fn route(&self, question_type: &str) -> RouterDecision {
+        route(question_type)
+    }
+
+    /// Map a `question_type` string to its per-question-type retrieval
+    /// `k`-budget.
+    ///
+    /// | `question_type`              | bucket    | default `k` |
+    /// |------------------------------|-----------|-------------|
+    /// | `single-session-preference`  | SS-Pref   | 22          |
+    /// | `multi-session`              | MS        | 50          |
+    /// | `temporal-reasoning`         | MS        | 50          |
+    /// | `knowledge-update`           | MS        | 50          |
+    /// | `single-session-user`        | SSU       | 12          |
+    /// | `single-session-assistant`   | SSU       | 12          |
+    /// | (unknown / empty)            | SS-Pref   | 22          |
+    ///
+    /// Unknown / future `question_type` strings fall back to the SS-Pref
+    /// bucket (22) — this matches the v2.0 baseline `k`, preserving
+    /// pre-G4 behavior for any harness-emitted type not yet enumerated.
+    #[must_use]
+    #[allow(
+        clippy::match_same_arms,
+        reason = "the explicit `single-session-preference` arm and the wildcard fallback both return `ss_pref` *today*, but they encode distinct intents — the explicit arm is the binding G4 mapping for that question_type; the wildcard is a conservative pre-G4 baseline (= v2.0 `k=22`) for unknown / future types. Collapsing them would silently couple the unknown-fallback to the SS-Pref value, so a future operator who tunes SS-Pref alone would also drift the fallback. Keep them split for forward extensibility."
+    )]
+    pub fn k_for_type(&self, question_type: &str) -> usize {
+        match question_type {
+            "single-session-preference" => self.k_budget.ss_pref,
+            "multi-session" | "temporal-reasoning" | "knowledge-update" => self.k_budget.ms,
+            "single-session-user" | "single-session-assistant" => self.k_budget.ssu,
+            // Conservative fallback: SS-Pref budget (22) matches the
+            // v2.0 baseline `k`, so unknown types behave like the
+            // pre-G4 floor instead of accidentally amplifying or
+            // starving recall on a typo.
+            _ => self.k_budget.ss_pref,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     //! Smoke tests; the binding 6-fixture decision-table fuzz lives in
@@ -141,5 +327,74 @@ mod tests {
         assert!(d.enable_ms_card);
         assert!(d.enable_ssu_card);
         assert!(!d.enable_supersession_card);
+    }
+
+    // -----------------------------------------------------------------------
+    // G4: KBudget + IntentRouter::k_for_type
+    //
+    // These tests construct a router with an explicit `KBudget` so they
+    // never touch the process environment — env-var fuzzing lives in
+    // `pensyve-core/tests/test_intent_router.rs` where the
+    // `RouterEnvGuard` mutex is available.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn k_budget_default_matches_g4_locked_constants() {
+        let kb = KBudget::default();
+        assert_eq!(kb.ss_pref, K_BUDGET_SS_PREF_DEFAULT);
+        assert_eq!(kb.ss_pref, 22);
+        assert_eq!(kb.ms, K_BUDGET_MS_DEFAULT);
+        assert_eq!(kb.ms, 50);
+        assert_eq!(kb.ssu, K_BUDGET_SSU_DEFAULT);
+        assert_eq!(kb.ssu, 12);
+    }
+
+    #[test]
+    fn k_for_type_maps_each_question_type_to_correct_bucket() {
+        let router = IntentRouter::with_budget(KBudget {
+            ss_pref: 22,
+            ms: 50,
+            ssu: 12,
+        });
+        // SS-Pref bucket
+        assert_eq!(router.k_for_type("single-session-preference"), 22);
+        // MS bucket (three types share it)
+        assert_eq!(router.k_for_type("multi-session"), 50);
+        assert_eq!(router.k_for_type("temporal-reasoning"), 50);
+        assert_eq!(router.k_for_type("knowledge-update"), 50);
+        // SSU bucket (two types share it)
+        assert_eq!(router.k_for_type("single-session-user"), 12);
+        assert_eq!(router.k_for_type("single-session-assistant"), 12);
+    }
+
+    #[test]
+    fn k_for_type_unknown_falls_back_to_ss_pref_bucket() {
+        // Use distinct values per bucket so a fallback regression that
+        // accidentally returned MS or SSU would surface as a wrong-int
+        // failure instead of a silent pass.
+        let router = IntentRouter::with_budget(KBudget {
+            ss_pref: 7,
+            ms: 99,
+            ssu: 33,
+        });
+        assert_eq!(router.k_for_type("future-unknown-type"), 7);
+        assert_eq!(router.k_for_type(""), 7);
+        assert_eq!(router.k_for_type("MULTI-SESSION"), 7); // case-sensitive
+    }
+
+    #[test]
+    fn intent_router_route_forwards_to_free_function() {
+        let router = IntentRouter::with_budget(KBudget::default());
+        for qt in [
+            "multi-session",
+            "temporal-reasoning",
+            "knowledge-update",
+            "single-session-preference",
+            "single-session-user",
+            "single-session-assistant",
+            "unknown-xyz",
+        ] {
+            assert_eq!(router.route(qt), route(qt), "mismatch for {qt}");
+        }
     }
 }

--- a/pensyve-core/tests/test_intent_router.rs
+++ b/pensyve-core/tests/test_intent_router.rs
@@ -21,7 +21,10 @@ use std::sync::{Mutex, OnceLock};
 use uuid::Uuid;
 
 use pensyve_core::retrieval::cards::{MultiSessionCard, RetrievalCard};
-use pensyve_core::retrieval::intent_router::{RouterDecision, route};
+use pensyve_core::retrieval::intent_router::{
+    IntentRouter, KBudget, K_BUDGET_MS_DEFAULT, K_BUDGET_MS_ENV, K_BUDGET_SSU_DEFAULT,
+    K_BUDGET_SSU_ENV, K_BUDGET_SS_PREF_DEFAULT, K_BUDGET_SS_PREF_ENV, RouterDecision, route,
+};
 use pensyve_core::storage::StorageTrait;
 use pensyve_core::storage::sqlite::SqliteBackend;
 
@@ -372,6 +375,177 @@ fn g3_router_mode_raises_cross_session_threshold_to_three() {
         "Carol (2 sessions) must NOT surface under G3 ≥3 threshold; got:\n{out}",
     );
 }
+
+// ---------------------------------------------------------------------------
+// G4 P2: KBudget::from_env env-var fuzz
+//
+// These tests mutate `PENSYVE_K_BUDGET_*` env vars and so must serialize
+// against the same process-wide lock as the G3 router-env tests.
+// ---------------------------------------------------------------------------
+
+/// RAII guard that holds the process-wide env lock AND mutates the three
+/// `PENSYVE_K_BUDGET_*` variables for the lifetime of the guard. Previous
+/// values are captured at construction and restored on drop. Mirrors
+/// [`RouterEnvGuard`].
+struct KBudgetEnvGuard {
+    _serial: std::sync::MutexGuard<'static, ()>,
+    previous: [(&'static str, Option<String>); 3],
+}
+
+#[allow(
+    unsafe_code,
+    reason = "test-only env-var guard; std::env::set_var/remove_var require unsafe in modern Rust because env mutation is process-global. The struct holds the process-wide router_env_lock for its lifetime so concurrent test threads cannot race."
+)]
+impl KBudgetEnvGuard {
+    /// Acquire the lock and apply the given (key, Option<value>) trio.
+    /// `Some(v)` sets the key; `None` removes it.
+    fn apply(values: [(&'static str, Option<&str>); 3]) -> Self {
+        let serial = router_env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let previous: [(&'static str, Option<String>); 3] = [
+            (values[0].0, std::env::var(values[0].0).ok()),
+            (values[1].0, std::env::var(values[1].0).ok()),
+            (values[2].0, std::env::var(values[2].0).ok()),
+        ];
+        // SAFETY: serialized via the mutex held in `serial`.
+        unsafe {
+            for (key, value) in values {
+                match value {
+                    Some(v) => std::env::set_var(key, v),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+        Self {
+            _serial: serial,
+            previous,
+        }
+    }
+}
+
+#[allow(
+    unsafe_code,
+    reason = "test-only env-var guard; see KBudgetEnvGuard::apply for justification"
+)]
+impl Drop for KBudgetEnvGuard {
+    fn drop(&mut self) {
+        // SAFETY: drop runs while we still hold the serialization lock.
+        unsafe {
+            for (key, prev) in &self.previous {
+                match prev {
+                    Some(v) => std::env::set_var(key, v),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+    }
+}
+
+/// All three env vars unset → `KBudget::from_env` returns the locked
+/// G4 defaults (`SS-Pref=22, MS=50, SSU=12`).
+#[test]
+fn k_budget_from_env_falls_back_to_defaults_when_unset() {
+    let _env = KBudgetEnvGuard::apply([
+        (K_BUDGET_SS_PREF_ENV, None),
+        (K_BUDGET_MS_ENV, None),
+        (K_BUDGET_SSU_ENV, None),
+    ]);
+    let kb = KBudget::from_env();
+    assert_eq!(kb.ss_pref, K_BUDGET_SS_PREF_DEFAULT);
+    assert_eq!(kb.ms, K_BUDGET_MS_DEFAULT);
+    assert_eq!(kb.ssu, K_BUDGET_SSU_DEFAULT);
+}
+
+/// Each env var, when set to a parseable positive integer, overrides
+/// only its own bucket — the other two stay on their locked defaults.
+#[test]
+fn k_budget_from_env_reads_each_variable_independently() {
+    {
+        let _env = KBudgetEnvGuard::apply([
+            (K_BUDGET_SS_PREF_ENV, Some("17")),
+            (K_BUDGET_MS_ENV, None),
+            (K_BUDGET_SSU_ENV, None),
+        ]);
+        let kb = KBudget::from_env();
+        assert_eq!(kb.ss_pref, 17);
+        assert_eq!(kb.ms, K_BUDGET_MS_DEFAULT);
+        assert_eq!(kb.ssu, K_BUDGET_SSU_DEFAULT);
+    }
+    {
+        let _env = KBudgetEnvGuard::apply([
+            (K_BUDGET_SS_PREF_ENV, None),
+            (K_BUDGET_MS_ENV, Some("64")),
+            (K_BUDGET_SSU_ENV, None),
+        ]);
+        let kb = KBudget::from_env();
+        assert_eq!(kb.ss_pref, K_BUDGET_SS_PREF_DEFAULT);
+        assert_eq!(kb.ms, 64);
+        assert_eq!(kb.ssu, K_BUDGET_SSU_DEFAULT);
+    }
+    {
+        let _env = KBudgetEnvGuard::apply([
+            (K_BUDGET_SS_PREF_ENV, None),
+            (K_BUDGET_MS_ENV, None),
+            (K_BUDGET_SSU_ENV, Some("9")),
+        ]);
+        let kb = KBudget::from_env();
+        assert_eq!(kb.ss_pref, K_BUDGET_SS_PREF_DEFAULT);
+        assert_eq!(kb.ms, K_BUDGET_MS_DEFAULT);
+        assert_eq!(kb.ssu, 9);
+    }
+}
+
+/// Unparseable values, negative values (which fail `usize` parse), and
+/// explicit `0` all fall back to the locked defaults. `0` is treated
+/// as unset because a zero k-budget would short-circuit recall —
+/// anyone wanting to suppress recall should use a dedicated kill
+/// switch, not `K_BUDGET_*=0`.
+#[test]
+fn k_budget_from_env_rejects_garbage_and_zero() {
+    let _env = KBudgetEnvGuard::apply([
+        (K_BUDGET_SS_PREF_ENV, Some("not-a-number")),
+        (K_BUDGET_MS_ENV, Some("0")),
+        (K_BUDGET_SSU_ENV, Some("-5")),
+    ]);
+    let kb = KBudget::from_env();
+    assert_eq!(kb.ss_pref, K_BUDGET_SS_PREF_DEFAULT);
+    assert_eq!(kb.ms, K_BUDGET_MS_DEFAULT);
+    assert_eq!(kb.ssu, K_BUDGET_SSU_DEFAULT);
+}
+
+/// `IntentRouter::from_env` threads the env-resolved budget through to
+/// `k_for_type`. Sanity check: setting only the MS bucket via env
+/// changes the `multi-session` k but leaves SS-Pref/SSU on defaults.
+#[test]
+fn intent_router_from_env_threads_budget_into_k_for_type() {
+    let _env = KBudgetEnvGuard::apply([
+        (K_BUDGET_SS_PREF_ENV, None),
+        (K_BUDGET_MS_ENV, Some("123")),
+        (K_BUDGET_SSU_ENV, None),
+    ]);
+    let router = IntentRouter::from_env();
+    assert_eq!(router.k_for_type("multi-session"), 123);
+    assert_eq!(router.k_for_type("temporal-reasoning"), 123);
+    assert_eq!(router.k_for_type("knowledge-update"), 123);
+    assert_eq!(
+        router.k_for_type("single-session-preference"),
+        K_BUDGET_SS_PREF_DEFAULT
+    );
+    assert_eq!(
+        router.k_for_type("single-session-user"),
+        K_BUDGET_SSU_DEFAULT
+    );
+    // Unknown type falls back to SS-Pref bucket (default 22).
+    assert_eq!(
+        router.k_for_type("future-unspecified"),
+        K_BUDGET_SS_PREF_DEFAULT
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (back to G3 router-mode tests)
+// ---------------------------------------------------------------------------
 
 /// **`full` mode behaves like `router` mode for MS card.** Per spec,
 /// both `router` and `full` enable the MS-card-side gates; the router

--- a/pensyve-core/tests/test_intent_router.rs
+++ b/pensyve-core/tests/test_intent_router.rs
@@ -22,8 +22,8 @@ use uuid::Uuid;
 
 use pensyve_core::retrieval::cards::{MultiSessionCard, RetrievalCard};
 use pensyve_core::retrieval::intent_router::{
-    IntentRouter, KBudget, K_BUDGET_MS_DEFAULT, K_BUDGET_MS_ENV, K_BUDGET_SSU_DEFAULT,
-    K_BUDGET_SSU_ENV, K_BUDGET_SS_PREF_DEFAULT, K_BUDGET_SS_PREF_ENV, RouterDecision, route,
+    IntentRouter, K_BUDGET_MS_DEFAULT, K_BUDGET_MS_ENV, K_BUDGET_SS_PREF_DEFAULT,
+    K_BUDGET_SS_PREF_ENV, K_BUDGET_SSU_DEFAULT, K_BUDGET_SSU_ENV, KBudget, RouterDecision, route,
 };
 use pensyve_core::storage::StorageTrait;
 use pensyve_core::storage::sqlite::SqliteBackend;

--- a/pensyve-core/tests/test_ms_card_v2.rs
+++ b/pensyve-core/tests/test_ms_card_v2.rs
@@ -314,11 +314,10 @@ fn ms_v1_new_constructor_ignores_ms_card_days_env() {
     let card = MultiSessionCard::new();
     let out = card
         .build("any", backend.as_ref(), ns, None, None, None)
-        .expect("G2/G3 entry-path `new()` must surface 2-day entity regardless of PENSYVE_MS_CARD_DAYS");
-    assert!(
-        out.contains("Carol"),
-        "expected entity Carol; got:\n{out}"
-    );
+        .expect(
+            "G2/G3 entry-path `new()` must surface 2-day entity regardless of PENSYVE_MS_CARD_DAYS",
+        );
+    assert!(out.contains("Carol"), "expected entity Carol; got:\n{out}");
 }
 
 // ---------------------------------------------------------------------------

--- a/pensyve-core/tests/test_ms_card_v2.rs
+++ b/pensyve-core/tests/test_ms_card_v2.rs
@@ -1,0 +1,558 @@
+//! Integration tests for the G4 MS-card-v2 + supersession output-merge
+//! (Approach A) — pre-reg lock @ pensyve-docs@8930c4a.
+//!
+//! Coverage matrix (per G4-P3 task spec):
+//!
+//! 1. **`PENSYVE_MS_CARD_DAYS=2` surfaces 2-day cross-session pattern** —
+//!    the v2 path with the env-var default = 2 yields output for a
+//!    2-day cross-session entity that the G3 ≥3-day threshold would
+//!    have dropped.
+//! 2. **`PENSYVE_MS_CARD_DAYS=4` suppresses 2- and 3-day patterns** —
+//!    explicit env-override raises the bar above the v2 default.
+//! 3. **G3 default (env unset, v2 path active) → defaults to 2** —
+//!    `MultiSessionCard::v2()` with no env var picks
+//!    [`MS_CARD_CROSS_SESSION_THRESHOLD_G4`] (= 2).
+//! 4. **G3 path regression: existing `new()` callers default to G2/G3
+//!    dispatch, NOT v2** — `MultiSessionCard::new()` with no env var
+//!    behaves as G2 baseline (threshold = 2 here too, but via the G2
+//!    code path: `ms_days = None`).
+//! 5. **`merge_supersession_chain` prepends chain entities** — unit-
+//!    style test against a synthesized chain string.
+//! 6. **`SupersessionCard::build_chain_only` returns chain text without
+//!    `--- SUPERSESSION CHAIN ---` scaffolding** — emits the bullet
+//!    block alone.
+//! 7. **Composite integration: MS-card-v2 + Supersession in same chain
+//!    yields merged output** — end-to-end through `CompositeCard::g4_default`.
+//!
+//! Env-var fixture pattern mirrors `tests/test_intent_router.rs` —
+//! every test that mutates `PENSYVE_MS_CARD_DAYS` (or the existing
+//! `PENSYVE_RETRIEVAL_CARDS_G3`) holds a process-wide mutex for the
+//! lifetime of an `MsCardEnvGuard` so concurrent test threads cannot
+//! race the cached env reads on `MultiSessionCard::v2()` construction.
+
+use std::sync::{Mutex, OnceLock};
+
+use uuid::Uuid;
+
+use pensyve_core::retrieval::cards::multi_session::{
+    MS_CARD_CROSS_SESSION_THRESHOLD_G4, MS_CARD_DAYS_ENV, MS_CARD_SUPERSESSION_FOOTER,
+    MS_CARD_SUPERSESSION_HEADER,
+};
+use pensyve_core::retrieval::cards::supersession::{
+    SUPERSESSION_CARD_FOOTER, SUPERSESSION_CARD_HEADER,
+};
+use pensyve_core::retrieval::cards::{
+    CompositeCard, MultiSessionCard, RetrievalCard, SupersessionCard,
+};
+use pensyve_core::storage::StorageTrait;
+use pensyve_core::storage::sqlite::SqliteBackend;
+
+use rusqlite::Connection;
+use tempfile::TempDir;
+
+// ---------------------------------------------------------------------------
+// Env-var serialization (mirrors RouterEnvGuard in test_intent_router.rs)
+// ---------------------------------------------------------------------------
+
+/// `MultiSessionCard::v2()` reads `PENSYVE_MS_CARD_DAYS` at construction;
+/// tests that mutate that variable must run serially or the cached
+/// `ms_days` will race across threads. The mutex is process-wide.
+fn ms_days_env_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+/// RAII guard that holds the process-wide [`ms_days_env_lock`] AND
+/// mutates `PENSYVE_MS_CARD_DAYS` for the lifetime of the guard. The
+/// previous value is captured at construction and restored on drop.
+struct MsCardEnvGuard {
+    _serial: std::sync::MutexGuard<'static, ()>,
+    previous: Option<String>,
+}
+
+#[allow(
+    unsafe_code,
+    reason = "test-only env-var guard; std::env::set_var/remove_var require unsafe in modern Rust because env mutation is process-global. The struct holds the process-wide ms_days_env_lock for its lifetime so concurrent test threads cannot race."
+)]
+impl MsCardEnvGuard {
+    fn set(value: &str) -> Self {
+        let serial = ms_days_env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let previous = std::env::var(MS_CARD_DAYS_ENV).ok();
+        // SAFETY: serialized via the mutex in `serial`.
+        unsafe {
+            std::env::set_var(MS_CARD_DAYS_ENV, value);
+        }
+        Self {
+            _serial: serial,
+            previous,
+        }
+    }
+
+    fn unset() -> Self {
+        let serial = ms_days_env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let previous = std::env::var(MS_CARD_DAYS_ENV).ok();
+        // SAFETY: serialized via the mutex in `serial`.
+        unsafe {
+            std::env::remove_var(MS_CARD_DAYS_ENV);
+        }
+        Self {
+            _serial: serial,
+            previous,
+        }
+    }
+}
+
+#[allow(
+    unsafe_code,
+    reason = "test-only env-var guard; see MsCardEnvGuard::set for justification"
+)]
+impl Drop for MsCardEnvGuard {
+    fn drop(&mut self) {
+        // SAFETY: drop runs while we still hold the serialization lock.
+        unsafe {
+            match &self.previous {
+                Some(v) => std::env::set_var(MS_CARD_DAYS_ENV, v),
+                None => std::env::remove_var(MS_CARD_DAYS_ENV),
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SQLite fixtures
+// ---------------------------------------------------------------------------
+
+fn open_backend() -> (TempDir, std::path::PathBuf, Box<dyn StorageTrait>) {
+    let dir = tempfile::tempdir().unwrap();
+    let backend: Box<dyn StorageTrait> = Box::new(SqliteBackend::open(dir.path()).unwrap());
+    let db_path = backend
+        .db_path()
+        .expect("SqliteBackend must expose its disk path")
+        .to_path_buf();
+    (dir, db_path, backend)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn insert_obs(
+    conn: &Connection,
+    namespace_id: &str,
+    entity_type: &str,
+    instance: &str,
+    action: &str,
+    content: &str,
+    event_time: Option<&str>,
+    chain_summary: Option<&str>,
+) {
+    conn.execute(
+        "INSERT INTO observation_memories \
+         (id, namespace_id, episode_id, entity_type, instance, action, \
+          content, event_time, created_at, agent_id, user_id, chain_summary) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+        rusqlite::params![
+            Uuid::new_v4().to_string(),
+            namespace_id,
+            Uuid::new_v4().to_string(),
+            entity_type,
+            instance,
+            action,
+            content,
+            event_time,
+            "2023-01-01T00:00:00Z",
+            None::<String>,
+            None::<String>,
+            chain_summary,
+        ],
+    )
+    .unwrap();
+}
+
+/// Seed an entity across `n_days` distinct date-day buckets in
+/// `2024-01-XX`. Returns the namespace UUID used.
+fn seed_n_day_entity(conn: &Connection, instance: &str, n_days: usize) -> Uuid {
+    let ns = Uuid::new_v4();
+    let ns_str = ns.to_string();
+    for d in 0..n_days {
+        insert_obs(
+            conn,
+            &ns_str,
+            "person",
+            instance,
+            "discussed",
+            &format!("mention day {d}"),
+            Some(&format!("2024-01-{:02}T10:00:00Z", d + 1)),
+            None,
+        );
+    }
+    ns
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: PENSYVE_MS_CARD_DAYS=2 surfaces a 2-day cross-session entity
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ms_v2_with_env_2_days_surfaces_2_session_entity() {
+    let _g = MsCardEnvGuard::set("2");
+    let (_dir, db_path, backend) = open_backend();
+    let conn = Connection::open(&db_path).unwrap();
+    let ns = seed_n_day_entity(&conn, "Alice", 2);
+    drop(conn);
+
+    let card = MultiSessionCard::v2();
+    let out = card
+        .build("any", backend.as_ref(), ns, None, None, None)
+        .expect("v2 with PENSYVE_MS_CARD_DAYS=2 must surface a 2-session entity");
+    assert!(
+        out.contains("Alice"),
+        "expected entity Alice in card; got:\n{out}"
+    );
+    assert!(
+        out.contains("2 sessions"),
+        "expected '2 sessions' count; got:\n{out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: PENSYVE_MS_CARD_DAYS=4 suppresses 2- and 3-day patterns
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ms_v2_with_env_4_days_suppresses_2_and_3_session_entities() {
+    let _g = MsCardEnvGuard::set("4");
+    let (_dir, db_path, backend) = open_backend();
+    let conn = Connection::open(&db_path).unwrap();
+    let ns = Uuid::new_v4();
+    let ns_str = ns.to_string();
+    // 2-day entity:
+    for d in 0..2 {
+        insert_obs(
+            &conn,
+            &ns_str,
+            "person",
+            "TwoDay",
+            "discussed",
+            "snippet",
+            Some(&format!("2024-02-{:02}T10:00:00Z", d + 1)),
+            None,
+        );
+    }
+    // 3-day entity:
+    for d in 0..3 {
+        insert_obs(
+            &conn,
+            &ns_str,
+            "person",
+            "ThreeDay",
+            "discussed",
+            "snippet",
+            Some(&format!("2024-03-{:02}T10:00:00Z", d + 1)),
+            None,
+        );
+    }
+    drop(conn);
+
+    let card = MultiSessionCard::v2();
+    let out = card.build("any", backend.as_ref(), ns, None, None, None);
+    assert!(
+        out.is_none(),
+        "PENSYVE_MS_CARD_DAYS=4 must suppress all entities below 4 days; got: {out:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: env unset → v2 default = MS_CARD_CROSS_SESSION_THRESHOLD_G4 (= 2)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ms_v2_env_unset_defaults_to_2_days() {
+    let _g = MsCardEnvGuard::unset();
+    // Sanity: the constant is what the spec locks (≥2).
+    assert_eq!(
+        MS_CARD_CROSS_SESSION_THRESHOLD_G4, 2,
+        "G4 pre-reg lock @ pensyve-docs@8930c4a fixes default v2 threshold at 2"
+    );
+
+    let (_dir, db_path, backend) = open_backend();
+    let conn = Connection::open(&db_path).unwrap();
+    let ns = seed_n_day_entity(&conn, "Bob", 2);
+    drop(conn);
+
+    let card = MultiSessionCard::v2();
+    let out = card
+        .build("any", backend.as_ref(), ns, None, None, None)
+        .expect("v2 with env unset must surface 2-day entity (default = 2)");
+    assert!(
+        out.contains("Bob"),
+        "expected entity Bob in card; got:\n{out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 4: existing `new()` callers ignore PENSYVE_MS_CARD_DAYS (G2/G3 path)
+// ---------------------------------------------------------------------------
+
+/// Regression guard for the G3 + G2 entry path. `MultiSessionCard::new()`
+/// must remain on the G2/G3 dispatch (`ms_days = None`) regardless of
+/// `PENSYVE_MS_CARD_DAYS`. Setting the env var to a high value (so that
+/// any v2 dispatch would suppress the entity) and using `new()` instead
+/// of `v2()` must STILL surface a 2-day entity at the G2 baseline
+/// threshold.
+#[test]
+fn ms_v1_new_constructor_ignores_ms_card_days_env() {
+    let _g = MsCardEnvGuard::set("99");
+    let (_dir, db_path, backend) = open_backend();
+    let conn = Connection::open(&db_path).unwrap();
+    let ns = seed_n_day_entity(&conn, "Carol", 2);
+    drop(conn);
+
+    // `new()` (G2 entry path) — `question_type = None` keeps us on
+    // baseline dispatch even if `PENSYVE_RETRIEVAL_CARDS_G3` is set.
+    let card = MultiSessionCard::new();
+    let out = card
+        .build("any", backend.as_ref(), ns, None, None, None)
+        .expect("G2/G3 entry-path `new()` must surface 2-day entity regardless of PENSYVE_MS_CARD_DAYS");
+    assert!(
+        out.contains("Carol"),
+        "expected entity Carol; got:\n{out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 5: merge_supersession_chain prepends chain entities
+// ---------------------------------------------------------------------------
+
+/// `merge_supersession_chain` is pure — exercise the truth table without
+/// touching `SQLite` at all. The card's `ms_days` / `g3_mode` fields don't
+/// influence the merge output for these inputs.
+#[test]
+fn merge_supersession_chain_truth_table() {
+    let card = MultiSessionCard::v2();
+
+    // (Some, Some) — chain block + \n\n + base
+    let merged = card
+        .merge_supersession_chain(
+            Some("- chain summary one\n- chain summary two"),
+            Some("--- CROSS-SESSION ENTITIES ---\n- person: alice\n--- END CROSS-SESSION ENTITIES ---".to_string()),
+        )
+        .expect("merged output must be Some when at least one input is non-empty");
+    assert!(
+        merged.starts_with(MS_CARD_SUPERSESSION_HEADER),
+        "merged output must start with the MS supersession header; got:\n{merged}"
+    );
+    assert!(
+        merged.contains(MS_CARD_SUPERSESSION_FOOTER),
+        "merged output must contain the MS supersession footer; got:\n{merged}"
+    );
+    assert!(
+        merged.contains("- chain summary one"),
+        "chain content must surface; got:\n{merged}"
+    );
+    assert!(
+        merged.contains("- person: alice"),
+        "base content must follow chain; got:\n{merged}"
+    );
+    // Chain block precedes the base block
+    let chain_idx = merged.find(MS_CARD_SUPERSESSION_HEADER).unwrap();
+    let base_idx = merged.find("--- CROSS-SESSION ENTITIES ---").unwrap();
+    assert!(
+        chain_idx < base_idx,
+        "supersession chain must be PREPENDED, not appended; chain_idx={chain_idx} base_idx={base_idx}"
+    );
+
+    // (Some, None) — chain block alone
+    let chain_only = card
+        .merge_supersession_chain(Some("- only chain"), None)
+        .expect("chain-only must be Some");
+    assert!(chain_only.contains("- only chain"));
+    assert!(!chain_only.contains("CROSS-SESSION"));
+
+    // (None, Some) — base alone, no merge wrapper
+    let base_only = card
+        .merge_supersession_chain(None, Some("base text".to_string()))
+        .expect("base-only must be Some");
+    assert_eq!(base_only, "base text");
+
+    // (None, None) — None
+    assert!(card.merge_supersession_chain(None, None).is_none());
+
+    // Empty / whitespace chain treated as None
+    let whitespace_chain = card.merge_supersession_chain(Some("   \n  "), Some("base".to_string()));
+    assert_eq!(
+        whitespace_chain.as_deref(),
+        Some("base"),
+        "all-whitespace chain must NOT inject an empty supersession block"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 6: SupersessionCard::build_chain_only returns chain text without scaffolding
+// ---------------------------------------------------------------------------
+
+#[test]
+fn supersession_build_chain_only_omits_card_scaffolding() {
+    let (_dir, db_path, backend) = open_backend();
+    let _ = backend; // backend kept alive solely to keep db_path valid.
+    let ns = Uuid::new_v4();
+    let ns_str = ns.to_string();
+    let conn = Connection::open(&db_path).unwrap();
+    insert_obs(
+        &conn,
+        &ns_str,
+        "person",
+        "alice",
+        "discussed",
+        "irrelevant",
+        Some("2024-04-01T10:00:00Z"),
+        Some("Alice migrated SF -> NY -> SF over three sessions."),
+    );
+    insert_obs(
+        &conn,
+        &ns_str,
+        "person",
+        "alice",
+        "discussed",
+        "irrelevant",
+        Some("2024-04-02T10:00:00Z"),
+        Some("Bob's role evolved from intern to architect."),
+    );
+
+    let chain_only = SupersessionCard::new()
+        .build_chain_only(&conn, ns, None, None)
+        .expect("two non-NULL chain summaries must produce a non-empty chain block");
+
+    // Must NOT contain the standalone-card scaffolding markers.
+    assert!(
+        !chain_only.contains(SUPERSESSION_CARD_HEADER),
+        "build_chain_only output must NOT contain standalone SUPERSESSION_CARD_HEADER; got:\n{chain_only}"
+    );
+    assert!(
+        !chain_only.contains(SUPERSESSION_CARD_FOOTER),
+        "build_chain_only output must NOT contain standalone SUPERSESSION_CARD_FOOTER; got:\n{chain_only}"
+    );
+    // MUST contain the bullet body verbatim.
+    assert!(
+        chain_only.contains("- Alice migrated SF -> NY -> SF over three sessions."),
+        "chain bullet for alice missing; got:\n{chain_only}"
+    );
+    assert!(
+        chain_only.contains("- Bob's role evolved from intern to architect."),
+        "chain bullet for bob missing; got:\n{chain_only}"
+    );
+
+    // Sanity: standalone build_from_conn (via the trait `build()`) DOES carry the scaffolding.
+    let standalone = SupersessionCard::new()
+        .build("any", backend.as_ref(), ns, None, None, None)
+        .expect("standalone supersession build must surface the same chain summaries");
+    assert!(standalone.contains(SUPERSESSION_CARD_HEADER));
+    assert!(standalone.contains(SUPERSESSION_CARD_FOOTER));
+}
+
+// ---------------------------------------------------------------------------
+// Test 7: Composite integration — MS-card-v2 + Supersession in same chain yields merged output
+// ---------------------------------------------------------------------------
+
+/// Mock card that always defers (returns `None`) — fills the peer + ssu
+/// slots in the composite without depending on `PeerCardAdapter` or
+/// `SingleSessionUserCard` fixtures.
+struct EmptyCard(&'static str);
+
+impl RetrievalCard for EmptyCard {
+    fn build(
+        &self,
+        _q: &str,
+        _s: &dyn StorageTrait,
+        _ns: Uuid,
+        _a: Option<pensyve_core::types::AgentId>,
+        _u: Option<pensyve_core::types::UserId>,
+        _qt: Option<&str>,
+    ) -> Option<String> {
+        None
+    }
+    fn name(&self) -> &'static str {
+        self.0
+    }
+}
+
+#[test]
+fn composite_integration_ms_v2_with_supersession_emits_merged_block() {
+    let _g = MsCardEnvGuard::set("2");
+    let (_dir, db_path, backend) = open_backend();
+    let ns = Uuid::new_v4();
+    let ns_str = ns.to_string();
+    let conn = Connection::open(&db_path).unwrap();
+    // Cross-session entity (≥2 days) so MS-card-v2 emits content.
+    for d in 0..2 {
+        insert_obs(
+            &conn,
+            &ns_str,
+            "person",
+            "Diana",
+            "discussed",
+            "snippet",
+            Some(&format!("2024-05-{:02}T10:00:00Z", d + 1)),
+            None,
+        );
+    }
+    // A row carrying a chain_summary so SupersessionCard surfaces.
+    insert_obs(
+        &conn,
+        &ns_str,
+        "topic",
+        "topic-with-summary",
+        "noted",
+        "irrelevant",
+        Some("2024-05-10T10:00:00Z"),
+        Some("Diana's team rotated lead three times."),
+    );
+    drop(conn);
+
+    // Construct an MS-card-v2 with a supersession-chain handle attached
+    // (Approach A wiring) and a separate standalone SupersessionCard for
+    // the SSC slot in the composite.
+    let ms_v2 = MultiSessionCard::v2().with_supersession_chain(SupersessionCard::new());
+
+    let composite = CompositeCard::g4_default(
+        Box::new(EmptyCard("peer")),
+        Box::new(ms_v2),
+        Box::new(EmptyCard("ssu")),
+        Box::new(SupersessionCard::new()),
+    );
+
+    let out = composite
+        .build("any", backend.as_ref(), ns, None, None, None)
+        .expect("composite must produce merged output with at least MS + SSC content");
+
+    // The MS-card section carries the prepended supersession chain
+    // under the (MS) markers, and the standalone SSC section carries
+    // the unscoped SUPERSESSION_CARD_HEADER markers. Both must be
+    // present.
+    assert!(
+        out.contains(MS_CARD_SUPERSESSION_HEADER),
+        "MS-card supersession-chain block (Approach A merge) must be present; got:\n{out}"
+    );
+    assert!(
+        out.contains(MS_CARD_SUPERSESSION_FOOTER),
+        "MS-card supersession-chain footer must be present; got:\n{out}"
+    );
+    assert!(
+        out.contains("Diana"),
+        "MS-card base content (entity Diana) must surface; got:\n{out}"
+    );
+    assert!(
+        out.contains(SUPERSESSION_CARD_HEADER),
+        "standalone SupersessionCard block must still be present; got:\n{out}"
+    );
+
+    // Order check: MS-card's merged supersession block must appear BEFORE
+    // the standalone SupersessionCard block in the composite output.
+    let ms_chain_idx = out.find(MS_CARD_SUPERSESSION_HEADER).unwrap();
+    let standalone_idx = out.find(SUPERSESSION_CARD_HEADER).unwrap();
+    assert!(
+        ms_chain_idx < standalone_idx,
+        "MS-card merged block must precede standalone SupersessionCard block; ms_chain={ms_chain_idx} standalone={standalone_idx}"
+    );
+}

--- a/pensyve-python/python/pensyve/_core.pyi
+++ b/pensyve-python/python/pensyve/_core.pyi
@@ -73,10 +73,9 @@ class Pensyve:
             extractor: Optional observation extractor. Supported values:
                 - `"local-llm"` / `"local-vllm"`: OpenAI-compatible local
                   backend; offline-first.
-                - `"batched-local-llm"`: deferred per-episode extraction
-                  drained by `flush_extractions()`.
-                - `"haiku"` / `"haiku-batched"` / `"haiku-cached"` /
-                  `"haiku-nocache"`: Anthropic Haiku 4.5 paths.
+                - `"batched-local-llm"`: same inner extractor wrapped in
+                  a semaphore-gated batch path; activates via
+                  `flush_extractions()`.
                 - `None` (default) skips extraction entirely.
             extractor_api_key: Explicit API key for the configured extractor.
             reranker: Cross-encoder reranker applied post-fusion. Default

--- a/pensyve-python/python/pensyve/_core.pyi
+++ b/pensyve-python/python/pensyve/_core.pyi
@@ -57,43 +57,67 @@ class Pensyve:
         extractor: str | None = None,
         extractor_api_key: str | None = None,
         reranker: str | None = "BGERerankerBase",
-        extractor_cache: HaikuExtractionCache | None = None,
+        extractor_base_url: str | None = None,
+        extractor_model: str | None = None,
+        extractor_max_concurrency: int | None = None,
+        agent_id: str | None = None,
+        user_id: str | None = None,
+        k_budget: dict[str, int] | None = None,
+        ms_card_days: int | None = None,
     ) -> None:
         """Create or open a Pensyve instance.
 
         Args:
             path: Directory for storage files (default: ~/.pensyve/default).
             namespace: Namespace name (default: "default").
-            extractor: Optional observation extractor.
-                - `"haiku"` wires the Anthropic Haiku 4.5 extractor
-                  (requires `ANTHROPIC_API_KEY` env var unless
-                  `extractor_api_key` is provided).
-                - `"haiku-batched"` wraps Haiku in the Anthropic Messages
-                  Batches API for bulk re-ingestion (50% per-token discount).
-                - `"haiku-cached"` serves per-episode extraction from a
-                  prewarmed cache built via
-                  `prewarm_haiku_extraction_cache(...)` — the canonical
-                  bulk path. Requires `extractor_cache=...`.
-                - `"haiku-nocache"` is the diagnostic path with prompt
-                  caching disabled.
-                - `"local-vllm"` wires an OpenAI-compatible local-LLM
-                  extractor for offline-first deployments (reads
-                  `PENSYVE_LOCAL_LLM_URL`, `PENSYVE_LOCAL_LLM_MODEL`,
-                  `PENSYVE_LOCAL_LLM_API_KEY` from the environment; defaults
-                  to `http://localhost:8888/v1`, model `"local"`, no auth).
+            extractor: Optional observation extractor. Supported values:
+                - `"local-llm"` / `"local-vllm"`: OpenAI-compatible local
+                  backend; offline-first.
+                - `"batched-local-llm"`: deferred per-episode extraction
+                  drained by `flush_extractions()`.
+                - `"haiku"` / `"haiku-batched"` / `"haiku-cached"` /
+                  `"haiku-nocache"`: Anthropic Haiku 4.5 paths.
                 - `None` (default) skips extraction entirely.
             extractor_api_key: Explicit API key for the configured extractor.
-                Overrides `ANTHROPIC_API_KEY` (haiku) or
-                `PENSYVE_LOCAL_LLM_API_KEY` (local-vllm).
-            reranker: Cross-encoder reranker applied post-fusion in `recall`
-                and `recall_grouped`. Default `"BGERerankerBase"` — the
-                algorithm-spec default. Pass `None` to disable (skips the
-                ~150MB fastembed model download, but this is a weaker
-                algorithm than the spec describes). `"JINARerankerV1TurboEn"`
-                is also supported as an English-only alternative.
-            extractor_cache: Required when `extractor="haiku-cached"`. Build
-                via `prewarm_haiku_extraction_cache(messages_groups, ...)`.
-                Ignored for all other extractor values.
+            reranker: Cross-encoder reranker applied post-fusion. Default
+                `"BGERerankerBase"`. Pass `None` to disable.
+            extractor_base_url: Override for the local-LLM endpoint
+                (precedes `PENSYVE_EXTRACTOR_URL`).
+            extractor_model: Override for the local-LLM model id (precedes
+                `PENSYVE_EXTRACTOR_MODEL`).
+            extractor_max_concurrency: In-flight ceiling for
+                `extractor="batched-local-llm"`.
+            agent_id: G1 multi-tenant scope — UUID-shaped string.
+            user_id: G1 multi-tenant scope — UUID-shaped string.
+            k_budget: G4 retrieval-side k-budget per `question_type`
+                family. Dict shape:
+                `{"ss_pref": int, "ms": int, "ssu": int}`. Missing keys
+                fall back to the locked defaults
+                `{"ss_pref": 22, "ms": 50, "ssu": 12}`. Precedence:
+                kwarg > `PENSYVE_K_BUDGET_*` env > default. Pre-reg lock
+                at `pensyve-docs@8930c4a`.
+            ms_card_days: G4 MS-card-v2 cross-session day threshold.
+                Default `2`. Precedence: kwarg > `PENSYVE_MS_CARD_DAYS`
+                env > default. Pre-reg lock at `pensyve-docs@8930c4a`.
+        """
+        ...
+
+    @property
+    def k_budget(self) -> dict[str, int]:
+        """Resolved k-budget per `question_type` family.
+
+        Returns a dict with keys ``ss_pref``, ``ms``, ``ssu``. Reflects
+        the kwarg > env > default precedence locked at
+        ``pensyve-docs@8930c4a``.
+        """
+        ...
+
+    @property
+    def ms_card_days(self) -> int:
+        """Resolved MS-card-v2 cross-session day threshold.
+
+        Reflects the kwarg > env > default precedence locked at
+        ``pensyve-docs@8930c4a`` (default = 2).
         """
         ...
 

--- a/pensyve-python/src/lib.rs
+++ b/pensyve-python/src/lib.rs
@@ -21,6 +21,7 @@ use pensyve_core::retrieval::cards::{
     CompositeCard, MultiSessionCard, PeerCardAdapter, RetrievalCard, SingleSessionUserCard,
     SupersessionCard,
 };
+use pensyve_core::retrieval::intent_router::{IntentRouter, KBudget};
 use pensyve_core::storage::StorageTrait;
 use pensyve_core::storage::sqlite::SqliteBackend;
 use pensyve_core::types::{self, EntityKind, EpisodicMemory, Namespace, Outcome, SemanticMemory};
@@ -387,17 +388,19 @@ struct PensyveInner {
     /// with `Pensyve(reranker=None)` for embedded/offline contexts where
     /// the ~150MB model download is unacceptable.
     reranker: Option<Arc<pensyve_core::reranker::Reranker>>,
-    /// G4 P5: resolved k-budget per `question_type` family. Set at
-    /// construction via the `k_budget` kwarg / `PENSYVE_K_BUDGET_*` env
-    /// vars / locked defaults. Currently stored for Python-side
-    /// observability + future wiring into `IntentRouter::k_for_type` (G4
-    /// P2). Recall pipeline does not yet consume this — see TODO(g4-p5).
-    k_budget: KBudget,
+    /// G4 P5: stateful intent router with the resolved per-`question_type`
+    /// k-budget cached at construction. Built from the `k_budget` kwarg /
+    /// `PENSYVE_K_BUDGET_*` env vars / locked defaults via
+    /// `IntentRouter::with_budget(...)`. Routed recall paths
+    /// (`recall_grouped_with_router`) consume this directly; the
+    /// Python-side `k_budget` getter inspects `IntentRouter::k_budget()`.
+    intent_router: IntentRouter,
     /// G4 P5: resolved MS-card-v2 cross-session day threshold. Set at
     /// construction via the `ms_card_days` kwarg / `PENSYVE_MS_CARD_DAYS`
-    /// env var / locked default of 2. Currently stored for observability
-    /// and future wiring into `MultiSessionCard::with_days` (G4 P3).
-    /// Recall pipeline does not yet consume this — see TODO(g4-p5).
+    /// env var / locked default of 2. Threaded into the
+    /// `MultiSessionCard::with_ms_days(Some(_))` builder at every card
+    /// construction site so the recall pipeline (composite-card path)
+    /// observes the resolved value.
     ms_card_days: usize,
 }
 
@@ -417,71 +420,21 @@ struct PensyveInner {
 //   - Precedence: kwarg > env > default (matches v2.1's
 //     `Pensyve::with_peer_card(bool)` pattern).
 //
-// NOTE: the upstream Rust API surface (`IntentRouter::k_for_type` +
-// `MultiSessionCard::with_days`) is being built in parallel by G4 P2 / P3.
-// Until those branches merge to `main`, this module **stubs the resolution
-// logic** and stores the values on `PensyveInner` for Python-side
-// observability, but does NOT yet plumb them through the recall engine.
-// The wiring point is marked with `TODO(g4-p5)`. See the report.
+// The upstream Rust API surface
+// (`pensyve_core::retrieval::intent_router::{KBudget, IntentRouter}` and
+// `MultiSessionCard::with_ms_days`) lands via G4 P2 / P3. The PyO3 layer
+// imports the upstream `KBudget` directly (single source of truth for
+// the locked default constants + env-var parsing), wraps it in an
+// `IntentRouter` for the routed-recall path, and threads
+// `ms_card_days` into the lone `MultiSessionCard::new()` site via
+// `MultiSessionCard::with_ms_days(Some(_))`.
 
-/// Default k-budget per pre-reg `pensyve-docs@8930c4a`. Anchored as a
-/// const so that test fixtures and the resolver agree byte-for-byte on
-/// the locked numbers.
-const G4_DEFAULT_K_SS_PREF: usize = 22;
-const G4_DEFAULT_K_MS: usize = 50;
-const G4_DEFAULT_K_SSU: usize = 12;
-
-/// Default MS-card-v2 cross-session day threshold per pre-reg.
+/// Default MS-card-v2 cross-session day threshold per pre-reg
+/// `pensyve-docs@8930c4a`. Mirrors the constant defined in
+/// `pensyve_core::retrieval::cards::multi_session` so the kwarg /
+/// env / default precedence resolver here matches the locked value
+/// without depending on a private constant on the core side.
 const G4_DEFAULT_MS_CARD_DAYS: usize = 2;
-
-/// Resolved k-budget per `question_type` family.
-///
-/// The three slots correspond to the three card-archetype k caps under
-/// G4: `ss_pref` (single-session-preference), `ms` (multi-session +
-/// temporal-reasoning + knowledge-update), `ssu` (single-session-user
-/// and single-session-assistant). The `IntentRouter` (G4 P2) consumes
-/// this via a dispatch on `question_type` -> the appropriate slot.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct KBudget {
-    pub ss_pref: usize,
-    pub ms: usize,
-    pub ssu: usize,
-}
-
-impl KBudget {
-    /// Pre-reg-locked defaults: `{SS-Pref: 22, MS: 50, SSU: 12}`.
-    pub(crate) const fn defaults() -> Self {
-        Self {
-            ss_pref: G4_DEFAULT_K_SS_PREF,
-            ms: G4_DEFAULT_K_MS,
-            ssu: G4_DEFAULT_K_SSU,
-        }
-    }
-
-    /// Read budget from `PENSYVE_K_BUDGET_*` env vars, falling back to
-    /// the locked defaults for any var that is unset or unparseable.
-    /// Mirrors the env-driven path that the `IntentRouter` (G4 P2) will
-    /// expose at the Rust-core level.
-    pub(crate) fn from_env() -> Self {
-        let mut b = Self::defaults();
-        if let Ok(s) = std::env::var("PENSYVE_K_BUDGET_SS_PREF")
-            && let Ok(n) = s.parse()
-        {
-            b.ss_pref = n;
-        }
-        if let Ok(s) = std::env::var("PENSYVE_K_BUDGET_MS")
-            && let Ok(n) = s.parse()
-        {
-            b.ms = n;
-        }
-        if let Ok(s) = std::env::var("PENSYVE_K_BUDGET_SSU")
-            && let Ok(n) = s.parse()
-        {
-            b.ssu = n;
-        }
-        b
-    }
-}
 
 /// Parse a `{"ss_pref": 22, "ms": 50, "ssu": 12}` dict from the kwarg.
 ///
@@ -490,7 +443,7 @@ impl KBudget {
 /// Unknown keys are rejected with `ValueError` to catch typos early
 /// (e.g. `"ss_pref" -> "sspref"`).
 fn parse_k_budget_dict(dict: &Bound<'_, PyDict>) -> PyResult<KBudget> {
-    let mut budget = KBudget::defaults();
+    let mut budget = KBudget::default();
     for (k, v) in dict.iter() {
         let key: String = k.extract().map_err(|_| {
             PyTypeError::new_err("k_budget keys must be strings: 'ss_pref' | 'ms' | 'ssu'")
@@ -602,9 +555,9 @@ impl PyPensyve {
         agent_id: Option<String>,
         user_id: Option<String>,
         // G4 P5: retrieval-side k-budget + MS-card day threshold.
-        // Stub-stored on `PensyveInner` until G4 P2 / P3 land the
-        // upstream `IntentRouter::k_for_type` + `MultiSessionCard::with_days`
-        // wiring points. Pre-reg lock `pensyve-docs@8930c4a`.
+        // Plumbed end-to-end into the upstream `IntentRouter` (G4 P2)
+        // and `MultiSessionCard::with_ms_days` (G4 P3) at construction.
+        // Pre-reg lock `pensyve-docs@8930c4a`.
         k_budget: Option<Bound<'_, PyDict>>,
         ms_card_days: Option<usize>,
     ) -> PyResult<Self> {
@@ -637,17 +590,17 @@ impl PyPensyve {
         // do NOT inherit from the env. This matches the v2.1
         // `with_peer_card(bool)` precedence pattern.
         //
-        // TODO(g4-p5): plumb `k_budget` into the IntentRouter once
-        // `pensyve_core::retrieval::intent_router::k_for_type(...)` lands
-        // (G4 P2). Plumb `ms_card_days` into MultiSessionCard once
-        // `MultiSessionCard::with_days(...)` lands (G4 P3). Both APIs are
-        // not yet on `main` — values are stored on `PensyveInner` so the
-        // Python kwargs are wired end-to-end at the binding boundary
-        // and downstream wiring is a single-edit follow-up.
+        // The resolved `KBudget` is wrapped in an `IntentRouter` so
+        // routed recall (`RecallEngine::recall_grouped_with_router`,
+        // G4 P2) consumes it directly without re-reading env vars on
+        // the per-call hot path. `resolved_ms_card_days` is threaded
+        // into every `MultiSessionCard::new()` site below via
+        // `MultiSessionCard::with_ms_days(Some(_))` (G4 P3).
         let resolved_k_budget = match k_budget {
             Some(dict) => parse_k_budget_dict(&dict)?,
             None => KBudget::from_env(),
         };
+        let resolved_intent_router = IntentRouter::with_budget(resolved_k_budget);
         let resolved_ms_card_days = resolve_ms_card_days(ms_card_days);
 
         // G1 fix: resolve the embedder's load-time `NetworkPolicy` at handle
@@ -809,7 +762,7 @@ impl PyPensyve {
                 agent_id: agent_id_uuid,
                 user_id: user_id_uuid,
                 recall_across_users_allowed,
-                k_budget: resolved_k_budget,
+                intent_router: resolved_intent_router,
                 ms_card_days: resolved_ms_card_days,
             }),
         })
@@ -830,10 +783,11 @@ impl PyPensyve {
     /// `pensyve-docs@8930c4a`.
     #[getter]
     fn k_budget<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let kb = self.inner.intent_router.k_budget();
         let d = PyDict::new(py);
-        d.set_item("ss_pref", self.inner.k_budget.ss_pref)?;
-        d.set_item("ms", self.inner.k_budget.ms)?;
-        d.set_item("ssu", self.inner.k_budget.ssu)?;
+        d.set_item("ss_pref", kb.ss_pref)?;
+        d.set_item("ms", kb.ms)?;
+        d.set_item("ssu", kb.ssu)?;
         Ok(d)
     }
 
@@ -1324,8 +1278,18 @@ impl PyPensyve {
             // intended mode without relying on a process-env mutation
             // (round-4 fix; see comment block above the
             // `g3_mode_value` computation).
+            //
+            // G4 P5: thread the resolved `ms_card_days` through
+            // `MultiSessionCard::with_ms_days(Some(_))` (G4 P3) so the
+            // card observes the kwarg / env / locked-default value
+            // resolved at `Pensyve::new` time, byte-for-byte matching
+            // the precedence the introspection getter reports.
             cards.push((
-                Box::new(MultiSessionCard::new().with_g3_mode(g3_mode_value)),
+                Box::new(
+                    MultiSessionCard::new()
+                        .with_g3_mode(g3_mode_value)
+                        .with_ms_days(Some(self.inner.ms_card_days)),
+                ),
                 G2_MULTI_SESSION_CARD_CAP,
             ));
         }

--- a/pensyve-python/src/lib.rs
+++ b/pensyve-python/src/lib.rs
@@ -442,6 +442,13 @@ const G4_DEFAULT_MS_CARD_DAYS: usize = 2;
 /// partial dict (e.g. `{"ms": 60}`) without restating the other slots.
 /// Unknown keys are rejected with `ValueError` to catch typos early
 /// (e.g. `"ss_pref" -> "sspref"`).
+///
+/// Zero values are rejected with `ValueError`, mirroring the env-path
+/// guard in [`KBudget::from_env`]: a zero k-budget would short-circuit
+/// the entire recall pipeline, so we surface the misuse explicitly here
+/// rather than silently letting it through. Operators that genuinely
+/// want to suppress recall should use a dedicated kill-switch, not
+/// `k_budget={"...": 0}`.
 fn parse_k_budget_dict(dict: &Bound<'_, PyDict>) -> PyResult<KBudget> {
     let mut budget = KBudget::default();
     for (k, v) in dict.iter() {
@@ -451,6 +458,13 @@ fn parse_k_budget_dict(dict: &Bound<'_, PyDict>) -> PyResult<KBudget> {
         let val: usize = v.extract().map_err(|_| {
             PyTypeError::new_err(format!("k_budget['{key}'] must be a non-negative integer"))
         })?;
+        if val == 0 {
+            return Err(PyValueError::new_err(format!(
+                "k_budget['{key}'] must be > 0; zero would short-circuit recall. \
+                 Omit the key to inherit the default, or use a dedicated kill-switch \
+                 to disable recall."
+            )));
+        }
         match key.as_str() {
             "ss_pref" => budget.ss_pref = val,
             "ms" => budget.ms = val,
@@ -469,13 +483,21 @@ fn parse_k_budget_dict(dict: &Bound<'_, PyDict>) -> PyResult<KBudget> {
 ///
 /// Env var: `PENSYVE_MS_CARD_DAYS` (parsed as `usize`; unparseable
 /// values fall back to the default). Default: `2`.
+///
+/// Zero is treated as unset on both the kwarg and env paths, mirroring
+/// the core-side guard in `multi_session::resolve_ms_days`: a 0-day
+/// threshold would surface every entity (no cross-session signal) and
+/// `MultiSessionCard::with_ms_days(Some(0))` already filters it to
+/// `None` internally — without this filter the `ms_card_days` getter
+/// would lie about the effective threshold.
 fn resolve_ms_card_days(kwarg: Option<usize>) -> usize {
-    if let Some(d) = kwarg {
+    if let Some(d) = kwarg.filter(|&n| n > 0) {
         return d;
     }
     std::env::var("PENSYVE_MS_CARD_DAYS")
         .ok()
-        .and_then(|s| s.parse().ok())
+        .and_then(|s| s.trim().parse::<usize>().ok())
+        .filter(|&n| n > 0)
         .unwrap_or(G4_DEFAULT_MS_CARD_DAYS)
 }
 

--- a/pensyve-python/src/lib.rs
+++ b/pensyve-python/src/lib.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use chrono::{DateTime, Utc};
-use pyo3::exceptions::{PyRuntimeError, PyValueError};
+use pyo3::exceptions::{PyRuntimeError, PyTypeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use uuid::Uuid;
@@ -387,6 +387,145 @@ struct PensyveInner {
     /// with `Pensyve(reranker=None)` for embedded/offline contexts where
     /// the ~150MB model download is unacceptable.
     reranker: Option<Arc<pensyve_core::reranker::Reranker>>,
+    /// G4 P5: resolved k-budget per `question_type` family. Set at
+    /// construction via the `k_budget` kwarg / `PENSYVE_K_BUDGET_*` env
+    /// vars / locked defaults. Currently stored for Python-side
+    /// observability + future wiring into `IntentRouter::k_for_type` (G4
+    /// P2). Recall pipeline does not yet consume this — see TODO(g4-p5).
+    k_budget: KBudget,
+    /// G4 P5: resolved MS-card-v2 cross-session day threshold. Set at
+    /// construction via the `ms_card_days` kwarg / `PENSYVE_MS_CARD_DAYS`
+    /// env var / locked default of 2. Currently stored for observability
+    /// and future wiring into `MultiSessionCard::with_days` (G4 P3).
+    /// Recall pipeline does not yet consume this — see TODO(g4-p5).
+    ms_card_days: usize,
+}
+
+// ---------------------------------------------------------------------------
+// G4 P5: k-budget + ms_card_days resolution
+// ---------------------------------------------------------------------------
+//
+// G4 introduces two new construction-time configurations:
+//
+//   1. k-budget per `question_type` (G4 P2 — `IntentRouter::k_for_type`)
+//   2. MS-card-v2 cross-session day threshold (G4 P3)
+//
+// Both are env-driven by default but should also be reachable via PyO3
+// kwargs for SDK consumers. Pre-reg lock at `pensyve-docs@8930c4a`:
+//   - k-budget defaults: `{SS-Pref: 22, MS: 50, SSU: 12}`
+//   - MS-card-days default: `2`
+//   - Precedence: kwarg > env > default (matches v2.1's
+//     `Pensyve::with_peer_card(bool)` pattern).
+//
+// NOTE: the upstream Rust API surface (`IntentRouter::k_for_type` +
+// `MultiSessionCard::with_days`) is being built in parallel by G4 P2 / P3.
+// Until those branches merge to `main`, this module **stubs the resolution
+// logic** and stores the values on `PensyveInner` for Python-side
+// observability, but does NOT yet plumb them through the recall engine.
+// The wiring point is marked with `TODO(g4-p5)`. See the report.
+
+/// Default k-budget per pre-reg `pensyve-docs@8930c4a`. Anchored as a
+/// const so that test fixtures and the resolver agree byte-for-byte on
+/// the locked numbers.
+const G4_DEFAULT_K_SS_PREF: usize = 22;
+const G4_DEFAULT_K_MS: usize = 50;
+const G4_DEFAULT_K_SSU: usize = 12;
+
+/// Default MS-card-v2 cross-session day threshold per pre-reg.
+const G4_DEFAULT_MS_CARD_DAYS: usize = 2;
+
+/// Resolved k-budget per `question_type` family.
+///
+/// The three slots correspond to the three card-archetype k caps under
+/// G4: `ss_pref` (single-session-preference), `ms` (multi-session +
+/// temporal-reasoning + knowledge-update), `ssu` (single-session-user
+/// and single-session-assistant). The `IntentRouter` (G4 P2) consumes
+/// this via a dispatch on `question_type` -> the appropriate slot.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct KBudget {
+    pub ss_pref: usize,
+    pub ms: usize,
+    pub ssu: usize,
+}
+
+impl KBudget {
+    /// Pre-reg-locked defaults: `{SS-Pref: 22, MS: 50, SSU: 12}`.
+    pub(crate) const fn defaults() -> Self {
+        Self {
+            ss_pref: G4_DEFAULT_K_SS_PREF,
+            ms: G4_DEFAULT_K_MS,
+            ssu: G4_DEFAULT_K_SSU,
+        }
+    }
+
+    /// Read budget from `PENSYVE_K_BUDGET_*` env vars, falling back to
+    /// the locked defaults for any var that is unset or unparseable.
+    /// Mirrors the env-driven path that the `IntentRouter` (G4 P2) will
+    /// expose at the Rust-core level.
+    pub(crate) fn from_env() -> Self {
+        let mut b = Self::defaults();
+        if let Ok(s) = std::env::var("PENSYVE_K_BUDGET_SS_PREF")
+            && let Ok(n) = s.parse()
+        {
+            b.ss_pref = n;
+        }
+        if let Ok(s) = std::env::var("PENSYVE_K_BUDGET_MS")
+            && let Ok(n) = s.parse()
+        {
+            b.ms = n;
+        }
+        if let Ok(s) = std::env::var("PENSYVE_K_BUDGET_SSU")
+            && let Ok(n) = s.parse()
+        {
+            b.ssu = n;
+        }
+        b
+    }
+}
+
+/// Parse a `{"ss_pref": 22, "ms": 50, "ssu": 12}` dict from the kwarg.
+///
+/// Missing keys fall back to the locked defaults — callers can supply a
+/// partial dict (e.g. `{"ms": 60}`) without restating the other slots.
+/// Unknown keys are rejected with `ValueError` to catch typos early
+/// (e.g. `"ss_pref" -> "sspref"`).
+fn parse_k_budget_dict(dict: &Bound<'_, PyDict>) -> PyResult<KBudget> {
+    let mut budget = KBudget::defaults();
+    for (k, v) in dict.iter() {
+        let key: String = k.extract().map_err(|_| {
+            PyTypeError::new_err("k_budget keys must be strings: 'ss_pref' | 'ms' | 'ssu'")
+        })?;
+        let val: usize = v.extract().map_err(|_| {
+            PyTypeError::new_err(format!(
+                "k_budget['{key}'] must be a non-negative integer"
+            ))
+        })?;
+        match key.as_str() {
+            "ss_pref" => budget.ss_pref = val,
+            "ms" => budget.ms = val,
+            "ssu" => budget.ssu = val,
+            other => {
+                return Err(PyValueError::new_err(format!(
+                    "Unknown k_budget key '{other}'. Expected one of: 'ss_pref', 'ms', 'ssu'"
+                )));
+            }
+        }
+    }
+    Ok(budget)
+}
+
+/// Resolve `ms_card_days` per pre-reg precedence: kwarg > env > default.
+///
+/// Env var: `PENSYVE_MS_CARD_DAYS` (parsed as `usize`; unparseable
+/// values fall back to the default). Default: `2`.
+fn resolve_ms_card_days(kwarg: Option<usize>) -> usize {
+    if let Some(d) = kwarg {
+        return d;
+    }
+    std::env::var("PENSYVE_MS_CARD_DAYS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(G4_DEFAULT_MS_CARD_DAYS)
 }
 
 // ---------------------------------------------------------------------------
@@ -433,8 +572,17 @@ impl PyPensyve {
     ///         Total in-flight = harness workers × this — keep
     ///         `workers × max_concurrency` ≤ 16 on a 128 GB UMA box where
     ///         vLLM is co-resident; OOM-killer fires above ~24.
+    ///     `k_budget`: G4 retrieval-side k-budget per `question_type`
+    ///         family. Dict shape: `{"ss_pref": int, "ms": int, "ssu": int}`.
+    ///         Missing keys fall back to the locked defaults
+    ///         `{ss_pref: 22, ms: 50, ssu: 12}`. Precedence:
+    ///         kwarg > `PENSYVE_K_BUDGET_*` env > default. Pre-reg lock
+    ///         at `pensyve-docs@8930c4a`.
+    ///     `ms_card_days`: G4 MS-card-v2 cross-session day threshold.
+    ///         Default 2. Precedence: kwarg > `PENSYVE_MS_CARD_DAYS` env >
+    ///         default. Pre-reg lock at `pensyve-docs@8930c4a`.
     #[new]
-    #[pyo3(signature = (path=None, namespace=None, extractor=None, extractor_api_key=None, reranker=Some("BGERerankerBase".to_string()), extractor_base_url=None, extractor_model=None, extractor_max_concurrency=None, agent_id=None, user_id=None))]
+    #[pyo3(signature = (path=None, namespace=None, extractor=None, extractor_api_key=None, reranker=Some("BGERerankerBase".to_string()), extractor_base_url=None, extractor_model=None, extractor_max_concurrency=None, agent_id=None, user_id=None, k_budget=None, ms_card_days=None))]
     #[allow(
         clippy::needless_pass_by_value,
         clippy::too_many_arguments,
@@ -453,6 +601,12 @@ impl PyPensyve {
         // binding boundary; pre-reg §3.0 item 6 (8 → 10 params).
         agent_id: Option<String>,
         user_id: Option<String>,
+        // G4 P5: retrieval-side k-budget + MS-card day threshold.
+        // Stub-stored on `PensyveInner` until G4 P2 / P3 land the
+        // upstream `IntentRouter::k_for_type` + `MultiSessionCard::with_days`
+        // wiring points. Pre-reg lock `pensyve-docs@8930c4a`.
+        k_budget: Option<Bound<'_, PyDict>>,
+        ms_card_days: Option<usize>,
     ) -> PyResult<Self> {
         // G1: parse the scope strings at the binding boundary and surface
         // a Python `ValueError` on parse failure (matches PyO3 idiom).
@@ -476,6 +630,25 @@ impl PyPensyve {
             pensyve_core::network_policy::NetworkPolicy::from_env(""),
             Some(pensyve_core::network_policy::NetworkPolicy::Permissive)
         );
+
+        // G4 P5: resolve k-budget + ms_card_days with precedence
+        // kwarg > env > default. The kwarg path takes the dict value as
+        // a partial override of the locked defaults; missing dict keys
+        // do NOT inherit from the env. This matches the v2.1
+        // `with_peer_card(bool)` precedence pattern.
+        //
+        // TODO(g4-p5): plumb `k_budget` into the IntentRouter once
+        // `pensyve_core::retrieval::intent_router::k_for_type(...)` lands
+        // (G4 P2). Plumb `ms_card_days` into MultiSessionCard once
+        // `MultiSessionCard::with_days(...)` lands (G4 P3). Both APIs are
+        // not yet on `main` — values are stored on `PensyveInner` so the
+        // Python kwargs are wired end-to-end at the binding boundary
+        // and downstream wiring is a single-edit follow-up.
+        let resolved_k_budget = match k_budget {
+            Some(dict) => parse_k_budget_dict(&dict)?,
+            None => KBudget::from_env(),
+        };
+        let resolved_ms_card_days = resolve_ms_card_days(ms_card_days);
 
         // G1 fix: resolve the embedder's load-time `NetworkPolicy` at handle
         // construction so `NetworkPolicy::Disabled` propagates from the
@@ -636,8 +809,41 @@ impl PyPensyve {
                 agent_id: agent_id_uuid,
                 user_id: user_id_uuid,
                 recall_across_users_allowed,
+                k_budget: resolved_k_budget,
+                ms_card_days: resolved_ms_card_days,
             }),
         })
+    }
+
+    // -----------------------------------------------------------------
+    // G4 P5: introspection getters for the resolved k-budget + MS-card
+    // day threshold. These exist primarily so Python tests can assert
+    // the kwarg > env > default precedence without round-tripping
+    // through the (still-being-built) recall pipeline. They are also
+    // useful for SDK consumers debugging unexpected retrieval shape.
+    // -----------------------------------------------------------------
+
+    /// Resolved k-budget per `question_type` family.
+    ///
+    /// Returns a dict with keys `ss_pref`, `ms`, `ssu`. The values
+    /// reflect the kwarg > env > default precedence locked at
+    /// `pensyve-docs@8930c4a`.
+    #[getter]
+    fn k_budget<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let d = PyDict::new(py);
+        d.set_item("ss_pref", self.inner.k_budget.ss_pref)?;
+        d.set_item("ms", self.inner.k_budget.ms)?;
+        d.set_item("ssu", self.inner.k_budget.ssu)?;
+        Ok(d)
+    }
+
+    /// Resolved MS-card-v2 cross-session day threshold.
+    ///
+    /// Reflects the kwarg > env > default precedence locked at
+    /// `pensyve-docs@8930c4a` (default = 2).
+    #[getter]
+    fn ms_card_days(&self) -> usize {
+        self.inner.ms_card_days
     }
 
     /// Get or create an entity.

--- a/pensyve-python/src/lib.rs
+++ b/pensyve-python/src/lib.rs
@@ -449,9 +449,7 @@ fn parse_k_budget_dict(dict: &Bound<'_, PyDict>) -> PyResult<KBudget> {
             PyTypeError::new_err("k_budget keys must be strings: 'ss_pref' | 'ms' | 'ssu'")
         })?;
         let val: usize = v.extract().map_err(|_| {
-            PyTypeError::new_err(format!(
-                "k_budget['{key}'] must be a non-negative integer"
-            ))
+            PyTypeError::new_err(format!("k_budget['{key}'] must be a non-negative integer"))
         })?;
         match key.as_str() {
             "ss_pref" => budget.ss_pref = val,

--- a/pensyve-python/tests/test_g4_kwargs.py
+++ b/pensyve-python/tests/test_g4_kwargs.py
@@ -145,6 +145,23 @@ def test_k_budget_non_int_value_raises_type_error(store_path):
         )
 
 
+def test_k_budget_zero_value_raises_value_error(store_path):
+    """A zero k-budget would short-circuit recall — reject explicitly.
+
+    Mirrors the env-path guard in ``KBudget::from_env`` (filters zero
+    silently). The kwarg path is louder: callers passing ``0`` almost
+    certainly mean a typo or misunderstanding, so we surface it with a
+    clear error message rather than silently inheriting the default.
+    """
+    for key in ("ss_pref", "ms", "ssu"):
+        with pytest.raises(ValueError, match=r"must be > 0"):
+            pensyve.Pensyve(
+                path=store_path,
+                reranker=None,
+                k_budget={key: 0},
+            )
+
+
 # ---------------------------------------------------------------------------
 # ms_card_days
 # ---------------------------------------------------------------------------
@@ -179,5 +196,32 @@ def test_ms_card_days_kwarg_overrides_env(monkeypatch, store_path):
 def test_ms_card_days_unparseable_env_falls_back_to_default(monkeypatch, store_path):
     """Garbage env value should not crash; default takes over."""
     monkeypatch.setenv("PENSYVE_MS_CARD_DAYS", "garbage")
+    p = pensyve.Pensyve(path=store_path, reranker=None)
+    assert p.ms_card_days == 2
+
+
+def test_ms_card_days_kwarg_zero_falls_back_to_env_then_default(
+    monkeypatch, store_path
+):
+    """Zero kwarg is treated as unset (parity with core's resolve_ms_days).
+
+    ``MultiSessionCard::with_ms_days(Some(0))`` already filters zero
+    internally, so accepting ``ms_card_days=0`` here would make the
+    getter lie about the effective threshold. Mirror the env-path guard:
+    fall through to env (also filtered for zero), then to the default.
+    """
+    # No env: kwarg=0 -> default 2
+    p = pensyve.Pensyve(path=store_path, reranker=None, ms_card_days=0)
+    assert p.ms_card_days == 2
+
+    # Env=5, kwarg=0 -> env wins (kwarg=0 is unset)
+    monkeypatch.setenv("PENSYVE_MS_CARD_DAYS", "5")
+    p2 = pensyve.Pensyve(path=store_path, reranker=None, ms_card_days=0)
+    assert p2.ms_card_days == 5
+
+
+def test_ms_card_days_env_zero_falls_back_to_default(monkeypatch, store_path):
+    """Zero env value is treated as unset (parity with core's resolve_ms_days)."""
+    monkeypatch.setenv("PENSYVE_MS_CARD_DAYS", "0")
     p = pensyve.Pensyve(path=store_path, reranker=None)
     assert p.ms_card_days == 2

--- a/pensyve-python/tests/test_g4_kwargs.py
+++ b/pensyve-python/tests/test_g4_kwargs.py
@@ -1,0 +1,183 @@
+"""G4 P5 — PyO3 kwargs for k_budget + ms_card_days.
+
+Pre-reg anchor: ``pensyve-docs@8930c4a``. Locked decisions:
+
+* k-budget defaults: ``{"ss_pref": 22, "ms": 50, "ssu": 12}``
+* MS-card-days default: ``2``
+* Precedence: kwarg > env > default (mirrors v2.1's
+  ``Pensyve::with_peer_card(bool)`` pattern)
+
+These tests verify the PyO3 binding boundary in isolation. The
+**downstream wiring** (IntentRouter k_for_type from G4 P2,
+MultiSessionCard::with_days from G4 P3) is not yet on ``main`` — the
+constructor stores resolved values on the inner handle and exposes them
+via ``k_budget`` / ``ms_card_days`` getters for behavioral verification.
+When P2/P3 land, the assertions here will continue to pass and
+additional pipeline-level tests can be added.
+"""
+
+from __future__ import annotations
+
+import tempfile
+
+import pytest
+
+import pensyve
+
+
+@pytest.fixture
+def store_path():
+    """Fresh tempdir for each test — Pensyve construction needs a path."""
+    with tempfile.TemporaryDirectory(prefix="pensyve_g4_p5_") as d:
+        yield d
+
+
+@pytest.fixture(autouse=True)
+def _clear_g4_env(monkeypatch):
+    """Ensure no leaked G4 env vars from prior tests influence defaults.
+
+    Tests that need to set these vars do so explicitly via monkeypatch.
+    """
+    for k in (
+        "PENSYVE_K_BUDGET_SS_PREF",
+        "PENSYVE_K_BUDGET_MS",
+        "PENSYVE_K_BUDGET_SSU",
+        "PENSYVE_MS_CARD_DAYS",
+    ):
+        monkeypatch.delenv(k, raising=False)
+
+
+# ---------------------------------------------------------------------------
+# k_budget
+# ---------------------------------------------------------------------------
+
+
+def test_k_budget_default_when_kwarg_and_env_missing(store_path):
+    """No kwarg + no env -> locked defaults {22, 50, 12}."""
+    p = pensyve.Pensyve(path=store_path, reranker=None)
+    assert p.k_budget == {"ss_pref": 22, "ms": 50, "ssu": 12}
+
+
+def test_k_budget_kwarg_full_dict_overrides_defaults(store_path):
+    """Full dict kwarg sets all three slots."""
+    p = pensyve.Pensyve(
+        path=store_path,
+        reranker=None,
+        k_budget={"ss_pref": 30, "ms": 60, "ssu": 15},
+    )
+    assert p.k_budget == {"ss_pref": 30, "ms": 60, "ssu": 15}
+
+
+def test_k_budget_kwarg_partial_dict_inherits_defaults(store_path):
+    """Partial dict only overrides supplied keys; missing keys stay
+    at the locked defaults (NOT inherited from env, per pre-reg)."""
+    p = pensyve.Pensyve(
+        path=store_path,
+        reranker=None,
+        k_budget={"ms": 100},
+    )
+    assert p.k_budget == {"ss_pref": 22, "ms": 100, "ssu": 12}
+
+
+def test_k_budget_env_overrides_default_when_kwarg_missing(monkeypatch, store_path):
+    """env > default when no kwarg supplied."""
+    monkeypatch.setenv("PENSYVE_K_BUDGET_SS_PREF", "99")
+    monkeypatch.setenv("PENSYVE_K_BUDGET_MS", "77")
+    monkeypatch.setenv("PENSYVE_K_BUDGET_SSU", "55")
+    p = pensyve.Pensyve(path=store_path, reranker=None)
+    assert p.k_budget == {"ss_pref": 99, "ms": 77, "ssu": 55}
+
+
+def test_k_budget_kwarg_overrides_env(monkeypatch, store_path):
+    """kwarg > env. Pre-reg precedence: kwarg wins even when env is set."""
+    monkeypatch.setenv("PENSYVE_K_BUDGET_MS", "100")
+    p = pensyve.Pensyve(
+        path=store_path,
+        reranker=None,
+        k_budget={"ss_pref": 22, "ms": 50, "ssu": 12},
+    )
+    # Env said MS=100 but kwarg said 50 — kwarg wins.
+    assert p.k_budget["ms"] == 50
+
+
+def test_k_budget_partial_kwarg_does_not_pull_from_env_for_other_keys(
+    monkeypatch, store_path
+):
+    """When kwarg is provided (even partial), missing dict keys fall back
+    to the locked defaults, NOT to env. This matches the v2.1
+    `with_peer_card(bool)` semantics: kwarg presence opts out of env."""
+    monkeypatch.setenv("PENSYVE_K_BUDGET_SS_PREF", "999")
+    p = pensyve.Pensyve(
+        path=store_path,
+        reranker=None,
+        k_budget={"ms": 60},
+    )
+    # ss_pref kwarg key was missing — should be DEFAULT (22), not env (999).
+    assert p.k_budget["ss_pref"] == 22
+    assert p.k_budget["ms"] == 60
+    assert p.k_budget["ssu"] == 12
+
+
+def test_k_budget_unparseable_env_falls_back_to_default(monkeypatch, store_path):
+    """A garbage env value should not crash; defaults take over for that slot."""
+    monkeypatch.setenv("PENSYVE_K_BUDGET_MS", "not-a-number")
+    p = pensyve.Pensyve(path=store_path, reranker=None)
+    assert p.k_budget["ms"] == 50  # default, not crash
+
+
+def test_k_budget_unknown_key_raises_value_error(store_path):
+    """Typos like `sspref` get rejected with a clear error."""
+    with pytest.raises(ValueError, match="Unknown k_budget key"):
+        pensyve.Pensyve(
+            path=store_path,
+            reranker=None,
+            k_budget={"sspref": 30},
+        )
+
+
+def test_k_budget_non_int_value_raises_type_error(store_path):
+    """Non-int values get rejected at the parse boundary."""
+    with pytest.raises(TypeError):
+        pensyve.Pensyve(
+            path=store_path,
+            reranker=None,
+            k_budget={"ms": "fifty"},
+        )
+
+
+# ---------------------------------------------------------------------------
+# ms_card_days
+# ---------------------------------------------------------------------------
+
+
+def test_ms_card_days_default_when_kwarg_and_env_missing(store_path):
+    """No kwarg + no env -> locked default of 2."""
+    p = pensyve.Pensyve(path=store_path, reranker=None)
+    assert p.ms_card_days == 2
+
+
+def test_ms_card_days_kwarg_overrides_default(store_path):
+    """kwarg sets the value."""
+    p = pensyve.Pensyve(path=store_path, reranker=None, ms_card_days=7)
+    assert p.ms_card_days == 7
+
+
+def test_ms_card_days_env_overrides_default(monkeypatch, store_path):
+    """env > default when no kwarg."""
+    monkeypatch.setenv("PENSYVE_MS_CARD_DAYS", "5")
+    p = pensyve.Pensyve(path=store_path, reranker=None)
+    assert p.ms_card_days == 5
+
+
+def test_ms_card_days_kwarg_overrides_env(monkeypatch, store_path):
+    """kwarg > env. Pre-reg precedence."""
+    monkeypatch.setenv("PENSYVE_MS_CARD_DAYS", "5")
+    p = pensyve.Pensyve(path=store_path, reranker=None, ms_card_days=2)
+    assert p.ms_card_days == 2
+
+
+def test_ms_card_days_unparseable_env_falls_back_to_default(monkeypatch, store_path):
+    """Garbage env value should not crash; default takes over."""
+    monkeypatch.setenv("PENSYVE_MS_CARD_DAYS", "garbage")
+    p = pensyve.Pensyve(path=store_path, reranker=None)
+    assert p.ms_card_days == 2


### PR DESCRIPTION
## G4 Implementation Cycle

Per `pensyve-docs/research/benchmark-sprint/v3/g4/preregistration.md` (LOCKED at pensyve-docs@8930c4a).

Bundles three sub-PR equivalents:
- **G4 P2** (`feat/g4-impl-p2-k-budget`): IntentRouter + KBudget per question_type, env-driven via PENSYVE_K_BUDGET_{SS_PREF,MS,SSU}; defaults SS-Pref=22, MS=50, SSU=12; recall_grouped_with_router() additive method
- **G4 P3** (`feat/g4-impl-p3-ms-card-v2`): MultiSessionCard::v2() / with_ms_days() constructor; PENSYVE_MS_CARD_DAYS env (default 2); supersession output-merge (Approach A) with markers `--- SUPERSESSION CHAIN (MS) ---`
- **G4 P5** (`feat/g4-impl-p5-pyo3`): PyO3 kwargs `k_budget` (dict) + `ms_card_days` (int); precedence kwarg > env > default; integration fixup commit replaces local KBudget stub with pensyve-core import + renames with_days()→with_ms_days()

## Test deltas

Per-branch (pre-integration):
- P2: +9 tests (486 → 495 with feature flag)
- P3: +7 tests (486 → 493 with feature flag)
- P5: +14 tests (55 → 69 in pensyve-python)

Post-integration: see CI output

## Cross-PR companions

- pensyve-docs PR for G4 P1 scaffold + G4 P4 harness adapter (separate repo)
- This PR is gated on the G4 pre-reg lock at pensyve-docs@8930c4a

## Discipline

Implementation discipline mirrors the G3 cycle (pensyve#86, pensyve@52e5249 merge pattern). All sub-branches merged via `--no-ff`. Pre-reg + lock-SHA discipline preserved per G3 §4.7.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * G4 retrieval mode with per-question-type budgeting for improved recall control.
  * Configurable multi-session thresholds and optional supersession-chain merging; composite output now can prepend merged chains.
  * Python API: new constructor kwargs for retrieval budgeting (k_budget), ms_card_days, and extractor endpoint/model/concurrency.

* **Enhancements**
  * Intent routing extended to respect per-type budgets via env/constructor settings.
  * Output clipping refined to preserve section-marker lines between bullets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->