### PR TITLE
chore(gateway): mock-embedder fallback log level WARN → INFO when opted-in

### DIFF
--- a/pensyve-mcp-gateway/src/main.rs
+++ b/pensyve-mcp-gateway/src/main.rs
@@ -93,7 +93,11 @@ fn init_resources(config: &GatewayConfig) -> Result<InitResources> {
                 }
                 Err(mini_err) => {
                     if std::env::var("PENSYVE_ALLOW_MOCK_EMBEDDER").is_ok() {
-                        tracing::warn!("Using mock embedder (768 dims) — {mini_err}");
+                        // PENSYVE_ALLOW_MOCK_EMBEDDER is the explicit opt-in
+                        // for environments that intentionally ship without the
+                        // ONNX models (e.g. prod containers built without the
+                        // model artifacts). Surface as info, not warn.
+                        tracing::info!("Using mock embedder (768 dims) — {mini_err}");
                         OnnxEmbedder::new_mock(768)
                     } else {
                         return Err(anyhow::anyhow!(


### PR DESCRIPTION
## Summary

\`PENSYVE_ALLOW_MOCK_EMBEDDER=1\` is the explicit opt-in for environments that intentionally ship without the ONNX models (e.g. production containers built without the model artifacts). When that flag is set, logging "Using mock embedder" as a warn is just noise — it fires on every container start and competes with real warnings during incident triage.

Keep the upstream \`"GTE model unavailable"\` line as warn (it reflects a real fallback condition we'd want to fix in the image). Downgrade only the final mock acceptance to info.

## Test plan
- [x] Diff is a single line + comment change
- [ ] Next container start in prod: confirm "Using mock embedder" lands as INFO not WARN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated logging messages and documentation for fallback embedding system configuration to provide clearer guidance on mock embedder usage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/major7apps/pensyve/pull/106?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->