### PR TITLE
[codex] add native Pensyve command and mention workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ See [`integrations/claude-code/README.md`](integrations/claude-code/README.md) f
 
 ### Codex Plugin
 
-First-class working memory for OpenAI Codex with a plugin manifest, bundled MCP server config, hooks, skills, and `$pensyve` skill invocation.
+First-class working memory for OpenAI Codex with a plugin manifest, bundled MCP server config, hooks, skills, `/pensyve`, and `$pensyve` skill invocation.
 
 Add this repo's Codex plugin as a local marketplace, then install it:
 
@@ -293,7 +293,7 @@ Set your API key for the bundled MCP server:
 export PENSYVE_API_KEY="psy_your_key_here"
 ```
 
-The plugin bundles `integrations/codex-plugin/.mcp.json`, so Codex can load the Pensyve MCP server without copying a project config file. Use `/skills` or `$pensyve` for explicit memory work, or let the bundled hooks and instructions prompt Codex to recall before substantive project decisions.
+The plugin bundles `integrations/codex-plugin/.mcp.json`, so Codex can load the Pensyve MCP server without copying a project config file. Use `/skills`, `$pensyve`, or `/pensyve` for explicit memory work, or let the bundled hooks and instructions prompt Codex to recall before substantive project decisions. `@pensyve` is documented as a text-level compatibility convention; true native Codex @-mention dispatch still needs platform support.
 
 See [`integrations/codex-plugin/README.md`](integrations/codex-plugin/README.md) for the manual fallback and local-stdio setup.
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -88,9 +88,11 @@ Try it:
 ```
 $pensyve what do you remember about this project?
 $pensyve remember that auth-service uses RS256 signing
