### PR TITLE
fix: thread IntentRouter through Pensyve.recall_grouped (#92)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.4.1] - Unreleased
 
-Two G4 follow-ups that close the integration gap surfaced by the 2026-05-08 G4 ablation wave (`pensyve-docs/research/benchmark-sprint/v3/g4/results.md` §6 H1 caveat). The wave's harness silently fell back to G3 cards on every G4-mechanism arm because the binding + IntentRouter wire-up were not in place; the wave's H1-H5 evidence is invalidated until both fixes land. Detailed phased plan: `pensyve-docs/plans/2026-05-09-pensyve-g4-followups.md`.
+G4 follow-up that closes one of two integration gaps surfaced by the 2026-05-08 G4 ablation wave (`pensyve-docs/research/benchmark-sprint/v3/g4/results.md` §6 H1 caveat). The wave's harness silently fell back to G3 cards on every G4-mechanism arm because the IntentRouter wire-up was not in place; the wave's H1-H5 evidence is invalidated until this and the companion `build_retrieval_card_g4` binding (separate PR) both land. Detailed phased plan: `pensyve-docs/plans/2026-05-09-pensyve-g4-followups.md`.
 
 ### Added
 
-- **`Pensyve.build_retrieval_card_g4(db_path, question_type, g2_cards, g3_features, g4_features)`** — PyO3 binding analogous to `build_retrieval_card_g3` (`pensyve-python/src/lib.rs:1173`). Adds `g4_features ⊆ {"k_budget", "ms_card_v2"}`. When `"ms_card_v2"` is in `g4_features`, the MS slot uses `MultiSessionCard::v2().with_g3_mode(...).with_ms_days(Some(ms_card_days)).with_supersession_chain(SupersessionCard::new())` (Approach A output-merge per pre-reg `pensyve-docs@8930c4a` §3.4 LOCKED) and the standalone `SupersessionCard` slot is dropped. When `g4_features = []`, behavior is byte-for-byte equivalent to `build_retrieval_card_g3` with the same first four arguments. No `pensyve-core` changes — `MultiSessionCard::v2()` and `with_supersession_chain` already exist (`multi_session.rs:273`, `:308`). Spec: `pensyve-docs/specs/2026-05-08-pensyve-build-retrieval-card-g4-binding.md`.
 - **`Pensyve.recall_grouped(query, *, ..., question_type=None)`** — new optional `question_type` kwarg threads `PensyveInner.intent_router` through `RecallEngine::recall_grouped_with_router(..., &intent_router)` so per-question-type `k_budget` (constructor kwarg / `PENSYVE_K_BUDGET_*` env / locked defaults `{ss_pref:22, ms:50, ssu:12}`) governs the candidate pool. When `None` (default), behavior is unchanged from v2.4.0 — backward-compat for SDK consumers who don't opt in. Resolves issue #92.
-
-### Fixed
-
-- **`pensyve.__version__` now tracks `CARGO_PKG_VERSION`** instead of the stale hardcoded `"0.1.0"` in `_core` (`pensyve-python/src/lib.rs:67`). Wheel metadata was already correct; this aligns the runtime attribute.
 
 ### Notes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to Pensyve will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.1] - Unreleased
+
+Two G4 follow-ups that close the integration gap surfaced by the 2026-05-08 G4 ablation wave (`pensyve-docs/research/benchmark-sprint/v3/g4/results.md` §6 H1 caveat). The wave's harness silently fell back to G3 cards on every G4-mechanism arm because the binding + IntentRouter wire-up were not in place; the wave's H1-H5 evidence is invalidated until both fixes land. Detailed phased plan: `pensyve-docs/plans/2026-05-09-pensyve-g4-followups.md`.
+
+### Added
+
+- **`Pensyve.build_retrieval_card_g4(db_path, question_type, g2_cards, g3_features, g4_features)`** — PyO3 binding analogous to `build_retrieval_card_g3` (`pensyve-python/src/lib.rs:1173`). Adds `g4_features ⊆ {"k_budget", "ms_card_v2"}`. When `"ms_card_v2"` is in `g4_features`, the MS slot uses `MultiSessionCard::v2().with_g3_mode(...).with_ms_days(Some(ms_card_days)).with_supersession_chain(SupersessionCard::new())` (Approach A output-merge per pre-reg `pensyve-docs@8930c4a` §3.4 LOCKED) and the standalone `SupersessionCard` slot is dropped. When `g4_features = []`, behavior is byte-for-byte equivalent to `build_retrieval_card_g3` with the same first four arguments. No `pensyve-core` changes — `MultiSessionCard::v2()` and `with_supersession_chain` already exist (`multi_session.rs:273`, `:308`). Spec: `pensyve-docs/specs/2026-05-08-pensyve-build-retrieval-card-g4-binding.md`.
+- **`Pensyve.recall_grouped(query, *, ..., question_type=None)`** — new optional `question_type` kwarg threads `PensyveInner.intent_router` through `RecallEngine::recall_grouped_with_router(..., &intent_router)` so per-question-type `k_budget` (constructor kwarg / `PENSYVE_K_BUDGET_*` env / locked defaults `{ss_pref:22, ms:50, ssu:12}`) governs the candidate pool. When `None` (default), behavior is unchanged from v2.4.0 — backward-compat for SDK consumers who don't opt in. Resolves issue #92.
+
+### Fixed
+
+- **`pensyve.__version__` now tracks `CARGO_PKG_VERSION`** instead of the stale hardcoded `"0.1.0"` in `_core` (`pensyve-python/src/lib.rs:67`). Wheel metadata was already correct; this aligns the runtime attribute.
+
+### Notes
+
+- **Cross-SDK parity for `question_type`** (TS/Go/WASM `recall_grouped` surfaces) is **deferred to v2.5.x** or a follow-up issue. The Python binding is the path the G4 ablation harness exercises; SDK consumers on other languages continue to use the un-routed `recall_grouped` until the parity work lands.
+- **Defaults unchanged.** G3 + G4 retrieval surface remain default-OFF behind env gates. Flipping any default is gated on the G4 ablation wave's *re-run* (with both fixes in place) per the plan referenced above. The wave-validated finding "G3 surface flip on top of reranker is a NET-NEGATIVE regression" (−17Q on MS) stands and informs the v2.5.x defaults discussion.
+- **`pensyve-python` wheel: aarch64-linux only**, same as v2.4.0.
+- **MSRV unchanged** at 1.88.
+
 ## [2.4.0] - 2026-05-07
 
 Bundles G2 + G3 + G4 retrieval-side mechanism + Phase 23 production hardening accumulated since the v2.2.0 milestone tag. The 2.2.0 → 2.4.0 jump (skipping 2.3.0) reflects the magnitude of the surface change. **The G3 and G4 retrieval mechanisms ship default-OFF behind env gates**; flipping them on is gated by the locked G4 ablation pre-registration (`pensyve-docs/research/benchmark-sprint/v3/g4/preregistration.md @ 8930c4a`) §3.6 / §4.3 decision tree, evaluated against the wave whose results land in `pensyve-docs/research/benchmark-sprint/v3/g4/results.md`.

--- a/pensyve-python/python/pensyve/_core.pyi
+++ b/pensyve-python/python/pensyve/_core.pyi
@@ -168,6 +168,7 @@ class Pensyve:
         order: Literal["chronological", "relevance"] = "chronological",
         max_groups: int | None = None,
         types: list[str] | None = None,
+        question_type: str | None = None,
     ) -> list[SessionGroup]:
         """Recall memories matching a query, clustered by source session.
 
@@ -181,13 +182,26 @@ class Pensyve:
         Args:
             query: Search query string.
             limit: Maximum number of memories to consider across all groups
-                (default: 50).
+                (default: 50). When ``question_type`` is provided, this
+                value is **overridden** by the resolved per-question-type
+                k-budget from the IntentRouter — the router is the
+                authoritative source for retrieval-side k decisions.
             order: "chronological" (default, oldest session first) or
                 "relevance" (highest-scoring session first).
             max_groups: Optional cap on the number of groups returned.
             types: Optional list of memory type strings to filter the
                 candidate pool *before* grouping. Mirrors the equivalent
                 kwarg on :meth:`recall`. Default ``None`` (no filter).
+            question_type: Optional ``LongMemEval``-style question-type
+                string (e.g. ``"single-session-preference"``,
+                ``"multi-session"``, ``"single-session-user"``). When
+                provided, recall routes through the cached IntentRouter
+                (resolved at construction from the ``k_budget`` kwarg /
+                ``PENSYVE_K_BUDGET_*`` env / locked defaults), and the
+                router's per-type k-budget overrides ``limit``. When
+                ``None`` (default), behavior is unchanged from prior
+                versions — backward-compat for v2.4.x SDK consumers.
+                Resolves issue #92 (G4 follow-up from PR #88).
 
         Raises:
             ValueError: If ``order`` is not one of the supported values.

--- a/pensyve-python/src/lib.rs
+++ b/pensyve-python/src/lib.rs
@@ -1049,13 +1049,28 @@ impl PyPensyve {
     /// Args:
     ///     query: Search query string.
     ///     limit: Maximum number of memories to consider across all groups
-    ///         (default: 50).
+    ///         (default: 50). When `question_type` is provided, this value
+    ///         is **overridden** by the resolved per-question-type k-budget
+    ///         from [`IntentRouter::k_for_type`] — the router is the
+    ///         authoritative source for retrieval-side k decisions.
     ///     order: "chronological" (default, oldest session first) or
     ///         "relevance" (highest group score first).
     ///     `max_groups`: Optional cap on the number of groups returned.
     ///     types: Optional list of memory type strings to filter by, e.g.
     ///         `["episodic"]`. Mirrors the equivalent kwarg on `recall`.
-    #[pyo3(signature = (query, *, limit=50, order="chronological", max_groups=None, types=None))]
+    ///     `question_type`: Optional `LongMemEval`-style question-type
+    ///         string (e.g. `"single-session-preference"`,
+    ///         `"multi-session"`, `"single-session-user"`). When
+    ///         provided, recall routes through
+    ///         [`RecallEngine::recall_grouped_with_router`] using
+    ///         [`PensyveInner::intent_router`] (resolved at construction
+    ///         from the `k_budget` kwarg / `PENSYVE_K_BUDGET_*` env vars
+    ///         / locked defaults). The router's `k_for_type(question_
+    ///         type)` overrides `limit`. When `None` (default), behavior
+    ///         is unchanged from prior versions — backward-compat for
+    ///         v2.4.x SDK consumers. Resolves issue #92 (G4 follow-up
+    ///         from PR #88).
+    #[pyo3(signature = (query, *, limit=50, order="chronological", max_groups=None, types=None, question_type=None))]
     fn recall_grouped(
         &self,
         query: &str,
@@ -1063,6 +1078,7 @@ impl PyPensyve {
         order: &str,
         max_groups: Option<usize>,
         types: Option<Vec<String>>,
+        question_type: Option<&str>,
     ) -> PyResult<Vec<PySessionGroup>> {
         if query.is_empty() {
             return Err(PyRuntimeError::new_err("query must not be empty"));
@@ -1105,9 +1121,28 @@ impl PyPensyve {
         // G1: scope-by-default — same as `recall`.
         engine = engine.with_scope(self.inner.agent_id, self.inner.user_id);
 
-        let groups = engine
-            .recall_grouped(query, self.inner.namespace.id, &config)
-            .map_err(|e| PyRuntimeError::new_err(format!("Recall failed: {e}")))?;
+        // Issue #92: when `question_type` is provided, route through the
+        // IntentRouter so the per-question-type k-budget governs the
+        // candidate pool. The router is cached on `PensyveInner` at
+        // construction (kwarg > env > default precedence per pre-reg
+        // `pensyve-docs@8930c4a`); this method is the public entry point
+        // that surfaces it to SDK callers.
+        //
+        // When `question_type` is None, preserve existing behavior:
+        // call the un-routed `recall_grouped` directly so v2.4.x callers
+        // who don't pass the new kwarg see no change.
+        let groups = if let Some(qt) = question_type {
+            engine.recall_grouped_with_router(
+                &self.inner.intent_router,
+                query,
+                self.inner.namespace.id,
+                qt,
+                &config,
+            )
+        } else {
+            engine.recall_grouped(query, self.inner.namespace.id, &config)
+        }
+        .map_err(|e| PyRuntimeError::new_err(format!("Recall failed: {e}")))?;
 
         Ok(groups
             .into_iter()

--- a/pensyve-python/tests/test_recall_grouped.py
+++ b/pensyve-python/tests/test_recall_grouped.py
@@ -62,3 +62,114 @@ def test_recall_grouped_types_none_keeps_default_behavior(tmp_path: Path) -> Non
     # query happens not to hit anything, which is fine — we only assert shape).
     groups = p.recall_grouped("magazine", limit=10)
     assert isinstance(groups, list)
+
+
+# ---------------------------------------------------------------------------
+# Issue #92 — IntentRouter wire-up via `question_type` kwarg
+# ---------------------------------------------------------------------------
+
+
+def test_recall_grouped_signature_exposes_question_type() -> None:
+    """Issue #92: ``question_type`` is a recognized keyword argument.
+
+    Before #92, the kwarg did not exist and passing it raised TypeError.
+    The signature check is a static guard — failure here means the
+    PyO3 binding lost the new kwarg.
+    """
+    import inspect
+
+    sig = inspect.signature(pensyve.Pensyve.recall_grouped)
+    assert "question_type" in sig.parameters, (
+        "recall_grouped should expose `question_type` kwarg per issue #92; "
+        f"got: {list(sig.parameters)}"
+    )
+
+
+def test_recall_grouped_question_type_kwarg_accepted(tmp_path: Path) -> None:
+    """Issue #92: ``question_type="multi-session"`` is accepted.
+
+    When provided, the call routes through ``recall_grouped_with_router``
+    so the resolved IntentRouter k-budget governs the candidate pool.
+    A non-empty corpus is seeded so the call exercises the router path
+    rather than short-circuiting on an empty namespace.
+    """
+    p = pensyve.Pensyve(path=str(tmp_path), namespace="t-issue-92")
+    _seed_episode(p)
+    groups = p.recall_grouped(
+        "magazine", limit=10, question_type="multi-session"
+    )
+    assert isinstance(groups, list)
+
+
+def test_recall_grouped_question_type_none_preserves_behavior(tmp_path: Path) -> None:
+    """Issue #92: ``question_type=None`` (default) routes through the
+    un-routed engine path, preserving v2.4.x behavior for callers who
+    don't pass the new kwarg.
+
+    Backward-compat smoke: SDK consumers updating from v2.4.0 should see
+    no behavioral change when they don't opt in.
+    """
+    p = pensyve.Pensyve(path=str(tmp_path), namespace="t-issue-92-none")
+    _seed_episode(p)
+
+    # Both forms must succeed and return list-shaped results.
+    no_kwarg = p.recall_grouped("magazine", limit=10)
+    explicit_none = p.recall_grouped("magazine", limit=10, question_type=None)
+    assert isinstance(no_kwarg, list)
+    assert isinstance(explicit_none, list)
+
+
+def test_recall_grouped_question_type_overrides_caller_limit(tmp_path: Path) -> None:
+    """Issue #92: when ``question_type`` is provided, the resolved k-budget
+    overrides ``limit`` per ``RecallEngine::recall_grouped_with_router``.
+
+    Router's authoritative behavior (engine.rs:498-505) — caller's
+    ``limit`` is ignored when the router resolves a different value for
+    the given question_type. The behavioral signal is that providing
+    ``question_type="multi-session"`` with the default k-budget (MS=50)
+    surfaces up to 50 candidates even when the caller said ``limit=5``.
+
+    With a small seeded corpus the absolute counts may be tiny, but the
+    call must succeed and return list-shaped results — the router
+    override is exercised by the path, not by counting.
+    """
+    p = pensyve.Pensyve(
+        path=str(tmp_path),
+        namespace="t-issue-92-override",
+        k_budget={"ss_pref": 22, "ms": 50, "ssu": 12},
+    )
+    _seed_episode(p)
+
+    routed = p.recall_grouped(
+        "magazine", limit=5, question_type="multi-session"
+    )
+    assert isinstance(routed, list)
+    # The router-overridden limit (50) > caller's limit (5). Even with a
+    # 1-episode seed the path completes; this is a smoke test for the
+    # router-override codepath, not a candidate-count assertion.
+
+
+def test_recall_grouped_question_type_with_custom_k_budget(tmp_path: Path) -> None:
+    """Issue #92: ``k_budget`` kwarg on the constructor flows through
+    the router into ``recall_grouped(question_type=...)``.
+
+    Cross-references the kwarg-set k_budget value with the
+    introspection getter (``p.k_budget``) to confirm the router was
+    constructed with the operator-provided budget — not the env or
+    defaults.
+    """
+    p = pensyve.Pensyve(
+        path=str(tmp_path),
+        namespace="t-issue-92-custom",
+        k_budget={"ss_pref": 30, "ms": 100, "ssu": 15},
+    )
+    assert p.k_budget == {"ss_pref": 30, "ms": 100, "ssu": 15}
+    _seed_episode(p)
+
+    # Run a routed recall — the call shouldn't crash, and the router
+    # should be the constructor-resolved one (verified above via the
+    # k_budget getter).
+    groups = p.recall_grouped(
+        "magazine", limit=5, question_type="multi-session"
+    )
+    assert isinstance(groups, list)

--- a/pensyve-python/tests/test_recall_grouped.py
+++ b/pensyve-python/tests/test_recall_grouped.py
@@ -31,6 +31,30 @@ def _seed_episode(p, user_name: str = "user", asst_name: str = "assistant") -> N
         ep.message("user", "I subscribed to The New Yorker")
 
 
+def _seed_many_episodes(p, count: int) -> None:
+    """Seed ``count`` distinct episodes — one per unique entity pair, one user
+    message each.
+
+    Each episode lives in its own ``episode_id`` so it produces a distinct
+    ``SessionGroup`` after grouping. Content varies per episode but keeps
+    overlapping vocabulary (``"magazine"``, ``"subscription"``, ``"reading"``)
+    so the recall query has plausible hits across the corpus regardless of
+    ranking. Used by the k-budget behavioral tests below to make the
+    candidate-pool cap observable: with N=60 distinct sessions seeded, a
+    routed call with ``ms`` budget ≪ N must surface fewer groups than an
+    un-routed call (whose ``limit`` defaults can be raised to admit more).
+    """
+    for i in range(count):
+        user = p.entity(f"user-{i}", kind="user")
+        asst = p.entity(f"assistant-{i}", kind="agent")
+        with p.episode(user, asst) as ep:
+            ep.message(
+                "user",
+                f"Episode {i}: I keep my magazine subscription active and"
+                " enjoy the reading habit it builds.",
+            )
+
+
 def test_recall_grouped_accepts_types_kwarg(tmp_path: Path) -> None:
     """W6: `types=` is a recognized keyword argument."""
     p = pensyve.Pensyve(path=str(tmp_path), namespace="t-types-kwarg")
@@ -123,53 +147,140 @@ def test_recall_grouped_question_type_overrides_caller_limit(tmp_path: Path) -> 
     """Issue #92: when ``question_type`` is provided, the resolved k-budget
     overrides ``limit`` per ``RecallEngine::recall_grouped_with_router``.
 
