### PR TITLE
Release v2.4.0 — G2+G3+G4 surface (defaults-off) + Phase 23 hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,44 @@ All notable changes to Pensyve will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.0] - 2026-05-07
+
+Bundles G2 + G3 + G4 retrieval-side mechanism + Phase 23 production hardening accumulated since the v2.2.0 milestone tag. The 2.2.0 → 2.4.0 jump (skipping 2.3.0) reflects the magnitude of the surface change. **The G3 and G4 retrieval mechanisms ship default-OFF behind env gates**; flipping them on is gated by the locked G4 ablation pre-registration (`pensyve-docs/research/benchmark-sprint/v3/g4/preregistration.md @ 8930c4a`) §3.6 / §4.3 decision tree, evaluated against the wave whose results land in `pensyve-docs/research/benchmark-sprint/v3/g4/results.md`.
+
+**Empirical anchor:** G2 (`pensyve@a85f089`, PR #78) shipped retrieval-side composition (`RetrievalCard` trait + 3 cards + 4-arm ablation harness). G3 (`pensyve@3519b73`, PR #86) added intent router + supersession summarizer + typed-slot enrichment + MMR diversity. G4 (`pensyve@799f172`, PR #88) added k-budget per question_type + MS-card-v2 + PyO3 kwargs. Phase 23 (`pensyve@db67b91`, PR #87) hardened the gateway: distributed tracing + Redis rate limits + circuit breakers.
+
+### Added
+
+- **G2 — retrieval-side composition** (`pensyve-core::retrieval`): `RetrievalCard` trait with three production cards — `PeerCard`, `MultiSessionCard`, `SingleSessionUserCard`. The 4-arm ablation harness lives in `pensyve-benchmarks` for research reproducibility; SDK consumers compose via `RecallEngine::recall_grouped(...)`.
+- **G3 — intent routing + diversity**:
+  - `pensyve-core::retrieval::intent_router::{IntentRouter, RouterDecision}` — per-question-type per-card enable flags (single-session-preference / multi-session / single-session-user / temporal-reasoning / knowledge-update / single-session-assistant).
+  - `pensyve-core::retrieval::supersession_summarizer` — output-level merge of supersession chains with `--- SUPERSESSION CHAIN (MS) ---` markers (Approach A).
+  - **MMR diversity** — `RecallEngine::with_mmr_lambda(λ)` builder; default λ=0.5 when enabled. Order: reranker → MMR → cards.
+  - Typed-slot enrichment — schema-aware extraction for known slot types.
+- **G4 — k-budget per question_type + MS-card-v2**:
+  - `pensyve-core::retrieval::intent_router::KBudget { ss_pref, ms, ssu }` — per-bucket recall caps. Defaults `{ss_pref:22, ms:50, ssu:12}` per locked pre-reg §3.7. Mapping: `single-session-preference → ss_pref`; `multi-session | temporal-reasoning | knowledge-update → ms`; `single-session-user | single-session-assistant → ssu`.
+  - `RecallEngine::recall_grouped_with_router(&router, query, ns_id, question_type, &config)` — additive; routes `config.limit` through `KBudget` per question_type.
+  - `MultiSessionCard::v2()` + `with_ms_days(days)` — opt-in stricter MS-card threshold (default=2 days when enabled).
+  - **PyO3 constructor kwargs** on `Pensyve.__init__`: `k_budget: dict[str,int]` (overrides env), `ms_card_days: int`. Resolution order: kwarg > env > default.
+  - **Env knobs** (default-OFF behind `PENSYVE_RETRIEVAL_CARDS=peer+ms+ssu` opt-in): `PENSYVE_K_BUDGET_SS_PREF`, `PENSYVE_K_BUDGET_MS`, `PENSYVE_K_BUDGET_SSU`, `PENSYVE_MS_CARD_DAYS`, `PENSYVE_MMR_LAMBDA`, `PENSYVE_PEER_CARD`, `PENSYVE_SSU_N`, `PENSYVE_RETRIEVAL_CARDS_G3`.
+- **Phase 23 — gateway production hardening** (`pensyve-mcp-gateway`):
+  - **W3C `traceparent` middleware** — extracts/propagates trace context across requests; structured logging includes `trace_id` / `span_id` for correlation.
+  - **Redis-backed plan-aware rate limits** — atomic Lua check-and-increment script in `pensyve-mcp-gateway::rate_limit::redis_atomic_increment`. Plan tiers: free 30 RPM / 1k daily, business 300 RPM / 50k daily, enterprise unlimited. RFC 7231 `Retry-After` header on 429 responses.
+  - **Circuit breakers** — auth (5 fail / 60s window / 30s cooldown) + Stripe (3 fail / 60s window / 60s cooldown) via `pensyve-mcp-gateway::circuit_breaker`. Env-configurable `PENSYVE_CB_AUTH_*` / `PENSYVE_CB_STRIPE_*`. Bounded buffer (`PENSYVE_STRIPE_BUFFER_SIZE`, default 5000, drop-oldest) for Stripe outage tolerance.
+  - **Zero new Cargo deps** — uses `std::sync::Mutex` + `VecDeque` only.
+
+### Changed
+
+- **Recall pipeline order** — reranker → MMR → cards (G3 invariant carried forward into G4).
+- **Cargo workspace version bumped `2.2.0 → 2.4.0`** across 8 manifests (workspace members + `pensyve-wasm`) plus 2 `pyproject.toml` files (`./pyproject.toml`, `pensyve-python/pyproject.toml`). The lagged `pensyve-benchmarks` and `pensyve-wasm` (previously at 2.1.0) join the lockstep at this cut. Inter-crate version pins updated correspondingly.
+
+### Notes
+
+- **G3/G4 retrieval mechanism defaults are OFF.** SDK consumers calling `Pensyve.recall(...)` without `PENSYVE_RETRIEVAL_CARDS` set get the v2.1 baseline behavior. The locked pre-reg §3.6 ship-strategy decision (`v2.4.0` defaults-on if H1 PASS) is **deferred to a post-wave point release** (`v2.4.x` or `v2.5.0`) to decouple publish from research validation.
+- **Issue #92** (`major7apps/pensyve#92`) — `IntentRouter` is constructed on `PensyveInner` but the public `Pensyve.recall(...)` and `Pensyve.recall_grouped(...)` SDK entry points do not yet thread it; `k_budget` resolution flows through the harness `compose_for_g4_grid` adapter only. **Tracked for v2.4.x** before any defaults-flip cycle.
+- **`pensyve-python` wheel: aarch64-linux only** for this release per locked pre-reg decision; broader wheel matrix returns when the cross-compile prebuilts story is resolved (see `pensyve-docs` memory `feedback_onnx_cross_compile.md`).
+- **MSRV unchanged** at 1.88.
+
 ## [2.1.0] - 2026-05-04
 
 The first formal v2-line release. v2.0 was the locked benchmark substrate (`pensyve@4afede9` / `020defd`) used through Phase F-A and Phase G0; the matching Cargo tag never cut. v2.1 ships v2.0 baseline + peer-card recall-time injection + the `NetworkPolicy` fail-closed contract specified in `pensyve-docs/specs/2026-05-04-pensyve-v3-revision-b.md` §5.8 and `pensyve-docs/specs/2026-05-04-pensyve-v2.1-ship.md`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2792,7 +2792,7 @@ dependencies = [
 
 [[package]]
 name = "pensyve-benchmarks"
-version = "2.1.0"
+version = "2.4.0"
 dependencies = [
  "chrono",
  "pensyve-core",
@@ -2807,7 +2807,7 @@ dependencies = [
 
 [[package]]
 name = "pensyve-cli"
-version = "2.2.0"
+version = "2.4.0"
 dependencies = [
  "clap",
  "dirs",
@@ -2818,7 +2818,7 @@ dependencies = [
 
 [[package]]
 name = "pensyve-core"
-version = "2.2.0"
+version = "2.4.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2847,7 +2847,7 @@ dependencies = [
 
 [[package]]
 name = "pensyve-mcp"
-version = "2.2.0"
+version = "2.4.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -2863,7 +2863,7 @@ dependencies = [
 
 [[package]]
 name = "pensyve-mcp-gateway"
-version = "2.2.0"
+version = "2.4.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2895,7 +2895,7 @@ dependencies = [
 
 [[package]]
 name = "pensyve-mcp-tools"
-version = "2.2.0"
+version = "2.4.0"
 dependencies = [
  "pensyve-core",
  "rmcp",
@@ -2910,7 +2910,7 @@ dependencies = [
 
 [[package]]
 name = "pensyve-python"
-version = "2.2.0"
+version = "2.4.0"
 dependencies = [
  "chrono",
  "pensyve-core",

--- a/pensyve-benchmarks/Cargo.toml
+++ b/pensyve-benchmarks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pensyve-benchmarks"
-version = "2.1.0"
+version = "2.4.0"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"
@@ -8,7 +8,7 @@ description = "Evaluation framework for Pensyve memory engine"
 publish = false
 
 [dependencies]
-pensyve-core = { path = "../pensyve-core", version = "2.1.0" }
+pensyve-core = { path = "../pensyve-core", version = "2.4.0" }
 rand = "0.10"
 rand_distr = "0.6"
 serde = { version = "1", features = ["derive"] }

--- a/pensyve-cli/Cargo.toml
+++ b/pensyve-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pensyve-cli"
-version = "2.2.0"
+version = "2.4.0"
 edition = "2024"
 description = "Pensyve command-line interface — universal memory runtime for AI agents"
 rust-version = "1.88"
@@ -14,7 +14,7 @@ name = "pensyve"
 path = "src/main.rs"
 
 [dependencies]
-pensyve-core = { path = "../pensyve-core", version = "2.2.0" }
+pensyve-core = { path = "../pensyve-core", version = "2.4.0" }
 clap = { version = "4", features = ["derive"] }
 serde_json = "1"
 uuid = { version = "1", features = ["v4"] }

--- a/pensyve-core/Cargo.toml
+++ b/pensyve-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pensyve-core"
-version = "2.2.0"
+version = "2.4.0"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/pensyve-mcp-gateway/Cargo.toml
+++ b/pensyve-mcp-gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pensyve-mcp-gateway"
-version = "2.2.0"
+version = "2.4.0"
 edition = "2024"
 description = "Remote MCP gateway for Pensyve Cloud — Streamable HTTP transport"
 rust-version = "1.88"
@@ -18,8 +18,8 @@ name = "pensyve-mcp-gateway"
 path = "src/main.rs"
 
 [dependencies]
-pensyve-core = { path = "../pensyve-core", version = "2.2.0", features = ["postgres", "observation-extraction"] }
-pensyve-mcp-tools = { path = "../pensyve-mcp-tools", version = "2.1.0" }
+pensyve-core = { path = "../pensyve-core", version = "2.4.0", features = ["postgres", "observation-extraction"] }
+pensyve-mcp-tools = { path = "../pensyve-mcp-tools", version = "2.4.0" }
 rmcp = { version = "1.6", features = ["server", "transport-streamable-http-server", "macros"] }
 axum = "0.8"
 tower-http = { version = "0.6", features = ["compression-gzip", "compression-br"] }

--- a/pensyve-mcp-tools/Cargo.toml
+++ b/pensyve-mcp-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pensyve-mcp-tools"
-version = "2.2.0"
+version = "2.4.0"
 edition = "2024"
 description = "Shared MCP tool definitions for Pensyve servers"
 rust-version = "1.88"
@@ -13,7 +13,7 @@ documentation = "https://pensyve.com/docs"
 name = "pensyve_mcp_tools"
 
 [dependencies]
-pensyve-core = { path = "../pensyve-core", version = "2.2.0" }
+pensyve-core = { path = "../pensyve-core", version = "2.4.0" }
 rmcp = { version = "1.6", features = ["server", "macros"] }
 tokio = { version = "1", features = ["full"] }
 # G1/P3a: needed for `CancellationToken::new()` passed to

--- a/pensyve-mcp/Cargo.toml
+++ b/pensyve-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pensyve-mcp"
-version = "2.2.0"
+version = "2.4.0"
 edition = "2024"
 description = "Pensyve MCP server (stdio transport) — universal memory runtime for AI agents"
 rust-version = "1.88"
@@ -14,8 +14,8 @@ name = "pensyve-mcp"
 path = "src/main.rs"
 
 [dependencies]
-pensyve-core = { path = "../pensyve-core", version = "2.2.0" }
-pensyve-mcp-tools = { path = "../pensyve-mcp-tools", version = "2.1.0" }
+pensyve-core = { path = "../pensyve-core", version = "2.4.0" }
+pensyve-mcp-tools = { path = "../pensyve-mcp-tools", version = "2.4.0" }
 rmcp = { version = "1.6", features = ["server", "transport-io", "macros"] }
 tokio = { version = "1", features = ["full"] }
 uuid = { version = "1", features = ["v4"] }

--- a/pensyve-python/Cargo.toml
+++ b/pensyve-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pensyve-python"
-version = "2.2.0"
+version = "2.4.0"
 edition = "2024"
 rust-version = "1.88"
 readme = "README.md"
@@ -15,7 +15,7 @@ name = "pensyve_python"
 crate-type = ["cdylib"]
 
 [dependencies]
-pensyve-core = { path = "../pensyve-core", version = "2.2.0", features = ["observation-extraction"] }
+pensyve-core = { path = "../pensyve-core", version = "2.4.0", features = ["observation-extraction"] }
 pyo3 = { version = "^0.28.3", features = ["extension-module"] }
 uuid = { version = "1", features = ["v4"] }
 chrono = "0.4"

--- a/pensyve-python/pyproject.toml
+++ b/pensyve-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pensyve"
-version = "2.2.0"
+version = "2.4.0"
 description = "Universal memory runtime for AI agents — framework-agnostic, protocol-native, offline-first"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/pensyve-wasm/Cargo.toml
+++ b/pensyve-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pensyve-wasm"
-version = "2.1.0"
+version = "2.4.0"
 edition = "2024"
 
 [workspace]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pensyve"
-version = "2.1.0"
+version = "2.4.0"
 description = "Universal memory runtime for AI agents — framework-agnostic, protocol-native, offline-first"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Cuts \`v2.4.0\` per the **Path B** decision in \`pensyve-docs/plans/read-pensyve-docs-session-handoff-2026-0-fancy-nest.md\` (operator-confirmed during the overnight session): bundle G2 + G3 + G4 retrieval-side mechanism + Phase 23 production hardening accumulated since the \`v2.2.0\` milestone tag.

**Key property**: G3/G4 retrieval mechanisms ship **default-OFF behind env gates**. SDK consumers calling \`Pensyve.recall(...)\` without \`PENSYVE_RETRIEVAL_CARDS\` set get the v2.1 baseline behavior. The G4 ablation wave (see \`pensyve-docs#5\` — \`research/benchmark-sprint/v3/g4/results.md\`) validated that this is the correct ship configuration — ARM-1-G4-BASELINE (reranker-only over G3 baseline) outperformed all G3-surface-on configurations by 23+ questions on a 90-Q matrix.

## What's in this PR

### Manifest bumps (lockstep)

- \`pensyve-core\`, \`pensyve-python\`, \`pensyve-mcp\`, \`pensyve-mcp-tools\`, \`pensyve-mcp-gateway\`, \`pensyve-cli\`: 2.2.0 → 2.4.0
- \`pensyve-benchmarks\`, \`pensyve-wasm\` (lagged at 2.1.0): 2.1.0 → 2.4.0 (joining workspace cadence)
- \`pensyve-python/pyproject.toml\`: 2.2.0 → 2.4.0
- Root \`pyproject.toml\`: 2.1.0 → 2.4.0

8 inter-crate dep pins updated correspondingly. \`Cargo.lock\` regenerated.

### Skipped 2.3.0

The 2.2.0 → 2.4.0 jump reflects the magnitude of the surface change (G2 + G3 + G4 + Phase 23). G3 cycle gate-failed without falling back; v2.3.0 was held per pre-reg \`pensyve-docs/research/benchmark-sprint/v3/g3/preregistration.md\` §4.5.

### CHANGELOG entry

Full \`[2.4.0]\` entry covering:
- **Added**: G2 (RetrievalCard trait + 3 cards), G3 (intent router + supersession summarizer + typed-slot enrichment + MMR diversity), G4 (k-budget per question_type, MS-card-v2, PyO3 kwargs), Phase 23 (W3C traceparent + Redis-backed plan-aware rate limits with Lua atomic + circuit breakers for auth + Stripe).
- **Changed**: Reranker → MMR → cards order; lockstep manifest bump.
- **Notes**: G3/G4 mechanism defaults are OFF; issue #92 deferred to v2.4.x; pensyve-python wheel aarch64-linux only; MSRV unchanged at 1.88.

## Build/test gates verified

Run on \`b87e5b7\` against \`db67b91\`:
- \`cargo build --workspace --release\` ✅
- \`cargo test --workspace\` ✅ (669 tests, 0 failures)
- \`cargo clippy --workspace --all-targets --all-features -- -D warnings\` ✅
- \`cargo fmt --all -- --check\` ✅

## Tag

Annotated tag \`v2.4.0\` exists locally at \`b87e5b7\`. **Push the tag after this PR merges** so it points at the merge commit on \`main\`. Or fast-forward main and push the existing tag — operator's call.

## Followup (separate)

1. **G4 wave + audit fixes + results.md** — \`pensyve-docs#5\` (separate PR, already opened).
2. **\`build_retrieval_card_g4\` PyO3 binding** — design at \`pensyve-docs/specs/2026-05-08-pensyve-build-retrieval-card-g4-binding.md\`. Required for any future G4 cycle re-test.
3. **Issue #92** — load-bearing for any defaults-flip cycle.

## Test plan

- [ ] CI: \`cargo build/test/clippy/fmt\` all green on this PR
- [ ] After merge: push existing \`v2.4.0\` tag (or re-tag merge commit); \`cargo publish\` topo order; \`maturin publish --release\` aarch64-linux

🤖 Path B v2.4.0 cut authored autonomously during the overnight session per the v2.4.0 plan handoff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated all package and component versions to 2.4.0

* **Documentation**
  * Added v2.4.0 release notes documenting retrieval-side mechanism composition changes, gateway production hardening enhancements including tracing and rate limiting, retrieval pipeline updates, and SDK surface default modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->