### PR TITLE
feat(retrieval): Personalized PageRank retrieval (Phase 2C)

### DIFF
--- a/pensyve-benchmarks/src/bin/real_content_eval.rs
+++ b/pensyve-benchmarks/src/bin/real_content_eval.rs
@@ -613,7 +613,7 @@ fn main() {
         weights: [0.25, 0.10, 0.15, 0.05, 0.20, 0.10, 0.10, 0.05],
         recall_timeout_secs: 5,
         rrf_k: 60,
-        rrf_weights: [1.0, 0.8, 1.0, 0.8, 0.5, 0.5, 1.2],
+        rrf_weights: [1.0, 0.8, 1.0, 0.8, 0.5, 0.5, 1.2, 1.0],
         beam_width: 10,
         max_depth: 4,
     };

--- a/pensyve-cli/src/main.rs
+++ b/pensyve-cli/src/main.rs
@@ -288,7 +288,7 @@ fn cmd_recall(
         weights: [0.30, 0.15, 0.20, 0.10, 0.10, 0.05, 0.05, 0.05],
         recall_timeout_secs: 5,
         rrf_k: 60,
-        rrf_weights: [1.0, 0.8, 1.0, 0.8, 0.5, 0.5, 1.2],
+        rrf_weights: [1.0, 0.8, 1.0, 0.8, 0.5, 0.5, 1.2, 1.0],
         beam_width: 10,
         max_depth: 4,
     };

--- a/pensyve-core/benches/cognitive_engine.rs
+++ b/pensyve-core/benches/cognitive_engine.rs
@@ -69,6 +69,140 @@ fn bench_dep_parse_extract(c: &mut Criterion) {
     });
 }
 
+/// Phase 2C — `PprIndex::build_from_storage` on a 10k-passage
+/// namespace. The brief's acceptance criterion is p95 < 500ms.
+///
+/// Builds an in-memory `SQLite` with the migration-v3 schema, seeds
+/// 10k passages × 5 entities (50k passage-entity edges) with a
+/// realistic skew (some entities appear in many passages, most in
+/// 1-2) so the degree dampener has work to do, then benchmarks
+/// `PprIndex::build_from_storage`. The seeding step is OUTSIDE the
+/// iter loop so the timer only measures the build itself.
+fn bench_ppr_build_from_storage_10k(c: &mut Criterion) {
+    use rusqlite::Connection;
+
+    let namespace_id = Uuid::new_v4().to_string();
+    let conn = Connection::open_in_memory().unwrap();
+    conn.execute_batch(
+        "CREATE TABLE kg_entities (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            namespace_id TEXT NOT NULL,
+            lemma TEXT NOT NULL,
+            embedding BLOB,
+            created_at INTEGER NOT NULL,
+            UNIQUE(namespace_id, lemma)
+        );
+        CREATE TABLE kg_passage_entities (
+            passage_id TEXT NOT NULL,
+            entity_id INTEGER NOT NULL,
+            weight REAL NOT NULL,
+            PRIMARY KEY(passage_id, entity_id)
+        );",
+    )
+    .unwrap();
+
+    // 500 distinct entity lemmas; 10k passages each connected to 5
+    // entities, with skew: entity_idx = (passage_idx * 7 + offset) %
+    // 500 — the multiplier creates a deterministic but unevenly
+    // distributed entity-degree profile (some entities show up
+    // ~100x, others ~20x).
+    let n_entities = 500_usize;
+    let n_passages = 10_000_usize;
+    for ent_idx in 0..n_entities {
+        conn.execute(
+            "INSERT INTO kg_entities (namespace_id, lemma, created_at) VALUES (?1, ?2, 0)",
+            rusqlite::params![namespace_id, format!("entity_{ent_idx}")],
+        )
+        .unwrap();
+    }
+    // Wrap the bulk insert in a transaction for sane seeding speed.
+    let tx = conn.unchecked_transaction().unwrap();
+    for p_idx in 0..n_passages {
+        let pid = Uuid::new_v4().to_string();
+        for k in 0..5 {
+            let ent_idx = ((p_idx * 7 + k) % n_entities) + 1; // SQLite ids are 1-based
+            tx.execute(
+                "INSERT OR IGNORE INTO kg_passage_entities (passage_id, entity_id, weight) VALUES (?1, ?2, 1.0)",
+                rusqlite::params![pid, i64::try_from(ent_idx).unwrap()],
+            )
+            .unwrap();
+        }
+    }
+    tx.commit().unwrap();
+
+    c.bench_function("ppr_build_from_storage_10k_passages", |bencher| {
+        bencher.iter(|| {
+            let _ = pensyve_core::retrieval::ppr::PprIndex::build_from_storage(
+                black_box(&conn),
+                black_box(&namespace_id),
+            )
+            .unwrap();
+        });
+    });
+}
+
+/// Phase 2C — `PprIndex::query` on a 10k-passage index. Companion to
+/// the build bench; verifies the query-side path also stays cheap.
+fn bench_ppr_query_10k(c: &mut Criterion) {
+    use rusqlite::Connection;
+
+    let namespace_id = Uuid::new_v4().to_string();
+    let conn = Connection::open_in_memory().unwrap();
+    conn.execute_batch(
+        "CREATE TABLE kg_entities (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            namespace_id TEXT NOT NULL,
+            lemma TEXT NOT NULL,
+            embedding BLOB,
+            created_at INTEGER NOT NULL,
+            UNIQUE(namespace_id, lemma)
+        );
+        CREATE TABLE kg_passage_entities (
+            passage_id TEXT NOT NULL,
+            entity_id INTEGER NOT NULL,
+            weight REAL NOT NULL,
+            PRIMARY KEY(passage_id, entity_id)
+        );",
+    )
+    .unwrap();
+
+    let n_entities = 500_usize;
+    let n_passages = 10_000_usize;
+    for ent_idx in 0..n_entities {
+        conn.execute(
+            "INSERT INTO kg_entities (namespace_id, lemma, created_at) VALUES (?1, ?2, 0)",
+            rusqlite::params![namespace_id, format!("entity_{ent_idx}")],
+        )
+        .unwrap();
+    }
+    let tx = conn.unchecked_transaction().unwrap();
+    for p_idx in 0..n_passages {
+        let pid = Uuid::new_v4().to_string();
+        for k in 0..5 {
+            let ent_idx = ((p_idx * 7 + k) % n_entities) + 1;
+            tx.execute(
+                "INSERT OR IGNORE INTO kg_passage_entities (passage_id, entity_id, weight) VALUES (?1, ?2, 1.0)",
+                rusqlite::params![pid, i64::try_from(ent_idx).unwrap()],
+            )
+            .unwrap();
+        }
+    }
+    tx.commit().unwrap();
+
+    let idx =
+        pensyve_core::retrieval::ppr::PprIndex::build_from_storage(&conn, &namespace_id).unwrap();
+    // Seed with 3 query entities (a realistic count after dep-parse).
+    let seeds: Vec<Uuid> = (0..3)
+        .map(|i| pensyve_core::retrieval::ppr::lemma_uuid(&format!("entity_{i}")))
+        .collect();
+
+    c.bench_function("ppr_query_10k_passages_alpha_0_15", |bencher| {
+        bencher.iter(|| {
+            let _ = idx.query(black_box(&seeds), black_box(&[]), 0.15, 20, 50);
+        });
+    });
+}
+
 criterion_group!(
     benches,
     bench_cosine_768,
@@ -76,5 +210,7 @@ criterion_group!(
     bench_rrf_fusion,
     bench_ring_buffer,
     bench_dep_parse_extract,
+    bench_ppr_build_from_storage_10k,
+    bench_ppr_query_10k,
 );
 criterion_main!(benches);

--- a/pensyve-core/src/config.rs
+++ b/pensyve-core/src/config.rs
@@ -68,9 +68,25 @@ pub struct RetrievalConfig {
     /// RRF constant k. Default 60.
     #[serde(default = "default_rrf_k")]
     pub rrf_k: u32,
-    /// Per-signal RRF weights: vec, bm25, activation, spread, intent, confidence, entity affinity.
+    /// Per-signal RRF weights, indexed in the order the engine emits
+    /// rankings:
+    ///   0: vector similarity
+    ///   1: BM25 / FTS
+    ///   2: ACT-R activation
+    ///   3: spreading-activation BFS
+    ///   4: intent alignment
+    ///   5: confidence / reliability
+    ///   6: entity affinity
+    ///   7: Personalized `PageRank` (Phase 2C; PPR ranking is emitted only
+    ///      when `PENSYVE_PPR=1` AND a `PprIndex` is attached to the
+    ///      `RecallEngine` — otherwise slot 7 is a no-op placeholder).
+    ///
+    /// Slot 7 was added in Phase 2C; the v2.4.x baseline shipped a
+    /// 7-slot array. Default value 1.0 keeps PPR at parity with the
+    /// other graph signals when it IS active, and is a strict no-op
+    /// when it is not (no ranking emitted → no weight applied).
     #[serde(default = "default_rrf_weights")]
-    pub rrf_weights: [f32; 7],
+    pub rrf_weights: [f32; 8],
     /// Beam search width. Default 10.
     #[serde(default = "default_beam_width")]
     pub beam_width: usize,
@@ -82,8 +98,12 @@ pub struct RetrievalConfig {
 fn default_rrf_k() -> u32 {
     60
 }
-fn default_rrf_weights() -> [f32; 7] {
-    [1.0, 0.8, 1.0, 0.8, 0.5, 0.5, 1.2]
+fn default_rrf_weights() -> [f32; 8] {
+    // [vector, bm25, activation, spread, intent, confidence, entity_affinity, ppr]
+    // Slot 7 (PPR) added in Phase 2C; default 1.0 keeps PPR at parity
+    // with the other graph signals when the engine emits a PPR ranking
+    // (gated on `PENSYVE_PPR=1` AND an attached `PprIndex`).
+    [1.0, 0.8, 1.0, 0.8, 0.5, 0.5, 1.2, 1.0]
 }
 fn default_beam_width() -> usize {
     10
@@ -151,7 +171,7 @@ impl Default for PensyveConfig {
                 weights: [0.25, 0.10, 0.15, 0.05, 0.20, 0.10, 0.10, 0.05],
                 recall_timeout_secs: 5,
                 rrf_k: 60,
-                rrf_weights: [1.0, 0.8, 1.0, 0.8, 0.5, 0.5, 1.2],
+                rrf_weights: [1.0, 0.8, 1.0, 0.8, 0.5, 0.5, 1.2, 1.0],
                 beam_width: 10,
                 max_depth: 4,
             },

--- a/pensyve-core/src/config.rs
+++ b/pensyve-core/src/config.rs
@@ -85,7 +85,14 @@ pub struct RetrievalConfig {
     /// 7-slot array. Default value 1.0 keeps PPR at parity with the
     /// other graph signals when it IS active, and is a strict no-op
     /// when it is not (no ranking emitted → no weight applied).
-    #[serde(default = "default_rrf_weights")]
+    ///
+    /// The custom deserializer [`deserialize_rrf_weights`] accepts
+    /// BOTH 7- and 8-element inputs for backwards compatibility —
+    /// see that function's doc for the migration contract.
+    #[serde(
+        default = "default_rrf_weights",
+        deserialize_with = "deserialize_rrf_weights"
+    )]
     pub rrf_weights: [f32; 8],
     /// Beam search width. Default 10.
     #[serde(default = "default_beam_width")]
@@ -104,6 +111,56 @@ fn default_rrf_weights() -> [f32; 8] {
     // with the other graph signals when the engine emits a PPR ranking
     // (gated on `PENSYVE_PPR=1` AND an attached `PprIndex`).
     [1.0, 0.8, 1.0, 0.8, 0.5, 0.5, 1.2, 1.0]
+}
+
+/// Custom deserializer for `rrf_weights` that accepts BOTH the
+/// pre-Phase-2C 7-element shape AND the Phase 2C 8-element shape.
+///
+/// Backwards-compatibility contract (`CodeRabbit` PR #116 P0 #1):
+/// `#[serde(default)]` alone only fires when the field is absent from
+/// the input. Existing user configs that explicitly write a 7-element
+/// array (the v2.4.x baseline) would otherwise fail to deserialize
+/// into `[f32; 8]` and silently break every downstream consumer.
+///
+/// Behavior:
+/// - 8 elements → pass through unchanged.
+/// - 7 elements → pad with the PPR-slot default (`1.0`). This is a
+///   strict no-op at runtime because the engine emits a PPR ranking
+///   only when `PENSYVE_PPR=1` AND a `PprIndex` is attached; a 1.0
+///   multiplier on an absent ranking does nothing. The migration is
+///   silent (no warning, no log) because the new default reproduces
+///   baseline behavior byte-for-byte for callers that haven't opted
+///   into PPR.
+/// - Anything else → deserialization error with a clear message.
+fn deserialize_rrf_weights<'de, D>(deserializer: D) -> Result<[f32; 8], D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de::Error;
+    let raw: Vec<f32> = Vec::deserialize(deserializer)?;
+    match raw.len() {
+        8 => {
+            // Safety: length matches the target array; from_slice is
+            // bounds-checked once.
+            let mut out = [0.0_f32; 8];
+            out.copy_from_slice(&raw);
+            Ok(out)
+        }
+        7 => {
+            // Pad with the PPR slot default (1.0). Note: we don't
+            // delegate to `default_rrf_weights()[7]` to avoid coupling
+            // the migration semantics to a future default-tuning
+            // change; the 1.0 here is the *pad* value, fixed for the
+            // backwards-compat contract.
+            let mut out = [0.0_f32; 8];
+            out[..7].copy_from_slice(&raw);
+            out[7] = 1.0;
+            Ok(out)
+        }
+        n => Err(D::Error::custom(format!(
+            "rrf_weights must contain 7 (pre-Phase-2C) or 8 (Phase 2C) elements; got {n}"
+        ))),
+    }
 }
 fn default_beam_width() -> usize {
     10
@@ -307,5 +364,108 @@ mod tests {
         assert_eq!(config.storage.path, "/tmp/test-pensyve");
         assert_eq!(config.extraction.default_tier, 2);
         assert_eq!(config.retrieval.default_limit, 10);
+    }
+
+    // -----------------------------------------------------------------------
+    // Phase 2C backwards-compatibility tests (CodeRabbit PR #116 P0 #1)
+    //
+    // Existing v2.4.x configs use a 7-element rrf_weights array; the
+    // Phase 2C extension to 8 elements would silently break those
+    // configs without `deserialize_rrf_weights`. These tests pin both
+    // shapes against future regressions.
+    // -----------------------------------------------------------------------
+
+    /// Helper: build a minimal `RetrievalConfig` JSON document with the
+    /// given `rrf_weights` array. All other fields are non-optional
+    /// and must be present for `Deserialize` to succeed.
+    fn retrieval_json(weights_lit: &str) -> String {
+        format!(
+            r#"{{
+                "default_limit": 5,
+                "max_candidates": 100,
+                "weights": [0.25, 0.10, 0.15, 0.05, 0.20, 0.10, 0.10, 0.05],
+                "recall_timeout_secs": 5,
+                "rrf_k": 60,
+                "rrf_weights": {weights_lit},
+                "beam_width": 10,
+                "max_depth": 4
+            }}"#
+        )
+    }
+
+    #[test]
+    fn deserialize_8_element_rrf_weights_passes_through() {
+        let json = retrieval_json("[1.0, 0.8, 1.0, 0.8, 0.5, 0.5, 1.2, 1.5]");
+        let cfg: RetrievalConfig = serde_json::from_str(&json).expect("8-element parse");
+        assert_eq!(
+            cfg.rrf_weights,
+            [1.0_f32, 0.8, 1.0, 0.8, 0.5, 0.5, 1.2, 1.5],
+            "8-element rrf_weights must pass through unchanged"
+        );
+    }
+
+    #[test]
+    fn deserialize_7_element_rrf_weights_pads_with_one() {
+        // CodeRabbit PR #116 P0 #1: a v2.4.x config with a 7-element
+        // rrf_weights array MUST continue to deserialize. The
+        // missing slot 7 (PPR) gets padded with 1.0 so the migration
+        // is a strict no-op at runtime (engine emits PPR ranking
+        // only when `PENSYVE_PPR=1` + PprIndex attached; 1.0 mask
+        // multiplier on an absent ranking does nothing).
+        let json = retrieval_json("[1.0, 0.8, 1.0, 0.8, 0.5, 0.5, 1.2]");
+        let cfg: RetrievalConfig = serde_json::from_str(&json).expect(
+            "v2.4.x 7-element rrf_weights MUST deserialize for backwards compat (PR #116 P0 #1)",
+        );
+        assert_eq!(
+            cfg.rrf_weights,
+            [1.0_f32, 0.8, 1.0, 0.8, 0.5, 0.5, 1.2, 1.0],
+            "7-element array must pad slot 7 with 1.0 (PPR default no-op)"
+        );
+    }
+
+    #[test]
+    fn deserialize_wrong_length_rrf_weights_errors_with_clear_message() {
+        // 6 elements → error.
+        let json = retrieval_json("[1.0, 0.8, 1.0, 0.8, 0.5, 0.5]");
+        let err = serde_json::from_str::<RetrievalConfig>(&json).expect_err("must reject 6 elts");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("rrf_weights") && msg.contains('7') && msg.contains('8'),
+            "error message must name the field and the accepted shapes; got {msg}"
+        );
+
+        // 9 elements → error.
+        let json = retrieval_json("[1.0, 0.8, 1.0, 0.8, 0.5, 0.5, 1.2, 1.0, 0.5]");
+        let err = serde_json::from_str::<RetrievalConfig>(&json).expect_err("must reject 9 elts");
+        assert!(
+            err.to_string().contains("rrf_weights"),
+            "error message must name the field"
+        );
+
+        // 0 elements → error.
+        let json = retrieval_json("[]");
+        let err = serde_json::from_str::<RetrievalConfig>(&json).expect_err("must reject 0 elts");
+        assert!(
+            err.to_string().contains("rrf_weights"),
+            "error message must name the field"
+        );
+    }
+
+    #[test]
+    fn deserialize_missing_rrf_weights_uses_default() {
+        // When the field is absent entirely, `#[serde(default)]`
+        // still fires (independent of the custom deserializer) and
+        // populates from `default_rrf_weights()`.
+        let json = r#"{
+            "default_limit": 5,
+            "max_candidates": 100,
+            "weights": [0.25, 0.10, 0.15, 0.05, 0.20, 0.10, 0.10, 0.05],
+            "recall_timeout_secs": 5,
+            "rrf_k": 60,
+            "beam_width": 10,
+            "max_depth": 4
+        }"#;
+        let cfg: RetrievalConfig = serde_json::from_str(json).expect("missing field uses default");
+        assert_eq!(cfg.rrf_weights, default_rrf_weights());
     }
 }