-    Router's authoritative behavior (engine.rs:498-505) — caller's
+    Router's authoritative behavior (``engine.rs:498-505``) — caller's
     ``limit`` is ignored when the router resolves a different value for
-    the given question_type. The behavioral signal is that providing
-    ``question_type="multi-session"`` with the default k-budget (MS=50)
-    surfaces up to 50 candidates even when the caller said ``limit=5``.
+    the given question_type.
 
-    With a small seeded corpus the absolute counts may be tiny, but the
-    call must succeed and return list-shaped results — the router
-    override is exercised by the path, not by counting.
+    Behavioral assertion strategy (mirrors the Rust engine test
+    ``recall_grouped_with_router_overrides_caller_limit`` at
+    ``pensyve-core/src/retrieval/engine.rs:1630``): seed ``N``
+    distinct one-message episodes (each a singleton ``SessionGroup``)
+    with ``N`` well above the ``ms`` budget under test, then compare:
+
+    1. **routed-small** — ``question_type="multi-session"`` with
+       ``ms=5``: the candidate pool must be capped at 5, so the
+       returned group count is ≤ 5 regardless of caller's high
+       ``limit=50``.
+    2. **routed-large** — ``question_type="multi-session"`` with
+       ``ms=50``: the candidate pool grows; the group count is
+       strictly larger than the small-budget run (and ≤ 50).
+    3. **un-routed** — no ``question_type``: the caller's ``limit``
+       is honored (un-routed path), giving us a lower bound that
+       confirms there is enough corpus signal for the budget cap to
+       be meaningful.
+
+    The (1) vs (2) contrast is the load-bearing assertion: it can
+    only succeed if the router actually overrides the candidate
+    pool. A silent fallback to the un-routed path would either
+    return identical counts or violate the strict inequality.
     """
-    p = pensyve.Pensyve(
-        path=str(tmp_path),
-        namespace="t-issue-92-override",
+    n_seed = 60  # well above both the small (5) and large (50) ms budgets
+
+    # Routed-small: ms=5 forces the multi-session bucket low.
+    p_small = pensyve.Pensyve(
+        path=str(tmp_path / "small"),
+        namespace="t-issue-92-override-small",
+        k_budget={"ss_pref": 22, "ms": 5, "ssu": 12},
+    )
+    _seed_many_episodes(p_small, n_seed)
+    routed_small = p_small.recall_grouped(
+        "magazine", limit=50, question_type="multi-session"
+    )
+    routed_small_n = sum(len(g.memories) for g in routed_small)
+
+    # Routed-large: ms=50 (locked default) lets the candidate pool
+    # grow; we expect strictly more groups than the small-budget run.
+    p_large = pensyve.Pensyve(
+        path=str(tmp_path / "large"),
+        namespace="t-issue-92-override-large",
         k_budget={"ss_pref": 22, "ms": 50, "ssu": 12},
     )
-    _seed_episode(p)
-
-    routed = p.recall_grouped(
-        "magazine", limit=5, question_type="multi-session"
+    _seed_many_episodes(p_large, n_seed)
+    routed_large = p_large.recall_grouped(
+        "magazine", limit=50, question_type="multi-session"
     )
-    assert isinstance(routed, list)
-    # The router-overridden limit (50) > caller's limit (5). Even with a
-    # 1-episode seed the path completes; this is a smoke test for the
-    # router-override codepath, not a candidate-count assertion.
+    routed_large_n = sum(len(g.memories) for g in routed_large)
+
+    # Un-routed: same corpus, no question_type — caller's limit governs.
+    unrouted = p_large.recall_grouped("magazine", limit=50)
+    unrouted_n = sum(len(g.memories) for g in unrouted)
+
+    assert isinstance(routed_small, list)
+    assert isinstance(routed_large, list)
+    assert isinstance(unrouted, list)
+
+    # Cap bound: routed-small candidate pool capped at ms=5, so the
+    # number of recalled memories must not exceed that budget.
+    assert routed_small_n <= 5, (
+        f"routed-small candidate pool should be capped at ms=5; "
+        f"got {routed_small_n} memories"
+    )
+
+    # Override signal: the larger ms budget must surface strictly more
+    # memories than the small budget on the same corpus. If the routed
+    # path silently fell back to the un-routed pipeline, both would
+    # collapse to the caller's limit (50) and this assertion would
+    # fail.
+    assert routed_large_n > routed_small_n, (
+        f"router override broken: small ms=5 produced {routed_small_n} "
+        f"memories, large ms=50 produced {routed_large_n} — expected "
+        f"strictly more under the larger budget"
+    )
+
+    # Sanity floor: the un-routed path must surface more than the
+    # small-budget routed path; otherwise the corpus is too thin and
+    # the cap (1) would have passed vacuously.
+    assert unrouted_n > routed_small_n, (
+        f"corpus too thin for cap to be meaningful: un-routed produced "
+        f"{unrouted_n} memories, routed-small produced {routed_small_n} "
+        f"— need un-routed > 5 to confirm the cap on routed-small is real"
+    )
 
 
 def test_recall_grouped_question_type_with_custom_k_budget(tmp_path: Path) -> None:
     """Issue #92: ``k_budget`` kwarg on the constructor flows through
     the router into ``recall_grouped(question_type=...)``.
 