+/pensyve status
+@pensyve recall release workflow decisions
 ```
 
-The plugin bundles its `.mcp.json`, skills, hooks, assets, and install metadata. Current Codex explicit invocation uses `/skills` or `$pensyve`; app-style `$app-slug` invocation can be added later through `.app.json` when a registered Pensyve Codex app/connector exists.
+The plugin bundles its `.mcp.json`, skills, commands, hooks, assets, and install metadata. Current reliable Codex explicit invocation uses `/skills`, `$pensyve`, or `/pensyve`. The `@pensyve` form is a text-level compatibility convention, not native autocomplete or selector behavior; app-style `$app-slug` invocation can be added later through `.app.json` when a registered Pensyve Codex app/connector exists.
 
 ### Local
 

--- a/docs/agent-context.md
+++ b/docs/agent-context.md
@@ -159,6 +159,7 @@ First-class OpenAI Codex plugin package:
 
 - Bundled `.mcp.json` for the Pensyve Cloud MCP server using `PENSYVE_API_KEY`
 - Skills including `pensyve` for Codex-native `$pensyve` invocation
+- `/pensyve` command and `mention-workflow` skill for explicit and text-level `@pensyve` memory requests
 - Lifecycle hooks: SessionStart and UserPromptSubmit
 - Local marketplace metadata under `.agents/plugins/marketplace.json`
 - Manual `AGENTS.md` fallback for Codex environments without plugin support

--- a/integrations/codex-plugin/.codex-plugin/plugin.json
+++ b/integrations/codex-plugin/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pensyve",
-  "version": "1.4.0",
-  "description": "Persistent working memory for Codex with Pensyve recall, capture, hooks, skills, and MCP tools",
+  "version": "1.4.1",
+  "description": "Persistent working memory for Codex with Pensyve recall, capture, hooks, skills, commands, and MCP tools",
   "author": {
     "name": "Major7 Apps",
     "url": "https://github.com/major7apps/pensyve"
@@ -15,10 +15,10 @@
   "interface": {
     "displayName": "Pensyve",
     "shortDescription": "Working memory for Codex agents",
-    "longDescription": "Give Codex persistent project memory that survives across sessions. Pensyve stores decisions, patterns, preferences, and outcomes, then retrieves the right context with the current retrieval stack: SelRoute classification, dependency-parse knowledge graph construction, Personalized PageRank, RPE-gated consolidation, and Vendi-Score diversity reranking when their gates are enabled.",
+    "longDescription": "Give Codex persistent project memory that survives across sessions. Pensyve stores decisions, patterns, preferences, and outcomes, then retrieves the right context with the current retrieval stack: SelRoute classification, dependency-parse knowledge graph construction, Personalized PageRank, RPE-gated consolidation, and Vendi-Score diversity reranking when their gates are enabled. Explicit workflows are available through $pensyve, /pensyve, and a text-level @pensyve compatibility convention while native Codex @-mention dispatch is pending platform support.",
     "developerName": "Major7 Apps",
     "category": "Productivity",
-    "capabilities": ["Interactive", "Write", "MCP", "Skills", "Hooks"],
+    "capabilities": ["Interactive", "Write", "MCP", "Skills", "Hooks", "Commands"],
     "websiteURL": "https://pensyve.com",
     "brandColor": "#2E6F68",
     "composerIcon": "./assets/pensyve-icon.svg",
@@ -26,6 +26,7 @@
     "defaultPrompt": [
       "Use Pensyve to recall relevant project memory before we continue.",
       "$pensyve what do you remember about this project?",
+      "/pensyve status",
       "$pensyve review my memory health and suggest cleanup."
     ]
   }

--- a/integrations/codex-plugin/CHANGELOG.md
+++ b/integrations/codex-plugin/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to the Pensyve Codex CLI adapter are documented in this file
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). The Codex CLI adapter versions independently of the Claude Code plugin.
 
+## [1.4.1] - 2026-05-24
+
+### Added
+
+- `/pensyve` Codex command for explicit recall, remember, observe, inspect, status, review, forget, and mention-help workflows.
+- `mention-workflow` skill that treats literal `@pensyve` text as explicit memory intent while documenting that true Codex @-mention dispatch is not currently exposed for local plugin bundles.
+- Short architecture brief covering desired UX, @-mention feasibility, plugin layout, MCP/local integration, auth/config, and migration from the Claude Code plugin.
+
+### Changed
+
+- Plugin metadata, README, and static validation now include command and mention-workflow surfaces.
+
 ## [1.4.0] - 2026-05-24
 
 ### Added

--- a/integrations/codex-plugin/README.md
+++ b/integrations/codex-plugin/README.md
@@ -31,6 +31,7 @@ The plugin bundles:
 
 - `.mcp.json` for the Pensyve MCP server
 - `skills/` including the first-class `pensyve` skill for `$pensyve` invocation
+- `commands/` including `/pensyve` for explicit recall, remember, inspect, status, and review flows
 - `hooks/hooks.json` for SessionStart and UserPromptSubmit memory guidance
 - install metadata and assets for Codex plugin surfaces
 
@@ -96,7 +97,17 @@ Codex CLI automatically loads `AGENTS.md` from the project root into every agent
 
 Pensyve now ships as a native Codex plugin package. The manifest points Codex at bundled skills, the plugin-scoped `.mcp.json`, and lifecycle hooks. The Memory Reflex Rule in `AGENTS.md` remains the reasoning layer: *before substantive answers, recall by entity; when a lesson lands, observe immediately with a one-line surface*. Flow sections (When Debugging, When Designing, When Refactoring, Longitudinal Work) guide the model through consult-memory + capture-lesson steps.
 
-**Codex-native invocation:** select the `pensyve` skill through `/skills` or type `$pensyve` in the prompt. Current Codex docs use `$skill` and `$app-slug` mentions for explicit invocation; the plugin is structured so a future registered Pensyve app/connector can be added via `.app.json` without changing the memory rules.
+**Codex-native invocation:** select the `pensyve` skill through `/skills`, type `$pensyve`, or use `/pensyve` for explicit memory work. Current Codex plugin guidance supports plugin and skill installation/discovery, while the local plugin model does not expose true `@pensyve` composer dispatch. The plugin therefore treats `@pensyve recall ...` as a text-level compatibility convention when the model sees it, and is structured so a future registered Pensyve app/connector can be added via `.app.json` without changing the memory rules.
+
+**Mention-style examples:**
+
+```text
+$pensyve what do you remember about this project?
+/pensyve recall release workflow decisions
+@pensyve recall Codex plugin install decisions
+```
+
+The `@pensyve` form is not native autocomplete or selector behavior today. It is a readable convention that routes through the same MCP tools as `$pensyve` and `/pensyve`.
 
 **Episode lifecycle:** Hooks can prime the model at session start and prompt submit, but episodes still open lazily on the first `pensyve_observe` call. Server-side consolidation handles aging.
 
@@ -148,6 +159,8 @@ See [MCP Tools Reference](https://pensyve.com/docs/api-reference/mcp-tools) for 
 - **Memory as substrate** — not a feature the user invokes; always there, continuous, carried across sessions
 - **Codex-first package** — plugin manifest, bundled MCP server, hooks, skills, assets, and local marketplace metadata
 - **Skill invocation** — `$pensyve` gives users an explicit memory entry point while implicit recall still works for substantive work
+- **Command invocation** — `/pensyve` gives users a command-shaped entry point for recall, remember, inspect, status, and review
+- **Mention-compatible convention** — `@pensyve` is accepted as user intent in text while true Codex @-mention dispatch waits on platform support
 - **1:1 memory model with Claude Code** — same conventions and same memory types, adapted to Codex's plugin and skill surfaces
 - **MCP contract-respecting** — every rule's call examples verified against `pensyve-mcp-tools/src/params.rs`
 - **Single-file fallback** — Codex CLI's `AGENTS.md` remains available for environments that cannot install plugins
@@ -157,6 +170,7 @@ See [MCP Tools Reference](https://pensyve.com/docs/api-reference/mcp-tools) for 
 - **Website:** [pensyve.com](https://pensyve.com)
 - **GitHub:** [github.com/major7apps/pensyve](https://github.com/major7apps/pensyve)
 - **Spec:** [Working-memory substrate design](https://github.com/major7apps/pensyve-docs/blob/main/specs/2026-04-18-pensyve-working-memory-substrate-design.md)
+- **Codex plugin architecture:** [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)
 
 ## License
 

--- a/integrations/codex-plugin/README.md
+++ b/integrations/codex-plugin/README.md
@@ -144,6 +144,7 @@ Use `/plugins` to disable or uninstall the plugin. If you installed the fallback
 
 | Tool | Description |
 |---|---|
+| `pensyve_status` | Check connection, namespace, and memory stats for `/pensyve status` |
 | `pensyve_recall` | Search memories by semantic similarity |
 | `pensyve_remember` | Store a durable fact (semantic memory) |
 | `pensyve_observe` | Record a session observation (episodic / procedural via `[procedural]` prefix) |

--- a/integrations/codex-plugin/commands/pensyve.md
+++ b/integrations/codex-plugin/commands/pensyve.md
@@ -1,5 +1,5 @@
 ---
-description: Route explicit Pensyve memory requests through the bundled MCP server; supports recall, remember, inspect, status, review, and mention-style guidance.
+description: Route explicit Pensyve memory requests through the bundled MCP server; supports recall, remember, observe, inspect, status, review, forget, and mention-style guidance.
 ---
 
 # Pensyve Memory Command
@@ -11,8 +11,8 @@ the existing Pensyve MCP tools and CLI surfaces instead of duplicating memory lo
 
 1. Read the user's request after `/pensyve`.
    - Treat literal `@pensyve` text as the same explicit memory intent.
-   - If no action is specified, ask whether the user wants recall, remember, inspect, status, or
-     memory review.
+   - If no action is specified, ask whether the user wants recall, remember, observe, inspect,
+     status, review, forget, or mention-help.
 2. Check whether Pensyve MCP tools are available.
    - If available, call `pensyve_status` for status requests or proceed directly to the requested
      MCP operation.

--- a/integrations/codex-plugin/commands/pensyve.md
+++ b/integrations/codex-plugin/commands/pensyve.md
@@ -40,7 +40,7 @@ comparison, or write-after-read workflow.
 
 Use the existing MCP surface:
 
-```
+```text
 pensyve_status
 pensyve_recall(query, entity?, types?, limit?, min_confidence?)
 pensyve_remember(entity, fact, confidence?)
@@ -52,7 +52,7 @@ pensyve_forget(entity)
 
 Examples:
 
-```
+```text
 /pensyve recall decisions about release workflow
 /pensyve remember that npm provenance needs id-token: write
 /pensyve status
@@ -86,7 +86,7 @@ For destructive actions:
 
 Return a concise result:
 
-```
+```md
 ## Result
 - Action: recall | remember | observe | inspect | status | review | forget | mention-help
 - Entity: <entity or none>

--- a/integrations/codex-plugin/commands/pensyve.md
+++ b/integrations/codex-plugin/commands/pensyve.md
@@ -1,0 +1,103 @@
+---
+description: Route explicit Pensyve memory requests through the bundled MCP server; supports recall, remember, inspect, status, review, and mention-style guidance.
+---
+
+# Pensyve Memory Command
+
+Use `/pensyve` for explicit memory work in Codex. This command is intentionally thin: it routes to
+the existing Pensyve MCP tools and CLI surfaces instead of duplicating memory logic.
+
+## Preflight
+
+1. Read the user's request after `/pensyve`.
+   - Treat literal `@pensyve` text as the same explicit memory intent.
+   - If no action is specified, ask whether the user wants recall, remember, inspect, status, or
+     memory review.
+2. Check whether Pensyve MCP tools are available.
+   - If available, call `pensyve_status` for status requests or proceed directly to the requested
+     MCP operation.
+   - If unavailable, report: "Pensyve MCP is not connected for this session."
+3. Do not read or write local memory files, `.claude/` files, or plugin metadata as memory storage.
+4. Strip secrets, API keys, passwords, tokens, private URLs, and credentials before any write.
+
+## Plan
+
+Classify the request into one action:
+
+- **recall**: answer from relevant memories with `pensyve_recall`.
+- **remember**: store a durable fact with `pensyve_remember`.
+- **observe**: capture a session outcome or procedure with `pensyve_observe`.
+- **inspect**: list memory for one entity with `pensyve_inspect`.
+- **status**: check connection, namespace, and memory stats with `pensyve_status`.
+- **review**: use the `memory-review` skill and its confirmation workflow.
+- **forget**: require explicit confirmation, then call `pensyve_forget`.
+- **mention-help**: explain the current `$pensyve`, `/pensyve`, and `@pensyve` options.
+
+Prefer one MCP call for simple requests. Use multiple calls only when the user asks for a review,
+comparison, or write-after-read workflow.
+
+## Commands
+
+Use the existing MCP surface:
+
+```
+pensyve_status
+pensyve_recall(query, entity?, types?, limit?, min_confidence?)
+pensyve_remember(entity, fact, confidence?)
+pensyve_episode_start(participants)
+pensyve_observe(episode_id, content, source_entity, about_entity, content_type?)
+pensyve_inspect(entity, limit?)
+pensyve_forget(entity)
+```
+
+Examples:
+
+```
+/pensyve recall decisions about release workflow
+/pensyve remember that npm provenance needs id-token: write
+/pensyve status
+/pensyve mention help
+@pensyve recall Codex plugin install decisions
+```
+
+True @-mention dispatch is not currently exposed for local Codex plugin bundles. The `@pensyve`
+form above is a text-level compatibility convention: handle it when the user types it, but do not
+claim Codex provides native `@pensyve` autocomplete or selector behavior.
+
+## Verification
+
+After executing a read:
+
+- Confirm the response came from Pensyve memory, or state that no relevant memories were found.
+- Keep summaries short and avoid dumping raw memory records unless asked.
+
+After executing a write:
+
+- Report the entity, memory type, and sanitized one-line summary that was stored.
+- If a write fails, report the failed item and continue with any non-dependent work.
+
+For destructive actions:
+
+- Re-state the entity targeted for deletion.
+- Wait for explicit confirmation before calling `pensyve_forget(entity)`.
+- After deletion, verify with `pensyve_inspect(entity, limit?)` when available.
+
+## Summary
+
+Return a concise result:
+
+```
+## Result
+- Action: recall | remember | observe | inspect | status | review | forget | mention-help
+- Entity: <entity or none>
+- Status: success | partial | failed
+- Details: <short memory-grounded summary>
+```
+
+## Next Steps
+
+- For missing MCP configuration: set `PENSYVE_API_KEY` for cloud MCP, or configure local stdio with
+  `pensyve-mcp --stdio`.
+- For mention-style workflows: use `$pensyve` or `/pensyve` for reliable explicit invocation today;
+  use `@pensyve` as a readable convention until Codex exposes native plugin mention dispatch.
+- For memory hygiene: run `/pensyve review <entity>` and follow the confirmation prompts.

--- a/integrations/codex-plugin/docs/ARCHITECTURE.md
+++ b/integrations/codex-plugin/docs/ARCHITECTURE.md
@@ -47,7 +47,10 @@ docs/ARCHITECTURE.md            # This brief
 ```
 
 The manifest should stay thin and point at bundled surfaces. Memory behavior belongs in skills,
