### PR TITLE
Fix npm release publishing and rebuild reliability

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: write
-  id-token: write
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,6 +108,9 @@ jobs:
         if: env.HAS_NPM_TOKEN != ''
         working-directory: pensyve-ts
         shell: bash
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          HAS_NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 env:
   CARGO_TERM_COLOR: always
@@ -88,6 +89,9 @@ jobs:
     name: Publish to npm
     runs-on: ubuntu-latest
     environment: release
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v5
       - uses: oven-sh/setup-bun@v2
@@ -100,10 +104,46 @@ jobs:
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
-      - name: Publish to npm
+      - name: Check npm publish access
         if: env.HAS_NPM_TOKEN != ''
         working-directory: pensyve-ts
-        run: npm publish --access public
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          PACKAGE_NAME="$(node -p "require('./package.json').name")"
+          PACKAGE_VERSION="$(node -p "require('./package.json').version")"
+
+          if npm view "${PACKAGE_NAME}@${PACKAGE_VERSION}" version --json >/dev/null 2>&1; then
+            echo "${PACKAGE_NAME}@${PACKAGE_VERSION} already exists on npm; skipping publish."
+            echo "NPM_SHOULD_PUBLISH=false" >> "$GITHUB_ENV"
+            exit 0
+          fi
+
+          if ! NPM_USER="$(npm whoami 2>/tmp/npm-whoami.err)"; then
+            echo "::error::NPM_TOKEN is set but npm authentication failed. Replace it with an automation or granular token that can publish ${PACKAGE_NAME}."
+            cat /tmp/npm-whoami.err >&2
+            exit 1
+          fi
+
+          if ! OWNERS="$(npm owner ls "${PACKAGE_NAME}" 2>/tmp/npm-owner.err)"; then
+            echo "::error::Unable to read owners for ${PACKAGE_NAME}. The NPM_TOKEN user may not have package access."
+            cat /tmp/npm-owner.err >&2
+            exit 1
+          fi
+
+          if ! printf '%s\n' "$OWNERS" | awk '{print $1}' | grep -Fx "$NPM_USER" >/dev/null; then
+            echo "::error::NPM_TOKEN authenticates as ${NPM_USER}, but that user is not an owner of ${PACKAGE_NAME}."
+            echo "Owners returned by npm:"
+            printf '%s\n' "$OWNERS"
+            exit 1
+          fi
+
+          echo "NPM_SHOULD_PUBLISH=true" >> "$GITHUB_ENV"
+      - name: Publish to npm
+        if: env.HAS_NPM_TOKEN != '' && env.NPM_SHOULD_PUBLISH == 'true'
+        working-directory: pensyve-ts
+        run: npm publish --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           HAS_NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -128,6 +168,7 @@ jobs:
     name: Build CLI (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest
@@ -143,6 +184,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        continue-on-error: true
         with:
           key: cli-${{ matrix.target }}
       - name: Build CLI
@@ -183,6 +225,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        continue-on-error: true
         with:
           key: mcp-${{ matrix.target }}
       - name: Build MCP server

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Your agent stops being amnesiac. Decisions, patterns, and outcomes persist acros
 
 ```bash
 pip install pensyve          # Python (PyPI)
-npm install pensyve          # TypeScript (npm)
+npm install @pensyve/sdk     # TypeScript (npm)
 go get github.com/major7apps/pensyve/pensyve-go@latest  # Go
 ```
 
@@ -330,7 +330,7 @@ curl -X POST http://localhost:3000/v1/recall_grouped \
 HTTP client with timeout, retry, and structured errors.
 
 ```typescript
-import { Pensyve } from "pensyve";
+import { Pensyve } from "@pensyve/sdk";
 
 const p = new Pensyve({
   baseUrl: "http://localhost:3000",

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -235,15 +235,15 @@ HTTP client with configurable timeout, retry, and structured errors.
 ### Install
 
 ```bash
-npm install pensyve
+npm install @pensyve/sdk
 # or
-bun add pensyve
+bun add @pensyve/sdk
 ```
 
 ### Quick start
 
 ```typescript
-import { Pensyve } from "pensyve";
+import { Pensyve } from "@pensyve/sdk";
 
 const p = new Pensyve({
   baseUrl: "http://localhost:3000", // local gateway

--- a/pensyve-ts/README.md
+++ b/pensyve-ts/README.md
@@ -1,6 +1,6 @@
-# pensyve
+# @pensyve/sdk
 
-[![npm](https://img.shields.io/npm/v/pensyve)](https://www.npmjs.com/package/pensyve)
+[![npm](https://img.shields.io/npm/v/@pensyve/sdk)](https://www.npmjs.com/package/@pensyve/sdk)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://github.com/major7apps/pensyve/blob/main/LICENSE)
 
 TypeScript SDK for **[Pensyve](https://pensyve.com)** — the universal memory runtime for AI agents.
@@ -10,15 +10,15 @@ Give your agents durable memory that persists across sessions, learns from outco
 ## Install
 
 ```bash
-npm install pensyve
+npm install @pensyve/sdk
 # or
-bun add pensyve
+bun add @pensyve/sdk
 ```
 
 ## Quick Start
 
 ```typescript
-import { Pensyve } from "pensyve";
+import { Pensyve } from "@pensyve/sdk";
 
 const pensyve = new Pensyve({
   baseUrl: "http://localhost:8000",

--- a/pensyve-ts/package.json
+++ b/pensyve-ts/package.json
@@ -17,7 +17,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/major7apps/pensyve.git",
+    "url": "git+https://github.com/major7apps/pensyve.git",
     "directory": "pensyve-ts"
   },
   "homepage": "https://pensyve.com",


### PR DESCRIPTION
## Summary
- add npm publish preflight for `@pensyve/sdk` auth, owner validation, already-published version skips, and provenance publishing
- keep release binary builds moving when rust-cache fails and disable CLI matrix fail-fast so one target does not cancel the rest
- correct TypeScript SDK npm install/import docs and package repository URL

## Root Cause
The v2.5.0 npm publish failed after a successful TS build because the configured `NPM_TOKEN` was rejected for publishing `@pensyve/sdk@2.5.0`. The package exists and is public, so the workflow now fails earlier with a specific owner/auth diagnostic instead of surfacing npm's generic E404. Separately, the Windows CLI cache failure cancelled the rest of the CLI matrix; the workflow now treats cache restore as best-effort and uses `fail-fast: false`.

## Test Plan
- `python3` JSON parse for `pensyve-ts/package.json`
- `python3` YAML parse for `.github/workflows/release.yml`
- static workflow text assertions for npm preflight/provenance and release cache handling
- docs scan for stale `pensyve` npm install/import examples
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions and TypeScript SDK examples to use the new package name.

* **Chores**
  * Unified package naming across docs and package metadata.
  * Improved CI publishing flow to gate npm publishes, expanded workflow permissions, and made build jobs more resilient to cache/step failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/major7apps/pensyve/pull/121?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->