-    Cross-references the kwarg-set k_budget value with the
-    introspection getter (``p.k_budget``) to confirm the router was
-    constructed with the operator-provided budget — not the env or
-    defaults.
+    Two-axis verification:
+
+    1. **Introspection** — ``p.k_budget`` reflects the constructor
+       kwarg verbatim (kwarg > env > default precedence).
+    2. **Behavioral** — the constructor-supplied ``ms`` value
+       actually caps the candidate pool when ``recall_grouped`` is
+       called with ``question_type="multi-session"``. Seeding
+       ``N=60`` episodes with a custom ``ms=8`` budget proves the
+       value flows from constructor → cached ``intent_router`` →
+       ``recall_grouped_with_router`` rather than being shadowed by
+       env or defaults.
     """
+    custom_ms = 8
     p = pensyve.Pensyve(
         path=str(tmp_path),
         namespace="t-issue-92-custom",
-        k_budget={"ss_pref": 30, "ms": 100, "ssu": 15},
+        k_budget={"ss_pref": 30, "ms": custom_ms, "ssu": 15},
     )
-    assert p.k_budget == {"ss_pref": 30, "ms": 100, "ssu": 15}
-    _seed_episode(p)
+    assert p.k_budget == {"ss_pref": 30, "ms": custom_ms, "ssu": 15}
+    _seed_many_episodes(p, count=60)
 
-    # Run a routed recall — the call shouldn't crash, and the router
-    # should be the constructor-resolved one (verified above via the
-    # k_budget getter).
-    groups = p.recall_grouped(
-        "magazine", limit=5, question_type="multi-session"
+    # Routed call with a high caller limit — the router-resolved
+    # ms=custom_ms must override and cap the candidate pool.
+    routed = p.recall_grouped("magazine", limit=50, question_type="multi-session")
+    routed_n = sum(len(g.memories) for g in routed)
+    assert isinstance(routed, list)
+    assert routed_n <= custom_ms, (
+        f"custom k_budget not honored: ms={custom_ms} should cap routed "
+        f"recall, got {routed_n} memories"
     )
-    assert isinstance(groups, list)
+
+    # Un-routed contrast: with the same corpus and same caller limit
+    # but no question_type, the caller's limit governs, so we expect
+    # more memories than the custom-budget routed call. This rules
+    # out a silent fallback that would have shown identical counts.
+    unrouted = p.recall_grouped("magazine", limit=50)
+    unrouted_n = sum(len(g.memories) for g in unrouted)
+    assert unrouted_n > routed_n, (
+        f"router override broken: routed (ms={custom_ms}) returned "
+        f"{routed_n}, un-routed returned {unrouted_n} — expected "
+        f"un-routed > routed to confirm constructor k_budget flowed "
+        f"through to the router"
+    )


### PR DESCRIPTION
## Summary

Resolves #92. PR #88 (G4 implementation) introduced `KBudget` + `IntentRouter` + the `k_budget` / `ms_card_days` PyO3 kwargs, but per the locked pre-reg scope, the public SDK recall path bypassed the router — `k_budget` resolution was introspection-only. The 2026-05-08 G4 wave's `run.log` confirmed this: even ARM-3-K-BUDGET (where k-budget is the *only* G4 mechanism) silently fell back to ARM-2 because the router never reached recall (results.md §6 H1 caveat).

This PR threads `self.inner.intent_router` through `Pensyve.recall_grouped(...)` so the resolved per-question-type k-budget governs the candidate pool when callers opt in.

**Public API delta** (additive, backward-compatible):

```python
# Existing call — unchanged behavior, no opt-in
groups = p.recall_grouped(query, limit=50)

# New: opt-in to router-resolved k-budget
groups = p.recall_grouped(query, question_type="multi-session")
# → routes through RecallEngine::recall_grouped_with_router
# → router.k_for_type("multi-session") → 50 (locked default)
# → caller's `limit` is overridden by the router's authoritative value
```

**Backward-compat** preserved: `question_type=None` (default) and missing kwarg both map to the existing un-routed `RecallEngine::recall_grouped(...)` path. v2.4.x SDK consumers see no behavior change unless they opt in.

CHANGELOG.md entry added under `[2.4.1] - Unreleased` covering both this fix and the companion `build_retrieval_card_g4` binding (#97).

## Out of scope (deferred)

- **Cross-SDK parity** — TS/Go/WASM `recall_grouped` surfaces unchanged; deferred to v2.5.x or follow-up issue. Python is the surface the G4 harness exercises.
- **`Pensyve.recall(...)` (flat path)** — `RecallEngine` has no `recall_with_router` analog at this commit; deferred until a router-aware flat-recall API is needed.

## Test plan

- [x] `cargo fmt --all -- --check` GREEN
- [x] `cargo clippy -p pensyve-python --all-targets --all-features -- -D warnings` GREEN
- [x] `maturin develop --release` succeeds; `inspect.signature(pensyve.Pensyve.recall_grouped).parameters` exposes `question_type`
- [x] **5 new behavioral tests** in `test_recall_grouped.py`: signature check, kwarg accepted, `None` preserves behavior, router-overrides-limit codepath, custom k_budget flows through
- [x] **32/32 tests GREEN** (5 new #92 + 27 pre-existing G3/G4/recall_grouped)
- [ ] Post-merge: `maturin develop --release` against `main` on DGX; smoke that custom `k_budget` overrides take effect on routed recall

## Composability with #97

Both PRs are independent and composable per the binding spec §5: `build_retrieval_card_g4` operates on a caller-provided SQLite path (per-question tempdir; bypasses `RecallEngine`), while this PR wires the router into the general SDK recall pipeline. Combined harness flow becomes `p.recall_grouped(query, question_type=qt)` (this PR) + `p.build_retrieval_card_g4(db_path, ...)` (#97).

## Plan reference

[`pensyve-docs/plans/2026-05-09-pensyve-g4-followups.md`](https://github.com/major7apps/pensyve-docs/blob/plan/2026-05-09-g4-followups/plans/2026-05-09-pensyve-g4-followups.md) Phase 1B. Per Phase 0.7, issue #93 is the canonical tracking issue for this work; #92 will be closed as a duplicate of #93 after both PRs merge (Phase 1C).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional question_type parameter to recall_grouped() enabling per-question-type retrieval budgeting (default preserves prior behavior).  
* **Updated**
  * Changelog entry for upcoming 2.4.1 with G4 follow-up notes; retrieval defaults remain gated off.  
  * Minimum supported Rust version set to 1.88.  
  * Binary wheel scope limited to aarch64-linux.  
* **Tests**
  * Added tests covering the new question_type behavior and routing semantics.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/major7apps/pensyve/pull/98)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->