-commands, hooks, and the MCP server.
+commands, hooks, and the MCP server. Commands are shipped in the `commands/` directory by Codex
+plugin package convention rather than as a `commands` manifest key; the current Codex plugin
+validation schema accepts `skills` and `mcpServers` path fields but rejects unsupported manifest
+fields.
 
 ## MCP And Local Command Integration
 

--- a/integrations/codex-plugin/docs/ARCHITECTURE.md
+++ b/integrations/codex-plugin/docs/ARCHITECTURE.md
@@ -1,0 +1,95 @@
+# Pensyve Codex Plugin Architecture
+
+Short architecture brief for making Pensyve a first-class Codex-native plugin.
+
+## Desired User Experience
+
+Pensyve should feel like Codex working memory, not a separate database task. Users get three layers:
+
+- Ambient memory: hooks and `AGENTS.md` nudge Codex to recall before substantive decisions and
+  capture confirmed lessons.
+- Explicit memory: `$pensyve`, `/skills`, and `/pensyve` route direct memory requests.
+- Mention-style memory: `@pensyve recall ...` is accepted as a text convention and handled by the
+  mention workflow skill.
+
+Common flows:
+
+- `$pensyve what do you remember about this repo?`
+- `/pensyve remember that release publish needs npm provenance permissions`
+- `@pensyve recall Codex plugin install decisions`
+- `/pensyve status`
+
+## @-Mention Feasibility
+
+Codex does not currently expose true @-mention dispatch for local plugin bundles. Local plugin
+surfaces available today are plugin manifests, skills, commands, hooks, app/connector metadata where
+registered, marketplace entries, and MCP server configuration.
+
+That means Pensyve can support a practical `@pensyve` convention in text, but not a native composer
+experience with autocomplete, picker integration, or guaranteed dispatcher semantics. A true
+`@pensyve` workflow needs Codex platform support for plugin mention registration, or a registered
+Pensyve app/connector surface that Codex can expose in the composer.
+
+## Plugin Layout
+
+The current bundle is `integrations/codex-plugin/`:
+
+```text
+.codex-plugin/plugin.json       # Codex plugin manifest
+.agents/plugins/marketplace.json # Local marketplace metadata
+.mcp.json                       # Pensyve Cloud MCP config using PENSYVE_API_KEY
+AGENTS.md                       # Single-file memory substrate fallback
+skills/                         # Codex skills, including pensyve and mention-workflow
+commands/                       # Slash commands, including /pensyve
+hooks/                          # SessionStart and UserPromptSubmit guidance hooks
+assets/                         # Plugin icon and logo
+docs/ARCHITECTURE.md            # This brief
+```
+
+The manifest should stay thin and point at bundled surfaces. Memory behavior belongs in skills,
+commands, hooks, and the MCP server.
+
+## MCP And Local Command Integration
+
+All memory operations reuse the existing Pensyve runtime surfaces:
+
+- Cloud MCP: `.mcp.json` uses `https://mcp.pensyve.com/mcp` with
+  `bearer_token_env_var: "PENSYVE_API_KEY"`.
+- Local MCP: users can configure `pensyve-mcp --stdio` for offline/self-hosted memory.
+- CLI fallback: `pensyve-cli status`, recall, remember, inspect, and forget remain useful for manual
+  verification, but Codex plugin workflows should prefer MCP tools.
+
+The `/pensyve` command is a router, not a reimplementation. It maps user intent to
+`pensyve_recall`, `pensyve_remember`, `pensyve_observe`, `pensyve_inspect`, `pensyve_status`, and
+`pensyve_forget`.
+
+## Auth And Config Model
+
+Cloud mode uses one environment variable:
+
+```bash
+export PENSYVE_API_KEY="psy_your_key_here"
+```
+
+The plugin does not store secrets. Project-specific local mode can use MCP env values such as
+`PENSYVE_PATH` and `PENSYVE_NAMESPACE` in a local stdio config. Read-only keys can support recall
+and status workflows; write-capable keys are required for remember, observe, and forget operations.
+
+## Migration From The Claude Code Plugin
+
+Reuse the Claude plugin's memory model, but adapt to Codex primitives:
+
+- Claude slash commands map to `/pensyve` sub-intents and MCP tool calls.
+- Claude skills map directly to Codex skills under `skills/`.
+- Claude hooks map to Codex `SessionStart` and `UserPromptSubmit` guidance hooks where supported.
+- Claude background agents do not have a one-to-one Codex local plugin equivalent today; keep
+  curation as explicit skills or future app/connector behavior.
+- Both adapters must keep all memory reads and writes behind MCP tools.
+
+## Implementation Path
+
+1. Current increment: ship `/pensyve`, `mention-workflow`, and this architecture brief.
+2. Next increment: add a registered Pensyve app/connector via `.app.json` when the Codex platform
+   exposes the needed registration surface for Pensyve.
+3. Platform-dependent increment: replace the text-level `@pensyve` convention with true native
+   @-mention dispatch once Codex supports plugin mention registration.

