### PR TITLE
feat(retrieval): SelRoute query-type classifier (Phase 2A)

### DIFF
--- a/pensyve-core/src/observability.rs
+++ b/pensyve-core/src/observability.rs
@@ -10,6 +10,25 @@ const DURATION_BUCKETS: &[f64] = &[
     0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
 ];
 
+/// Histogram buckets for `SelRoute` classifier confidence values (range
+/// `[0.0, 1.0]`). Boundaries are dense at the 0.5 threshold because the
+/// engine integration falls back to the `IDENTITY` mask when
+/// `confidence < 0.5`, so observing the distribution around that cut-off
+/// is the most diagnostic question.
+const CONFIDENCE_BUCKETS: &[f64] = &[0.0, 0.1, 0.25, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0];
+
+/// Per-question-type label set for the `selroute_by_type` Prometheus
+/// counters. Index order MUST match
+/// [`crate::retrieval::query_classifier::selroute_metric_index`].
+const SELROUTE_TYPE_LABELS: [&str; 6] = [
+    "temporal-reasoning",
+    "multi-session",
+    "knowledge-update",
+    "single-session-user",
+    "single-session-assistant",
+    "single-session-preference",
+];
+
 /// A hand-rolled Prometheus-compatible histogram backed by `AtomicU64` counters.
 ///
 /// Buckets are cumulative: each bucket counts all observations <= its boundary,
@@ -89,6 +108,22 @@ pub struct PensyveMetrics {
     pub extraction_fallback_count: AtomicU64,
     pub embedding_failure_count: AtomicU64,
 
+    // Phase 2A: SelRoute query-classifier metrics.
+    /// Total queries classified by the `SelRoute` pipeline (incremented
+    /// only when `PENSYVE_SELROUTE` is enabled).
+    pub selroute_classified: AtomicU64,
+    /// Classifications where confidence `< 0.5` — the caller applies
+    /// the `IDENTITY` mask but still records the route for diagnostics.
+    pub selroute_fallback_count: AtomicU64,
+    /// Per-question-type classification counters. Index layout matches
+    /// `query_classifier::selroute_metric_index`:
+    /// `[temporal_reasoning, multi_session, knowledge_update,
+    ///   single_session_user, single_session_assistant,
+    ///   single_session_preference]`.
+    pub selroute_by_type: [AtomicU64; 6],
+    /// Distribution of `SelRoute` classification confidence values.
+    pub selroute_confidence_histogram: HistogramBuckets,
+
     // Histograms
     pub recall_duration: HistogramBuckets,
     pub embed_duration: HistogramBuckets,
@@ -107,10 +142,49 @@ impl PensyveMetrics {
             consolidation_count: AtomicU64::new(0),
             extraction_fallback_count: AtomicU64::new(0),
             embedding_failure_count: AtomicU64::new(0),
+            selroute_classified: AtomicU64::new(0),
+            selroute_fallback_count: AtomicU64::new(0),
+            // [AtomicU64; 6] cannot use [AtomicU64::new(0); 6] because
+            // AtomicU64 is !Copy; build the array element-wise.
+            selroute_by_type: [
+                AtomicU64::new(0),
+                AtomicU64::new(0),
+                AtomicU64::new(0),
+                AtomicU64::new(0),
+                AtomicU64::new(0),
+                AtomicU64::new(0),
+            ],
+            selroute_confidence_histogram: HistogramBuckets::new(CONFIDENCE_BUCKETS),
             recall_duration: HistogramBuckets::new(DURATION_BUCKETS),
             embed_duration: HistogramBuckets::new(DURATION_BUCKETS),
             store_duration: HistogramBuckets::new(DURATION_BUCKETS),
         }
+    }
+
+    /// Record a `SelRoute` classification.
+    ///
+    /// - `type_index` is the result of
+    ///   [`crate::retrieval::query_classifier::selroute_metric_index`] —
+    ///   `Some(idx)` for recognized types, `None` for unknown (the
+    ///   counter is still bumped on `selroute_classified` but no
+    ///   per-type slot is incremented).
+    /// - `confidence` is recorded in the confidence histogram, and a
+    ///   value below `0.5` increments `selroute_fallback_count`.
+    pub fn record_selroute_classification(&self, type_index: Option<usize>, confidence: f32) {
+        self.selroute_classified.fetch_add(1, Ordering::Relaxed);
+        if confidence < 0.5 {
+            self.selroute_fallback_count.fetch_add(1, Ordering::Relaxed);
+        }
+        if let Some(idx) = type_index
+            && let Some(slot) = self.selroute_by_type.get(idx)
+        {
+            slot.fetch_add(1, Ordering::Relaxed);
+        }
+        // Clamp negatives defensively before observation; the
+        // classifier always returns >=0.0 today but the histogram
+        // expects non-negative observations.
+        self.selroute_confidence_histogram
+            .observe(f64::from(confidence.max(0.0)));
     }
 
     /// Record a completed recall operation with its duration in milliseconds.
@@ -149,6 +223,10 @@ impl PensyveMetrics {
     }
 
     /// Export all metrics in Prometheus text exposition format.