--- a/pensyve-core/src/observability.rs
+++ b/pensyve-core/src/observability.rs
@@ -165,9 +165,12 @@ pub struct PensyveMetrics {
     /// `max_iter` and the `alpha` damping factor.
     pub ppr_iterations_total: AtomicU64,
     /// Number of PPR queries that reached `max_iter` without
-    /// converging to the `||·||_1 < 1e-6` threshold. The acceptance
-    /// criterion is 0 on the unit-test graphs; a non-zero production
-    /// value signals degenerate restart vectors or pathological graphs.
+    /// converging to the configured convergence tolerance (currently
+    /// `CONVERGENCE_TOL = 1e-4` in
+    /// [`crate::retrieval::ppr`] — see that constant's doc for the
+    /// f32 / bipartite-graph rationale). The acceptance criterion is
+    /// 0 on the unit-test graphs; a non-zero production value signals
+    /// degenerate restart vectors or pathological graphs.
     pub ppr_convergence_failures: AtomicU64,
     /// Wall-clock distribution of `PprIndex::query` execution.
     pub ppr_duration: HistogramBuckets,
@@ -464,7 +467,7 @@ impl PensyveMetrics {
         let _ = writeln!(buf, "pensyve_ppr_iterations_total {ppr_iters}");
         let _ = writeln!(
             buf,
-            "# HELP pensyve_ppr_convergence_failures_total PPR queries that reached max_iter without converging."
+            "# HELP pensyve_ppr_convergence_failures_total PPR queries that reached max_iter without converging to the configured tolerance."
         );
         let _ = writeln!(buf, "# TYPE pensyve_ppr_convergence_failures_total counter");
         let _ = writeln!(buf, "pensyve_ppr_convergence_failures_total {ppr_failures}");

--- a/pensyve-core/src/observability.rs
+++ b/pensyve-core/src/observability.rs
@@ -155,6 +155,28 @@ pub struct PensyveMetrics {
     /// criterion is < 5ms p95.
     pub dep_parse_duration: HistogramBuckets,
 
+    // Phase 2C: Personalized `PageRank` retrieval metrics.
+    /// Total recall calls that emitted a PPR ranking (incremented only
+    /// when `PENSYVE_PPR` is enabled AND a `PprIndex` is attached to
+    /// the `RecallEngine`).
+    pub ppr_query_count: AtomicU64,
+    /// Sum of power-iteration iterations across all PPR queries. Divide
+    /// by `ppr_query_count` for the average; useful for tuning
+    /// `max_iter` and the `alpha` damping factor.
+    pub ppr_iterations_total: AtomicU64,
+    /// Number of PPR queries that reached `max_iter` without
+    /// converging to the `||·||_1 < 1e-6` threshold. The acceptance
+    /// criterion is 0 on the unit-test graphs; a non-zero production
+    /// value signals degenerate restart vectors or pathological graphs.
+    pub ppr_convergence_failures: AtomicU64,
+    /// Wall-clock distribution of `PprIndex::query` execution.
+    pub ppr_duration: HistogramBuckets,
+    /// Sum of entity-seed counts across PPR queries (sum of
+    /// `query_entities.len()` per call). Together with
+    /// `ppr_query_count` this gives average restart-vector size — a
+    /// proxy for dep-parse query-entity coverage.
+    pub ppr_entity_seeds_count: AtomicU64,
+
     // Histograms
     pub recall_duration: HistogramBuckets,
     pub embed_duration: HistogramBuckets,
@@ -191,6 +213,11 @@ impl PensyveMetrics {
             dep_parse_lexicon_miss_count: AtomicU64::new(0),
             dep_parse_skipped_long_sentence: AtomicU64::new(0),
             dep_parse_duration: HistogramBuckets::new(DURATION_BUCKETS),
+            ppr_query_count: AtomicU64::new(0),
+            ppr_iterations_total: AtomicU64::new(0),
+            ppr_convergence_failures: AtomicU64::new(0),
+            ppr_duration: HistogramBuckets::new(DURATION_BUCKETS),
+            ppr_entity_seeds_count: AtomicU64::new(0),
             recall_duration: HistogramBuckets::new(DURATION_BUCKETS),
             embed_duration: HistogramBuckets::new(DURATION_BUCKETS),
             store_duration: HistogramBuckets::new(DURATION_BUCKETS),
@@ -418,6 +445,36 @@ impl PensyveMetrics {
             "pensyve_dep_parse_skipped_long_sentence_total {dep_parse_skipped}"
         );
 
+        // Phase 2C: Personalized PageRank retrieval counters.
+        let ppr_queries = self.ppr_query_count.load(Ordering::Relaxed);
+        let ppr_iters = self.ppr_iterations_total.load(Ordering::Relaxed);
+        let ppr_failures = self.ppr_convergence_failures.load(Ordering::Relaxed);
+        let ppr_seeds = self.ppr_entity_seeds_count.load(Ordering::Relaxed);
+        let _ = writeln!(
+            buf,
+            "# HELP pensyve_ppr_query_count_total Total recall calls that emitted a Phase 2C PPR ranking."
+        );
+        let _ = writeln!(buf, "# TYPE pensyve_ppr_query_count_total counter");
+        let _ = writeln!(buf, "pensyve_ppr_query_count_total {ppr_queries}");
+        let _ = writeln!(
+            buf,
+            "# HELP pensyve_ppr_iterations_total Sum of PPR power-iteration iterations across all queries."
+        );
+        let _ = writeln!(buf, "# TYPE pensyve_ppr_iterations_total counter");
+        let _ = writeln!(buf, "pensyve_ppr_iterations_total {ppr_iters}");
+        let _ = writeln!(
+            buf,
+            "# HELP pensyve_ppr_convergence_failures_total PPR queries that reached max_iter without converging."
+        );
+        let _ = writeln!(buf, "# TYPE pensyve_ppr_convergence_failures_total counter");
+        let _ = writeln!(buf, "pensyve_ppr_convergence_failures_total {ppr_failures}");
+        let _ = writeln!(
+            buf,
+            "# HELP pensyve_ppr_entity_seeds_count_total Sum of restart-vector entity-seed counts across PPR queries."
+        );
+        let _ = writeln!(buf, "# TYPE pensyve_ppr_entity_seeds_count_total counter");
+        let _ = writeln!(buf, "pensyve_ppr_entity_seeds_count_total {ppr_seeds}");
+
         // Histograms
         buf.push_str(&self.recall_duration.prometheus_text(
             "pensyve_recall_duration_seconds",
@@ -438,6 +495,10 @@ impl PensyveMetrics {
         buf.push_str(&self.dep_parse_duration.prometheus_text(
             "pensyve_dep_parse_duration_seconds",
             "Phase 2B dep-parse + persist pipeline duration in seconds.",
+        ));
+        buf.push_str(&self.ppr_duration.prometheus_text(
+            "pensyve_ppr_duration_seconds",
+            "Phase 2C Personalized PageRank query duration in seconds.",
         ));
 
         buf

--- a/pensyve-core/src/recall_grouped.rs
+++ b/pensyve-core/src/recall_grouped.rs
@@ -382,6 +382,7 @@ mod tests {
             confidence_score: 0.0,
             entity_score: 0.0,
             type_boost: 1.0,
+            ppr_score: None,
             final_score,
         }
     }

--- a/pensyve-core/src/retrieval/engine.rs
+++ b/pensyve-core/src/retrieval/engine.rs
@@ -826,7 +826,20 @@ impl<'a> RecallEngine<'a> {
         let mut ppr_score_by_id: std::collections::HashMap<Uuid, f32> =
             std::collections::HashMap::new();
         let mut ranking_ppr: Vec<(Uuid, f32)> = Vec::new();
-        let ppr_enabled_flag = self.ppr_index.is_some() && crate::retrieval::ppr::ppr_enabled();
+        // PPR honors the Phase 2C runtime contract: the engine fires
+        // PPR only when ALL three preconditions hold:
+        //   (a) a `PprIndex` is attached via `with_ppr`
+        //   (b) `PENSYVE_PPR=1` (cached OnceLock env read)
+        //   (c) `PENSYVE_DEP_PARSE=1` (CodeRabbit PR #116 round 2:
+        //       a stale `PprIndex` attached after dep-parse was
+        //       turned off would otherwise still drive PPR rankings
+        //       — the contract documented at the top of Phase 2C is
+        //       "PPR is useful only when `PENSYVE_DEP_PARSE=1` is
+        //       also set", so the runtime check enforces that
+        //       contract.)
+        let ppr_enabled_flag = self.ppr_index.is_some()
+            && crate::retrieval::ppr::ppr_enabled()
+            && crate::extraction::dep_parse::dep_parse_enabled();
         if ppr_enabled_flag {
             // Safety: `ppr_enabled_flag` checks `is_some()` above.
             let ppr_index = self.ppr_index.unwrap();
@@ -1941,19 +1954,20 @@ mod tests {
 
     #[test]
     fn recall_with_ppr_index_populates_ppr_score_when_flag_enabled() {
-        // This test runs only when `PENSYVE_PPR=1` because the flag
-        // is OnceLock-cached process-wide; we can't safely flip it
-        // here without affecting parallel tests. The test is skipped
-        // (returns early) when the flag is off, matching the
+        // This test runs only when BOTH `PENSYVE_PPR=1` AND
+        // `PENSYVE_DEP_PARSE=1` are set, because the engine's PPR
+        // gate (CodeRabbit PR #116 round 2 P0) requires both. Both
+        // flags are OnceLock-cached process-wide so we can't safely
+        // flip them here without affecting parallel tests; the test
+        // returns early when either is off, matching the
         // process-cached env-flag pattern used elsewhere in the
         // codebase. To exercise it locally, run:
-        //   PENSYVE_PPR=1 cargo test -p pensyve-core --lib \
-        //     recall_with_ppr_index_populates_ppr_score_when_flag_enabled \
-        //     -- --ignored
-        // (We mark it #[ignore] specifically to prevent test-suite
-        // pollution; the engineering value is in the recall_*
-        // integration tests below that assert no regression.)
-        if !crate::retrieval::ppr::ppr_enabled() {
+        //   PENSYVE_PPR=1 PENSYVE_DEP_PARSE=1 \
+        //     cargo test -p pensyve-core --lib \
+        //     recall_with_ppr_index_populates_ppr_score_when_flag_enabled
+        if !crate::retrieval::ppr::ppr_enabled()
+            || !crate::extraction::dep_parse::dep_parse_enabled()
+        {
             return;
         }
 
@@ -2012,35 +2026,38 @@ mod tests {
             .expect("Alice memory should appear in recall");
         assert!(
             found.ppr_score.is_some(),
-            "ppr_score must be populated when PprIndex is attached AND PENSYVE_PPR=1"
+            "ppr_score must be populated when PprIndex is attached AND PENSYVE_PPR=1 AND PENSYVE_DEP_PARSE=1"
         );
     }
 
     #[test]
     fn recall_with_ppr_flag_but_no_kg_overlap_preserves_bfs_spread() {
-        // CodeRabbit PR #116 P1 #2: when PENSYVE_PPR=1 is set AND a
+        // CodeRabbit PR #116 P1 #2 + Round 2 inline: when
+        // `PENSYVE_PPR=1` + `PENSYVE_DEP_PARSE=1` are set AND a
         // PprIndex is attached BUT the query has zero entity overlap
         // with the KG, `ranking_ppr` comes back empty and
         // `has_discriminative_signal` filters it out. Before the fix,
         // `spread_weight = 0.0` was triggered by the flag alone, so
         // the BFS spread signal got zeroed AND the empty PPR ranking
         // got dropped — leaving the graph dimension of RRF
-        // unrepresented for this query. The fixed behavior: when PPR
-        // does NOT contribute, the BFS spread signal stays at its
-        // unmasked weight.
+        // unrepresented for this query.
         //
-        // This test exercises the runtime contract by:
-        // 1. Building a PprIndex from a namespace whose KG has no
-        //    overlap with the query lemmas (KG contains "Acme" only;
-        //    query is "quantum physics" — no entity match).
-        // 2. Asserting the recall still returns results AND that the
-        //    BFS spread signal could have contributed (i.e., recall
-        //    did not collapse into a degenerate single-signal mix).
+        // The round-2 review pointed out that the original test was
+        // an incomplete probe: calling `recall(...)` with no target
+        // entity leaves `ranking_spread` empty by construction (the
+        // engine never invokes `MemoryGraph::beam_search` without a
+        // target entity), so it couldn't actually exercise the
+        // BFS-preservation path. This rewrite uses
+        // `recall_with_entity(...)` with an attached `MemoryGraph` so
+        // `ranking_spread` is non-empty and we can observe whether
+        // the engine zeroed out its weight.
         //
-        // Returns early when PENSYVE_PPR is off, matching the
+        // Returns early when either flag is off, matching the
         // process-cached env-flag pattern in
         // `recall_with_ppr_index_populates_ppr_score_when_flag_enabled`.
-        if !crate::retrieval::ppr::ppr_enabled() {
+        if !crate::retrieval::ppr::ppr_enabled()
+            || !crate::extraction::dep_parse::dep_parse_enabled()
+        {
             return;
         }
 
@@ -2052,15 +2069,29 @@ mod tests {
 
         let ns = Namespace::new("ppr-no-overlap-test");
         storage.save_namespace(&ns).unwrap();
-        // The stored memory's content includes "quantum physics" so
-        // BM25 / vector signals have something to match on.
-        let mem = setup_episodic(
+        // Memory `mem_q` matches the query lexically; memory `mem_bfs`
+        // is reachable from the target entity via the MemoryGraph but
+        // does NOT match the query lexically — it's the "BFS-only"
+        // signal. If the engine correctly preserves the BFS weight
+        // when PPR contributes no signal, `mem_bfs` will surface
+        // through the spread ranking.
+        let mem_q = setup_episodic(
             &storage,
             &embedder,
             &ns,
             "quantum physics relativity theory",
         );
-        vector_index.add(mem.id, &mem.embedding).unwrap();
+        let mem_bfs = setup_episodic(&storage, &embedder, &ns, "unrelated bookkeeping content");
+        vector_index.add(mem_q.id, &mem_q.embedding).unwrap();
+        vector_index.add(mem_bfs.id, &mem_bfs.embedding).unwrap();
+
+        // Build a MemoryGraph with an edge from a target entity to
+        // `mem_bfs`. `beam_search` walks outgoing edges from the
+        // target, so this guarantees `ranking_spread` is non-empty
+        // when we pass the target entity to `recall_with_entity`.
+        let target_entity = Uuid::new_v4();
+        let mut graph = crate::graph::MemoryGraph::new();
+        graph.add_edge(target_entity, mem_bfs.id, 1.0);
 
         // Seed a KG with an entity ("Acme") that does NOT appear in
         // the query. The PprIndex will be non-empty (so the engine
@@ -2091,31 +2122,50 @@ mod tests {
         let ppr_index =
             crate::retrieval::ppr::PprIndex::build_from_storage(&conn, &ns.id.to_string()).unwrap();
 
-        // Query "quantum physics" has zero KG overlap with the
-        // "Acme"-only KG.
-        let engine =
-            RecallEngine::new(&storage, &embedder, &vector_index, &config).with_ppr(&ppr_index);
-        let result = engine.recall("quantum physics", ns.id, 5).unwrap();
+        // Query "quantum physics" has zero KG overlap. Pass the
+        // target entity so `recall_with_entity` runs `beam_search`
+        // and populates `ranking_spread`.
+        let engine = RecallEngine::new(&storage, &embedder, &vector_index, &config)
+            .with_ppr(&ppr_index)
+            .with_graph(&graph);
+        let result = engine
+            .recall_with_entity("quantum physics", ns.id, 5, Some(target_entity))
+            .unwrap();
 
-        // The non-zero-overlap memory MUST still appear in the
-        // results — recall must NOT collapse just because PPR is
-        // enabled but produced no signal.
+        // The query-matching memory MUST appear in the results —
+        // recall must NOT collapse just because PPR is enabled but
+        // produced no signal.
         assert!(
             !result.memories.is_empty(),
             "recall must still return results when PPR is enabled but produces no signal"
         );
-        let found = result.memories.iter().find(|c| c.memory_id == mem.id);
+        let found_q = result.memories.iter().find(|c| c.memory_id == mem_q.id);
         assert!(
-            found.is_some(),
-            "the matching memory must survive the no-PPR-signal path"
+            found_q.is_some(),
+            "the lexically-matching memory must survive the no-PPR-signal path"
         );
-        // ppr_score for this memory is None because the query had
+
+        // The BFS-reachable memory MUST also surface — this is the
+        // load-bearing assertion that proves the BFS-spread weight
+        // was NOT zeroed when PPR produced no signal. Before the
+        // P1 #2 fix, `spread_weight = 0.0` would filter
+        // `ranking_spread` out of the RRF fusion and `mem_bfs`
+        // would not appear.
+        let found_bfs = result.memories.iter().find(|c| c.memory_id == mem_bfs.id);
+        assert!(
+            found_bfs.is_some(),
+            "BFS-reachable memory must surface when PPR produces no signal — \
+             implies ranking_spread weight was preserved (not zeroed)"
+        );
+
+        // ppr_score for both candidates is None because the query had
         // no KG overlap (no entity seeds → empty ranking → no
         // ppr_score_by_id entry).
-        let candidate = found.unwrap();
-        assert!(
-            candidate.ppr_score.is_none(),
-            "ppr_score must be None when PPR produced no discriminative signal for this query"
-        );
+        for candidate in &result.memories {
+            assert!(
+                candidate.ppr_score.is_none(),
+                "ppr_score must be None when PPR produced no discriminative signal for this query"
+            );
+        }
     }
 }

--- a/pensyve-core/src/retrieval/engine.rs
+++ b/pensyve-core/src/retrieval/engine.rs
@@ -274,6 +274,13 @@ pub struct ScoredCandidate {
     pub entity_score: f32,
     /// 1.0 default; can boost specific memory types.
     pub type_boost: f32,
+    /// Personalized `PageRank` mass for this passage (Phase 2C). `None`
+    /// when PPR was inactive on the recall — either `PENSYVE_PPR` was
+    /// off, no `PprIndex` was attached, the query produced no entity
+    /// seeds that exist in the KG, or this memory was not in the
+    /// top-k PPR ranking. Surfaced through the SDK for downstream
+    /// inspection (additive + non-breaking).
+    pub ppr_score: Option<f32>,
     /// Weighted fusion of all signals.
     pub final_score: f32,
 }
@@ -317,6 +324,13 @@ pub struct RecallEngine<'a> {
     /// when `None`, preserving the v2.2.0 default-OFF behavior for
     /// callers that haven't migrated.
     mmr_lambda: Option<f32>,
+    /// Phase 2C: optional Personalized `PageRank` index over the
+    /// dep-parse KG. When attached AND `PENSYVE_PPR=1`, the recall
+    /// engine emits a PPR ranking as the 8th RRF signal. The index is
+    /// borrowed `&'a` so callers retain ownership and can rebuild it
+    /// out-of-band (e.g., after a batch of new observations land via
+    /// the Phase 2B dep-parse hook).
+    ppr_index: Option<&'a crate::retrieval::ppr::PprIndex>,
 }
 
 /// Maximum number of candidates to pass into the cross-encoder for reranking.
@@ -341,6 +355,7 @@ impl<'a> RecallEngine<'a> {
             user_id: None,
             agent_only: None,
             mmr_lambda: None,
+            ppr_index: None,
         }
     }
 
@@ -348,6 +363,24 @@ impl<'a> RecallEngine<'a> {
     #[must_use]
     pub fn with_graph(mut self, graph: &'a MemoryGraph) -> Self {
         self.graph = Some(graph);
+        self
+    }
+
+    /// Phase 2C: attach an optional [`crate::retrieval::ppr::PprIndex`]
+    /// for Personalized `PageRank` scoring.
+    ///
+    /// When attached AND `PENSYVE_PPR=1`, the recall engine extracts
+    /// query entities via Phase 2B's dep-parse, looks up matching
+    /// entities in the index, and emits a PPR passage ranking as the
+    /// 8th RRF signal. The spreading-activation BFS signal
+    /// (`ranking_spread`) is zeroed out for the same query to avoid
+    /// double-counting graph signal.
+    ///
+    /// When NOT attached OR when `PENSYVE_PPR` is off, recall is
+    /// byte-for-byte identical to the pre-2C 7-signal mix.
+    #[must_use]
+    pub fn with_ppr(mut self, index: &'a crate::retrieval::ppr::PprIndex) -> Self {
+        self.ppr_index = Some(index);
         self
     }
 
@@ -763,17 +796,84 @@ impl<'a> RecallEngine<'a> {
             }
         };
 
+        // 8. Phase 2C Personalized PageRank ranking.
+        //
+        // Active only when BOTH:
+        //   (a) a `PprIndex` has been attached via `with_ppr`
+        //   (b) `PENSYVE_PPR=1` (cached OnceLock env read)
+        //
+        // The brief's parameter defaults (alpha=0.15, max_iter=20,
+        // top_k=50) are documented inline. When PPR fires, the
+        // spreading-activation BFS signal (`ranking_spread`) is zeroed
+        // out via `ppr_active` below to avoid double-counting graph
+        // signal — `ranking_spread` is BFS over the memory-graph
+        // edges, `ranking_ppr` is the entity-graph PPR mass; both are
+        // "graph signals" and adding them with full weight inflates
+        // the graph contribution to RRF.
+        //
+        // Query entities are derived by feeding `query` through the
+        // Phase 2B dep-parse extractor (with a sentinel passage_id —
+        // we're not persisting). Lemmas are then mapped to UUIDs via
+        // `ppr::lemma_uuid`, which uses the same RFC 4122 v5 namespace
+        // as the dep-parse hook's entity persistence. Dense seeds
+        // come from `ranking_vec` (the existing vector-similarity
+        // ranking, already computed above) so PPR's restart vector
+        // benefits from semantic similarity even when the lexical
+        // dep-parse misses entities.
+        let mut ppr_score_by_id: std::collections::HashMap<Uuid, f32> =
+            std::collections::HashMap::new();
+        let mut ranking_ppr: Vec<(Uuid, f32)> = Vec::new();
+        let ppr_active = self.ppr_index.is_some() && crate::retrieval::ppr::ppr_enabled();
+        if ppr_active {
+            // Safety: `ppr_active` checks `is_some()` above.
+            let ppr_index = self.ppr_index.unwrap();
+            // Extract query entities. Passage_id is Uuid::nil()
+            // because we're not persisting the resulting triples —
+            // this is a read-only dep-parse call for entity
+            // candidates only. The dep-parse extractor does NOT touch
+            // the global metrics counters for synthetic Uuid::nil()
+            // passages (the consolidation hook is what increments).
+            let parsed = crate::extraction::dep_parse::extract_triples(Uuid::nil(), query);
+            let query_entity_uuids: Vec<Uuid> = parsed
+                .entities
+                .iter()
+                .map(|lemma| crate::retrieval::ppr::lemma_uuid(lemma))
+                .collect();
+            // Dense seeds: passages from the vector-similarity
+            // ranking, scored by the vector score. PPR's restart
+            // vector normalizes the seed mass, so the raw scores
+            // here only need to be proportional.
+            let dense_seeds: Vec<(Uuid, f32)> = ranking_vec.clone();
+            // PPR brief defaults: alpha = 0.15 (restart probability),
+            // max_iter = 20 (production graph default; small unit-
+            // test graphs use larger caps — see ppr.rs module doc),
+            // top_k = 50 (we re-merge through RRF so this is the
+            // upper-bound on the PPR signal's contribution).
+            ranking_ppr = ppr_index.query(&query_entity_uuids, &dense_seeds, 0.15, 20, 50);
+            for (id, score) in &ranking_ppr {
+                ppr_score_by_id.insert(*id, *score);
+            }
+        }
+
         // Merge via RRF — only include rankings with discriminative signal.
         // A ranking where all scores are identical (e.g., empty graph, no access history)
         // adds noise and dilutes the strong signals like vector similarity.
+        //
+        // When PPR is active, zero out the BFS spread weight to avoid
+        // double-counting graph signal. The spread ranking is still
+        // included in `all_rankings` (its content may still be useful
+        // when PPR returns zero results, e.g., when no query entities
+        // exist in the KG) but its weight contribution is zero.
+        let spread_weight = if ppr_active { 0.0 } else { masked_weight(3) };
         let all_rankings = vec![
             (ranking_vec, masked_weight(0)),
             (ranking_bm25, masked_weight(1)),
             (ranking_activation, masked_weight(2)),
-            (ranking_spread, masked_weight(3)),
+            (ranking_spread, spread_weight),
             (ranking_intent, masked_weight(4)),
             (ranking_confidence, masked_weight(5)),
             (ranking_entity, masked_weight(6)),
+            (ranking_ppr, masked_weight(7)),
         ];
 
         let (rankings, rrf_weights): (Vec<_>, Vec<_>) = all_rankings
@@ -854,6 +954,7 @@ impl<'a> RecallEngine<'a> {
                         0.0
                     };
 
+                    let ppr_score = ppr_score_by_id.get(&id).copied();
                     ScoredCandidate {
                         memory_id: id,
                         memory: mem.clone(),
@@ -866,6 +967,7 @@ impl<'a> RecallEngine<'a> {
                         confidence_score,
                         entity_score,
                         type_boost: 1.0,
+                        ppr_score,
                         final_score: rrf_score,
                     }
                 })
@@ -1238,6 +1340,7 @@ fn score_candidate(
         confidence_score,
         entity_score: 0.0,
         type_boost,
+        ppr_score: None,
         final_score,
     }
 }
@@ -1783,6 +1886,114 @@ mod tests {
             groups_unknown.len() <= 5,
             "unknown type falls back to SS-Pref bucket (5); got {} groups",
             groups_unknown.len()
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Phase 2C integration tests — PPR attached to RecallEngine
+    //
+    // We use `query_with_stats`-shaped expectations by relying on the
+    // returned `ScoredCandidate.ppr_score` field rather than the global
+    // metrics counters (which are polluted by parallel tests).
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn recall_without_ppr_index_returns_none_ppr_score() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = SqliteBackend::open(dir.path()).unwrap();
+        let embedder = OnnxEmbedder::new_mock(64);
+        let mut vector_index = VectorIndex::new(64, 16);
+        let config = test_config();
+
+        let ns = Namespace::new("ppr-none-test");
+        storage.save_namespace(&ns).unwrap();
+        let mem = setup_episodic(&storage, &embedder, &ns, "Alice works at Acme.");
+        vector_index.add(mem.id, &mem.embedding).unwrap();
+
+        let engine = RecallEngine::new(&storage, &embedder, &vector_index, &config);
+        let result = engine.recall("Alice", ns.id, 5).unwrap();
+        for candidate in &result.memories {
+            assert!(
+                candidate.ppr_score.is_none(),
+                "ppr_score must be None when no PprIndex is attached"
+            );
+        }
+    }
+
+    #[test]
+    fn recall_with_ppr_index_populates_ppr_score_when_flag_enabled() {
+        // This test runs only when `PENSYVE_PPR=1` because the flag
+        // is OnceLock-cached process-wide; we can't safely flip it
+        // here without affecting parallel tests. The test is skipped
+        // (returns early) when the flag is off, matching the
+        // process-cached env-flag pattern used elsewhere in the
+        // codebase. To exercise it locally, run:
+        //   PENSYVE_PPR=1 cargo test -p pensyve-core --lib \
+        //     recall_with_ppr_index_populates_ppr_score_when_flag_enabled \
+        //     -- --ignored
+        // (We mark it #[ignore] specifically to prevent test-suite
+        // pollution; the engineering value is in the recall_*
+        // integration tests below that assert no regression.)
+        if !crate::retrieval::ppr::ppr_enabled() {
+            return;
+        }
+
+        // Build a tiny KG via raw SQL so the PprIndex has something to
+        // index against. The test database also gets a real
+        // observation row whose Uuid matches the kg_passage_entities
+        // passage_id, so the engine's recall returns a candidate the
+        // PPR ranking can attach a score to.
+        let dir = tempfile::tempdir().unwrap();
+        let storage = SqliteBackend::open(dir.path()).unwrap();
+        let embedder = OnnxEmbedder::new_mock(64);
+        let mut vector_index = VectorIndex::new(64, 16);
+        let config = test_config();
+
+        let ns = Namespace::new("ppr-active-test");
+        storage.save_namespace(&ns).unwrap();
+        let mem = setup_episodic(&storage, &embedder, &ns, "Alice works at Acme.");
+        vector_index.add(mem.id, &mem.embedding).unwrap();
+
+        // Build an in-memory PPR index that knows about Alice + the
+        // saved observation's id (acting as passage_id). The recall
+        // engine's "synthetic-dep-parse" path will extract "Alice"
+        // from the query, map it via lemma_uuid, and seed PPR.
+        let conn = rusqlite::Connection::open(storage.db_path().unwrap()).unwrap();
+        conn.execute(
+            "INSERT OR IGNORE INTO kg_entities (namespace_id, lemma, created_at) VALUES (?1, 'Alice', 0)",
+            rusqlite::params![ns.id.to_string()],
+        )
+        .unwrap();
+        let alice_id: i64 = conn
+            .query_row(
+                "SELECT id FROM kg_entities WHERE namespace_id = ?1 AND lemma = 'Alice'",
+                rusqlite::params![ns.id.to_string()],
+                |r| r.get(0),
+            )
+            .unwrap();
+        conn.execute(
+            "INSERT OR REPLACE INTO kg_passage_entities (passage_id, entity_id, weight) VALUES (?1, ?2, 1.0)",
+            rusqlite::params![mem.id.to_string(), alice_id],
+        )
+        .unwrap();
+        let ppr_index =
+            crate::retrieval::ppr::PprIndex::build_from_storage(&conn, &ns.id.to_string()).unwrap();
+
+        let engine =
+            RecallEngine::new(&storage, &embedder, &vector_index, &config).with_ppr(&ppr_index);
+        let result = engine.recall("Alice", ns.id, 5).unwrap();
+
+        // The Alice-containing observation should appear in the
+        // result, and (because PPR fired) its ppr_score should be
+        // populated.
+        let found = result
+            .memories
+            .iter()
+            .find(|c| c.memory_id == mem.id)
+            .expect("Alice memory should appear in recall");
+        assert!(
+            found.ppr_score.is_some(),
+            "ppr_score must be populated when PprIndex is attached AND PENSYVE_PPR=1"
         );
     }
 }

--- a/pensyve-core/src/retrieval/engine.rs
+++ b/pensyve-core/src/retrieval/engine.rs
@@ -592,7 +592,7 @@ impl<'a> RecallEngine<'a> {
         // `selroute_by_type` / confidence-histogram telemetry covers
         // ALL SelRoute decisions, not just queries that returned hits.
         // Per CodeRabbit review on #114 (2026-05-21).
-        let selroute_mask: Option<[f32; 7]> =
+        let selroute_mask: Option<[f32; 8]> =
             if crate::retrieval::query_classifier::selroute_enabled() {
                 let classification = crate::retrieval::query_classifier::classify_query(query);
                 let metrics = crate::observability::metrics();
@@ -737,19 +737,28 @@ impl<'a> RecallEngine<'a> {
         };
         ranking_entity.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
 
-        // Phase 2A SelRoute mask: when the env-gate fired and the
+        // Phase 2A/2C SelRoute mask: when the env-gate fired and the
         // classification confidence cleared the 0.5 threshold,
-        // `selroute_mask` holds a `[f32; 7]` to multiply against the
-        // engine's per-signal RRF weights. Slots 0..6 align with
-        // `[vec, bm25, activation, spread, intent, confidence]`; the
-        // 7th slot is reserved for the future PPR signal (Phase 2C)
-        // and the entity-affinity weight at `rrf_weights[6]` is left
-        // unchanged regardless of the mask. When the mask is None the
-        // expression below is a strict no-op (identity).
+        // `selroute_mask` holds a `[f32; 8]` to multiply against the
+        // engine's per-signal RRF weights. Slots align with the engine
+        // ranking emission order:
+        //   0: vec   1: bm25   2: activation   3: spread
+        //   4: intent   5: confidence   6: entity_affinity   7: PPR
+        //
+        // The Phase 2A guard kept slot 6 (entity affinity) unchanged so
+        // A/B sweeps could isolate the SelRoute effect from the
+        // entity-affinity signal. Phase 2C keeps that guard at slot 6
+        // and EXTENDS the mask to slot 7 (PPR) so per-route PPR weights
+        // (e.g., 1.5 for multi-session, 0.5 for preference) propagate
+        // through. When the mask is None the expression below is a
+        // strict no-op (identity).
         let masked_weight = |idx: usize| -> f32 {
             let base = self.config.rrf_weights[idx];
             match selroute_mask {
-                Some(mask) if idx < 6 => base * mask[idx],
+                // Mask applies to slots 0..5 (Phase 2A) and slot 7
+                // (Phase 2C PPR). Slot 6 (entity affinity) is
+                // explicitly preserved unchanged.
+                Some(mask) if idx < 6 || idx == 7 => base * mask[idx],
                 _ => base,
             }
         };
@@ -1296,7 +1305,7 @@ mod tests {
             weights: TEST_WEIGHTS,
             recall_timeout_secs: 5,
             rrf_k: 60,
-            rrf_weights: [1.0, 0.8, 1.0, 0.8, 0.5, 0.5, 1.2],
+            rrf_weights: [1.0, 0.8, 1.0, 0.8, 0.5, 0.5, 1.2, 1.0],
             beam_width: 10,
             max_depth: 4,
         }

--- a/pensyve-core/src/retrieval/engine.rs
+++ b/pensyve-core/src/retrieval/engine.rs
@@ -803,29 +803,32 @@ impl<'a> RecallEngine<'a> {
         //   (b) `PENSYVE_PPR=1` (cached OnceLock env read)
         //
         // The brief's parameter defaults (alpha=0.15, max_iter=20,
-        // top_k=50) are documented inline. When PPR fires, the
-        // spreading-activation BFS signal (`ranking_spread`) is zeroed
-        // out via `ppr_active` below to avoid double-counting graph
-        // signal — `ranking_spread` is BFS over the memory-graph
-        // edges, `ranking_ppr` is the entity-graph PPR mass; both are
-        // "graph signals" and adding them with full weight inflates
-        // the graph contribution to RRF.
+        // top_k=50) are documented inline. Query entities are derived
+        // by feeding `query` through the Phase 2B dep-parse extractor
+        // (with a sentinel passage_id — we're not persisting). Lemmas
+        // are then mapped to UUIDs via `ppr::lemma_uuid`, which uses
+        // the same RFC 4122 v5 namespace as the dep-parse hook's
+        // entity persistence. Dense seeds come from `ranking_vec` (the
+        // existing vector-similarity ranking, already computed above)
+        // so PPR's restart vector benefits from semantic similarity
+        // even when the lexical dep-parse misses entities.
         //
-        // Query entities are derived by feeding `query` through the
-        // Phase 2B dep-parse extractor (with a sentinel passage_id —
-        // we're not persisting). Lemmas are then mapped to UUIDs via
-        // `ppr::lemma_uuid`, which uses the same RFC 4122 v5 namespace
-        // as the dep-parse hook's entity persistence. Dense seeds
-        // come from `ranking_vec` (the existing vector-similarity
-        // ranking, already computed above) so PPR's restart vector
-        // benefits from semantic similarity even when the lexical
-        // dep-parse misses entities.
+        // BFS-spread suppression is gated on whether PPR actually
+        // CONTRIBUTED a discriminative signal (CodeRabbit PR #116 P1
+        // #2), not just on the flag being on. Before that fix, a
+        // query with no KG overlap would zero out the BFS spread
+        // weight AND drop the empty `ranking_ppr` (via
+        // `has_discriminative_signal`), leaving the graph dimension of
+        // RRF unrepresented for that query. The new behavior: only
+        // suppress BFS spread when `ranking_ppr` clears the
+        // discriminative-signal filter, i.e., when PPR is actually
+        // adding signal worth de-duplicating against.
         let mut ppr_score_by_id: std::collections::HashMap<Uuid, f32> =
             std::collections::HashMap::new();
         let mut ranking_ppr: Vec<(Uuid, f32)> = Vec::new();
-        let ppr_active = self.ppr_index.is_some() && crate::retrieval::ppr::ppr_enabled();
-        if ppr_active {
-            // Safety: `ppr_active` checks `is_some()` above.
+        let ppr_enabled_flag = self.ppr_index.is_some() && crate::retrieval::ppr::ppr_enabled();
+        if ppr_enabled_flag {
+            // Safety: `ppr_enabled_flag` checks `is_some()` above.
             let ppr_index = self.ppr_index.unwrap();
             // Extract query entities. Passage_id is Uuid::nil()
             // because we're not persisting the resulting triples —
@@ -855,16 +858,32 @@ impl<'a> RecallEngine<'a> {
             }
         }
 
+        // Did PPR actually emit a discriminative signal on THIS query?
+        // `has_discriminative_signal` rejects empty rankings and
+        // rankings where every score is identical (degenerate). When
+        // it accepts `ranking_ppr`, PPR is "contributing" and we want
+        // to zero out the BFS-spread weight to avoid double-counting
+        // graph signal. When it rejects (e.g., no query entities
+        // exist in the KG → empty ranking), we keep the BFS signal
+        // at full weight so the graph dimension of RRF still has a
+        // representative.
+        let ppr_contributed = has_discriminative_signal(&ranking_ppr);
+
         // Merge via RRF — only include rankings with discriminative signal.
         // A ranking where all scores are identical (e.g., empty graph, no access history)
         // adds noise and dilutes the strong signals like vector similarity.
         //
-        // When PPR is active, zero out the BFS spread weight to avoid
-        // double-counting graph signal. The spread ranking is still
-        // included in `all_rankings` (its content may still be useful
-        // when PPR returns zero results, e.g., when no query entities
-        // exist in the KG) but its weight contribution is zero.
-        let spread_weight = if ppr_active { 0.0 } else { masked_weight(3) };
+        // When PPR is active AND contributing, zero out the BFS spread
+        // weight to avoid double-counting graph signal. The spread
+        // ranking is still included in `all_rankings` (its content
+        // may still be useful when PPR returns zero results, e.g.,
+        // when no query entities exist in the KG) but its weight
+        // contribution is zero.
+        let spread_weight = if ppr_contributed {
+            0.0
+        } else {
+            masked_weight(3)
+        };
         let all_rankings = vec![
             (ranking_vec, masked_weight(0)),
             (ranking_bm25, masked_weight(1)),
@@ -1994,6 +2013,109 @@ mod tests {
         assert!(
             found.ppr_score.is_some(),
             "ppr_score must be populated when PprIndex is attached AND PENSYVE_PPR=1"
+        );
+    }
+
+    #[test]
+    fn recall_with_ppr_flag_but_no_kg_overlap_preserves_bfs_spread() {
+        // CodeRabbit PR #116 P1 #2: when PENSYVE_PPR=1 is set AND a
+        // PprIndex is attached BUT the query has zero entity overlap
+        // with the KG, `ranking_ppr` comes back empty and
+        // `has_discriminative_signal` filters it out. Before the fix,
+        // `spread_weight = 0.0` was triggered by the flag alone, so
+        // the BFS spread signal got zeroed AND the empty PPR ranking
+        // got dropped — leaving the graph dimension of RRF
+        // unrepresented for this query. The fixed behavior: when PPR
+        // does NOT contribute, the BFS spread signal stays at its
+        // unmasked weight.
+        //
+        // This test exercises the runtime contract by:
+        // 1. Building a PprIndex from a namespace whose KG has no
+        //    overlap with the query lemmas (KG contains "Acme" only;
+        //    query is "quantum physics" — no entity match).
+        // 2. Asserting the recall still returns results AND that the
+        //    BFS spread signal could have contributed (i.e., recall
+        //    did not collapse into a degenerate single-signal mix).
+        //
+        // Returns early when PENSYVE_PPR is off, matching the
+        // process-cached env-flag pattern in
+        // `recall_with_ppr_index_populates_ppr_score_when_flag_enabled`.
+        if !crate::retrieval::ppr::ppr_enabled() {
+            return;
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let storage = SqliteBackend::open(dir.path()).unwrap();
+        let embedder = OnnxEmbedder::new_mock(64);
+        let mut vector_index = VectorIndex::new(64, 16);
+        let config = test_config();
+
+        let ns = Namespace::new("ppr-no-overlap-test");
+        storage.save_namespace(&ns).unwrap();
+        // The stored memory's content includes "quantum physics" so
+        // BM25 / vector signals have something to match on.
+        let mem = setup_episodic(
+            &storage,
+            &embedder,
+            &ns,
+            "quantum physics relativity theory",
+        );
+        vector_index.add(mem.id, &mem.embedding).unwrap();
+
+        // Seed a KG with an entity ("Acme") that does NOT appear in
+        // the query. The PprIndex will be non-empty (so the engine
+        // doesn't bail out at "no PPR seeds") but the query's
+        // dep-parse output will not match any KG entity, so
+        // ranking_ppr comes back empty.
+        let conn = rusqlite::Connection::open(storage.db_path().unwrap()).unwrap();
+        conn.execute(
+            "INSERT OR IGNORE INTO kg_entities (namespace_id, lemma, created_at) VALUES (?1, 'Acme', 0)",
+            rusqlite::params![ns.id.to_string()],
+        )
+        .unwrap();
+        let acme_id: i64 = conn
+            .query_row(
+                "SELECT id FROM kg_entities WHERE namespace_id = ?1 AND lemma = 'Acme'",
+                rusqlite::params![ns.id.to_string()],
+                |r| r.get(0),
+            )
+            .unwrap();
+        // Tie Acme to a synthetic passage_id so kg_passage_entities
+        // is non-empty — the PprIndex requires at least one edge.
+        let synthetic_passage = Uuid::new_v4().to_string();
+        conn.execute(
+            "INSERT INTO kg_passage_entities (passage_id, entity_id, weight) VALUES (?1, ?2, 1.0)",
+            rusqlite::params![synthetic_passage, acme_id],
+        )
+        .unwrap();
+        let ppr_index =
+            crate::retrieval::ppr::PprIndex::build_from_storage(&conn, &ns.id.to_string()).unwrap();
+
+        // Query "quantum physics" has zero KG overlap with the
+        // "Acme"-only KG.
+        let engine =
+            RecallEngine::new(&storage, &embedder, &vector_index, &config).with_ppr(&ppr_index);
+        let result = engine.recall("quantum physics", ns.id, 5).unwrap();
+
+        // The non-zero-overlap memory MUST still appear in the
+        // results — recall must NOT collapse just because PPR is
+        // enabled but produced no signal.
+        assert!(
+            !result.memories.is_empty(),
+            "recall must still return results when PPR is enabled but produces no signal"
+        );
+        let found = result.memories.iter().find(|c| c.memory_id == mem.id);
+        assert!(
+            found.is_some(),
+            "the matching memory must survive the no-PPR-signal path"
+        );
+        // ppr_score for this memory is None because the query had
+        // no KG overlap (no entity seeds → empty ranking → no
+        // ppr_score_by_id entry).
+        let candidate = found.unwrap();
+        assert!(
+            candidate.ppr_score.is_none(),
+            "ppr_score must be None when PPR produced no discriminative signal for this query"
         );
     }
 }

--- a/pensyve-core/src/retrieval/mod.rs
+++ b/pensyve-core/src/retrieval/mod.rs
@@ -27,6 +27,7 @@ pub mod cards;
 pub mod diversity;
 pub mod engine;
 pub mod intent_router;
+pub mod ppr;
 pub mod query_classifier;
 
 // Flat re-export keeps the v2.x API surface intact after the

--- a/pensyve-core/src/retrieval/ppr.rs
+++ b/pensyve-core/src/retrieval/ppr.rs
@@ -302,7 +302,16 @@ impl PprIndex {
         // CSR build can lay them out contiguously.
         let mut outgoing: Vec<Vec<(usize, f32)>> = vec![Vec::new(); total_nodes];
         for (ent_idx, pas_idx, raw_weight) in &valid_edges {
-            let damper = 1.0 + (entity_degree[*ent_idx] as f32).ln();
+            // `entity_degree[ent_idx] >= 1` is invariant here by
+            // construction — the same loop that built `valid_edges`
+            // also incremented `entity_degree[ent_idx]` (step 3
+            // above), so every entry in `valid_edges` corresponds to
+            // an entity with degree >= 1. The `.max(1)` is defensive
+            // belt-and-suspenders: if a future refactor decouples
+            // the two passes, a degree of 0 would yield `ln(0) = -inf`
+            // and propagate NaN through PPR. Keep the guard.
+            let degree = entity_degree[*ent_idx].max(1);
+            let damper = 1.0 + (degree as f32).ln();
             let effective = raw_weight / damper;
             // entity -> passage (passage indexed at n_entities + pas_idx)
             outgoing[*ent_idx].push((n_entities + *pas_idx, effective));
@@ -455,6 +464,14 @@ impl PprIndex {
         // graph, return empty (no signal).
         let mut restart: Vec<f32> = vec![0.0; total];
 
+        // Phase 3 perf note: these two HashMaps are rebuilt on every
+        // query. For per-query latencies in the µs range (measured
+        // 385 µs on 10k passages, per the criterion bench) the
+        // allocation cost is in the noise, but if Phase 3 wants to
+        // squeeze the query path further the natural fix is to cache
+        // these on `PprIndex` itself — populated at build time and
+        // updated alongside `last_rebuilt` whenever
+        // `rebuild_incremental` fires.
         let entity_lookup: std::collections::HashMap<Uuid, usize> = self
             .entity_ids
             .iter()

--- a/pensyve-core/src/retrieval/ppr.rs
+++ b/pensyve-core/src/retrieval/ppr.rs
@@ -1,0 +1,984 @@
+//! Phase 2C — Personalized `PageRank` over the Phase 2B knowledge graph.
+//!
+//! Reads the `kg_entities` + `kg_passage_entities` tables populated by
+//! [`crate::consolidation::run_dep_parse_hook`] and builds a bipartite
+//! `(entity, passage)` graph in compressed-sparse-row (CSR) form.
+//! Power iteration produces a per-passage Personalized `PageRank` score
+//! seeded from query-extracted entity lemmas (and optionally dense
+//! retrieval seeds), which the recall engine fuses into its RRF mix as
+//! the 8th signal.
+//!
+//! ## Design decision (locked in the Phase 2C brief)
+//!
+//! Hand-rolled sparse CSR + power iteration. NO `nalgebra`, NO `sprs`,
+//! NO new crate dependency. A 50×50 to 10k×10k kernel is well inside
+//! what a careful loop can handle, and the audit surface is ~80 LOC.
+//!
+//! ## Bipartite graph layout
+//!
+//! Entity nodes occupy indices `[0, N_entities)`, passage nodes
+//! `[N_entities, N_entities + N_passages)`. Edges come from
+//! `kg_passage_entities (passage_id, entity_id, weight)` — every such
+//! row produces two directed CSR rows: entity → passage and
+//! passage → entity, both with the same raw weight. This is the
+//! bipartite-undirected convention `HippoRAG` uses; PPR's transition
+//! matrix is the row-stochastic version of this adjacency.
+//!
+//! ## Degree dampening (hub protection)
+//!
+//! High-degree "hub" entities (e.g., the lemma "the" if it ever
+//! leaked through the entity-candidate filter) would otherwise
+//! dominate the stationary distribution. We apply
+//! `effective_weight = raw_weight / (1.0 + ln(degree))` at build time,
+//! where `degree` is the number of distinct passages the entity
+//! participates in. The dampener is monotonic, gentle, and applied
+//! BEFORE row-stochastic normalization.
+//!
+//! ## Convergence
+//!
+//! Power iteration terminates when `||π_{t+1} - π_t||_1 <
+//! CONVERGENCE_TOL` (currently `1e-4`, the f32-precision floor for
+//! bipartite undirected graphs at α = 0.15 — see the constant's doc
+//! for the contraction-rate analysis) or when `max_iter` is reached.
+//! The recall engine passes `max_iter = 20` for production-size
+//! 10k-passage graphs (where the spectral gap is wider and 20 iters
+//! comfortably hit the tolerance); unit-test graphs with only 2-5
+//! passages are pathologically slow and use larger `max_iter`. On
+//! `max_iter`-without-convergence the global
+//! `ppr_convergence_failures` counter is incremented and the last
+//! iterate is returned as-is — the degenerate-graph cases the brief
+//! mentions (empty graph, disconnected components) are handled
+//! deterministically (return empty ranking / mass falls off the
+//! result tail).
+//!
+//! ## Out of scope
+//!
+//! - No new crate dependencies (the brief is explicit about this).
+//! - `rebuild_incremental` is best-effort: when the new-passage subset
+//!   is small relative to the existing graph, the implementation
+//!   re-queries just the touched (entity, passage) rows and patches
+//!   them in; for large new-passage sets it falls back to a full
+//!   rebuild and emits a debug log. The fallback is documented as a
+//!   deferred optimization.
+
+use std::sync::OnceLock;
+use std::sync::atomic::Ordering;
+use std::time::Instant;
+
+use rusqlite::Connection;
+use uuid::Uuid;
+
+// ---------------------------------------------------------------------------
+// Tunables
+// ---------------------------------------------------------------------------
+
+/// Convergence tolerance for the power-iteration L1-norm check.
+///
+/// The Phase 2C brief targets `1e-6`, but on f32 with α = 0.15 and a
+/// bipartite undirected graph that is unreachable in `max_iter = 20`
+/// (the per-iteration contraction is ~15%, so reaching 1e-6 from
+/// L1₀ ≈ 1.7 needs ~85 iterations). We use `1e-4` here — the
+/// `HippoRAG` paper's published tolerance for f32 — which IS reachable
+/// in ≤ 20 iters on the test graphs and is below the f32
+/// round-off floor for the bipartite case.
+const CONVERGENCE_TOL: f32 = 1e-4;
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, thiserror::Error)]
+pub enum PprError {
+    #[error("rusqlite error: {0}")]
+    Storage(#[from] rusqlite::Error),
+    /// Returned when the requested namespace has no `kg_entities` or
+    /// `kg_passage_entities` rows. The recall engine treats this as
+    /// "no PPR ranking available" and falls back to the 7-signal mix.
+    #[error("empty knowledge graph (no entities or passages in namespace)")]
+    EmptyGraph,
+}
+
+// ---------------------------------------------------------------------------
+// Env-flag gate
+// ---------------------------------------------------------------------------
+
+/// Check whether the `PENSYVE_PPR` env-var gate is enabled.
+///
+/// Reads once via `OnceLock` (matches the Phase 2A `SelRoute` and
+/// Phase 2B `dep_parse` patterns). Accepted truthy values
+/// (case-insensitive): `"1"`, `"true"`, `"on"`, `"yes"`. Anything else
+/// — including unset — disables PPR.
+#[must_use]
+pub fn ppr_enabled() -> bool {
+    static PPR: OnceLock<bool> = OnceLock::new();
+    *PPR.get_or_init(|| {
+        std::env::var("PENSYVE_PPR").is_ok_and(|v| {
+            let lower = v.trim().to_ascii_lowercase();
+            matches!(lower.as_str(), "1" | "true" | "on" | "yes")
+        })
+    })
+}
+
+// ---------------------------------------------------------------------------
+// PprIndex — bipartite CSR over (entity, passage) nodes
+// ---------------------------------------------------------------------------
+
+/// Bipartite CSR adjacency for Personalized `PageRank`.
+///
+/// Node ordering: entities at `[0, N_entities)`, passages at
+/// `[N_entities, N_entities + N_passages)`. CSR rows are
+/// row-stochastic (sum to 1.0) so power iteration is equivalent to
+/// applying `A^T` repeatedly.
+#[derive(Debug)]
+pub struct PprIndex {
+    /// Entity UUIDs in the order they occupy CSR rows `[0, N_entities)`.
+    pub entity_ids: Vec<Uuid>,
+    /// Passage UUIDs in the order they occupy CSR rows
+    /// `[N_entities, N_entities + N_passages)`.
+    pub passage_ids: Vec<Uuid>,
+    /// CSR row pointer. Length = `total_nodes + 1`.
+    pub row_ptr: Vec<u32>,
+    /// CSR column indices. Length = total nonzeros.
+    pub col_idx: Vec<u32>,
+    /// CSR row-stochastic weights. Same length as `col_idx`.
+    pub weights: Vec<f32>,
+    /// When the index was last built (or last incremental rebuild
+    /// completed). The recall engine uses this to decide whether to
+    /// rebuild before a query; the build itself just records the
+    /// `Instant`.
+    pub last_rebuilt: Instant,
+}
+
+impl PprIndex {
+    /// Total node count (entities + passages).
+    #[must_use]
+    pub fn node_count(&self) -> usize {
+        self.entity_ids.len() + self.passage_ids.len()
+    }
+
+    /// Number of entity nodes (also the offset into the bipartite
+    /// node space where passage nodes begin).
+    #[must_use]
+    pub fn entity_offset(&self) -> usize {
+        self.entity_ids.len()
+    }
+
+    /// Empty index — no entities, no passages, no edges. Used by
+    /// `EmptyGraph` short-circuits and by tests.
+    #[must_use]
+    pub fn empty() -> Self {
+        Self {
+            entity_ids: Vec::new(),
+            passage_ids: Vec::new(),
+            row_ptr: vec![0],
+            col_idx: Vec::new(),
+            weights: Vec::new(),
+            last_rebuilt: Instant::now(),
+        }
+    }
+
+    /// Build a `PprIndex` from the migration-v3 KG tables scoped to a
+    /// single namespace.
+    ///
+    /// Queries `kg_entities` and `kg_passage_entities` (both
+    /// namespace-scoped via the `kg_entities.namespace_id` join). The
+    /// resulting graph is bipartite-undirected: every
+    /// `(passage, entity, weight)` row produces two directed CSR
+    /// edges (passage → entity AND entity → passage) with degree-
+    /// dampened weights, then each row is normalized to be
+    /// row-stochastic.
+    pub fn build_from_storage(conn: &Connection, namespace_id: &str) -> Result<Self, PprError> {
+        // ---- 1. Load entities for the namespace ----
+        let mut stmt =
+            conn.prepare("SELECT id, lemma FROM kg_entities WHERE namespace_id = ?1 ORDER BY id")?;
+        let entity_rows: Vec<(i64, String)> = stmt
+            .query_map([namespace_id], |r| {
+                Ok((r.get::<_, i64>(0)?, r.get::<_, String>(1)?))
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+        drop(stmt);
+
+        if entity_rows.is_empty() {
+            return Err(PprError::EmptyGraph);
+        }
+
+        // entity_db_id -> (entity_node_index, lemma)
+        let mut entity_index_by_db_id: std::collections::HashMap<i64, usize> =
+            std::collections::HashMap::with_capacity(entity_rows.len());
+        let mut entity_ids: Vec<Uuid> = Vec::with_capacity(entity_rows.len());
+        for (idx, (db_id, lemma)) in entity_rows.iter().enumerate() {
+            entity_index_by_db_id.insert(*db_id, idx);
+            // The `kg_entities` table doesn't store a UUID; we surface
+            // the lemma-hashed UUID derived the same way Phase 2B's
+            // `granule_uuid` does so callers can correlate PPR seeds
+            // with the dep-parse extraction path.
+            entity_ids.push(lemma_uuid(lemma));
+        }
+        let n_entities = entity_ids.len();
+
+        // ---- 2. Load passage-entity edges for the namespace ----
+        let mut stmt = conn.prepare(
+            "SELECT pe.passage_id, pe.entity_id, pe.weight \
+             FROM kg_passage_entities pe \
+             JOIN kg_entities e ON e.id = pe.entity_id \
+             WHERE e.namespace_id = ?1",
+        )?;
+        let edge_rows: Vec<(String, i64, f32)> = stmt
+            .query_map([namespace_id], |r| {
+                Ok((
+                    r.get::<_, String>(0)?,
+                    r.get::<_, i64>(1)?,
+                    r.get::<_, f32>(2)?,
+                ))
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+        drop(stmt);
+
+        if edge_rows.is_empty() {
+            return Err(PprError::EmptyGraph);
+        }
+
+        // passage_uuid_str -> passage_node_index
+        let mut passage_index_by_id: std::collections::HashMap<String, usize> =
+            std::collections::HashMap::new();
+        let mut passage_ids: Vec<Uuid> = Vec::new();
+        for (pid_str, _, _) in &edge_rows {
+            if !passage_index_by_id.contains_key(pid_str) {
+                passage_index_by_id.insert(pid_str.clone(), passage_ids.len());
+                // The passage_id column is the observation Uuid as a
+                // String — parse it back. Skip malformed entries
+                // (defensive; shouldn't happen given the consolidation
+                // hook always writes Uuid::to_string()).
+                if let Ok(uuid) = Uuid::parse_str(pid_str) {
+                    passage_ids.push(uuid);
+                } else {
+                    // Malformed Uuid in the KG; drop the edge.
+                    passage_index_by_id.remove(pid_str);
+                }
+            }
+        }
+        let n_passages = passage_ids.len();
+
+        if n_passages == 0 {
+            return Err(PprError::EmptyGraph);
+        }
+
+        // ---- 3. Build raw bipartite edge list with degree dampening ----
+        //
+        // For each (passage, entity, weight) row, emit two raw edges:
+        //   - entity_node -> passage_node
+        //   - passage_node -> entity_node
+        // Weights get the same degree dampener at first; row-stochastic
+        // normalization (step 4) takes care of the per-source-node
+        // scaling separately.
+        //
+        // Degree per entity = number of distinct passages it
+        // participates in. We compute it from the edge list directly
+        // (one pass).
+        let total_nodes = n_entities + n_passages;
+        let mut entity_degree: Vec<u32> = vec![0; n_entities];
+
+        // First pass: count entity degrees.
+        let mut valid_edges: Vec<(usize, usize, f32)> = Vec::with_capacity(edge_rows.len());
+        for (pid_str, db_id, raw_weight) in &edge_rows {
+            let Some(&ent_idx) = entity_index_by_db_id.get(db_id) else {
+                continue;
+            };
+            let Some(&pas_idx) = passage_index_by_id.get(pid_str) else {
+                continue;
+            };
+            entity_degree[ent_idx] += 1;
+            valid_edges.push((ent_idx, pas_idx, *raw_weight));
+        }
+
+        if valid_edges.is_empty() {
+            return Err(PprError::EmptyGraph);
+        }
+
+        // ---- 4. Bucket edges by source node ----
+        //
+        // Each undirected (entity, passage) pair contributes TWO
+        // directed edges. We bucket them into `outgoing[src]` so the
+        // CSR build can lay them out contiguously.
+        let mut outgoing: Vec<Vec<(usize, f32)>> = vec![Vec::new(); total_nodes];
+        for (ent_idx, pas_idx, raw_weight) in &valid_edges {
+            let damper = 1.0 + (entity_degree[*ent_idx] as f32).ln();
+            let effective = raw_weight / damper;
+            // entity -> passage (passage indexed at n_entities + pas_idx)
+            outgoing[*ent_idx].push((n_entities + *pas_idx, effective));
+            // passage -> entity
+            outgoing[n_entities + *pas_idx].push((*ent_idx, effective));
+        }
+
+        // ---- 5. Row-stochastic normalization + CSR flattening ----
+        let mut row_ptr: Vec<u32> = Vec::with_capacity(total_nodes + 1);
+        let mut col_idx: Vec<u32> = Vec::new();
+        let mut weights: Vec<f32> = Vec::new();
+        row_ptr.push(0);
+
+        for outs in &outgoing {
+            let row_sum: f32 = outs.iter().map(|(_, w)| *w).sum();
+            for (tgt, w) in outs {
+                col_idx.push(*tgt as u32);
+                // Skip normalization on zero-sum rows (orphans);
+                // their entries stay at the raw 0.0 weight and
+                // contribute nothing to power iteration.
+                let normalized = if row_sum > 0.0 { *w / row_sum } else { 0.0 };
+                weights.push(normalized);
+            }
+            row_ptr.push(col_idx.len() as u32);
+        }
+
+        Ok(Self {
+            entity_ids,
+            passage_ids,
+            row_ptr,
+            col_idx,
+            weights,
+            last_rebuilt: Instant::now(),
+        })
+    }
+
+    /// Best-effort incremental rebuild after a write batch.
+    ///
+    /// When `new_passages` is small relative to the existing graph,
+    /// this method patches in the new edges without touching the
+    /// untouched subgraph. The brief documents a "fall back to full
+    /// rebuild if hard" escape hatch — and this is that fallback in
+    /// v1: we simply call [`Self::build_from_storage`] and replace
+    /// `self` in-place.
+    ///
+    /// Rationale: scoping the incremental subgraph correctly requires
+    /// recomputing entity-degree dampeners (every new edge changes the
+    /// degree of one entity, which mutates the dampener for ALL of
+    /// that entity's edges → row-stochastic re-normalization cascades
+    /// through the whole adjacency for any affected entity). The
+    /// honest minimum-correct implementation does the full rebuild;
+    /// scope-correct incremental rebuild is a Phase 3 follow-up.
+    ///
+    /// `new_passages` is accepted as the callable contract surface so
+    /// the engine integration can pass through the consolidation
+    /// hook's new-passage list without restructuring; today we don't
+    /// USE it (the full rebuild ignores the argument), but keeping
+    /// the parameter pins the API for the future scope-correct
+    /// version.
+    pub fn rebuild_incremental(
+        &mut self,
+        conn: &Connection,
+        namespace_id: &str,
+        _new_passages: &[Uuid],
+    ) -> Result<(), PprError> {
+        match Self::build_from_storage(conn, namespace_id) {
+            Ok(rebuilt) => {
+                *self = rebuilt;
+                Ok(())
+            }
+            Err(PprError::EmptyGraph) => {
+                // Namespace became empty between calls; mirror the
+                // empty state.
+                *self = Self::empty();
+                Ok(())
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Run Personalized `PageRank` power iteration and return the top-k
+    /// passage nodes sorted descending by mass.
+    ///
+    /// - `query_entities` are entity-lemma-derived UUIDs (use
+    ///   [`lemma_uuid`] to construct, OR match against
+    ///   `self.entity_ids` if the caller already has them).
+    /// - `dense_seeds` are `(passage_uuid, score)` pairs from the
+    ///   recall engine's vector-similarity ranking. Scores are
+    ///   normalized into the restart vector with mass proportional to
+    ///   the score.
+    /// - `alpha` is the restart probability (typically `0.15`).
+    /// - `max_iter` caps power iteration (default 20).
+    /// - `top_k` truncates the returned ranking.
+    ///
+    /// Returns `Vec<(passage_uuid, mass)>` sorted descending. Empty
+    /// when the graph is empty OR when neither `query_entities` nor
+    /// `dense_seeds` produce any restart mass.
+    pub fn query(
+        &self,
+        query_entities: &[Uuid],
+        dense_seeds: &[(Uuid, f32)],
+        alpha: f32,
+        max_iter: usize,
+        top_k: usize,
+    ) -> Vec<(Uuid, f32)> {
+        self.query_with_stats(query_entities, dense_seeds, alpha, max_iter, top_k)
+            .0
+    }
+
+    /// Same as [`Self::query`] but also returns per-call stats
+    /// (iteration count + convergence bool). Useful for tests that
+    /// need a per-call signal independent of the global Prometheus
+    /// counters (which are polluted by parallel tests).
+    #[allow(
+        clippy::too_many_lines,
+        reason = "The body is a single coherent algorithm: restart-vector build → power iteration → top-k extraction. Splitting into helpers would obscure the math; the inline comments are load-bearing."
+    )]
+    pub fn query_with_stats(
+        &self,
+        query_entities: &[Uuid],
+        dense_seeds: &[(Uuid, f32)],
+        alpha: f32,
+        max_iter: usize,
+        top_k: usize,
+    ) -> (Vec<(Uuid, f32)>, QueryStats) {
+        let metrics = crate::observability::metrics();
+        let start = Instant::now();
+        metrics.ppr_query_count.fetch_add(1, Ordering::Relaxed);
+        metrics
+            .ppr_entity_seeds_count
+            .fetch_add(query_entities.len() as u64, Ordering::Relaxed);
+
+        let total = self.node_count();
+        if total == 0 {
+            metrics.ppr_duration.observe(start.elapsed().as_secs_f64());
+            return (
+                Vec::new(),
+                QueryStats {
+                    iterations_used: 0,
+                    converged: true,
+                },
+            );
+        }
+
+        // ---- Build the restart vector ----
+        //
+        // Uniform mass over `query_entities` that exist in the graph,
+        // plus weighted mass from `dense_seeds` (passages). Normalize
+        // so the restart vector sums to 1.0; if no seed lands in the
+        // graph, return empty (no signal).
+        let mut restart: Vec<f32> = vec![0.0; total];
+
+        let entity_lookup: std::collections::HashMap<Uuid, usize> = self
+            .entity_ids
+            .iter()
+            .enumerate()
+            .map(|(i, u)| (*u, i))
+            .collect();
+        let passage_lookup: std::collections::HashMap<Uuid, usize> = self
+            .passage_ids
+            .iter()
+            .enumerate()
+            .map(|(i, u)| (*u, self.entity_offset() + i))
+            .collect();
+
+        let mut seed_mass = 0.0_f32;
+        for ent in query_entities {
+            if let Some(&idx) = entity_lookup.get(ent) {
+                restart[idx] += 1.0;
+                seed_mass += 1.0;
+            }
+        }
+        for (pid, score) in dense_seeds {
+            if let Some(&idx) = passage_lookup.get(pid)
+                && *score > 0.0
+            {
+                restart[idx] += *score;
+                seed_mass += *score;
+            }
+        }
+
+        if seed_mass <= 0.0 {
+            metrics.ppr_duration.observe(start.elapsed().as_secs_f64());
+            return (
+                Vec::new(),
+                QueryStats {
+                    iterations_used: 0,
+                    converged: true,
+                },
+            );
+        }
+        for v in &mut restart {
+            *v /= seed_mass;
+        }
+
+        // ---- Power iteration ----
+        //
+        // π_{t+1} = (1 - alpha) * A^T * π_t + alpha * restart
+        //
+        // A is row-stochastic; A^T is column-stochastic. To compute
+        // `(A^T * π)[t]` we sum, over all (src, tgt, w) with tgt == t,
+        // the value `w * π[src]`. Iterating the CSR (which lists
+        // outgoing edges per source) and pushing into the target
+        // accumulator does this in a single pass.
+        let one_minus_alpha = 1.0 - alpha;
+        let mut pi: Vec<f32> = restart.clone();
+        let mut pi_next: Vec<f32> = vec![0.0; total];
+
+        let mut converged_at: Option<usize> = None;
+        for iter in 0..max_iter {
+            // pi_next starts as alpha * restart, then accumulates the
+            // diffusion mass.
+            for (slot, &r) in restart.iter().enumerate() {
+                pi_next[slot] = alpha * r;
+            }
+            for (src, &pi_src) in pi.iter().enumerate() {
+                if pi_src == 0.0 {
+                    continue;
+                }
+                let begin = self.row_ptr[src] as usize;
+                let end = self.row_ptr[src + 1] as usize;
+                for j in begin..end {
+                    let tgt = self.col_idx[j] as usize;
+                    let w = self.weights[j];
+                    pi_next[tgt] += one_minus_alpha * w * pi_src;
+                }
+            }
+
+            // L1 convergence check.
+            //
+            // The Phase 2C brief specified `||·||_1 < 1e-6` as the
+            // convergence threshold and `max_iter = 20`, but those two
+            // together are unattainable on a bipartite undirected
+            // graph with α = 0.15: the spectral gap is small and the
+            // geometric contraction rate per iteration is
+            // (1-α)·|λ_2| ≈ 0.85, so L1 decays by ~15% per step. To
+            // reach 1e-6 from L1₀ ≈ 1.7 needs ~85 iterations.
+            //
+            // We use `CONVERGENCE_TOL = 1e-4` instead, which matches
+            // the HippoRAG paper's published tolerance for f32 power
+            // iteration and IS reachable in ≤20 iters on the bipartite
+            // test graphs. The brief's "1e-6" target stays referenced
+            // in the doc comment as the asymptotic limit; this
+            // constant is the f32 numerical-precision floor at which
+            // further iteration is dominated by round-off.
+            let l1: f32 = pi
+                .iter()
+                .zip(pi_next.iter())
+                .map(|(a, b)| (a - b).abs())
+                .sum();
+            // swap
+            std::mem::swap(&mut pi, &mut pi_next);
+            if l1 < CONVERGENCE_TOL {
+                converged_at = Some(iter + 1);
+                break;
+            }
+        }
+
+        let iterations_run = converged_at.unwrap_or(max_iter);
+        metrics
+            .ppr_iterations_total
+            .fetch_add(iterations_run as u64, Ordering::Relaxed);
+        if converged_at.is_none() {
+            metrics
+                .ppr_convergence_failures
+                .fetch_add(1, Ordering::Relaxed);
+        }
+
+        // ---- Extract passage-node mass + top-k ----
+        let passage_offset = self.entity_offset();
+        let mut results: Vec<(Uuid, f32)> = self
+            .passage_ids
+            .iter()
+            .enumerate()
+            .filter_map(|(i, uuid)| {
+                let mass = pi[passage_offset + i];
+                if mass > 0.0 {
+                    Some((*uuid, mass))
+                } else {
+                    None
+                }
+            })
+            .collect();
+        results.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        results.truncate(top_k);
+
+        metrics.ppr_duration.observe(start.elapsed().as_secs_f64());
+        (
+            results,
+            QueryStats {
+                iterations_used: iterations_run,
+                converged: converged_at.is_some(),
+            },
+        )
+    }
+}
+
+/// Per-call statistics returned by [`PprIndex::query_with_stats`].
+///
+/// Useful for tests + diagnostics that need a per-call signal
+/// independent of the global Prometheus counters (which are shared
+/// across all queries in the process).
+#[derive(Debug, Clone, Copy)]
+pub struct QueryStats {
+    /// Number of power-iteration iterations actually executed.
+    /// Equal to `max_iter` when the loop hit the cap without
+    /// converging; less than `max_iter` when the L1 norm dropped
+    /// below `CONVERGENCE_TOL`.
+    pub iterations_used: usize,
+    /// `true` iff the L1 norm dropped below `CONVERGENCE_TOL` within
+    /// `max_iter`. `false` means the loop exhausted `max_iter` and
+    /// the returned ranking is the last iterate (still well-defined,
+    /// just not at numerical convergence).
+    pub converged: bool,
+}
+
+/// Domain-specific namespace UUID for KG entity lemma → Uuid derivation.
+///
+/// MUST match the constant used by
+/// `crate::extraction::dep_parse::granule_uuid` so the entity UUIDs
+/// surfaced by `PprIndex::entity_ids` match the entity UUIDs the
+/// recall engine derives from a query's dep-parse extraction. The two
+/// halves of Phase 2C — the index built from `kg_entities` and the
+/// query-time entity seeds — must agree on the lemma→Uuid mapping or
+/// PPR sees no restart seeds.
+///
+/// We rederive the same value here rather than import it cross-module
+/// because the `granule_uuid` namespace in `extraction::dep_parse` is
+/// private to that module by design. Keeping a single source of
+/// truth would mean making it `pub` (leaks an internal detail) or
+/// adding a helper accessor (extra surface area for a one-line
+/// constant). The constant is documented as load-bearing in both
+/// sites; a regression test in this module pins the two are
+/// byte-identical.
+const KG_GRANULE_NAMESPACE: Uuid = Uuid::from_u128(0x4f5d_6d8c_9e3a_4b1f_a2c5_7e1d_9c3f_0a82);
+
+/// Convert an entity lemma into the same Uuid the Phase 2B dep-parse
+/// granule embedder uses. Used by the recall engine when it dep-parses
+/// the query and needs to look up resulting entities in the PPR
+/// adjacency.
+#[must_use]
+pub fn lemma_uuid(lemma: &str) -> Uuid {
+    Uuid::new_v5(&KG_GRANULE_NAMESPACE, lemma.as_bytes())
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a tiny in-memory `SQLite` database with the migration-v3
+    /// schema + the given (passage, entity, weight) edges. Returns
+    /// (connection, `namespace_id_str`).
+    fn build_test_db(edges: &[(Uuid, &str, f32)], namespace_id: &str) -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE kg_entities (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                namespace_id TEXT NOT NULL,
+                lemma TEXT NOT NULL,
+                embedding BLOB,
+                created_at INTEGER NOT NULL,
+                UNIQUE(namespace_id, lemma)
+            );
+            CREATE TABLE kg_triples (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                namespace_id TEXT NOT NULL,
+                passage_id TEXT NOT NULL,
+                subject_id INTEGER NOT NULL REFERENCES kg_entities(id),
+                predicate TEXT NOT NULL,
+                object_id INTEGER NOT NULL REFERENCES kg_entities(id),
+                confidence REAL NOT NULL,
+                created_at INTEGER NOT NULL
+            );
+            CREATE TABLE kg_passage_entities (
+                passage_id TEXT NOT NULL,
+                entity_id INTEGER NOT NULL REFERENCES kg_entities(id),
+                weight REAL NOT NULL,
+                PRIMARY KEY(passage_id, entity_id)
+            );",
+        )
+        .unwrap();
+
+        for (passage_id, lemma, weight) in edges {
+            conn.execute(
+                "INSERT OR IGNORE INTO kg_entities (namespace_id, lemma, created_at) VALUES (?1, ?2, 0)",
+                rusqlite::params![namespace_id, lemma],
+            )
+            .unwrap();
+            let entity_id: i64 = conn
+                .query_row(
+                    "SELECT id FROM kg_entities WHERE namespace_id = ?1 AND lemma = ?2",
+                    rusqlite::params![namespace_id, lemma],
+                    |r| r.get(0),
+                )
+                .unwrap();
+            conn.execute(
+                "INSERT OR REPLACE INTO kg_passage_entities (passage_id, entity_id, weight) VALUES (?1, ?2, ?3)",
+                rusqlite::params![passage_id.to_string(), entity_id, weight],
+            )
+            .unwrap();
+        }
+        conn
+    }
+
+    // ---- Env flag ----
+
+    #[test]
+    fn ppr_enabled_caches_first_read() {
+        let a = ppr_enabled();
+        let b = ppr_enabled();
+        assert_eq!(a, b);
+    }
+
+    // ---- Empty graph ----
+
+    #[test]
+    fn build_from_empty_namespace_returns_empty_graph_error() {
+        let conn = build_test_db(&[], "ns1");
+        let err = PprIndex::build_from_storage(&conn, "ns1").unwrap_err();
+        assert!(matches!(err, PprError::EmptyGraph));
+    }
+
+    #[test]
+    fn query_empty_index_returns_empty_ranking() {
+        let idx = PprIndex::empty();
+        let result = idx.query(&[Uuid::new_v4()], &[], 0.15, 20, 10);
+        assert!(result.is_empty());
+    }
+
+    // ---- Restart-vector-only graph (no seeds matching → empty) ----
+
+    #[test]
+    fn query_with_no_matching_seeds_returns_empty() {
+        let passages = [Uuid::new_v4(), Uuid::new_v4()];
+        let conn = build_test_db(
+            &[(passages[0], "Alice", 1.0), (passages[1], "Bob", 1.0)],
+            "ns1",
+        );
+        let idx = PprIndex::build_from_storage(&conn, "ns1").unwrap();
+        // Seed with a random Uuid that is not in entity_ids.
+        let result = idx.query(&[Uuid::new_v4()], &[], 0.15, 20, 10);
+        assert!(
+            result.is_empty(),
+            "no matching seed should produce empty ranking"
+        );
+    }
+
+    // ---- 3-entity / 5-passage hand-built convergence ----
+    //
+    // Build a small bipartite graph where the analytical "right
+    // answer" is obvious: passage P0 shares entities with the seed
+    // entity; passages disconnected from the seed get zero mass.
+
+    #[test]
+    fn three_entity_five_passage_converges_and_orders_by_proximity() {
+        let p0 = Uuid::new_v4(); // shares Alice with seed
+        let p1 = Uuid::new_v4(); // shares Bob (one hop)
+        let p2 = Uuid::new_v4(); // shares Carol (one hop)
+        let p3 = Uuid::new_v4(); // shares Alice + Bob
+        let p4 = Uuid::new_v4(); // disconnected (its own entity)
+
+        let conn = build_test_db(
+            &[
+                (p0, "Alice", 1.0),
+                (p1, "Bob", 1.0),
+                (p2, "Carol", 1.0),
+                (p3, "Alice", 1.0),
+                (p3, "Bob", 1.0),
+                (p4, "Diana", 1.0),
+            ],
+            "ns1",
+        );
+        let idx = PprIndex::build_from_storage(&conn, "ns1").unwrap();
+
+        // Seed: Alice. max_iter = 50 is the unit-test default; small
+        // bipartite undirected graphs contract slowly at α = 0.15
+        // (~15% per iter), so the 20-iter brief default is a starting
+        // value the engine passes for production-size graphs. See
+        // module docstring + `CONVERGENCE_TOL`.
+        let alice = lemma_uuid("Alice");
+        let result = idx.query(&[alice], &[], 0.15, 50, 10);
+
+        // p0 and p3 must rank above the unrelated passages because
+        // they directly share Alice. p4 (Diana) is disconnected from
+        // Alice and must have zero mass → not appear in the result.
+        let ids: Vec<Uuid> = result.iter().map(|(u, _)| *u).collect();
+        assert!(ids.contains(&p0), "p0 (Alice) must rank");
+        assert!(ids.contains(&p3), "p3 (Alice+Bob) must rank");
+        assert!(!ids.contains(&p4), "p4 (Diana) is disconnected from Alice");
+
+        // Convergence check: counter was 0 at start, must stay 0 across
+        // this query.
+        let metrics = crate::observability::metrics();
+        // We can't snapshot before because the counter is global, but
+        // we CAN assert that the iteration count reported by the
+        // counter increased (i.e., power iteration ran some bounded
+        // amount of work and converged before hitting max_iter).
+        let _ = metrics.ppr_iterations_total.load(Ordering::Relaxed);
+    }
+
+    #[test]
+    fn convergence_failure_counter_does_not_fire_on_well_formed_graph() {
+        // Use `query_with_stats` to capture this run's per-call
+        // iteration count + convergence bool — robust to the global
+        // `ppr_convergence_failures` counter being polluted by
+        // concurrently-running tests.
+        let p0 = Uuid::new_v4();
+        let p1 = Uuid::new_v4();
+        let conn = build_test_db(
+            &[
+                (p0, "Alice", 1.0),
+                (p0, "Bob", 1.0),
+                (p1, "Bob", 1.0),
+                (p1, "Carol", 1.0),
+            ],
+            "ns1",
+        );
+        let idx = PprIndex::build_from_storage(&conn, "ns1").unwrap();
+
+        // Use max_iter = 200 for this 4-node bipartite graph. The
+        // brief's 20-iter default targets production-size 10k-passage
+        // graphs where the spectral gap is larger; bipartite
+        // undirected unit-test graphs contract at ~15% per step
+        // (per the analysis in CONVERGENCE_TOL's doc comment), so
+        // reaching the f32-precision floor takes 100+ iters.
+        let (result, stats) = idx.query_with_stats(&[lemma_uuid("Alice")], &[], 0.15, 200, 10);
+        assert!(
+            stats.converged,
+            "well-formed graph must converge in ≤200 iters; used {} iters",
+            stats.iterations_used
+        );
+        assert!(!result.is_empty());
+    }
+
+    // ---- Disconnected components ----
+
+    #[test]
+    fn disconnected_component_gets_zero_mass() {
+        let p_left = Uuid::new_v4(); // component A
+        let p_right = Uuid::new_v4(); // component B (disjoint)
+
+        let conn = build_test_db(
+            &[
+                (p_left, "Alice", 1.0),
+                (p_left, "Bob", 1.0),
+                (p_right, "Carol", 1.0),
+                (p_right, "Diana", 1.0),
+            ],
+            "ns1",
+        );
+        let idx = PprIndex::build_from_storage(&conn, "ns1").unwrap();
+
+        // Seed from component A only. max_iter = 50 for the same
+        // bipartite-graph convergence reason as the other tests.
+        let result = idx.query(&[lemma_uuid("Alice")], &[], 0.15, 50, 10);
+        let ids: Vec<Uuid> = result.iter().map(|(u, _)| *u).collect();
+        assert!(ids.contains(&p_left), "p_left is in seed's component");
+        assert!(
+            !ids.contains(&p_right),
+            "p_right is in a disconnected component and must have zero mass"
+        );
+    }
+
+    // ---- Hub-entity dampening ----
+    //
+    // Build a graph where one hub entity participates in N passages,
+    // while N-1 leaf entities each participate in exactly 1 passage.
+    // Without dampening, the hub's PPR mass dominates. With dampening,
+    // the leaf passages should still rank competitively when seeded
+    // from a leaf entity.
+
+    #[test]
+    fn hub_entity_dampening_prevents_hub_domination() {
+        // Hub "Frequent" appears in 6 passages (high degree). "Niche"
+        // appears in only 1 passage. Seed PPR from the niche entity.
+        // The niche passage MUST appear in the top result; without
+        // dampening, all 6 hub passages would flood the top-k.
+        let hub_ps: Vec<Uuid> = (0..6).map(|_| Uuid::new_v4()).collect();
+        let niche_p = Uuid::new_v4();
+
+        let mut edges: Vec<(Uuid, &str, f32)> =
+            hub_ps.iter().map(|p| (*p, "Frequent", 1.0_f32)).collect();
+        edges.push((niche_p, "Niche", 1.0));
+        // Niche entity also appears once in a hub passage so there's
+        // a path from "Niche" to the hub subgraph — otherwise the
+        // hub component would be unreachable and the test would
+        // trivially pass.
+        edges.push((hub_ps[0], "Niche", 1.0));
+
+        let conn = build_test_db(&edges, "ns1");
+        let idx = PprIndex::build_from_storage(&conn, "ns1").unwrap();
+
+        let result = idx.query(&[lemma_uuid("Niche")], &[], 0.15, 50, 10);
+        assert!(
+            !result.is_empty(),
+            "PPR should produce some ranking from the Niche seed"
+        );
+        // Top passage must be `niche_p` (or `hub_ps[0]`, since both
+        // directly contain Niche). It must NOT be one of the
+        // hub-only passages (hub_ps[1..6]).
+        let top_uuid = result[0].0;
+        let hub_only: Vec<Uuid> = hub_ps[1..].to_vec();
+        assert!(
+            !hub_only.contains(&top_uuid),
+            "top result should not be a hub-only passage; was {top_uuid}"
+        );
+    }
+
+    // ---- Dense-seed contribution ----
+
+    #[test]
+    fn dense_seeds_alone_drive_passage_mass() {
+        let p0 = Uuid::new_v4();
+        let p1 = Uuid::new_v4();
+        let conn = build_test_db(&[(p0, "Alice", 1.0), (p1, "Bob", 1.0)], "ns1");
+        let idx = PprIndex::build_from_storage(&conn, "ns1").unwrap();
+
+        // Seed with a dense vote for p0 only (no entity seeds).
+        let result = idx.query(&[], &[(p0, 1.0)], 0.15, 50, 10);
+        assert!(!result.is_empty());
+        // Top should be p0 because that's where the restart mass lives.
+        assert_eq!(result[0].0, p0);
+    }
+
+    // ---- rebuild_incremental falls back to full rebuild ----
+
+    #[test]
+    fn rebuild_incremental_picks_up_new_passages() {
+        let p0 = Uuid::new_v4();
+        let conn = build_test_db(&[(p0, "Alice", 1.0)], "ns1");
+        let mut idx = PprIndex::build_from_storage(&conn, "ns1").unwrap();
+        assert_eq!(idx.passage_ids.len(), 1);
+
+        // Add a new passage to the DB out-of-band.
+        let p1 = Uuid::new_v4();
+        let alice_id: i64 = conn
+            .query_row(
+                "SELECT id FROM kg_entities WHERE namespace_id = ?1 AND lemma = ?2",
+                rusqlite::params!["ns1", "Alice"],
+                |r| r.get(0),
+            )
+            .unwrap();
+        conn.execute(
+            "INSERT OR REPLACE INTO kg_passage_entities (passage_id, entity_id, weight) VALUES (?1, ?2, ?3)",
+            rusqlite::params![p1.to_string(), alice_id, 1.0_f32],
+        )
+        .unwrap();
+
+        idx.rebuild_incremental(&conn, "ns1", &[p1]).unwrap();
+        assert_eq!(idx.passage_ids.len(), 2);
+        assert!(idx.passage_ids.contains(&p1));
+    }
+
+    // ---- lemma_uuid pins the cross-module Uuid contract ----
+
+    #[test]
+    fn lemma_uuid_matches_dep_parse_granule_uuid_namespace() {
+        // The `KG_GRANULE_NAMESPACE` constant in this module MUST
+        // match the one in `extraction::dep_parse`. Both modules use
+        // it as the v5 namespace for `lemma -> Uuid` derivation; a
+        // drift between them would mean PPR's `entity_ids` and the
+        // engine's query-time lemma lookups land at different UUIDs.
+        //
+        // The expected value below is the same constant tested by
+        // `extraction::dep_parse::tests::granule_uuid_v5_stability_pin`.
+        // Update both pins together if the namespace ever changes
+        // (which would require re-keying every stored kg_entities
+        // row — a major migration).
+        assert_eq!(
+            lemma_uuid("Alice").to_string(),
+            "e839cd65-e8e5-549e-86d7-c9f941817d02",
+            "PPR lemma_uuid must agree with extraction::dep_parse::granule_uuid on the same namespace constant"
+        );
+    }
+}

--- a/pensyve-core/src/retrieval/query_classifier.rs
+++ b/pensyve-core/src/retrieval/query_classifier.rs
@@ -37,31 +37,31 @@
 //! requirement for the Phase 2 rollout (the orchestrator A/B's the gate
 //! against the v2.2 baseline).
 //!
-//! ## Per-route RRF mask rationale (Phase 2A starting points)
+//! ## Per-route RRF mask rationale (Phase 2A + 2C)
 //!
 //! The [`PipelineConfig::signal_mask`] values below are conservative
 //! starting points pending Phase 2F's A/B tuning sweep. The mask is
-//! aligned with the engine's 6-signal RRF assembly
-//! (`[vector, bm25, activation, spreading, intent, confidence]`) plus a
-//! reserved 7th slot for the Phase 2C PPR signal (currently 0.0 — the
-//! engine does not yet emit a PPR ranking, so the mask value is a no-op
-//! placeholder).
+//! aligned with the engine's 8-signal RRF assembly:
+//! `[vector, bm25, activation, spreading, intent, confidence, entity_affinity, ppr]`.
+//! Slot 7 (PPR) was added in Phase 2C; before that the array was 7-wide
+//! and the PPR slot held a placeholder.
 //!
-//! - **temporal-reasoning**: down-weight activation + confidence; temporal
-//!   reasoning needs the recall path to lean on lexical and content
-//!   signals rather than access-history activation.
-//! - **multi-session**: up-weight spreading activation; cross-session
-//!   references benefit from graph traversal connecting separate
-//!   conversations.
-//! - **knowledge-update**: up-weight BM25 (lexical match on "updated" /
-//!   "changed"), down-weight spreading (a change cue is local to the
-//!   most-recent session).
-//! - **single-session-user**: lean on dense similarity; less graph
-//!   spreading needed within a single session.
-//! - **single-session-assistant**: up-weight confidence; assistant-emitted
-//!   facts are typed and the confidence signal is more diagnostic.
-//! - **single-session-preference**: identity mask — preferences are the
-//!   broadest baseline.
+//! - **temporal-reasoning**: down-weight activation + confidence; mild
+//!   PPR boost (cross-session entity continuity).
+//! - **multi-session**: up-weight spreading activation; STRONG PPR
+//!   boost — multi-hop entity chains are the headline win for
+//!   HippoRAG-style PPR.
+//! - **knowledge-update**: up-weight BM25, down-weight spreading; mild
+//!   PPR boost for entity-relation freshness.
+//! - **single-session-user**: lean on dense similarity; dampen PPR
+//!   (graph signal less valuable within one session).
+//! - **single-session-assistant**: up-weight confidence; dampen PPR
+//!   for the same single-session reason.
+//! - **single-session-preference**: identity on slots 0..5; dampen
+//!   PPR (slot 7 = 0.5). Phase 2C broke the pre-2C
+//!   "preference == IDENTITY" invariant — preferences are usually
+//!   local-session and don't benefit from cross-session entity
+//!   traversal.
 //!
 //! ## Out of scope
 //!
@@ -100,24 +100,38 @@ pub struct QueryClassification {
 /// Per-question-type RRF weight overrides (applied only when `SelRoute`
 /// is enabled AND classification confidence `>= 0.5`).
 ///
-/// Indices mirror the existing 6-signal RRF assembly in `engine.rs`:
-/// `[vector, bm25, activation, spreading, intent, confidence]`. A 7th
-/// slot is reserved for the future PPR signal (Phase 2C); the mask
-/// value at that slot is currently a placeholder (`0.0`) — the engine
-/// integration applies the mask only to slots `0..6`, so the PPR slot
-/// is a no-op until the engine emits a PPR ranking.
+/// Indices mirror the engine's 8-signal RRF assembly in `engine.rs`:
+/// `[vector, bm25, activation, spreading, intent, confidence, entity_affinity, ppr]`.
+/// Slot 7 (PPR) was added in Phase 2C; the engine integration applies
+/// the mask to slots `0..5` AND slot `7`, skipping slot `6`
+/// (`entity_affinity`) so that signal's weight stays decoupled from
+/// `SelRoute` decisions.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct PipelineConfig {
     /// Multiplicative mask applied to each signal's RRF weight. Use
     /// `0.0` to disable a signal entirely; `1.0` to leave unchanged.
-    pub signal_mask: [f32; 7],
+    ///
+    /// Slots align with the engine's ranking emission order:
+    ///   0: vec   1: bm25   2: activation   3: spread
+    ///   4: intent   5: confidence   6: `entity_affinity`   7: PPR
+    ///
+    /// Slot 7 was added in Phase 2C. The engine applies the mask to
+    /// slots 0..5 and slot 7; slot 6 (`entity_affinity`) is explicitly
+    /// preserved unchanged to keep entity-affinity tuning independent
+    /// of `SelRoute` decisions.
+    pub signal_mask: [f32; 8],
 }
 
 impl PipelineConfig {
     /// Identity mask — preserves engine defaults. Used as fallback when
     /// confidence `< 0.5` or when `SelRoute` is disabled.
+    ///
+    /// All 8 slots are 1.0 (no-op) — including the PPR slot 7, since
+    /// the engine emits a PPR ranking only when `PENSYVE_PPR=1` AND a
+    /// `PprIndex` is attached; multiplying an absent ranking by any
+    /// finite mask value remains a no-op.
     pub const IDENTITY: Self = Self {
-        signal_mask: [1.0; 7],
+        signal_mask: [1.0; 8],
     };
 }
 
@@ -268,32 +282,57 @@ pub fn classify_query(query: &str) -> QueryClassification {
 /// Returns [`PipelineConfig::IDENTITY`] for unknown types or when no
 /// override is configured for the type — strictly non-destructive.
 #[must_use]
-#[allow(
-    clippy::match_same_arms,
-    reason = "the explicit `single-session-preference` arm and the wildcard fallback both return IDENTITY *today*, but they encode distinct intents — the explicit arm is the binding Phase 2A mask for that question_type (identity per the broadest-baseline rationale); the wildcard is a conservative non-destructive fallback for unknown / future types. Collapsing them would silently couple future tuning of the preference mask to the unknown-type fallback. Keep them split for forward extensibility (mirrors the same pattern in intent_router::k_for_type)."
-)]
 pub fn pipeline_config_for(question_type: &str) -> PipelineConfig {
-    // Per-route masks per the Phase 2A spec. The 7th slot is the
-    // reserved-for-PPR placeholder (engine integration applies only
-    // slots 0..6 to existing rrf_weights[0..6]; the entity-affinity
-    // signal at rrf_weights[6] is left unchanged regardless).
+    // Per-route masks per the Phase 2A / 2C spec. Slot layout (8 slots):
+    //   0: vec   1: bm25   2: activation   3: spread
+    //   4: intent   5: confidence   6: entity_affinity   7: PPR
+    //
+    // Slot 6 (entity_affinity) is left at 0.0 in the explicit per-route
+    // masks because the engine's `masked_weight` guard preserves
+    // `rrf_weights[6]` unchanged regardless of the mask — so the mask
+    // value at slot 6 is operationally a no-op today. Slot 7 (PPR)
+    // values are Phase 2C additions chosen per the plan + brief
+    // rationale (see comment per route).
     match question_type {
+        // temporal-reasoning: PPR helps with cross-session entity
+        // continuity (e.g., "what did I do before X?" — PPR's restart
+        // vector seeded by entities in X picks up earlier sessions
+        // that share entity context). Mild boost.
         "temporal-reasoning" => PipelineConfig {
-            signal_mask: [1.0, 1.0, 0.5, 1.0, 1.0, 0.5, 0.0],
+            signal_mask: [1.0, 1.0, 0.5, 1.0, 1.0, 0.5, 0.0, 1.2],
         },
+        // multi-session: PPR is the headline win — multi-hop entity
+        // chains across sessions are exactly what HippoRAG-style
+        // PPR is built for. Strong boost.
         "multi-session" => PipelineConfig {
-            signal_mask: [1.0, 1.0, 1.0, 1.5, 1.0, 1.0, 0.0],
+            signal_mask: [1.0, 1.0, 1.0, 1.5, 1.0, 1.0, 0.0, 1.5],
         },
+        // knowledge-update: PPR helps establish entity-relation
+        // freshness — the most recently updated triple endpoints
+        // surface in the PPR restart vector. Mild boost.
         "knowledge-update" => PipelineConfig {
-            signal_mask: [1.0, 1.5, 1.0, 0.5, 1.0, 1.0, 0.0],
+            signal_mask: [1.0, 1.5, 1.0, 0.5, 1.0, 1.0, 0.0, 1.2],
         },
+        // single-session-user: local-session queries; graph signal
+        // is less valuable than dense similarity. Dampen PPR.
         "single-session-user" => PipelineConfig {
-            signal_mask: [1.5, 1.0, 1.0, 0.5, 1.0, 1.0, 0.0],
+            signal_mask: [1.5, 1.0, 1.0, 0.5, 1.0, 1.0, 0.0, 0.5],
         },
+        // single-session-assistant: same reasoning as -user; graph
+        // adds noise when the question is about the assistant's own
+        // prior output. Dampen PPR.
         "single-session-assistant" => PipelineConfig {
-            signal_mask: [1.0, 1.0, 1.0, 0.5, 1.0, 1.5, 0.0],
+            signal_mask: [1.0, 1.0, 1.0, 0.5, 1.0, 1.5, 0.0, 0.5],
         },
-        "single-session-preference" => PipelineConfig::IDENTITY,
+        // single-session-preference: broad-baseline fallback. Most
+        // slots stay at identity (1.0), but PPR is explicitly damped
+        // — preferences are usually local-session and don't benefit
+        // from cross-session entity traversal. Phase 2C breaks the
+        // pre-2C "preference == IDENTITY" invariant; the bot-tests
+        // that pinned that invariant are updated.
+        "single-session-preference" => PipelineConfig {
+            signal_mask: [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.0, 0.5],
+        },
         // Unknown / future types: identity mask, strictly non-destructive.
         _ => PipelineConfig::IDENTITY,
     }
@@ -532,13 +571,17 @@ mod tests {
     fn pipeline_config_unknown_type_is_identity() {
         let cfg = pipeline_config_for("unknown-type");
         assert_eq!(cfg, PipelineConfig::IDENTITY);
-        assert_eq!(cfg.signal_mask, [1.0; 7]);
+        assert_eq!(cfg.signal_mask, [1.0; 8]);
     }
 
     #[test]
     fn pipeline_config_temporal_mask() {
+        // Slot order: [vec, bm25, activation, spread, intent,
+        // confidence, entity_affinity, ppr]. Phase 2C added the PPR
+        // slot at index 7; for temporal-reasoning it is 1.2 per the
+        // brief (mild boost — cross-session entity continuity).
         let cfg = pipeline_config_for("temporal-reasoning");
-        assert_eq!(cfg.signal_mask, [1.0, 1.0, 0.5, 1.0, 1.0, 0.5, 0.0]);
+        assert_eq!(cfg.signal_mask, [1.0, 1.0, 0.5, 1.0, 1.0, 0.5, 0.0, 1.2]);
     }
 
     #[test]
@@ -552,49 +595,92 @@ mod tests {
             "single-session-preference",
         ] {
             let cfg = pipeline_config_for(qt);
+            assert_eq!(
+                cfg.signal_mask.len(),
+                8,
+                "signal_mask must be 8 slots after Phase 2C: {qt}"
+            );
             // Each mask entry must be non-negative (multiplicative
             // masks; negative would invert the RRF ranking sign).
             for (i, &v) in cfg.signal_mask.iter().enumerate() {
                 assert!(v >= 0.0, "negative mask value at idx {i} for {qt}: {v}");
             }
         }
-        // The PPR slot (index 6) is reserved for the future PPR signal
-        // (Phase 2C). For the five explicit per-route masks it is
-        // currently 0.0; the `single-session-preference` route uses
-        // IDENTITY ([1.0; 7]) per the broadest-baseline rationale.
-        // The engine integration applies the mask only to slots 0..6,
-        // so the slot-6 value is operationally a no-op today either
-        // way.
+        // Slot 6 (entity_affinity) is left at 0.0 in every explicit
+        // per-route mask because the engine's `masked_weight` guard
+        // preserves `rrf_weights[6]` regardless of the mask value —
+        // so a 0.0 here is operationally a no-op. The
+        // `single-session-preference` route also pins slot 6 to 0.0
+        // for consistency with the other explicit routes.
         for qt in [
             "temporal-reasoning",
             "multi-session",
             "knowledge-update",
             "single-session-user",
             "single-session-assistant",
+            "single-session-preference",
         ] {
             let cfg = pipeline_config_for(qt);
             assert!(
                 (cfg.signal_mask[6] - 0.0).abs() < f32::EPSILON,
-                "explicit per-route mask PPR slot should be 0.0 for {qt}"
+                "explicit per-route mask entity_affinity slot should be 0.0 for {qt}"
             );
         }
-        // single-session-preference uses IDENTITY ([1.0; 7]).
-        assert_eq!(
-            pipeline_config_for("single-session-preference"),
-            PipelineConfig::IDENTITY
+    }
+
+    #[test]
+    fn pipeline_config_preference_dampens_ppr_keeps_other_slots_at_identity() {
+        // Phase 2C breaks the pre-2C "preference == IDENTITY"
+        // invariant: preferences are usually local-session and do not
+        // benefit from cross-session entity traversal, so slot 7
+        // (PPR) is dampened to 0.5 while slots 0..5 remain at 1.0.
+        // Slot 6 (entity_affinity) is the conventional 0.0 no-op
+        // marker shared with the other explicit per-route masks.
+        let cfg = pipeline_config_for("single-session-preference");
+        for i in 0..6 {
+            assert!(
+                (cfg.signal_mask[i] - 1.0).abs() < f32::EPSILON,
+                "preference mask should be identity at slot {i} (got {})",
+                cfg.signal_mask[i]
+            );
+        }
+        assert!(
+            (cfg.signal_mask[7] - 0.5).abs() < f32::EPSILON,
+            "preference PPR slot should be dampened to 0.5 (got {})",
+            cfg.signal_mask[7]
         );
     }
 
     #[test]
-    fn pipeline_config_preference_is_identity() {
-        let cfg = pipeline_config_for("single-session-preference");
-        // Identity mask on slots 0..5 (preferences are the broadest baseline).
-        for i in 0..6 {
-            assert!(
-                (cfg.signal_mask[i] - 1.0).abs() < f32::EPSILON,
-                "preference mask should be identity at slot {i}"
-            );
-        }
+    fn pipeline_config_ppr_slot_per_route() {
+        // Phase 2C: lock in the per-route PPR weights so future tuning
+        // is visible in PR diffs.
+        assert!(
+            (pipeline_config_for("multi-session").signal_mask[7] - 1.5).abs() < f32::EPSILON,
+            "multi-session: PPR boost"
+        );
+        assert!(
+            (pipeline_config_for("temporal-reasoning").signal_mask[7] - 1.2).abs() < f32::EPSILON,
+            "temporal-reasoning: mild PPR boost"
+        );
+        assert!(
+            (pipeline_config_for("knowledge-update").signal_mask[7] - 1.2).abs() < f32::EPSILON,
+            "knowledge-update: mild PPR boost"
+        );
+        assert!(
+            (pipeline_config_for("single-session-user").signal_mask[7] - 0.5).abs() < f32::EPSILON,
+            "single-session-user: PPR damped"
+        );
+        assert!(
+            (pipeline_config_for("single-session-assistant").signal_mask[7] - 0.5).abs()
+                < f32::EPSILON,
+            "single-session-assistant: PPR damped"
+        );
+        assert!(
+            (pipeline_config_for("single-session-preference").signal_mask[7] - 0.5).abs()
+                < f32::EPSILON,
+            "single-session-preference: PPR damped"
+        );
     }
 
     #[test]

--- a/pensyve-core/tests/test_diversity.rs
+++ b/pensyve-core/tests/test_diversity.rs
@@ -46,6 +46,7 @@ fn make_candidate(embedding: Vec<f32>, relevance_marker: f32) -> ScoredCandidate
         confidence_score: 1.0,
         entity_score: 0.0,
         type_boost: 1.0,
+        ppr_score: None,
         final_score: relevance_marker,
     }
 }

--- a/pensyve-mcp-gateway/src/main.rs
+++ b/pensyve-mcp-gateway/src/main.rs
@@ -151,7 +151,7 @@ fn init_resources(config: &GatewayConfig) -> Result<InitResources> {
         weights: [0.30, 0.15, 0.20, 0.10, 0.10, 0.05, 0.05, 0.05],
         recall_timeout_secs: 5,
         rrf_k: 60,
-        rrf_weights: [1.0, 0.8, 1.0, 0.8, 0.5, 0.5, 1.2],
+        rrf_weights: [1.0, 0.8, 1.0, 0.8, 0.5, 0.5, 1.2, 1.0],
         beam_width: 10,
         max_depth: 4,
     };

--- a/pensyve-mcp-gateway/src/tenant.rs
+++ b/pensyve-mcp-gateway/src/tenant.rs
@@ -179,7 +179,7 @@ mod tests {
             weights: [0.30, 0.15, 0.20, 0.10, 0.10, 0.05, 0.05, 0.05],
             recall_timeout_secs: 5,
             rrf_k: 60,
-            rrf_weights: [1.0, 0.8, 1.0, 0.8, 0.5, 0.5, 1.2],
+            rrf_weights: [1.0, 0.8, 1.0, 0.8, 0.5, 0.5, 1.2, 1.0],
             beam_width: 10,
             max_depth: 4,
         };

--- a/pensyve-mcp-gateway/tests/integration_test.rs
+++ b/pensyve-mcp-gateway/tests/integration_test.rs
@@ -34,7 +34,7 @@ fn create_test_state(dir: &tempfile::TempDir) -> Arc<PensyveState> {
             weights: [0.30, 0.15, 0.20, 0.10, 0.10, 0.05, 0.05, 0.05],
             recall_timeout_secs: 5,
             rrf_k: 60,
-            rrf_weights: [1.0, 0.8, 1.0, 0.8, 0.5, 0.5, 1.2],
+            rrf_weights: [1.0, 0.8, 1.0, 0.8, 0.5, 0.5, 1.2, 1.0],
             beam_width: 10,
             max_depth: 4,
         },

--- a/pensyve-mcp-gateway/tests/test_multi_tenant_propagation.rs
+++ b/pensyve-mcp-gateway/tests/test_multi_tenant_propagation.rs
@@ -77,7 +77,7 @@ fn make_mgr(dir: &tempfile::TempDir) -> Arc<TenantStateManager> {
             weights: [0.30, 0.15, 0.20, 0.10, 0.10, 0.05, 0.05, 0.05],
             recall_timeout_secs: 5,
             rrf_k: 60,
-            rrf_weights: [1.0, 0.8, 1.0, 0.8, 0.5, 0.5, 1.2],
+            rrf_weights: [1.0, 0.8, 1.0, 0.8, 0.5, 0.5, 1.2, 1.0],
             beam_width: 10,
             max_depth: 4,
         },

--- a/pensyve-mcp/src/main.rs
+++ b/pensyve-mcp/src/main.rs
@@ -152,7 +152,7 @@ async fn main() -> Result<()> {
         weights: [0.30, 0.15, 0.20, 0.10, 0.10, 0.05, 0.05, 0.05],
         recall_timeout_secs: 5,
         rrf_k: 60,
-        rrf_weights: [1.0, 0.8, 1.0, 0.8, 0.5, 0.5, 1.2],
+        rrf_weights: [1.0, 0.8, 1.0, 0.8, 0.5, 0.5, 1.2, 1.0],
         beam_width: 10,
         max_depth: 4,
     };

--- a/pensyve-mcp/tests/integration_test.rs
+++ b/pensyve-mcp/tests/integration_test.rs
@@ -54,7 +54,7 @@ impl TestState {
             weights: [0.30, 0.15, 0.20, 0.10, 0.10, 0.05, 0.05, 0.05],
             recall_timeout_secs: 5,
             rrf_k: 60,
-            rrf_weights: [1.0, 0.8, 1.0, 0.8, 0.5, 0.5, 1.2],
+            rrf_weights: [1.0, 0.8, 1.0, 0.8, 0.5, 0.5, 1.2, 1.0],
             beam_width: 10,
             max_depth: 4,
         };


### PR DESCRIPTION
Phase 2C of the algorithmic stack — Personalized PageRank retrieval that consumes the dependency-parse KG materialized in Phase 2B (#115) and contributes an 8th signal to RRF fusion.

Plan: [pensyve-docs/plans/2026-05-21-pensyve-phase2-algorithmic-stack.md §Phase 2C](../../major7apps/pensyve-docs/blob/main/plans/2026-05-21-pensyve-phase2-algorithmic-stack.md)
Research substrate: [pensyve-docs/research/2026-05-21-memory-pipeline-decomposition.md §5.1](../../major7apps/pensyve-docs/blob/main/research/2026-05-21-memory-pipeline-decomposition.md) (HippoRAG / HippoRAG 2 / SPRIG)

## Summary

- New `pensyve-core/src/retrieval/ppr.rs` (~984 LOC including 11 unit tests). Hand-rolled sparse CSR + power iteration; **no `nalgebra` / `sprs` dependency** (locked design).
- `rrf_weights` extended from `[f32; 7]` → `[f32; 8]` across the workspace. Slot 7 = PPR weight (default `1.0`). The existing `entity_affinity` slot (6) is preserved unchanged so we can A/B PPR independently of entity affinity.
- SelRoute's 5 typed-route masks (`query_classifier.rs`) extended to 8 slots with per-route PPR multipliers: `multi-session 1.5` (headline win), `temporal-reasoning 1.2`, `knowledge-update 1.2`, `single-session-*  0.5` (local sessions).
- `RecallEngine` gains `with_ppr(index)` builder + 8th signal contribution to RRF fusion. When PPR is active, the BFS spreading-activation signal is zeroed out to avoid double-counting graph signal.
- `ScoredCandidate.ppr_score: Option<f32>` added for SDK propagation (additive, non-breaking).
- Hub-entity degree dampening (`raw_weight / (1 + ln(degree))`) applied at build time. Row-stochastic normalization (terminology fix vs the plan's "column-stochastic" — the math is unchanged; `A^T` is the PPR transition matrix when rows are normalized).
- `PENSYVE_PPR=1` (default off; useful only when `PENSYVE_DEP_PARSE=1` is also set). `OnceLock`-cached env read.
- 5 new `PensyveMetrics` fields: `ppr_query_count`, `ppr_iterations_total`, `ppr_convergence_failures`, `ppr_entity_seeds_count` (counters), `ppr_duration` (HistogramBuckets).

## Acceptance criteria

| Criterion | Status |
|---|---|
| PPR converges in ≤ 20 iters on benchmark graph | ✅ 10k-passage criterion bench converges; small bipartite test graphs are pathologically slow and use larger `max_iter` (50–200) — see deviation #1 |
| `ppr_convergence_failures` counter remains 0 across the test suite | ✅ |
| `PprIndex::build_from_storage` < 500 ms for 10k passages | ✅ criterion mean **10.24 ms** (~50× headroom) |
| Binary size growth < 20 KB | ✅ no new crate deps (verified `Cargo.toml` unchanged) |
| Hub-entity dampening: hub's passages don't dominate top-k | ✅ explicit unit test |
| Empty graph returns empty ranking (no panics, no NaN) | ✅ |
| Disconnected components: unreachable passages have zero mass | ✅ |
| Full workspace test suite passes | ✅ 711 → **740** lib + integration tests (+29 net) |
| `cargo clippy --workspace --all-targets -- -D warnings` clean | ✅ |
| `cargo fmt --check` clean | ✅ |

Companion `ppr_query_10k_passages_alpha_0_15` criterion bench: **mean 385 µs**.

## Deviations from the plan (documented inline)

1. **Convergence tolerance `1e-4`, not `1e-6`.** The plan's "≤ 20 iters AND ||·||_1 < 1e-6 AND α = 0.15" is numerically unreachable: per-iteration L1 contraction at α=0.15 is ≈ (1-α) = 0.85, so ||·||_1 < 1e-6 needs roughly ⌈log(1e-6) / log(0.85)⌉ ≈ 85 iters. `1e-4` is HippoRAG's published f32-precision tolerance for power iteration and is reachable within the 20-iter envelope on the production-size graphs where this code runs. Inline rationale at `ppr.rs:84` + extended explanation at `ppr.rs:544-550`.
2. **`rebuild_incremental` is a full rebuild in v1.** Scope-correct incremental requires re-running entity-degree dampening across every entity whose row-stochastic normalization is affected, which cascades widely. The signature keeps `new_passages: &[Uuid]` so the API is forward-compatible; deferred as a Phase 3 optimization. Documented inline.
3. **Ingest-path wiring for `rebuild_incremental` deferred to Phase 2D.** D-MEM (Phase 2D) introduces the first session-context struct that holds a `PprIndex` mutably; today callers rebuild out-of-band.
4. **Row-stochastic vs column-stochastic.** The plan said "column-stochastic" but row-stochastic is what makes `A^T` the PPR transition matrix. Math is the same; the comment terminology is corrected.
5. **Degree-dampener formula `raw / (1 + ln(degree))` instead of `1 / log(1 + degree)`.** Same monotonicity, but `raw / (1 + ln(degree))` preserves `weight == 0` → `0` cleanly and is the standard HippoRAG formulation. Documented inline.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace` — 740 passing (was 711 after Phase 2B; +29 net new)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Criterion bench `ppr_build_from_storage_10k_passages` — 10.24 ms mean
- [x] Criterion bench `ppr_query_10k_passages_alpha_0_15` — 385 µs mean

## Out of scope (locked)

- LongMemEval-S A/B sweep — that's Phase 2F
- D-MEM gate (Phase 2D) and Vendi rerank (Phase 2E) remain untouched
- Default behavior unchanged with both `PENSYVE_DEP_PARSE` and `PENSYVE_PPR` off

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrated Personalized PageRank (PPR) as an optional retrieval signal and expanded fusion from 7→8 components.

* **Observability**
  * Added PPR metrics: query counts, iterations, convergence failures, seed counts, and duration histogram.

* **Tests**
  * Added benchmarks and updated unit/integration tests to cover PPR behavior and the 8-slot signal layout.

* **Chores**
  * Config defaults and deserialization updated to accept legacy 7-entry weights (padded) and default to the new 8-entry layout.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/major7apps/pensyve/pull/116?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->