--- a/integrations/codex-plugin/scripts/lint-mcp-refs.sh
+++ b/integrations/codex-plugin/scripts/lint-mcp-refs.sh
@@ -1,27 +1,43 @@
 #!/usr/bin/env bash
 # Static MCP contract linter for the Pensyve Codex CLI adapter.
 #
-# Verifies that every pensyve_* call example in AGENTS.md
+# Verifies that every pensyve_* call example in the Codex plugin instructions
 # conforms to the current MCP tool schema in pensyve-mcp-tools/src/params.rs.
 # Catches the category of bug PR #58 surfaced in the Claude Code adapter
 # (unsupported parameters, missing required fields).
 #
-# Codex CLI uses a single consolidated AGENTS.md file for agent instructions,
-# so this script targets AGENTS.md directly.
-
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-RULES_FILE="$SCRIPT_DIR/../AGENTS.md"
+PLUGIN_ROOT="$SCRIPT_DIR/.."
+MCP_REF_FILES=(
+  "$PLUGIN_ROOT/AGENTS.md"
+  "$PLUGIN_ROOT/skills/pensyve/SKILL.md"
+  "$PLUGIN_ROOT/skills/mention-workflow/SKILL.md"
+  "$PLUGIN_ROOT/commands/pensyve.md"
+  "$PLUGIN_ROOT/docs/ARCHITECTURE.md"
+)
 
 EXIT_CODE=0
 