+    #[allow(
+        clippy::too_many_lines,
+        reason = "linear writeln! sequence per Prometheus metric — splitting per metric would add indirection without clarity. Grows by ~10 lines per new metric set."
+    )]
     pub fn prometheus_text(&self) -> String {
         let mut buf = String::with_capacity(512);
 
@@ -220,6 +298,37 @@ impl PensyveMetrics {
         let _ = writeln!(buf, "# TYPE pensyve_embedding_failure_total counter");
         let _ = writeln!(buf, "pensyve_embedding_failure_total {embedding_failure}");
 
+        // Phase 2A: SelRoute classifier counters.
+        let selroute_classified = self.selroute_classified.load(Ordering::Relaxed);
+        let selroute_fallback = self.selroute_fallback_count.load(Ordering::Relaxed);
+        let _ = writeln!(
+            buf,
+            "# HELP pensyve_selroute_classified_total Total queries auto-classified by SelRoute."
+        );
+        let _ = writeln!(buf, "# TYPE pensyve_selroute_classified_total counter");
+        let _ = writeln!(buf, "pensyve_selroute_classified_total {selroute_classified}");
+        let _ = writeln!(
+            buf,
+            "# HELP pensyve_selroute_fallback_total Total SelRoute classifications with confidence below 0.5."
+        );
+        let _ = writeln!(buf, "# TYPE pensyve_selroute_fallback_total counter");
+        let _ = writeln!(buf, "pensyve_selroute_fallback_total {selroute_fallback}");
+
+        // Per-question-type counters. Labels match the
+        // `selroute_metric_index` ordering in `query_classifier.rs`.
+        let _ = writeln!(
+            buf,
+            "# HELP pensyve_selroute_by_type_total SelRoute classifications by question_type."
+        );
+        let _ = writeln!(buf, "# TYPE pensyve_selroute_by_type_total counter");
+        for (idx, label) in SELROUTE_TYPE_LABELS.iter().enumerate() {
+            let count = self.selroute_by_type[idx].load(Ordering::Relaxed);
+            let _ = writeln!(
+                buf,
+                "pensyve_selroute_by_type_total{{question_type=\"{label}\"}} {count}"
+            );
+        }
+
         // Histograms
         buf.push_str(
             &self
@@ -235,6 +344,11 @@ impl PensyveMetrics {
             &self
                 .store_duration
                 .prometheus_text("pensyve_store_duration_seconds"),
+        );
+        buf.push_str(
+            &self
+                .selroute_confidence_histogram
+                .prometheus_text("pensyve_selroute_confidence"),
         );
 
         buf

--- a/pensyve-core/src/observability.rs
+++ b/pensyve-core/src/observability.rs
@@ -71,10 +71,17 @@ impl HistogramBuckets {
     }
 
     /// Format as Prometheus histogram exposition text.
-    pub fn prometheus_text(&self, name: &str) -> String {
+    ///
+    /// `help` is rendered into the `# HELP {name} {help}` line so that
+    /// non-duration histograms (e.g. dimensionless confidence) can carry
+    /// accurate semantics. Duration histograms should pass a phrase
+    /// ending in "in seconds" or "in milliseconds" for monitoring-tool
+    /// auto-detection; other observations should describe their unit
+    /// (e.g. "Classification confidence in [0.0, 1.0]").
+    pub fn prometheus_text(&self, name: &str, help: &str) -> String {
         use std::fmt::Write;
         let mut buf = String::new();
-        let _ = writeln!(buf, "# HELP {name} Duration in seconds");
+        let _ = writeln!(buf, "# HELP {name} {help}");
         let _ = writeln!(buf, "# TYPE {name} histogram");
         for (i, &boundary) in self.boundaries.iter().enumerate() {
             let count = self.counts[i].load(Ordering::Relaxed);
@@ -306,7 +313,10 @@ impl PensyveMetrics {
             "# HELP pensyve_selroute_classified_total Total queries auto-classified by SelRoute."
         );
         let _ = writeln!(buf, "# TYPE pensyve_selroute_classified_total counter");
-        let _ = writeln!(buf, "pensyve_selroute_classified_total {selroute_classified}");
+        let _ = writeln!(
+            buf,
+            "pensyve_selroute_classified_total {selroute_classified}"
+        );
         let _ = writeln!(
             buf,
             "# HELP pensyve_selroute_fallback_total Total SelRoute classifications with confidence below 0.5."
@@ -330,26 +340,22 @@ impl PensyveMetrics {
         }
 
         // Histograms
-        buf.push_str(
-            &self
-                .recall_duration
-                .prometheus_text("pensyve_recall_duration_seconds"),
-        );
-        buf.push_str(
-            &self
-                .embed_duration
-                .prometheus_text("pensyve_embed_duration_seconds"),
-        );
-        buf.push_str(
-            &self
-                .store_duration
-                .prometheus_text("pensyve_store_duration_seconds"),
-        );
-        buf.push_str(
-            &self
-                .selroute_confidence_histogram
-                .prometheus_text("pensyve_selroute_confidence"),
-        );
+        buf.push_str(&self.recall_duration.prometheus_text(
+            "pensyve_recall_duration_seconds",
+            "Recall operation duration in seconds.",
+        ));
+        buf.push_str(&self.embed_duration.prometheus_text(
+            "pensyve_embed_duration_seconds",
+            "Embedding generation duration in seconds.",
+        ));
+        buf.push_str(&self.store_duration.prometheus_text(
+            "pensyve_store_duration_seconds",
+            "Memory store operation duration in seconds.",
+        ));
+        buf.push_str(&self.selroute_confidence_histogram.prometheus_text(
+            "pensyve_selroute_confidence",
+            "SelRoute classification confidence distribution in [0.0, 1.0].",
+        ));
 
         buf
     }
@@ -470,7 +476,7 @@ mod tests {
         h.observe(0.15); // falls in 0.25 bucket
         h.observe(20.0); // only +Inf
 
-        let text = h.prometheus_text("test_duration_seconds");
+        let text = h.prometheus_text("test_duration_seconds", "Test duration in seconds.");
         assert!(text.contains("test_duration_seconds_bucket{le=\"0.005\"} 1"));
         assert!(text.contains("test_duration_seconds_bucket{le=\"+Inf\"} 3"));
         assert!(text.contains("test_duration_seconds_count 3"));

--- a/pensyve-core/src/retrieval/engine.rs
+++ b/pensyve-core/src/retrieval/engine.rs
@@ -594,6 +594,40 @@ impl<'a> RecallEngine<'a> {
         // Classify query intent for intent-based scoring.
         let intent = classify_intent(query);
 
+        // Phase 2A SelRoute: optional question-type classification +
+        // per-route RRF weight mask. Strictly gated behind the
+        // `PENSYVE_SELROUTE` env-var (read once via OnceLock — see
+        // `query_classifier::selroute_enabled`); when the gate is off
+        // the entire block is bypassed and the recall path is
+        // byte-for-byte identical to pre-Phase-2A behavior.
+        let selroute_mask: Option<[f32; 7]> = if crate::retrieval::query_classifier::selroute_enabled() {
+            let classification = crate::retrieval::query_classifier::classify_query(query);
+            let metrics = crate::observability::metrics();
+            metrics.record_selroute_classification(
+                crate::retrieval::query_classifier::selroute_metric_index(
+                    classification.question_type,
+                ),
+                classification.confidence,
+            );
+            // Apply the per-route mask only when confidence >= 0.5;
+            // below that the caller's contract says to use IDENTITY
+            // (which is a no-op and we just skip).
+            if classification.confidence >= 0.5 {
+                let cfg = crate::retrieval::query_classifier::pipeline_config_for(
+                    classification.question_type,
+                );
+                if cfg == crate::retrieval::query_classifier::PipelineConfig::IDENTITY {
+                    None
+                } else {
+                    Some(cfg.signal_mask)
+                }
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
         // Step 6–7: Build 6 independent rankings and merge via RRF.
         let candidates_found = candidates.len();
         let now = Utc::now();
@@ -696,17 +730,34 @@ impl<'a> RecallEngine<'a> {
         };
         ranking_entity.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
 
+        // Phase 2A SelRoute mask: when the env-gate fired and the
+        // classification confidence cleared the 0.5 threshold,
+        // `selroute_mask` holds a `[f32; 7]` to multiply against the
+        // engine's per-signal RRF weights. Slots 0..6 align with
+        // `[vec, bm25, activation, spread, intent, confidence]`; the
+        // 7th slot is reserved for the future PPR signal (Phase 2C)
+        // and the entity-affinity weight at `rrf_weights[6]` is left
+        // unchanged regardless of the mask. When the mask is None the
+        // expression below is a strict no-op (identity).
+        let masked_weight = |idx: usize| -> f32 {
+            let base = self.config.rrf_weights[idx];
+            match selroute_mask {
+                Some(mask) if idx < 6 => base * mask[idx],
+                _ => base,
+            }
+        };
+
         // Merge via RRF — only include rankings with discriminative signal.
         // A ranking where all scores are identical (e.g., empty graph, no access history)
         // adds noise and dilutes the strong signals like vector similarity.
         let all_rankings = vec![
-            (ranking_vec, self.config.rrf_weights[0]),
-            (ranking_bm25, self.config.rrf_weights[1]),
-            (ranking_activation, self.config.rrf_weights[2]),
-            (ranking_spread, self.config.rrf_weights[3]),
-            (ranking_intent, self.config.rrf_weights[4]),
-            (ranking_confidence, self.config.rrf_weights[5]),
-            (ranking_entity, self.config.rrf_weights[6]),
+            (ranking_vec, masked_weight(0)),
+            (ranking_bm25, masked_weight(1)),
+            (ranking_activation, masked_weight(2)),
+            (ranking_spread, masked_weight(3)),
+            (ranking_intent, masked_weight(4)),
+            (ranking_confidence, masked_weight(5)),
+            (ranking_entity, masked_weight(6)),
         ];
 
         let (rankings, rrf_weights): (Vec<_>, Vec<_>) = all_rankings

--- a/pensyve-core/src/retrieval/engine.rs
+++ b/pensyve-core/src/retrieval/engine.rs
@@ -600,33 +600,34 @@ impl<'a> RecallEngine<'a> {
         // `query_classifier::selroute_enabled`); when the gate is off
         // the entire block is bypassed and the recall path is
         // byte-for-byte identical to pre-Phase-2A behavior.
-        let selroute_mask: Option<[f32; 7]> = if crate::retrieval::query_classifier::selroute_enabled() {
-            let classification = crate::retrieval::query_classifier::classify_query(query);
-            let metrics = crate::observability::metrics();
-            metrics.record_selroute_classification(
-                crate::retrieval::query_classifier::selroute_metric_index(
-                    classification.question_type,
-                ),
-                classification.confidence,
-            );
-            // Apply the per-route mask only when confidence >= 0.5;
-            // below that the caller's contract says to use IDENTITY
-            // (which is a no-op and we just skip).
-            if classification.confidence >= 0.5 {
-                let cfg = crate::retrieval::query_classifier::pipeline_config_for(
-                    classification.question_type,
+        let selroute_mask: Option<[f32; 7]> =
+            if crate::retrieval::query_classifier::selroute_enabled() {
+                let classification = crate::retrieval::query_classifier::classify_query(query);
+                let metrics = crate::observability::metrics();
+                metrics.record_selroute_classification(
+                    crate::retrieval::query_classifier::selroute_metric_index(
+                        classification.question_type,
+                    ),
+                    classification.confidence,
                 );
-                if cfg == crate::retrieval::query_classifier::PipelineConfig::IDENTITY {
-                    None
+                // Apply the per-route mask only when confidence >= 0.5;
+                // below that the caller's contract says to use IDENTITY
+                // (which is a no-op and we just skip).
+                if classification.confidence >= 0.5 {
+                    let cfg = crate::retrieval::query_classifier::pipeline_config_for(
+                        classification.question_type,
+                    );
+                    if cfg == crate::retrieval::query_classifier::PipelineConfig::IDENTITY {
+                        None
+                    } else {
+                        Some(cfg.signal_mask)
+                    }
                 } else {
-                    Some(cfg.signal_mask)
+                    None
                 }
             } else {
                 None
-            }
-        } else {
-            None
-        };
+            };
 
         // Step 6–7: Build 6 independent rankings and merge via RRF.
         let candidates_found = candidates.len();

--- a/pensyve-core/src/retrieval/engine.rs
+++ b/pensyve-core/src/retrieval/engine.rs
@@ -580,26 +580,18 @@ impl<'a> RecallEngine<'a> {
             self.gather_candidates(query, namespace_id, max_candidates)?
         };
 
-        if candidates.is_empty() {
-            return Ok(RecallResult { memories: vec![] });
-        }
-
-        if start.elapsed() > timeout {
-            return Err(RecallError::Timeout(self.config.recall_timeout_secs));
-        }
-
-        // Step 5: Normalize BM25 scores (positional rank).
-        let bm25_map = self.build_bm25_map(query, namespace_id, max_candidates)?;
-
-        // Classify query intent for intent-based scoring.
-        let intent = classify_intent(query);
-
         // Phase 2A SelRoute: optional question-type classification +
         // per-route RRF weight mask. Strictly gated behind the
         // `PENSYVE_SELROUTE` env-var (read once via OnceLock — see
         // `query_classifier::selroute_enabled`); when the gate is off
         // the entire block is bypassed and the recall path is
         // byte-for-byte identical to pre-Phase-2A behavior.
+        //
+        // This block runs BEFORE the zero-candidate early return so
+        // `selroute_classified` / `selroute_fallback_count` /
+        // `selroute_by_type` / confidence-histogram telemetry covers
+        // ALL SelRoute decisions, not just queries that returned hits.
+        // Per CodeRabbit review on #114 (2026-05-21).
         let selroute_mask: Option<[f32; 7]> =
             if crate::retrieval::query_classifier::selroute_enabled() {
                 let classification = crate::retrieval::query_classifier::classify_query(query);
@@ -628,6 +620,20 @@ impl<'a> RecallEngine<'a> {
             } else {
                 None
             };
+
+        if candidates.is_empty() {
+            return Ok(RecallResult { memories: vec![] });
+        }
+
+        if start.elapsed() > timeout {
+            return Err(RecallError::Timeout(self.config.recall_timeout_secs));
+        }
+
+        // Step 5: Normalize BM25 scores (positional rank).
+        let bm25_map = self.build_bm25_map(query, namespace_id, max_candidates)?;
+
+        // Classify query intent for intent-based scoring.
+        let intent = classify_intent(query);
 
         // Step 6–7: Build 6 independent rankings and merge via RRF.
         let candidates_found = candidates.len();

--- a/pensyve-core/src/retrieval/mod.rs
+++ b/pensyve-core/src/retrieval/mod.rs
@@ -27,6 +27,7 @@ pub mod cards;
 pub mod diversity;
 pub mod engine;
 pub mod intent_router;
+pub mod query_classifier;
 
 // Flat re-export keeps the v2.x API surface intact after the
 // retrieval.rs -> retrieval/engine.rs refactor. New code introduced by G2

--- a/pensyve-core/src/retrieval/query_classifier.rs
+++ b/pensyve-core/src/retrieval/query_classifier.rs
@@ -152,9 +152,13 @@ fn patterns() -> &'static PatternBundle {
             r"(?i)(\bremember\b|\blast time\b|\bpreviously\b|\bearlier\b|\bin our (last|previous)\b|\bwe (discussed|talked|covered)\b)",
         )
         .expect("multi_session pattern compiles"),
-        // Knowledge-update: state-change cues.
+        // Knowledge-update: state-change cues. `now` alone is too
+        // common (fires on routine queries like "Tell me about X now")
+        // and would degrade retrieval — restrict to constructions that
+        // actually signal a state change: "right now", "as of now",
+        // "now that/it/uses/is".
         knowledge_update: Regex::new(
-            r"(?i)(\bnow\b|\bcurrently\b|\bcurrent\b|\bupdated?\b|\bchanged?\b|\binstead\b|\bno longer\b)",
+            r"(?i)(\bright now\b|\bas of now\b|\bnow (that|it|uses?|is)\b|\bcurrently\b|\bcurrent\b|\bupdated?\b|\bchanged?\b|\binstead\b|\bno longer\b)",
         )
         .expect("knowledge_update pattern compiles"),
         // Single-session-user: first-person self-references.
@@ -166,7 +170,7 @@ fn patterns() -> &'static PatternBundle {
         // assistant's prior output. Verb stems accept both past-tense
         // ("you said") and present-tense ("did you suggest") forms.
         single_assistant: Regex::new(
-            r"(?i)(\byou (said|told|wrote|suggested|suggest|recommended|recommend|wrote|write)\b|\byour (answer|response|suggestion|recommendation)\b)",
+            r"(?i)(\byou (said|told|wrote|write|suggested|suggest|recommended|recommend)\b|\byour (answer|response|suggestion|recommendation)\b)",
         )
         .expect("single_assistant pattern compiles"),
     })
@@ -187,12 +191,11 @@ fn patterns() -> &'static PatternBundle {
 /// - `0.7` — multiple groups fire and the highest-precedence one is
 ///   chosen (the caller still applies the per-route mask, but the
 ///   reduced confidence flags ambiguity for downstream logging).
-/// - `0.5` — no group fires; classifier returns the
-///   `single-session-preference` fallback at the confidence boundary
-///   (the caller's `>= 0.5` guard treats this as "use the IDENTITY mask
-///   but still record the route").
-/// - `0.0` — empty / whitespace-only query (caller should bypass
-///   per-route mask entirely).
+/// - `0.0` — no group fires (unclassified) OR the query is empty /
+///   whitespace-only. The caller's `>= 0.5` guard unconditionally
+///   bypasses per-route mask application in both cases, decoupling
+///   the fallback path from threshold or IDENTITY-mask tuning that
+///   may happen in a later phase.
 #[must_use]
 pub fn classify_query(query: &str) -> QueryClassification {
     let trimmed = query.trim();
@@ -239,10 +242,13 @@ pub fn classify_query(query: &str) -> QueryClassification {
     };
 
     let confidence = if groups_fired == 0 {
-        // Fallback: at the >=0.5 confidence boundary so the caller can
-        // either treat this as "apply the identity mask" or as "log
-        // route but skip masking", depending on its own threshold.
-        0.5
+        // Unclassified: return 0.0 so the caller's `>= 0.5` guard
+        // unconditionally bypasses per-route mask application. This
+        // decouples the fallback path from threshold tuning or
+        // IDENTITY-mask changes in later phases — if either is tuned
+        // independently, unclassified queries still won't accidentally
+        // start applying a non-identity mask.
+        0.0
     } else if groups_fired == 1 {
         1.0
     } else {
@@ -435,8 +441,7 @@ mod tests {
             // precedence is multi-session > assistant, so that query
             // classifies as multi-session. Verify only the unambiguous ones.
             assert!(
-                c.question_type == "single-session-assistant"
-                    || c.question_type == "multi-session",
+                c.question_type == "single-session-assistant" || c.question_type == "multi-session",
                 "unexpected classification {} for {q:?}",
                 c.question_type
             );
@@ -464,9 +469,7 @@ mod tests {
     #[test]
     fn temporal_outranks_other_signals() {
         // "before" + "my" + "we discussed" — temporal wins by precedence.
-        let c = classify_query(
-            "Before our meeting last week, we discussed my Rust project plans.",
-        );
+        let c = classify_query("Before our meeting last week, we discussed my Rust project plans.");
         assert_eq!(c.question_type, "temporal-reasoning");
         assert!(c.confidence >= 0.7);
     }
@@ -485,10 +488,12 @@ mod tests {
     fn unrelated_query_falls_back_to_preference() {
         let c = classify_query("Tell something about cats.");
         assert_eq!(c.question_type, "single-session-preference");
-        // No group fired -> fallback confidence 0.5.
+        // No group fired -> fallback confidence 0.0 (caller's `>= 0.5`
+        // guard unconditionally bypasses mask application; decouples
+        // fallback from threshold/IDENTITY-mask tuning in later phases).
         assert!(
-            (c.confidence - 0.5).abs() < f32::EPSILON,
-            "expected 0.5 fallback confidence, got {}",
+            c.confidence.abs() < f32::EPSILON,
+            "expected 0.0 fallback confidence, got {}",
             c.confidence
         );
     }
@@ -520,10 +525,7 @@ mod tests {
             // Each mask entry must be non-negative (multiplicative
             // masks; negative would invert the RRF ranking sign).
             for (i, &v) in cfg.signal_mask.iter().enumerate() {
-                assert!(
-                    v >= 0.0,
-                    "negative mask value at idx {i} for {qt}: {v}"
-                );
+                assert!(v >= 0.0, "negative mask value at idx {i} for {qt}: {v}");
             }
         }
         // The PPR slot (index 6) is reserved for the future PPR signal

--- a/pensyve-core/src/retrieval/query_classifier.rs
+++ b/pensyve-core/src/retrieval/query_classifier.rs
@@ -1,0 +1,604 @@
+//! Query classifier for Phase 2A `SelRoute` auto-routing.
+//!
+//! Maps a raw query string to one of the six `question_type` strings consumed
+//! by [`crate::retrieval::intent_router::IntentRouter`]. The classifier is the
+//! upstream of `IntentRouter` — it fills in the `question_type` when external
+//! callers do not provide one — and optionally exposes per-route RRF weight
+//! masks for the engine's 6-signal RRF assembly.
+//!
+//! ## Vocabulary
+//!
+//! Output `question_type` strings match the existing `IntentRouter`
+//! decision table exactly:
+//!
+//! - `"temporal-reasoning"` — temporal cues (before / after / when / since)
+//! - `"multi-session"` — explicit cross-session references (remember,
+//!   previously, last time, we discussed)
+//! - `"knowledge-update"` — change cues (now, currently, updated, no longer,
+//!   instead)
+//! - `"single-session-user"` — first-person self-references (I am, my, me)
+//! - `"single-session-assistant"` — second-person references to the
+//!   assistant's prior output (you said, your answer)
+//! - `"single-session-preference"` — broad fallback (the conservative
+//!   default; maps to the v2.0 baseline k=22 bucket in the
+//!   `IntentRouter`)
+//!
+//! Precedence: temporal-reasoning > multi-session > knowledge-update >
+//! single-session-* (user vs assistant) > single-session-preference. The
+//! ordering reflects specificity — temporal cues are the most discriminative,
+//! preferences are the broadest fallback.
+//!
+//! ## `SelRoute` env-var gate
+//!
+//! The Phase 2A integration in `engine.rs` is wrapped behind a
+//! `PENSYVE_SELROUTE` env-var gate read once at process start via
+//! `OnceLock`. When unset / `0` / `false`, the recall pipeline is
+//! byte-for-byte identical to pre-Phase-2A behavior — this is a hard
+//! requirement for the Phase 2 rollout (the orchestrator A/B's the gate
+//! against the v2.2 baseline).
+//!
+//! ## Per-route RRF mask rationale (Phase 2A starting points)
+//!
+//! The [`PipelineConfig::signal_mask`] values below are conservative
+//! starting points pending Phase 2F's A/B tuning sweep. The mask is
+//! aligned with the engine's 6-signal RRF assembly
+//! (`[vector, bm25, activation, spreading, intent, confidence]`) plus a
+//! reserved 7th slot for the Phase 2C PPR signal (currently 0.0 — the
+//! engine does not yet emit a PPR ranking, so the mask value is a no-op
+//! placeholder).
+//!
+//! - **temporal-reasoning**: down-weight activation + confidence; temporal
+//!   reasoning needs the recall path to lean on lexical and content
+//!   signals rather than access-history activation.
+//! - **multi-session**: up-weight spreading activation; cross-session
+//!   references benefit from graph traversal connecting separate
+//!   conversations.
+//! - **knowledge-update**: up-weight BM25 (lexical match on "updated" /
+//!   "changed"), down-weight spreading (a change cue is local to the
+//!   most-recent session).
+//! - **single-session-user**: lean on dense similarity; less graph
+//!   spreading needed within a single session.
+//! - **single-session-assistant**: up-weight confidence; assistant-emitted
+//!   facts are typed and the confidence signal is more diagnostic.
+//! - **single-session-preference**: identity mask — preferences are the
+//!   broadest baseline.
+//!
+//! ## Out of scope
+//!
+//! - **No I/O on the hot path.** Regex patterns are pre-compiled via
+//!   `OnceLock` at first call.
+//! - **No env-var reads on the hot path.** `selroute_enabled()` caches the
+//!   `PENSYVE_SELROUTE` env-var at first call (matches the existing
+//!   `IntentRouter` env-cache pattern).
+//! - **No mutation of existing `intent_router.rs`.** This module sits
+//!   upstream of `IntentRouter` and produces inputs to its existing
+//!   `route(question_type)` / `k_for_type(question_type)` API.
+
+use std::sync::OnceLock;
+
+use regex::Regex;
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/// Classification result for a raw query.
+#[derive(Debug, Clone, PartialEq)]
+pub struct QueryClassification {
+    /// One of the six `question_type` strings used by
+    /// [`crate::retrieval::intent_router::route`]. Falls back to
+    /// `"single-session-preference"` (the existing conservative default
+    /// that maps to the v2.0 baseline k=22 bucket) when no classifier
+    /// pattern fires.
+    pub question_type: &'static str,
+    /// Confidence in `[0.0, 1.0]`. When `< 0.5` the caller should fall
+    /// back to its baseline pipeline rather than apply per-route weight
+    /// masks.
+    pub confidence: f32,
+}
+
+/// Per-question-type RRF weight overrides (applied only when `SelRoute`
+/// is enabled AND classification confidence `>= 0.5`).
+///
+/// Indices mirror the existing 6-signal RRF assembly in `engine.rs`:
+/// `[vector, bm25, activation, spreading, intent, confidence]`. A 7th
+/// slot is reserved for the future PPR signal (Phase 2C); the mask
+/// value at that slot is currently a placeholder (`0.0`) — the engine
+/// integration applies the mask only to slots `0..6`, so the PPR slot
+/// is a no-op until the engine emits a PPR ranking.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PipelineConfig {
+    /// Multiplicative mask applied to each signal's RRF weight. Use
+    /// `0.0` to disable a signal entirely; `1.0` to leave unchanged.
+    pub signal_mask: [f32; 7],
+}
+
+impl PipelineConfig {
+    /// Identity mask — preserves engine defaults. Used as fallback when
+    /// confidence `< 0.5` or when `SelRoute` is disabled.
+    pub const IDENTITY: Self = Self {
+        signal_mask: [1.0; 7],
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Compiled-regex caches (OnceLock — pure-Rust stdlib, no extra crates)
+// ---------------------------------------------------------------------------
+
+/// Compiled regex bundle for the classifier. Each field is a single
+/// case-insensitive regex with alternation across all patterns that map
+/// to one `question_type` — this is significantly cheaper at match time
+/// than iterating per-pattern.
+struct PatternBundle {
+    temporal: Regex,
+    multi_session: Regex,
+    knowledge_update: Regex,
+    single_user: Regex,
+    single_assistant: Regex,
+}
+
+fn patterns() -> &'static PatternBundle {
+    static PATTERNS: OnceLock<PatternBundle> = OnceLock::new();
+    PATTERNS.get_or_init(|| PatternBundle {
+        // Temporal: before/after/since/when did/how long, relative
+        // time words (yesterday/tomorrow/last X), and ISO-ish date
+        // patterns (YYYY-MM-DD).
+        temporal: Regex::new(
+            r"(?i)(\bbefore\b|\bafter\b|\bsince\b|\bwhen did\b|\bhow long\b|\byesterday\b|\btomorrow\b|\blast (week|month|year|monday|tuesday|wednesday|thursday|friday|saturday|sunday)\b|\b\d{4}-\d{2}-\d{2}\b)",
+        )
+        .expect("temporal pattern compiles"),
+        // Multi-session: explicit cross-session references.
+        multi_session: Regex::new(
+            r"(?i)(\bremember\b|\blast time\b|\bpreviously\b|\bearlier\b|\bin our (last|previous)\b|\bwe (discussed|talked|covered)\b)",
+        )
+        .expect("multi_session pattern compiles"),
+        // Knowledge-update: state-change cues.
+        knowledge_update: Regex::new(
+            r"(?i)(\bnow\b|\bcurrently\b|\bcurrent\b|\bupdated?\b|\bchanged?\b|\binstead\b|\bno longer\b)",
+        )
+        .expect("knowledge_update pattern compiles"),
+        // Single-session-user: first-person self-references.
+        single_user: Regex::new(
+            r"(?i)(\bI (am|have|did|want|like)\b|\bmy\b|\bme\b|\bmyself\b)",
+        )
+        .expect("single_user pattern compiles"),
+        // Single-session-assistant: second-person references to the
+        // assistant's prior output. Verb stems accept both past-tense
+        // ("you said") and present-tense ("did you suggest") forms.
+        single_assistant: Regex::new(
+            r"(?i)(\byou (said|told|wrote|suggested|suggest|recommended|recommend|wrote|write)\b|\byour (answer|response|suggestion|recommendation)\b)",
+        )
+        .expect("single_assistant pattern compiles"),
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Classify a raw query into a `question_type` string + confidence.
+///
+/// Uses pre-compiled regex patterns initialized once via `OnceLock`.
+/// Pure function; no allocations on the hot path beyond the returned
+/// struct.
+///
+/// Confidence values:
+/// - `1.0` — exactly one pattern group fires.
+/// - `0.7` — multiple groups fire and the highest-precedence one is
+///   chosen (the caller still applies the per-route mask, but the
+///   reduced confidence flags ambiguity for downstream logging).
+/// - `0.5` — no group fires; classifier returns the
+///   `single-session-preference` fallback at the confidence boundary
+///   (the caller's `>= 0.5` guard treats this as "use the IDENTITY mask
+///   but still record the route").
+/// - `0.0` — empty / whitespace-only query (caller should bypass
+///   per-route mask entirely).
+#[must_use]
+pub fn classify_query(query: &str) -> QueryClassification {
+    let trimmed = query.trim();
+    if trimmed.is_empty() {
+        return QueryClassification {
+            question_type: "single-session-preference",
+            confidence: 0.0,
+        };
+    }
+
+    let p = patterns();
+    let temporal = p.temporal.is_match(trimmed);
+    let multi = p.multi_session.is_match(trimmed);
+    let knowledge = p.knowledge_update.is_match(trimmed);
+    let user = p.single_user.is_match(trimmed);
+    let assistant = p.single_assistant.is_match(trimmed);
+
+    let groups_fired = u8::from(temporal)
+        + u8::from(multi)
+        + u8::from(knowledge)
+        + u8::from(user)
+        + u8::from(assistant);
+
+    // Precedence: temporal > multi-session > knowledge-update >
+    // single-session-assistant > single-session-user > fallback.
+    //
+    // assistant before user: an "you said X about my Y" query is
+    // primarily about the assistant's prior output even though "my"
+    // also fires the user pattern. The IntentRouter k-budget treats
+    // both single-session-* types as the SSU bucket (k=12), so the
+    // distinction is purely for the per-route mask.
+    let question_type: &'static str = if temporal {
+        "temporal-reasoning"
+    } else if multi {
+        "multi-session"
+    } else if knowledge {
+        "knowledge-update"
+    } else if assistant {
+        "single-session-assistant"
+    } else if user {
+        "single-session-user"
+    } else {
+        "single-session-preference"
+    };
+
+    let confidence = if groups_fired == 0 {
+        // Fallback: at the >=0.5 confidence boundary so the caller can
+        // either treat this as "apply the identity mask" or as "log
+        // route but skip masking", depending on its own threshold.
+        0.5
+    } else if groups_fired == 1 {
+        1.0
+    } else {
+        // Multiple groups fired; precedence picked one, confidence
+        // reduced to reflect the ambiguity.
+        0.7
+    };
+
+    QueryClassification {
+        question_type,
+        confidence,
+    }
+}
+
+/// Map a classified `question_type` to its RRF weight override mask.
+///
+/// Returns [`PipelineConfig::IDENTITY`] for unknown types or when no
+/// override is configured for the type — strictly non-destructive.
+#[must_use]
+#[allow(
+    clippy::match_same_arms,
+    reason = "the explicit `single-session-preference` arm and the wildcard fallback both return IDENTITY *today*, but they encode distinct intents — the explicit arm is the binding Phase 2A mask for that question_type (identity per the broadest-baseline rationale); the wildcard is a conservative non-destructive fallback for unknown / future types. Collapsing them would silently couple future tuning of the preference mask to the unknown-type fallback. Keep them split for forward extensibility (mirrors the same pattern in intent_router::k_for_type)."
+)]
+pub fn pipeline_config_for(question_type: &str) -> PipelineConfig {
+    // Per-route masks per the Phase 2A spec. The 7th slot is the
+    // reserved-for-PPR placeholder (engine integration applies only
+    // slots 0..6 to existing rrf_weights[0..6]; the entity-affinity
+    // signal at rrf_weights[6] is left unchanged regardless).
+    match question_type {
+        "temporal-reasoning" => PipelineConfig {
+            signal_mask: [1.0, 1.0, 0.5, 1.0, 1.0, 0.5, 0.0],
+        },
+        "multi-session" => PipelineConfig {
+            signal_mask: [1.0, 1.0, 1.0, 1.5, 1.0, 1.0, 0.0],
+        },
+        "knowledge-update" => PipelineConfig {
+            signal_mask: [1.0, 1.5, 1.0, 0.5, 1.0, 1.0, 0.0],
+        },
+        "single-session-user" => PipelineConfig {
+            signal_mask: [1.5, 1.0, 1.0, 0.5, 1.0, 1.0, 0.0],
+        },
+        "single-session-assistant" => PipelineConfig {
+            signal_mask: [1.0, 1.0, 1.0, 0.5, 1.0, 1.5, 0.0],
+        },
+        "single-session-preference" => PipelineConfig::IDENTITY,
+        // Unknown / future types: identity mask, strictly non-destructive.
+        _ => PipelineConfig::IDENTITY,
+    }
+}
+
+/// Index into the [`crate::observability::PensyveMetrics::selroute_by_type`]
+/// array for a given `question_type` string.
+///
+/// Returns `Some(idx)` for the six recognized types; `None` for unknown.
+/// Used by the engine integration to bump the correct per-type counter
+/// without an unbounded `HashMap`.
+#[must_use]
+pub fn selroute_metric_index(question_type: &str) -> Option<usize> {
+    // Order matches the `selroute_by_type` field comment in
+    // `observability.rs` — keep these in lockstep.
+    match question_type {
+        "temporal-reasoning" => Some(0),
+        "multi-session" => Some(1),
+        "knowledge-update" => Some(2),
+        "single-session-user" => Some(3),
+        "single-session-assistant" => Some(4),
+        "single-session-preference" => Some(5),
+        _ => None,
+    }
+}
+
+/// Check whether the `SelRoute` env-var gate is enabled.
+///
+/// Reads `PENSYVE_SELROUTE` once via `OnceLock` — env-var changes
+/// post-init are NOT picked up. This matches the existing `IntentRouter`
+/// pattern of caching env reads at construction (`MultiSessionCard::g3_mode`,
+/// `KBudget::from_env`).
+///
+/// Accepted truthy values (case-insensitive): `"1"`, `"true"`, `"on"`,
+/// `"yes"`. Anything else — including unset — disables `SelRoute`.
+#[must_use]
+pub fn selroute_enabled() -> bool {
+    static SELROUTE: OnceLock<bool> = OnceLock::new();
+    *SELROUTE.get_or_init(|| {
+        std::env::var("PENSYVE_SELROUTE").is_ok_and(|v| {
+            let lower = v.trim().to_ascii_lowercase();
+            matches!(lower.as_str(), "1" | "true" | "on" | "yes")
+        })
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_query_returns_preference_fallback_with_zero_confidence() {
+        let c = classify_query("");
+        assert_eq!(c.question_type, "single-session-preference");
+        assert!((c.confidence - 0.0).abs() < f32::EPSILON);
+
+        let c = classify_query("   \t\n  ");
+        assert_eq!(c.question_type, "single-session-preference");
+        assert!((c.confidence - 0.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn temporal_reasoning_classification() {
+        for q in [
+            "What did I work on before yesterday?",
+            "When did we move to the new office?",
+            "How long ago did I start that project?",
+            "Tell me about my plans for last week.",
+            "I started the migration on 2025-11-12.",
+        ] {
+            let c = classify_query(q);
+            assert_eq!(
+                c.question_type, "temporal-reasoning",
+                "query did not classify as temporal: {q:?}"
+            );
+            assert!(
+                c.confidence >= 0.7,
+                "expected confidence >= 0.7 for {q:?}, got {}",
+                c.confidence
+            );
+        }
+    }
+
+    #[test]
+    fn multi_session_classification() {
+        for q in [
+            "Remember the API design we sketched?",
+            "What did we discuss in our last call?",
+            "We covered this previously — can you elaborate?",
+        ] {
+            let c = classify_query(q);
+            assert_eq!(
+                c.question_type, "multi-session",
+                "query did not classify as multi-session: {q:?}"
+            );
+            assert!(c.confidence >= 0.7);
+        }
+    }
+
+    #[test]
+    fn knowledge_update_classification() {
+        for q in [
+            "What is my current address?",
+            "I no longer use that framework.",
+            "The plan has changed — what are the new steps?",
+            "Use Postgres instead of SQLite now.",
+        ] {
+            let c = classify_query(q);
+            assert_eq!(
+                c.question_type, "knowledge-update",
+                "query did not classify as knowledge-update: {q:?}"
+            );
+            assert!(c.confidence >= 0.7);
+        }
+    }
+
+    #[test]
+    fn single_session_user_classification() {
+        for q in [
+            "I want a summary of my notes.",
+            "What do I like to eat for breakfast?",
+            "Tell me about myself.",
+        ] {
+            let c = classify_query(q);
+            assert_eq!(
+                c.question_type, "single-session-user",
+                "query did not classify as single-session-user: {q:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn single_session_assistant_classification() {
+        for q in [
+            "You said the migration would take three days — confirm?",
+            "Your answer earlier was incomplete; expand on the storage layer.",
+            "What did you suggest for the deployment topology?",
+        ] {
+            let c = classify_query(q);
+            // "Your answer earlier ..." also fires multi_session (earlier);
+            // precedence is multi-session > assistant, so that query
+            // classifies as multi-session. Verify only the unambiguous ones.
+            assert!(
+                c.question_type == "single-session-assistant"
+                    || c.question_type == "multi-session",
+                "unexpected classification {} for {q:?}",
+                c.question_type
+            );
+        }
+        // Unambiguous assistant-only query
+        let c = classify_query("What did you suggest for the deployment topology?");
+        assert_eq!(c.question_type, "single-session-assistant");
+        assert!(c.confidence >= 0.7);
+    }
+
+    #[test]
+    fn ambiguous_query_uses_precedence() {
+        // "earlier" -> multi-session; "I" + "my" -> single-session-user.
+        // Precedence: multi-session > single-session-user.
+        let c = classify_query("What did I say earlier about my Rust project?");
+        assert_eq!(c.question_type, "multi-session");
+        // Multiple groups fired -> confidence 0.7.
+        assert!(
+            (c.confidence - 0.7).abs() < f32::EPSILON,
+            "expected 0.7 ambiguous-confidence, got {}",
+            c.confidence
+        );
+    }
+
+    #[test]
+    fn temporal_outranks_other_signals() {
+        // "before" + "my" + "we discussed" — temporal wins by precedence.
+        let c = classify_query(
+            "Before our meeting last week, we discussed my Rust project plans.",
+        );
+        assert_eq!(c.question_type, "temporal-reasoning");
+        assert!(c.confidence >= 0.7);
+    }
+
+    #[test]
+    fn case_insensitive_matching() {
+        let lower = classify_query("when did we discuss this?");
+        let upper = classify_query("WHEN DID WE DISCUSS THIS?");
+        let mixed = classify_query("WheN DiD wE DiScUsS tHiS?");
+        assert_eq!(lower.question_type, upper.question_type);
+        assert_eq!(lower.question_type, mixed.question_type);
+        assert_eq!(lower.question_type, "temporal-reasoning");
+    }
+
+    #[test]
+    fn unrelated_query_falls_back_to_preference() {
+        let c = classify_query("Tell something about cats.");
+        assert_eq!(c.question_type, "single-session-preference");
+        // No group fired -> fallback confidence 0.5.
+        assert!(
+            (c.confidence - 0.5).abs() < f32::EPSILON,
+            "expected 0.5 fallback confidence, got {}",
+            c.confidence
+        );
+    }
+
+    #[test]
+    fn pipeline_config_unknown_type_is_identity() {
+        let cfg = pipeline_config_for("unknown-type");
+        assert_eq!(cfg, PipelineConfig::IDENTITY);
+        assert_eq!(cfg.signal_mask, [1.0; 7]);
+    }
+
+    #[test]
+    fn pipeline_config_temporal_mask() {
+        let cfg = pipeline_config_for("temporal-reasoning");
+        assert_eq!(cfg.signal_mask, [1.0, 1.0, 0.5, 1.0, 1.0, 0.5, 0.0]);
+    }
+
+    #[test]
+    fn pipeline_config_all_recognized_types_return_valid_masks() {
+        for qt in [
+            "temporal-reasoning",
+            "multi-session",
+            "knowledge-update",
+            "single-session-user",
+            "single-session-assistant",
+            "single-session-preference",
+        ] {
+            let cfg = pipeline_config_for(qt);
+            // Each mask entry must be non-negative (multiplicative
+            // masks; negative would invert the RRF ranking sign).
+            for (i, &v) in cfg.signal_mask.iter().enumerate() {
+                assert!(
+                    v >= 0.0,
+                    "negative mask value at idx {i} for {qt}: {v}"
+                );
+            }
+        }
+        // The PPR slot (index 6) is reserved for the future PPR signal
+        // (Phase 2C). For the five explicit per-route masks it is
+        // currently 0.0; the `single-session-preference` route uses
+        // IDENTITY ([1.0; 7]) per the broadest-baseline rationale.
+        // The engine integration applies the mask only to slots 0..6,
+        // so the slot-6 value is operationally a no-op today either
+        // way.
+        for qt in [
+            "temporal-reasoning",
+            "multi-session",
+            "knowledge-update",
+            "single-session-user",
+            "single-session-assistant",
+        ] {
+            let cfg = pipeline_config_for(qt);
+            assert!(
+                (cfg.signal_mask[6] - 0.0).abs() < f32::EPSILON,
+                "explicit per-route mask PPR slot should be 0.0 for {qt}"
+            );
+        }
+        // single-session-preference uses IDENTITY ([1.0; 7]).
+        assert_eq!(
+            pipeline_config_for("single-session-preference"),
+            PipelineConfig::IDENTITY
+        );
+    }
+
+    #[test]
+    fn pipeline_config_preference_is_identity() {
+        let cfg = pipeline_config_for("single-session-preference");
+        // Identity mask on slots 0..5 (preferences are the broadest baseline).
+        for i in 0..6 {
+            assert!(
+                (cfg.signal_mask[i] - 1.0).abs() < f32::EPSILON,
+                "preference mask should be identity at slot {i}"
+            );
+        }
+    }
+
+    #[test]
+    fn selroute_metric_index_round_trip() {
+        // All six recognized types resolve to distinct indices in [0, 6).
+        let mut seen = [false; 6];
+        for qt in [
+            "temporal-reasoning",
+            "multi-session",
+            "knowledge-update",
+            "single-session-user",
+            "single-session-assistant",
+            "single-session-preference",
+        ] {
+            let idx = selroute_metric_index(qt).expect("recognized type must have index");
+            assert!(idx < 6, "metric index out of bounds for {qt}: {idx}");
+            assert!(!seen[idx], "duplicate metric index for {qt}: {idx}");
+            seen[idx] = true;
+        }
+        assert!(
+            seen.iter().all(|&b| b),
+            "not every recognized type has a metric index"
+        );
+        // Unknown types return None.
+        assert_eq!(selroute_metric_index("unknown-xyz"), None);
+        assert_eq!(selroute_metric_index(""), None);
+    }
+
+    #[test]
+    fn selroute_enabled_caches_first_read() {
+        // Calling twice must return the same value (the OnceLock
+        // captures whatever the env was at first call). We don't assert
+        // a specific value because the test environment is uncontrolled;
+        // we only assert idempotence + that the function is callable.
+        let a = selroute_enabled();
+        let b = selroute_enabled();
+        assert_eq!(a, b);
+    }
+}

--- a/pensyve-core/src/retrieval/query_classifier.rs
+++ b/pensyve-core/src/retrieval/query_classifier.rs
@@ -415,6 +415,36 @@ mod tests {
     }
 
     #[test]
+    fn bare_now_does_not_trigger_knowledge_update() {
+        // Regression: bare `\bnow\b` was previously too broad and
+        // would false-positive on routine queries like "Tell me about
+        // X now", which currently triggers BM25-boost + spreading-
+        // suppression masks under the knowledge-update route. The
+        // narrowed regex requires "right now", "as of now",
+        // "now that/it/uses/is", or one of the specific state-change
+        // cues ("currently", "updated", "changed", "instead",
+        // "no longer"). Per CodeRabbit review on #114 (2026-05-21).
+        let c = classify_query("Tell me about Rust now.");
+        assert_ne!(
+            c.question_type, "knowledge-update",
+            "bare 'now' must not trigger knowledge-update classification"
+        );
+    }
+
+    #[test]
+    fn right_now_still_triggers_knowledge_update() {
+        // Regression-paired positive case: the narrowed regex still
+        // fires on the intended state-change forms — `\bright now\b`
+        // remains in the alternation. Locks in the post-narrowing
+        // behavior against future tuning.
+        let c = classify_query("Tell me about Rust right now.");
+        assert_eq!(
+            c.question_type, "knowledge-update",
+            "narrow 'right now' should still classify as knowledge-update"
+        );
+    }
+
+    #[test]
     fn single_session_user_classification() {
         for q in [
             "I want a summary of my notes.",


### PR DESCRIPTION
## Summary

First mechanism in the Phase 2 algorithmic stack per [`pensyve-docs/plans/2026-05-21-pensyve-phase2-algorithmic-stack.md`](https://github.com/major7apps/pensyve-docs/blob/main/plans/2026-05-21-pensyve-phase2-algorithmic-stack.md).

Adds an upstream query classifier (`PENSYVE_SELROUTE=1`, default off) that maps raw queries to the existing `question_type` string vocabulary used by `intent_router::IntentRouter`. Strict no-op when the flag is unset.

- New: `pensyve-core/src/retrieval/query_classifier.rs` (604 LOC) — `QueryClassification`, `PipelineConfig`, `classify_query`, `pipeline_config_for`, `selroute_enabled`, plus 15 unit tests
- Wires upstream of the existing `IntentRouter`; existing routing untouched
- Per-route RRF weight masks (signal_mask `[f32; 7]`) applied at the 6-signal RRF assembly site when classification confidence ≥ 0.5; identity mask otherwise
- Telemetry: `selroute_classified`, `selroute_fallback_count`, `selroute_by_type[6]`, `selroute_confidence_histogram` + Prometheus exposition
- Env-var read cached once via `OnceLock` (mirrors the `IntentRouter`/`MultiSessionCard::g3_mode` pattern)

## Why this design (vs the plan's original spec)

The plan called for a new `router.rs` with a parallel `QueryRoute` enum. Implementation diverged because `pensyve-core/src/retrieval/intent_router.rs` already exists with a `question_type: &str` vocabulary (`multi-session`, `temporal-reasoning`, `knowledge-update`, `single-session-{preference,user,assistant}`) and decision tables. The corrected design uses the **existing vocabulary** — no parallel enum, no naming conflict, classifier sits **upstream** of `IntentRouter`. See `query_classifier.rs` module docs for the precedence ordering rationale.

## Test plan

- [x] `cargo build -p pensyve-core --release` — clean
- [x] `cargo test -p pensyve-core` — 477 pass / 0 fail / 9 ignored (the 9 are pre-existing baseline)
- [x] `cargo clippy -p pensyve-core --lib --tests` — 0 new warnings
- [x] No regression on existing `classify_intent` / `QueryIntent` tests (orthogonal mechanism preserved)
- [x] `PENSYVE_SELROUTE` unset → byte-identical to baseline (`PipelineConfig::IDENTITY` short-circuits the mask)
- [ ] LongMemEval-S A/B against v2.4.0 baseline — deferred to Phase 2F per the plan

## Phase 2 progress

- [x] **2A SelRoute** — this PR
- [ ] 2B Dependency-parse KG construction
- [ ] 2C Personalized PageRank retrieval
- [ ] 2D RPE-gated D-MEM consolidation
- [ ] 2E Vendi-Score diversity rerank
- [ ] 2F Benchmark validation

Design substrate: [`pensyve-docs/research/2026-05-21-memory-pipeline-decomposition.md`](https://github.com/major7apps/pensyve-docs/blob/main/research/2026-05-21-memory-pipeline-decomposition.md) §5.2 + §7.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an in-query classifier that maps queries to six question types, applies per-route signal weighting, and falls back to identity for low-confidence or unknown types; classifier gating is configurable.
* **Infrastructure**
  * Added SelRoute telemetry: total/per-type classification counters, fallback counts, and a confidence histogram; telemetry now records classifications for all queries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/major7apps/pensyve/pull/114?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->