-if [ ! -f "$RULES_FILE" ]; then
-  echo "ERROR: AGENTS.md not found: $RULES_FILE"
-  exit 1
+echo "Checking required Codex plugin surfaces..."
+for file in "${MCP_REF_FILES[@]}"; do
+  if [ ! -f "$file" ]; then
+    echo "  FAIL: required file missing: $file"
+    EXIT_CODE=1
+  else
+    echo "  PASS: $file"
+  fi
+done
+echo ""
+
+if [ "$EXIT_CODE" != "0" ]; then
+  echo "Codex plugin surface checks FAILED."
+  exit "$EXIT_CODE"
 fi
 
-echo "Linting MCP references in $RULES_FILE..."
+echo "Linting MCP references in:"
+printf '  %s\n' "${MCP_REF_FILES[@]}"
 echo ""
 
 # Check 1: no actual use of unsupported 'related_entities' parameter in call examples.
@@ -40,7 +56,7 @@ done < <(awk '/pensyve_recall\(/{capture=1; buf=""}
        if(buf ~ /related_entities/ && buf !~ /\*\*no\*\*/ && buf !~ /no `related_entities`/)
        print FILENAME ": related_entities found in pensyve_recall block: " buf;
        capture=0
-       }' "$RULES_FILE")
+       }' "${MCP_REF_FILES[@]}")
 if [ "$FOUND_RELATED" = "0" ]; then
   echo "  PASS"
 else
@@ -62,7 +78,7 @@ done < <(awk '/pensyve_episode_start\(/{capture=1; buf=""}
        if(buf ~ /continuation_of/ && buf !~ /\*\*no\*\*/ && buf !~ /no `continuation_of`/)
        print FILENAME ": continuation_of found in pensyve_episode_start block: " buf;
        capture=0
-       }' "$RULES_FILE")
+       }' "${MCP_REF_FILES[@]}")
 if [ "$FOUND_CONT" = "0" ]; then
   echo "  PASS"
 else
@@ -89,7 +105,7 @@ done < <(awk '/pensyve_observe\(/{capture=1; buf=""; depth=0}
        if(buf !~ /source_entity/) print FILENAME ": missing source_entity near: " buf;
        if(buf !~ /about_entity/) print FILENAME ": missing about_entity near: " buf;
        capture=0;
-       }}' "$RULES_FILE")
+       }}' "${MCP_REF_FILES[@]}")
 if [ "$MISSING_FIELDS" = "0" ]; then
   echo "  PASS"
 else
@@ -100,7 +116,7 @@ echo ""
 # Check 4: provenance tag format — every proactive/auto-capture tag uses [<origin>/<trigger>/<tier>]
 echo "Check 4: provenance tag format"
 VALID_PROVENANCE_RE='\[(proactive|auto-capture)/(in-flight|stop|pre-compact|curator|user)/(tier-1|tier-2|residual/tier-1|residual/tier-2|open-question)\]'
-if rg -n '\[(proactive|auto-capture)' "$RULES_FILE" | rg -v "$VALID_PROVENANCE_RE"; then
+if rg -n '\[(proactive|auto-capture)' "${MCP_REF_FILES[@]}" | rg -v "$VALID_PROVENANCE_RE"; then
   echo "  FAIL: some provenance tags do not match [<origin>/<trigger>/<tier>] format"
   EXIT_CODE=1
 else
@@ -110,10 +126,23 @@ echo ""
 
 # Check 5: procedural memory convention — [procedural] prefix is used in observe content
 echo "Check 5: procedural convention uses [procedural] prefix in pensyve_observe content"
-if ! rg -q '\[procedural\]' "$RULES_FILE"; then
+if ! rg -q '\[procedural\]' "${MCP_REF_FILES[@]}"; then
   echo "  WARN: no [procedural] prefix usage found. Expected in AGENTS.md."
 else
   echo "  PASS"
+fi
+echo ""
+
+# Check 6: @-mention compatibility is explicit about today's Codex limitation.
+echo "Check 6: @-mention workflow documents current Codex dispatch limitation"
+if rg -q 'true @-mention dispatch is not currently exposed|Codex does not currently expose true @-mention dispatch' \
+  "$PLUGIN_ROOT/skills/mention-workflow/SKILL.md" \
+  "$PLUGIN_ROOT/commands/pensyve.md" \
+  "$PLUGIN_ROOT/docs/ARCHITECTURE.md"; then
+  echo "  PASS"
+else
+  echo "  FAIL: mention workflow must document that true @-mention dispatch is not currently exposed"
+  EXIT_CODE=1
 fi
 echo ""
 

--- a/integrations/codex-plugin/scripts/lint-mcp-refs.sh
+++ b/integrations/codex-plugin/scripts/lint-mcp-refs.sh
@@ -17,6 +17,11 @@ MCP_REF_FILES=(
   "$PLUGIN_ROOT/commands/pensyve.md"
   "$PLUGIN_ROOT/docs/ARCHITECTURE.md"
 )
+MENTION_DOC_FILES=(
+  "$PLUGIN_ROOT/skills/mention-workflow/SKILL.md"
+  "$PLUGIN_ROOT/commands/pensyve.md"
+  "$PLUGIN_ROOT/docs/ARCHITECTURE.md"
+)
 
 EXIT_CODE=0
 
@@ -127,7 +132,7 @@ echo ""
 # Check 5: procedural memory convention — [procedural] prefix is used in observe content
 echo "Check 5: procedural convention uses [procedural] prefix in pensyve_observe content"
 if ! rg -q '\[procedural\]' "${MCP_REF_FILES[@]}"; then
-  echo "  WARN: no [procedural] prefix usage found. Expected in AGENTS.md."
+  echo "  WARN: no [procedural] prefix usage found in configured plugin surfaces."
 else
   echo "  PASS"
 fi
@@ -135,13 +140,17 @@ echo ""
 
 # Check 6: @-mention compatibility is explicit about today's Codex limitation.
 echo "Check 6: @-mention workflow documents current Codex dispatch limitation"
-if rg -q 'true @-mention dispatch is not currently exposed|Codex does not currently expose true @-mention dispatch' \
-  "$PLUGIN_ROOT/skills/mention-workflow/SKILL.md" \
-  "$PLUGIN_ROOT/commands/pensyve.md" \
-  "$PLUGIN_ROOT/docs/ARCHITECTURE.md"; then
-  echo "  PASS"
-else
-  echo "  FAIL: mention workflow must document that true @-mention dispatch is not currently exposed"
+MISSING_MENTION_DOC=0
+for file in "${MENTION_DOC_FILES[@]}"; do
+  if rg -qi 'true @-mention dispatch is not currently exposed|Codex does not currently expose true @-mention dispatch' "$file"; then
+    echo "  PASS: $file"
+  else
+    echo "  FAIL: $file"
+    MISSING_MENTION_DOC=1
+  fi
+done
+if [ "$MISSING_MENTION_DOC" != "0" ]; then
+  echo "  FAIL: mention workflow must document that true @-mention dispatch is not currently exposed in every mention surface"
   EXIT_CODE=1
 fi
 echo ""

--- a/integrations/codex-plugin/skills/mention-workflow/SKILL.md
+++ b/integrations/codex-plugin/skills/mention-workflow/SKILL.md
@@ -63,4 +63,4 @@ routing yet.
 - Do not fabricate memories or imply that `@pensyve` is a native Codex composer primitive.
 - If Pensyve MCP tools are unavailable, say: "Pensyve MCP is not connected for this session."
   Then continue with non-memory work when possible.
-- Strip secrets, tokens, passwords, private keys, and credentials before writing memory.
+- Strip secrets, API keys, passwords, tokens, private URLs, and credentials before writing memory.

--- a/integrations/codex-plugin/skills/mention-workflow/SKILL.md
+++ b/integrations/codex-plugin/skills/mention-workflow/SKILL.md
@@ -43,7 +43,7 @@ routing yet.
    - For session outcomes or procedures, ensure an episode exists with
      `pensyve_episode_start(participants)`, then call:
 
-     ```
+     ```text
      pensyve_observe(
        episode_id: <working episode_id>,
        content: "[proactive/in-flight/tier-1] <observation>",

--- a/integrations/codex-plugin/skills/mention-workflow/SKILL.md
+++ b/integrations/codex-plugin/skills/mention-workflow/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: mention-workflow
+description: Use when the user types @pensyve, asks for an @-mention workflow, wants mention-style Pensyve memory access in Codex, or asks whether Pensyve supports Codex mentions.
+---
+
+# Pensyve Mention Workflow
+
+Use this skill to translate mention-style Pensyve requests into the current Codex plugin surfaces.
+
+## Current Capability
+
+Codex does not currently expose true @-mention dispatch for local plugin bundles. Treat a literal
+`@pensyve` in user text as explicit user intent, then route the request through the same Pensyve MCP
+tools used by `$pensyve`, `/skills`, and `/pensyve`.
+
+Recommended explicit invocations today:
+
+- `$pensyve what do you remember about this repo?`
+- `/pensyve recall release workflow decisions`
+- `@pensyve recall release workflow decisions`
+
+The third form is a compatibility convention: Codex can follow it when the text reaches the model,
+but the platform does not provide `@pensyve` autocomplete, selection, or guaranteed dispatcher
+routing yet.
+
+## Workflow
+
+1. Parse the text after `@pensyve`.
+   - If it is empty, ask one short question about whether the user wants recall, remember, status,
+     inspect, or memory review.
+   - If it contains a repo, file, feature, service, or person, use that as the primary entity.
+   - Otherwise fall back to the current repository name.
+
+2. Route read requests through existing MCP tools.
+   - For recall or questions about memory, call
+     `pensyve_recall(query, entity?, types?, limit?, min_confidence?)`.
+   - For memory inventory, call `pensyve_inspect(entity, limit?)`.
+   - For connection health, call `pensyve_status`.
+
+3. Route write requests through existing MCP tools.
+   - For durable facts, decisions, preferences, and constraints, call
+     `pensyve_remember(entity, fact, confidence?)`.
+   - For session outcomes or procedures, ensure an episode exists with
+     `pensyve_episode_start(participants)`, then call:
+
+     ```
+     pensyve_observe(
+       episode_id: <working episode_id>,
+       content: "[proactive/in-flight/tier-1] <observation>",
+       source_entity: "codex",
+       about_entity: "<entity>",
+       content_type: "text"
+     )
+     ```
+
+4. Require confirmation before destructive actions.
+   - If the mention asks to forget or delete memory, summarize the target entity and wait for an
+     explicit yes before calling `pensyve_forget(entity)`.
+
+## Response Style
+
+- Keep recall summaries concise and grounded in returned memories.
+- Do not fabricate memories or imply that `@pensyve` is a native Codex composer primitive.
+- If Pensyve MCP tools are unavailable, say: "Pensyve MCP is not connected for this session."
+  Then continue with non-memory work when possible.
+- Strip secrets, tokens, passwords, private keys, and credentials before writing memory.

--- a/integrations/codex-plugin/skills/mention-workflow/SKILL.md
+++ b/integrations/codex-plugin/skills/mention-workflow/SKILL.md
@@ -26,8 +26,8 @@ routing yet.
 ## Workflow
 
 1. Parse the text after `@pensyve`.
-   - If it is empty, ask one short question about whether the user wants recall, remember, status,
-     inspect, or memory review.
+   - If it is empty, ask one short question about whether the user wants recall, remember, observe,
+     inspect, status, review, or forget, and how they want to mention or reference the subject.
    - If it contains a repo, file, feature, service, or person, use that as the primary entity.
    - Otherwise fall back to the current repository name.
 

--- a/integrations/codex-plugin/skills/pensyve/SKILL.md
+++ b/integrations/codex-plugin/skills/pensyve/SKILL.md
@@ -5,7 +5,7 @@ description: Use when the user explicitly invokes Pensyve, asks what the agent r
 
 # Pensyve
 
-Use Pensyve as Codex's persistent working memory. The skill is intended for explicit `$pensyve` invocation from Codex, selection through `/skills`, and implicit routing when a task clearly depends on prior project memory.
+Use Pensyve as Codex's persistent working memory. The skill is intended for explicit `$pensyve` invocation from Codex, selection through `/skills`, `/pensyve` command workflows, text-level `@pensyve` compatibility requests, and implicit routing when a task clearly depends on prior project memory.
 
 ## When To Use
 
@@ -14,6 +14,7 @@ Use Pensyve as Codex's persistent working memory. The skill is intended for expl
 - You are about to make a substantive recommendation that prior project decisions could affect.
 - The user asks to review, clean up, or inspect memory state.
 - The user asks Codex to continue prior work without re-briefing.
+- The user types `@pensyve` as a mention-style memory request.
 
 Do not use this skill for trivial commands, simple formatting, one-off shell output, or facts that should not be persisted.
 
@@ -45,3 +46,4 @@ Do not use this skill for trivial commands, simple formatting, one-off shell out
 - If Pensyve MCP tools are unavailable, say: "Pensyve MCP is not connected for this session." Then continue without memory.
 - If a write fails, report the failed item and continue with any remaining requested work.
 - Never fabricate memories. Only present what Pensyve returned or what the current session established.
+- Do not claim true `@pensyve` platform dispatch. Current Codex support is `$pensyve`, `/skills`, `/pensyve`, and text-level `@pensyve` interpretation by the model.


### PR DESCRIPTION
## Summary

- Add a `/pensyve` Codex command that routes explicit recall, remember, observe, inspect, status, review, forget, and mention-help requests through existing Pensyve MCP tools.
- Add a `mention-workflow` Codex skill that treats literal `@pensyve` text as explicit memory intent while documenting that true native Codex @-mention dispatch is not currently exposed for local plugin bundles.
- Add a short Codex plugin architecture brief covering UX, @-mention feasibility, plugin layout, MCP/local integration, auth/config, and reuse from the Claude Code plugin.
- Update plugin metadata/docs and extend static validation so the new command, skill, and architecture brief stay checked against the MCP contract.

## Verification

- `bash integrations/codex-plugin/scripts/lint-mcp-refs.sh`
- `python3 /home/wshobson/.codex/skills/.system/plugin-creator/scripts/validate_plugin.py integrations/codex-plugin`
- `python3 -m json.tool integrations/codex-plugin/.codex-plugin/plugin.json`
- `python3 -m json.tool integrations/codex-plugin/.mcp.json`
- `python3 -m json.tool integrations/codex-plugin/.agents/plugins/marketplace.json`
- `git diff --check`
- `tar -czf /tmp/pensyve-codex-plugin-v1.4.1.tar.gz -C integrations codex-plugin`
- `tar -tzf /tmp/pensyve-codex-plugin-v1.4.1.tar.gz`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit /pensyve command surface, a /pensyve status step, and declared Commands capability; introduced a mention-style `@pensyve` workflow/skill.

* **Documentation**
  * Expanded README, guides, architecture, command reference, and skill docs with examples, invocation guidance, tooling notes, and changelog entry.

* **Chores**
  * Bumped plugin version to 1.4.1 and broadened validation/lint checks for plugin surfaces.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/major7apps/pensyve/pull/122?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->