### PR TITLE
Add tenant-scoped quotas and gateway resilience fixes

### DIFF
--- a/pensyve-mcp-gateway/src/auth.rs
+++ b/pensyve-mcp-gateway/src/auth.rs
@@ -19,6 +19,7 @@ use crate::middleware::tracing::TraceContext;
 #[derive(Clone, Debug)]
 pub struct AuthContext {
     pub key_id: String,
+    pub tenant_id: Option<String>,
     pub user_id: Option<String>,
     pub scope: String,
     pub stripe_customer_id: Option<String>,
@@ -31,6 +32,10 @@ struct OAuthClaims {
     sub: String,
     #[serde(default)]
     client_id: String,
+    #[serde(default)]
+    tenant_id: Option<String>,
+    #[serde(default)]
+    account_id: Option<String>,
     scope: Option<String>,
 }
 
@@ -154,6 +159,7 @@ impl AuthValidator {
 
         Some(AuthContext {
             key_id: format!("oauth:{}", &token_data.claims.client_id),
+            tenant_id: token_data.claims.tenant_id.or(token_data.claims.account_id),
             user_id: Some(token_data.claims.sub),
             scope: token_data.claims.scope.unwrap_or_else(|| "mcp".to_string()),
             stripe_customer_id: None,
@@ -172,6 +178,7 @@ impl AuthValidator {
             let user_id = self.key_user_hashes.get(&hash).cloned();
             return Some(AuthContext {
                 key_id: prefix.clone(),
+                tenant_id: None,
                 user_id,
                 scope: "mcp".to_string(),
                 stripe_customer_id: None,
@@ -375,6 +382,7 @@ fn parse_auth_context(body: &serde_json::Value) -> AuthContext {
             .and_then(|v| v.as_str())
             .unwrap_or("remote")
             .to_string(),
+        tenant_id: string_field(body, &["tenantId", "tenant_id", "accountId", "account_id"]),
         user_id: body
             .get("userId")
             .and_then(|v| v.as_str())
@@ -394,6 +402,15 @@ fn parse_auth_context(body: &serde_json::Value) -> AuthContext {
             .unwrap_or("free")
             .to_string(),
     }
+}
+
+fn string_field(body: &serde_json::Value, names: &[&str]) -> Option<String> {
+    names.iter().find_map(|name| {
+        body.get(*name)
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .map(String::from)
+    })
 }
 
 /// Describe the top-level shape of a JSON payload as a comma-joined
@@ -499,6 +516,7 @@ where
             if !state.auth_required {
                 req.extensions_mut().insert(AuthContext {
                     key_id: "dev".to_string(),
+                    tenant_id: None,
                     user_id: None,
                     scope: "mcp".to_string(),
                     stripe_customer_id: None,
@@ -613,6 +631,23 @@ mod tests {
     async fn test_auth_validator_empty_config_rejects_all() {
         let validator = AuthValidator::new(&test_config(vec![]));
         assert!(validator.validate("psy_anything", None).await.is_none());
+    }
+
+    #[test]
+    fn test_parse_auth_context_accepts_tenant_identity_fields() {
+        for field in ["tenantId", "tenant_id", "accountId", "account_id"] {
+            let body = serde_json::json!({
+                "valid": true,
+                "keyId": "key_123",
+                field: "tenant_abc",
+                "userId": "user_123",
+                "plan": "business",
+            });
+            let ctx = parse_auth_context(&body);
+            assert_eq!(ctx.tenant_id.as_deref(), Some("tenant_abc"));
+            assert_eq!(ctx.user_id.as_deref(), Some("user_123"));
+            assert_eq!(ctx.plan, "business");
+        }
     }
 
     // Ed25519 test key pair generated for unit tests only — not a real secret.

--- a/pensyve-mcp-gateway/src/auth.rs
+++ b/pensyve-mcp-gateway/src/auth.rs
@@ -156,12 +156,17 @@ impl AuthValidator {
         validation.set_audience(&["https://mcp.pensyve.com"]);
 
         let token_data = decode::<OAuthClaims>(token, decoding_key, &validation).ok()?;
+        let claims = token_data.claims;
+        let tenant_id = claims
+            .tenant_id
+            .filter(|s| !s.is_empty())
+            .or_else(|| claims.account_id.filter(|s| !s.is_empty()));
 
         Some(AuthContext {
-            key_id: format!("oauth:{}", &token_data.claims.client_id),
-            tenant_id: token_data.claims.tenant_id.or(token_data.claims.account_id),
-            user_id: Some(token_data.claims.sub),
-            scope: token_data.claims.scope.unwrap_or_else(|| "mcp".to_string()),
+            key_id: format!("oauth:{}", &claims.client_id),
+            tenant_id,
+            user_id: Some(claims.sub),
+            scope: claims.scope.unwrap_or_else(|| "mcp".to_string()),
             stripe_customer_id: None,
             plan: "free".to_string(),
         })
@@ -669,6 +674,10 @@ mod tests {
         iat: u64,
         #[serde(skip_serializing_if = "Option::is_none")]
         scope: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        tenant_id: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        account_id: Option<String>,
     }
 
     /// Helper: build an `AuthValidator` with JWT support using the test key pair.
@@ -704,6 +713,8 @@ mod tests {
             iat: now,
             exp: now + 3600,
             scope: Some("mcp".to_string()),
+            tenant_id: None,
+            account_id: None,
         }
     }
 
@@ -822,6 +833,18 @@ mod tests {
         let token = sign_jwt(&valid_claims());
         let ctx = validator.validate(&token, None).await.expect("valid JWT");
         assert_eq!(ctx.scope, "mcp");
+    }
+
+    #[tokio::test]
+    async fn test_jwt_empty_tenant_id_falls_back_to_account_id() {
+        let validator = validator_with_jwt(vec![]);
+        let mut claims = valid_claims();
+        claims.tenant_id = Some(String::new());
+        claims.account_id = Some("acct_123".to_string());
+        let token = sign_jwt(&claims);
+
+        let ctx = validator.validate(&token, None).await.expect("valid JWT");
+        assert_eq!(ctx.tenant_id.as_deref(), Some("acct_123"));
     }
 
     #[tokio::test]

--- a/pensyve-mcp-gateway/src/circuit_breaker.rs
+++ b/pensyve-mcp-gateway/src/circuit_breaker.rs
@@ -160,6 +160,9 @@ struct FallbackState {
     /// after `opened_at + cooldown_secs` is allowed through as a
     /// `HalfOpen` probe.
     opened_at: Option<Instant>,
+    /// Set when a HalfOpen probe is in flight. If the caller is cancelled
+    /// before recording an outcome, this lets the breaker recover.
+    half_opened_at: Option<Instant>,
 }
 
 impl FallbackState {
@@ -168,6 +171,7 @@ impl FallbackState {
             state: CircuitState::Closed,
             failures: Vec::new(),
             opened_at: None,
+            half_opened_at: None,
         }
     }
 
@@ -218,6 +222,7 @@ fn redis_probe_key(name: &str) -> String {
 /// every authenticated request; if Redis goes catatonic we MUST NOT
 /// inherit its latency.
 const REDIS_TIMEOUT: Duration = Duration::from_millis(100);
+const HALF_OPEN_PROBE_TIMEOUT: Duration = Duration::from_secs(30);
 
 // ---------------------------------------------------------------------------
 // Breaker
@@ -288,6 +293,7 @@ impl CircuitBreaker {
                 if fb.opened_at.is_none() {
                     fb.opened_at = Some(Instant::now());
                 }
+                fb.half_opened_at = None;
                 return Err(CircuitOpen {
                     name: self.config.name,
                     failures: self.config.failure_threshold,
@@ -308,12 +314,27 @@ impl CircuitBreaker {
             match fb.state {
                 CircuitState::Closed => return Ok(()),
                 CircuitState::HalfOpen => {
-                    return Err(CircuitOpen {
-                        name: self.config.name,
-                        failures: u32::try_from(fb.failures.len())
-                            .unwrap_or(self.config.failure_threshold),
-                        window_secs: self.config.window_secs,
-                    });
+                    if let Some(probe_started) = fb.half_opened_at
+                        && now.duration_since(probe_started) >= HALF_OPEN_PROBE_TIMEOUT
+                    {
+                        tracing::warn!(
+                            circuit = self.config.name,
+                            "HalfOpen probe timed out; allowing a replacement probe"
+                        );
+                        if self.redis.is_some() {
+                            true
+                        } else {
+                            fb.half_opened_at = Some(now);
+                            return Ok(());
+                        }
+                    } else {
+                        return Err(CircuitOpen {
+                            name: self.config.name,
+                            failures: u32::try_from(fb.failures.len())
+                                .unwrap_or(self.config.failure_threshold),
+                            window_secs: self.config.window_secs,
+                        });
+                    }
                 }
                 CircuitState::Open => {
                     // If cooldown has elapsed, transition to HalfOpen and let
@@ -332,6 +353,7 @@ impl CircuitBreaker {
                             );
                             fb.state = CircuitState::HalfOpen;
                             fb.opened_at = None;
+                            fb.half_opened_at = Some(now);
                             return Ok(());
                         }
                     } else {
@@ -351,13 +373,27 @@ impl CircuitBreaker {
                 .fallback
                 .lock()
                 .expect("circuit fallback mutex poisoned");
-            if matches!(fb.state, CircuitState::Open) {
-                tracing::info!(
-                    circuit = self.config.name,
-                    "Cooldown elapsed; entering Redis-coordinated HalfOpen probe"
-                );
+            match fb.state {
+                CircuitState::Open => {
+                    tracing::info!(
+                        circuit = self.config.name,
+                        "Cooldown elapsed; entering Redis-coordinated HalfOpen probe"
+                    );
+                }
+                CircuitState::HalfOpen => {
+                    tracing::info!(
+                        circuit = self.config.name,
+                        "HalfOpen probe timed out; entering replacement Redis-coordinated probe"
+                    );
+                }
+                CircuitState::Closed => {
+                    return Ok(());
+                }
+            }
+            if matches!(fb.state, CircuitState::Open | CircuitState::HalfOpen) {
                 fb.state = CircuitState::HalfOpen;
                 fb.opened_at = None;
+                fb.half_opened_at = Some(now);
                 return Ok(());
             }
         }
@@ -374,7 +410,7 @@ impl CircuitBreaker {
             return true;
         };
         let name = self.config.name;
-        let cooldown_secs = self.config.cooldown_secs.max(1);
+        let probe_ttl_secs = HALF_OPEN_PROBE_TIMEOUT.as_secs().max(1);
         let result: Result<redis::RedisResult<Option<String>>, _> =
             tokio::time::timeout(REDIS_TIMEOUT, async move {
                 redis::cmd("SET")
@@ -382,7 +418,7 @@ impl CircuitBreaker {
                     .arg("1")
                     .arg("NX")
                     .arg("EX")
-                    .arg(cooldown_secs)
+                    .arg(probe_ttl_secs)
                     .query_async(&mut redis)
                     .await
             })
@@ -441,6 +477,7 @@ impl CircuitBreaker {
                     fb.state = CircuitState::Closed;
                     fb.failures.clear();
                     fb.opened_at = None;
+                    fb.half_opened_at = None;
                 }
                 CircuitState::Open => {
                     // Defensive: a success while marked Open shouldn't
@@ -449,6 +486,7 @@ impl CircuitBreaker {
                     fb.state = CircuitState::Closed;
                     fb.failures.clear();
                     fb.opened_at = None;
+                    fb.half_opened_at = None;
                 }
             }
         }
@@ -501,6 +539,7 @@ impl CircuitBreaker {
                         );
                         fb.state = CircuitState::Open;
                         fb.opened_at = Some(now);
+                        fb.half_opened_at = None;
                         opened_now = true;
                     } else {
                         opened_now = false;
@@ -513,6 +552,7 @@ impl CircuitBreaker {
                     );
                     fb.state = CircuitState::Open;
                     fb.opened_at = Some(now);
+                    fb.half_opened_at = None;
                     // Clear the failure window so the probe failure
                     // doesn't double-count against the next Closed window.
                     fb.failures.clear();
@@ -525,6 +565,7 @@ impl CircuitBreaker {
                     // failures keeps the circuit open indefinitely, which
                     // is exactly what we want.
                     fb.opened_at = Some(now);
+                    fb.half_opened_at = None;
                     opened_now = false;
                 }
             }
@@ -680,6 +721,44 @@ mod tests {
         cb.record_success().await;
         assert_eq!(cb.current_state(), CircuitState::Closed);
         assert!(cb.check().await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn halfopen_abandoned_probe_times_out_and_allows_replacement() {
+        let cb = CircuitBreaker::new(
+            CircuitBreakerConfig {
+                cooldown_secs: 0,
+                ..test_config()
+            },
+            None,
+        );
+        for _ in 0..3 {
+            cb.record_failure().await;
+        }
+
+        assert!(cb.check().await.is_ok());
+        assert_eq!(cb.current_state(), CircuitState::HalfOpen);
+        {
+            let mut fb = cb.fallback.lock().expect("circuit fallback mutex poisoned");
+            fb.half_opened_at = Some(
+                Instant::now()
+                    .checked_sub(HALF_OPEN_PROBE_TIMEOUT + Duration::from_millis(1))
+                    .expect("test timestamp should not underflow"),
+            );
+        }
+
+        assert!(
+            cb.check().await.is_ok(),
+            "timed-out abandoned HalfOpen probe should allow a replacement"
+        );
+        assert_eq!(cb.current_state(), CircuitState::HalfOpen);
+        assert!(
+            cb.check().await.is_err(),
+            "replacement probe should stay exclusive until it records an outcome"
+        );
+
+        cb.record_success().await;
+        assert_eq!(cb.current_state(), CircuitState::Closed);
     }
 
     #[tokio::test]

--- a/pensyve-mcp-gateway/src/circuit_breaker.rs
+++ b/pensyve-mcp-gateway/src/circuit_breaker.rs
@@ -160,7 +160,7 @@ struct FallbackState {
     /// after `opened_at + cooldown_secs` is allowed through as a
     /// `HalfOpen` probe.
     opened_at: Option<Instant>,
-    /// Set when a HalfOpen probe is in flight. If the caller is cancelled
+    /// Set when a `HalfOpen` probe is in flight. If the caller is cancelled
     /// before recording an outcome, this lets the breaker recover.
     half_opened_at: Option<Instant>,
 }
@@ -231,6 +231,12 @@ fn redis_closed_key(name: &str) -> String {
 const REDIS_TIMEOUT: Duration = Duration::from_millis(100);
 const HALF_OPEN_PROBE_TIMEOUT: Duration = Duration::from_secs(30);
 
+enum CheckDecision {
+    Allow,
+    Reject(CircuitOpen),
+    Continue,
+}
+
 // ---------------------------------------------------------------------------
 // Breaker
 // ---------------------------------------------------------------------------
@@ -278,58 +284,10 @@ impl CircuitBreaker {
         // consult in-memory state (which may have just transitioned to
         // Open from a record_failure that hasn't reached Redis yet, e.g.
         // because Redis is slow).
-        if let Some(mut redis) = self.redis.clone() {
-            let result = tokio::time::timeout(REDIS_TIMEOUT, async {
-                let state: Option<String> = redis
-                    .get(redis_state_key(self.config.name))
-                    .await
-                    .ok()
-                    .flatten();
-                let closed: Option<String> = redis
-                    .get(redis_closed_key(self.config.name))
-                    .await
-                    .ok()
-                    .flatten();
-                let probe: Option<String> = redis
-                    .get(redis_probe_key(self.config.name))
-                    .await
-                    .ok()
-                    .flatten();
-                (state, closed, probe)
-            })
-            .await;
-            if let Ok((state, closed, probe)) = result {
-                if state.as_deref() == Some("open") {
-                    // Mirror to in-memory so HalfOpen probe logic stays consistent.
-                    let mut fb = self
-                        .fallback
-                        .lock()
-                        .expect("circuit fallback mutex poisoned");
-                    fb.state = CircuitState::Open;
-                    if fb.opened_at.is_none() {
-                        fb.opened_at = Some(Instant::now());
-                    }
-                    fb.half_opened_at = None;
-                    return Err(CircuitOpen {
-                        name: self.config.name,
-                        failures: self.config.failure_threshold,
-                        window_secs: self.config.window_secs,
-                    });
-                }
-                if closed.is_some() {
-                    self.close_fallback_state();
-                    return Ok(());
-                }
-                if probe.is_some() {
-                    return Err(CircuitOpen {
-                        name: self.config.name,
-                        failures: self.config.failure_threshold,
-                        window_secs: self.config.window_secs,
-                    });
-                }
-            }
-            // Redis says not-open OR Redis timed out — fall through to
-            // in-memory check; it will be authoritative.
+        match self.redis_preflight_decision().await {
+            CheckDecision::Allow => return Ok(()),
+            CheckDecision::Reject(err) => return Err(err),
+            CheckDecision::Continue => {}
         }
 
         let now = Instant::now();
@@ -433,6 +391,59 @@ impl CircuitBreaker {
         })
     }
 
+    async fn redis_preflight_decision(&self) -> CheckDecision {
+        let Some(mut redis) = self.redis.clone() else {
+            return CheckDecision::Continue;
+        };
+        let result = tokio::time::timeout(REDIS_TIMEOUT, async {
+            let state: Option<String> = redis
+                .get(redis_state_key(self.config.name))
+                .await
+                .ok()
+                .flatten();
+            let closed: Option<String> = redis
+                .get(redis_closed_key(self.config.name))
+                .await
+                .ok()
+                .flatten();
+            let probe: Option<String> = redis
+                .get(redis_probe_key(self.config.name))
+                .await
+                .ok()
+                .flatten();
+            (state, closed, probe)
+        })
+        .await;
+
+        let Ok((state, closed, probe)) = result else {
+            return CheckDecision::Continue;
+        };
+        if state.as_deref() == Some("open") {
+            self.mirror_open_from_redis();
+            return CheckDecision::Reject(self.threshold_open_error());
+        }
+        if closed.is_some() {
+            self.close_fallback_state();
+            return CheckDecision::Allow;
+        }
+        if probe.is_some() {
+            return CheckDecision::Reject(self.threshold_open_error());
+        }
+        CheckDecision::Continue
+    }
+
+    fn mirror_open_from_redis(&self) {
+        let mut fb = self
+            .fallback
+            .lock()
+            .expect("circuit fallback mutex poisoned");
+        fb.state = CircuitState::Open;
+        if fb.opened_at.is_none() {
+            fb.opened_at = Some(Instant::now());
+        }
+        fb.half_opened_at = None;
+    }
+
     fn close_fallback_state(&self) {
         let mut fb = self
             .fallback
@@ -442,6 +453,14 @@ impl CircuitBreaker {
         fb.failures.clear();
         fb.opened_at = None;
         fb.half_opened_at = None;
+    }
+
+    fn threshold_open_error(&self) -> CircuitOpen {
+        CircuitOpen {
+            name: self.config.name,
+            failures: self.config.failure_threshold,
+            window_secs: self.config.window_secs,
+        }
     }
 
     async fn claim_redis_probe(&self) -> bool {

--- a/pensyve-mcp-gateway/src/circuit_breaker.rs
+++ b/pensyve-mcp-gateway/src/circuit_breaker.rs
@@ -193,6 +193,9 @@ impl FallbackState {
 //   pensyve:cb:<name>:failures -> integer counter (TTL = window_secs)
 //   pensyve:cb:<name>:opened_at-> RFC3339 timestamp (TTL = cooldown_secs)
 //   pensyve:cb:<name>:probe    -> short-lived single HalfOpen probe claim
+//   pensyve:cb:<name>:closed   -> short-lived marker written by a successful
+//                                 probe so sibling pods can clear stale local
+//                                 Open state without waiting for their own probe
 //
 // State is derived as: if `state` key is "open" → Open; else if
 // `failures >= threshold` → trip to Open inside the breaker; else Closed.
@@ -215,6 +218,10 @@ fn redis_opened_at_key(name: &str) -> String {
 
 fn redis_probe_key(name: &str) -> String {
     format!("pensyve:cb:{name}:probe")
+}
+
+fn redis_closed_key(name: &str) -> String {
+    format!("pensyve:cb:{name}:closed")
 }
 
 /// Maximum time we wait on a Redis call inside a breaker check before
@@ -278,27 +285,48 @@ impl CircuitBreaker {
                     .await
                     .ok()
                     .flatten();
-                state
+                let closed: Option<String> = redis
+                    .get(redis_closed_key(self.config.name))
+                    .await
+                    .ok()
+                    .flatten();
+                let probe: Option<String> = redis
+                    .get(redis_probe_key(self.config.name))
+                    .await
+                    .ok()
+                    .flatten();
+                (state, closed, probe)
             })
             .await;
-            if let Ok(Some(s)) = result
-                && s == "open"
-            {
-                // Mirror to in-memory so HalfOpen probe logic stays consistent.
-                let mut fb = self
-                    .fallback
-                    .lock()
-                    .expect("circuit fallback mutex poisoned");
-                fb.state = CircuitState::Open;
-                if fb.opened_at.is_none() {
-                    fb.opened_at = Some(Instant::now());
+            if let Ok((state, closed, probe)) = result {
+                if state.as_deref() == Some("open") {
+                    // Mirror to in-memory so HalfOpen probe logic stays consistent.
+                    let mut fb = self
+                        .fallback
+                        .lock()
+                        .expect("circuit fallback mutex poisoned");
+                    fb.state = CircuitState::Open;
+                    if fb.opened_at.is_none() {
+                        fb.opened_at = Some(Instant::now());
+                    }
+                    fb.half_opened_at = None;
+                    return Err(CircuitOpen {
+                        name: self.config.name,
+                        failures: self.config.failure_threshold,
+                        window_secs: self.config.window_secs,
+                    });
                 }
-                fb.half_opened_at = None;
-                return Err(CircuitOpen {
-                    name: self.config.name,
-                    failures: self.config.failure_threshold,
-                    window_secs: self.config.window_secs,
-                });
+                if closed.is_some() {
+                    self.close_fallback_state();
+                    return Ok(());
+                }
+                if probe.is_some() {
+                    return Err(CircuitOpen {
+                        name: self.config.name,
+                        failures: self.config.failure_threshold,
+                        window_secs: self.config.window_secs,
+                    });
+                }
             }
             // Redis says not-open OR Redis timed out — fall through to
             // in-memory check; it will be authoritative.
@@ -405,6 +433,17 @@ impl CircuitBreaker {
         })
     }
 
+    fn close_fallback_state(&self) {
+        let mut fb = self
+            .fallback
+            .lock()
+            .expect("circuit fallback mutex poisoned");
+        fb.state = CircuitState::Closed;
+        fb.failures.clear();
+        fb.opened_at = None;
+        fb.half_opened_at = None;
+    }
+
     async fn claim_redis_probe(&self) -> bool {
         let Some(mut redis) = self.redis.clone() else {
             return true;
@@ -492,16 +531,17 @@ impl CircuitBreaker {
         }
 
         if let Some(mut redis) = self.redis.clone() {
+            let name = self.config.name;
+            let cooldown_secs = self.config.cooldown_secs.max(1);
             let _ = tokio::time::timeout(REDIS_TIMEOUT, async {
                 // Best-effort cleanup; failures here are non-fatal.
-                let _: Result<(), _> = redis.del::<_, ()>(redis_state_key(self.config.name)).await;
+                let _: Result<(), _> = redis.del::<_, ()>(redis_state_key(name)).await;
+                let _: Result<(), _> = redis.del::<_, ()>(redis_failures_key(name)).await;
+                let _: Result<(), _> = redis.del::<_, ()>(redis_opened_at_key(name)).await;
+                let _: Result<(), _> = redis.del::<_, ()>(redis_probe_key(name)).await;
                 let _: Result<(), _> = redis
-                    .del::<_, ()>(redis_failures_key(self.config.name))
+                    .set_ex::<_, _, ()>(redis_closed_key(name), "1", u64::from(cooldown_secs))
                     .await;
-                let _: Result<(), _> = redis
-                    .del::<_, ()>(redis_opened_at_key(self.config.name))
-                    .await;
-                let _: Result<(), _> = redis.del::<_, ()>(redis_probe_key(self.config.name)).await;
             })
             .await;
         }
@@ -597,6 +637,7 @@ impl CircuitBreaker {
                     }
                 }
                 if should_mark_open {
+                    let _: Result<(), _> = redis.del::<_, ()>(redis_closed_key(name)).await;
                     let _: Result<(), _> = redis.del::<_, ()>(redis_probe_key(name)).await;
                     // Mark Open in Redis with cooldown TTL so sibling
                     // pods see the same state.

--- a/pensyve-mcp-gateway/src/circuit_breaker.rs
+++ b/pensyve-mcp-gateway/src/circuit_breaker.rs
@@ -237,6 +237,17 @@ enum CheckDecision {
     Continue,
 }
 
+fn redis_opened_at_to_instant(opened_at: Option<&str>) -> Option<Instant> {
+    let opened_at = chrono::DateTime::parse_from_rfc3339(opened_at?)
+        .ok()?
+        .with_timezone(&chrono::Utc);
+    let elapsed = chrono::Utc::now()
+        .signed_duration_since(opened_at)
+        .to_std()
+        .ok()?;
+    Instant::now().checked_sub(elapsed)
+}
+
 // ---------------------------------------------------------------------------
 // Breaker
 // ---------------------------------------------------------------------------
@@ -411,15 +422,20 @@ impl CircuitBreaker {
                 .await
                 .ok()
                 .flatten();
-            (state, closed, probe)
+            let opened_at: Option<String> = redis
+                .get(redis_opened_at_key(self.config.name))
+                .await
+                .ok()
+                .flatten();
+            (state, closed, probe, opened_at)
         })
         .await;
 
-        let Ok((state, closed, probe)) = result else {
+        let Ok((state, closed, probe, opened_at)) = result else {
             return CheckDecision::Continue;
         };
         if state.as_deref() == Some("open") {
-            self.mirror_open_from_redis();
+            self.mirror_open_from_redis(opened_at.as_deref());
             return CheckDecision::Reject(self.threshold_open_error());
         }
         if closed.is_some() {
@@ -432,15 +448,13 @@ impl CircuitBreaker {
         CheckDecision::Continue
     }
 
-    fn mirror_open_from_redis(&self) {
+    fn mirror_open_from_redis(&self, opened_at: Option<&str>) {
         let mut fb = self
             .fallback
             .lock()
             .expect("circuit fallback mutex poisoned");
         fb.state = CircuitState::Open;
-        if fb.opened_at.is_none() {
-            fb.opened_at = Some(Instant::now());
-        }
+        fb.opened_at = Some(redis_opened_at_to_instant(opened_at).unwrap_or_else(Instant::now));
         fb.half_opened_at = None;
     }
 
@@ -449,8 +463,11 @@ impl CircuitBreaker {
             .fallback
             .lock()
             .expect("circuit fallback mutex poisoned");
+        let previous_state = fb.state;
         fb.state = CircuitState::Closed;
-        fb.failures.clear();
+        if !matches!(previous_state, CircuitState::Closed) {
+            fb.failures.clear();
+        }
         fb.opened_at = None;
         fb.half_opened_at = None;
     }
@@ -742,6 +759,16 @@ mod tests {
         assert_eq!(err.name, "test_breaker");
     }
 
+    #[test]
+    fn redis_opened_at_to_instant_preserves_elapsed_cooldown() {
+        let opened_at = (chrono::Utc::now() - chrono::Duration::seconds(5)).to_rfc3339();
+        let instant = redis_opened_at_to_instant(Some(&opened_at)).expect("timestamp should parse");
+        let elapsed = instant.elapsed();
+
+        assert!(elapsed >= Duration::from_secs(4), "elapsed was {elapsed:?}");
+        assert!(elapsed <= Duration::from_secs(6), "elapsed was {elapsed:?}");
+    }
+
     #[tokio::test]
     async fn cooldown_elapses_transitions_to_halfopen() {
         let cb = CircuitBreaker::new(test_config(), None);
@@ -781,6 +808,35 @@ mod tests {
         cb.record_success().await;
         assert_eq!(cb.current_state(), CircuitState::Closed);
         assert!(cb.check().await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn close_fallback_state_preserves_closed_failure_window() {
+        let cb = CircuitBreaker::new(test_config(), None);
+        cb.record_failure().await;
+        cb.record_failure().await;
+        assert_eq!(cb.current_state(), CircuitState::Closed);
+        assert_eq!(cb.failure_count(), 2);
+
+        cb.close_fallback_state();
+
+        assert_eq!(cb.current_state(), CircuitState::Closed);
+        assert_eq!(cb.failure_count(), 2);
+    }
+
+    #[tokio::test]
+    async fn close_fallback_state_clears_stale_open_failure_window() {
+        let cb = CircuitBreaker::new(test_config(), None);
+        for _ in 0..3 {
+            cb.record_failure().await;
+        }
+        assert_eq!(cb.current_state(), CircuitState::Open);
+        assert_eq!(cb.failure_count(), 3);
+
+        cb.close_fallback_state();
+
+        assert_eq!(cb.current_state(), CircuitState::Closed);
+        assert_eq!(cb.failure_count(), 0);
     }
 
     #[tokio::test]

--- a/pensyve-mcp-gateway/src/circuit_breaker.rs
+++ b/pensyve-mcp-gateway/src/circuit_breaker.rs
@@ -188,6 +188,7 @@ impl FallbackState {
 //                                 (TTL = cooldown_secs when "open"; absent in "closed")
 //   pensyve:cb:<name>:failures -> integer counter (TTL = window_secs)
 //   pensyve:cb:<name>:opened_at-> RFC3339 timestamp (TTL = cooldown_secs)
+//   pensyve:cb:<name>:probe    -> short-lived single HalfOpen probe claim
 //
 // State is derived as: if `state` key is "open" → Open; else if
 // `failures >= threshold` → trip to Open inside the breaker; else Closed.
@@ -206,6 +207,10 @@ fn redis_failures_key(name: &str) -> String {
 
 fn redis_opened_at_key(name: &str) -> String {
     format!("pensyve:cb:{name}:opened_at")
+}
+
+fn redis_probe_key(name: &str) -> String {
+    format!("pensyve:cb:{name}:probe")
 }
 
 /// Maximum time we wait on a Redis call inside a breaker check before
@@ -295,34 +300,111 @@ impl CircuitBreaker {
 
         let now = Instant::now();
         let cooldown = Duration::from_secs(u64::from(self.config.cooldown_secs));
-        let mut fb = self
-            .fallback
-            .lock()
-            .expect("circuit fallback mutex poisoned");
-        match fb.state {
-            CircuitState::Closed | CircuitState::HalfOpen => Ok(()),
-            CircuitState::Open => {
-                // If cooldown has elapsed, transition to HalfOpen and let
-                // this caller act as the probe. Subsequent callers in the
-                // same window will also see HalfOpen and pass — record_*
-                // gates the actual transition back to Closed.
-                if let Some(opened) = fb.opened_at
-                    && now.duration_since(opened) >= cooldown
-                {
-                    tracing::info!(
-                        circuit = self.config.name,
-                        "Cooldown elapsed; entering HalfOpen probe"
-                    );
-                    fb.state = CircuitState::HalfOpen;
-                    fb.opened_at = None;
-                    return Ok(());
+        let should_claim_redis_probe = {
+            let mut fb = self
+                .fallback
+                .lock()
+                .expect("circuit fallback mutex poisoned");
+            match fb.state {
+                CircuitState::Closed => return Ok(()),
+                CircuitState::HalfOpen => {
+                    return Err(CircuitOpen {
+                        name: self.config.name,
+                        failures: u32::try_from(fb.failures.len())
+                            .unwrap_or(self.config.failure_threshold),
+                        window_secs: self.config.window_secs,
+                    });
                 }
-                Err(CircuitOpen {
-                    name: self.config.name,
-                    failures: u32::try_from(fb.failures.len())
-                        .unwrap_or(self.config.failure_threshold),
-                    window_secs: self.config.window_secs,
-                })
+                CircuitState::Open => {
+                    // If cooldown has elapsed, transition to HalfOpen and let
+                    // this caller act as the probe. While the probe is
+                    // in flight, state remains HalfOpen and later callers
+                    // short-circuit instead of stampeding the downstream.
+                    if let Some(opened) = fb.opened_at
+                        && now.duration_since(opened) >= cooldown
+                    {
+                        if self.redis.is_some() {
+                            true
+                        } else {
+                            tracing::info!(
+                                circuit = self.config.name,
+                                "Cooldown elapsed; entering HalfOpen probe"
+                            );
+                            fb.state = CircuitState::HalfOpen;
+                            fb.opened_at = None;
+                            return Ok(());
+                        }
+                    } else {
+                        return Err(CircuitOpen {
+                            name: self.config.name,
+                            failures: u32::try_from(fb.failures.len())
+                                .unwrap_or(self.config.failure_threshold),
+                            window_secs: self.config.window_secs,
+                        });
+                    }
+                }
+            }
+        };
+
+        if should_claim_redis_probe && self.claim_redis_probe().await {
+            let mut fb = self
+                .fallback
+                .lock()
+                .expect("circuit fallback mutex poisoned");
+            if matches!(fb.state, CircuitState::Open) {
+                tracing::info!(
+                    circuit = self.config.name,
+                    "Cooldown elapsed; entering Redis-coordinated HalfOpen probe"
+                );
+                fb.state = CircuitState::HalfOpen;
+                fb.opened_at = None;
+                return Ok(());
+            }
+        }
+
+        Err(CircuitOpen {
+            name: self.config.name,
+            failures: self.config.failure_threshold,
+            window_secs: self.config.window_secs,
+        })
+    }
+
+    async fn claim_redis_probe(&self) -> bool {
+        let Some(mut redis) = self.redis.clone() else {
+            return true;
+        };
+        let name = self.config.name;
+        let cooldown_secs = self.config.cooldown_secs.max(1);
+        let result: Result<redis::RedisResult<Option<String>>, _> =
+            tokio::time::timeout(REDIS_TIMEOUT, async move {
+                redis::cmd("SET")
+                    .arg(redis_probe_key(name))
+                    .arg("1")
+                    .arg("NX")
+                    .arg("EX")
+                    .arg(cooldown_secs)
+                    .query_async(&mut redis)
+                    .await
+            })
+            .await;
+
+        match result {
+            Ok(Ok(Some(_))) => true,
+            Ok(Ok(None)) => false,
+            Ok(Err(e)) => {
+                tracing::debug!(
+                    circuit = self.config.name,
+                    error = %e,
+                    "Redis HalfOpen probe claim failed; using in-memory fallback claim"
+                );
+                true
+            }
+            Err(_) => {
+                tracing::debug!(
+                    circuit = self.config.name,
+                    "Redis HalfOpen probe claim timed out; using in-memory fallback claim"
+                );
+                true
             }
         }
     }
@@ -373,6 +455,7 @@ impl CircuitBreaker {
                 let _: Result<(), _> = redis
                     .del::<_, ()>(redis_opened_at_key(self.config.name))
                     .await;
+                let _: Result<(), _> = redis.del::<_, ()>(redis_probe_key(self.config.name)).await;
             })
             .await;
         }
@@ -465,6 +548,7 @@ impl CircuitBreaker {
                     }
                 }
                 if should_mark_open {
+                    let _: Result<(), _> = redis.del::<_, ()>(redis_probe_key(name)).await;
                     // Mark Open in Redis with cooldown TTL so sibling
                     // pods see the same state.
                     let _: Result<(), _> = redis
@@ -563,6 +647,31 @@ mod tests {
         // Next check should pass the caller through as a HalfOpen probe.
         assert!(cb.check().await.is_ok());
         assert_eq!(cb.current_state(), CircuitState::HalfOpen);
+    }
+
+    #[tokio::test]
+    async fn halfopen_allows_only_one_probe() {
+        let cb = CircuitBreaker::new(
+            CircuitBreakerConfig {
+                cooldown_secs: 0,
+                ..test_config()
+            },
+            None,
+        );
+        for _ in 0..3 {
+            cb.record_failure().await;
+        }
+
+        assert!(cb.check().await.is_ok());
+        assert_eq!(cb.current_state(), CircuitState::HalfOpen);
+        assert!(
+            cb.check().await.is_err(),
+            "second HalfOpen caller should be rejected until probe records an outcome"
+        );
+
+        cb.record_success().await;
+        assert_eq!(cb.current_state(), CircuitState::Closed);
+        assert!(cb.check().await.is_ok());
     }
 
     #[tokio::test]

--- a/pensyve-mcp-gateway/src/circuit_breaker.rs
+++ b/pensyve-mcp-gateway/src/circuit_breaker.rs
@@ -392,6 +392,11 @@ impl CircuitBreaker {
             Ok(Ok(Some(_))) => true,
             Ok(Ok(None)) => false,
             Ok(Err(e)) => {
+                // Redis coordinates the cross-pod single-probe contract
+                // only while it is reachable. If Redis is itself down,
+                // degrade to the in-memory single-process claim so the
+                // circuit can still recover instead of staying Open
+                // forever.
                 tracing::debug!(
                     circuit = self.config.name,
                     error = %e,
@@ -400,6 +405,9 @@ impl CircuitBreaker {
                 true
             }
             Err(_) => {
+                // Same availability trade-off as the Redis error branch:
+                // prefer a local probe over a permanently stuck Open
+                // circuit when the coordinator is unavailable.
                 tracing::debug!(
                     circuit = self.config.name,
                     "Redis HalfOpen probe claim timed out; using in-memory fallback claim"

--- a/pensyve-mcp-gateway/src/main.rs
+++ b/pensyve-mcp-gateway/src/main.rs
@@ -394,6 +394,7 @@ async fn async_main(config: GatewayConfig, res: InitResources) -> Result<()> {
 
     // Background consolidation — runs every PENSYVE_CONSOLIDATION_INTERVAL_SECS (default 6h).
     let consolidation_permits = Arc::new(tokio::sync::Semaphore::new(1));
+    let consolidation_cancel = ct.clone();
     tokio::spawn({
         let state = app_state;
         let consolidation_permits = consolidation_permits.clone();
@@ -407,13 +408,20 @@ async fn async_main(config: GatewayConfig, res: InitResources) -> Result<()> {
             interval.tick().await; // skip immediate first tick
             loop {
                 interval.tick().await;
+                if consolidation_cancel.is_cancelled() {
+                    return;
+                }
                 for ns_id in state.tenant_mgr.active_namespace_ids() {
+                    if consolidation_cancel.is_cancelled() {
+                        return;
+                    }
                     if let Some(ps) = state.tenant_mgr.get_state_by_namespace_id(ns_id) {
                         let config = pensyve_core::config::ConsolidationConfig::default();
                         let storage = ps.storage.clone();
                         let embedder = ps.embedder.clone();
                         let run_storage = storage.clone();
                         let run_embedder = embedder.clone();
+                        let run_cancel = consolidation_cancel.clone();
                         let Ok(_permit) = consolidation_permits.clone().acquire_owned().await
                         else {
                             tracing::warn!("Background consolidation semaphore closed");
@@ -421,8 +429,8 @@ async fn async_main(config: GatewayConfig, res: InitResources) -> Result<()> {
                         };
                         // G1/P3a: ConsolidationEngine::run gained `policy`
                         // + `cancel`. The engine performs no network calls
-                        // today; pass Disabled (fail-closed) and a fresh
-                        // never-cancelled token for this background loop.
+                        // today; pass Disabled (fail-closed) and the shared
+                        // shutdown token so blocking work can exit promptly.
                         let run = tokio::task::spawn_blocking(move || {
                             pensyve_core::consolidation::ConsolidationEngine::run(
                                 run_storage.as_ref(),
@@ -430,7 +438,7 @@ async fn async_main(config: GatewayConfig, res: InitResources) -> Result<()> {
                                 &config,
                                 ns_id,
                                 &pensyve_core::network_policy::NetworkPolicy::Disabled,
-                                &tokio_util::sync::CancellationToken::new(),
+                                &run_cancel,
                             )
                         })
                         .await;
@@ -500,16 +508,11 @@ async fn async_main(config: GatewayConfig, res: InitResources) -> Result<()> {
 }
 
 fn spawn_runtime_stall_watchdog() {
-    let interval = std::env::var("PENSYVE_RUNTIME_WATCHDOG_INTERVAL_MS")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .map(Duration::from_millis)
-        .unwrap_or_else(|| Duration::from_secs(1));
-    let threshold = std::env::var("PENSYVE_RUNTIME_WATCHDOG_LAG_MS")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .map(Duration::from_millis)
-        .unwrap_or_else(|| Duration::from_secs(2));
+    let interval = positive_millis_env(
+        "PENSYVE_RUNTIME_WATCHDOG_INTERVAL_MS",
+        Duration::from_secs(1),
+    );
+    let threshold = positive_millis_env("PENSYVE_RUNTIME_WATCHDOG_LAG_MS", Duration::from_secs(2));
 
     tokio::spawn(async move {
         let mut ticker = tokio::time::interval(interval);
@@ -534,8 +537,36 @@ fn spawn_runtime_stall_watchdog() {
     });
 }
 
+fn positive_millis_env(name: &str, default: Duration) -> Duration {
+    positive_millis_value(std::env::var(name).ok().as_deref(), default)
+}
+
+fn positive_millis_value(value: Option<&str>, default: Duration) -> Duration {
+    value
+        .and_then(|s| s.parse::<u64>().ok())
+        .filter(|millis| *millis > 0)
+        .map(Duration::from_millis)
+        .unwrap_or(default)
+}
+
 async fn health_handler() -> &'static str {
     "ok"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn positive_millis_env_falls_back_for_unset_or_zero() {
+        let default = Duration::from_secs(1);
+        assert_eq!(positive_millis_value(None, default), default);
+        assert_eq!(positive_millis_value(Some("0"), default), default);
+        assert_eq!(
+            positive_millis_value(Some("25"), default),
+            Duration::from_millis(25)
+        );
+    }
 }
 
 async fn readiness_handler(

--- a/pensyve-mcp-gateway/src/main.rs
+++ b/pensyve-mcp-gateway/src/main.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use anyhow::Result;
 use axum::Router;
@@ -389,6 +390,8 @@ async fn async_main(config: GatewayConfig, res: InitResources) -> Result<()> {
     // TTLs handle window expiry on the primary path, and the in-memory
     // fallback prunes entries on read inside `RateLimiter::check_fallback`.
 
+    spawn_runtime_stall_watchdog();
+
     // Background consolidation — runs every PENSYVE_CONSOLIDATION_INTERVAL_SECS (default 6h).
     tokio::spawn({
         let state = app_state;
@@ -405,19 +408,27 @@ async fn async_main(config: GatewayConfig, res: InitResources) -> Result<()> {
                 for ns_id in state.tenant_mgr.active_namespace_ids() {
                     if let Some(ps) = state.tenant_mgr.get_state_by_namespace_id(ns_id) {
                         let config = pensyve_core::config::ConsolidationConfig::default();
+                        let storage = ps.storage.clone();
+                        let embedder = ps.embedder.clone();
+                        let run_storage = storage.clone();
+                        let run_embedder = embedder.clone();
                         // G1/P3a: ConsolidationEngine::run gained `policy`
                         // + `cancel`. The engine performs no network calls
                         // today; pass Disabled (fail-closed) and a fresh
                         // never-cancelled token for this background loop.
-                        match pensyve_core::consolidation::ConsolidationEngine::run(
-                            ps.storage.as_ref(),
-                            &ps.embedder,
-                            &config,
-                            ns_id,
-                            &pensyve_core::network_policy::NetworkPolicy::Disabled,
-                            &tokio_util::sync::CancellationToken::new(),
-                        ) {
-                            Ok(cs) => {
+                        let run = tokio::task::spawn_blocking(move || {
+                            pensyve_core::consolidation::ConsolidationEngine::run(
+                                run_storage.as_ref(),
+                                &run_embedder,
+                                &config,
+                                ns_id,
+                                &pensyve_core::network_policy::NetworkPolicy::Disabled,
+                                &tokio_util::sync::CancellationToken::new(),
+                            )
+                        })
+                        .await;
+                        match run {
+                            Ok(Ok(cs)) => {
                                 if cs.promoted > 0 || cs.archived > 0 {
                                     tracing::info!(
                                         namespace_id = %ns_id,
@@ -427,7 +438,7 @@ async fn async_main(config: GatewayConfig, res: InitResources) -> Result<()> {
                                         "Background consolidation complete"
                                     );
                                 }
-                                let _ = ps.storage.log_activity(
+                                let _ = storage.log_activity(
                                     ns_id,
                                     "consolidate",
                                     &serde_json::json!({
@@ -437,11 +448,18 @@ async fn async_main(config: GatewayConfig, res: InitResources) -> Result<()> {
                                     }),
                                 );
                             }
-                            Err(e) => {
+                            Ok(Err(e)) => {
                                 tracing::warn!(
                                     namespace_id = %ns_id,
                                     error = %e,
                                     "Background consolidation failed"
+                                );
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    namespace_id = %ns_id,
+                                    error = %e,
+                                    "Background consolidation task failed"
                                 );
                             }
                         }
@@ -472,6 +490,41 @@ async fn async_main(config: GatewayConfig, res: InitResources) -> Result<()> {
         .await?;
 
     Ok(())
+}
+
+fn spawn_runtime_stall_watchdog() {
+    let interval = std::env::var("PENSYVE_RUNTIME_WATCHDOG_INTERVAL_MS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .map(Duration::from_millis)
+        .unwrap_or_else(|| Duration::from_secs(1));
+    let threshold = std::env::var("PENSYVE_RUNTIME_WATCHDOG_LAG_MS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .map(Duration::from_millis)
+        .unwrap_or_else(|| Duration::from_secs(2));
+
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(interval);
+        ticker.tick().await;
+        let mut last = Instant::now();
+        loop {
+            ticker.tick().await;
+            let now = Instant::now();
+            let elapsed = now.saturating_duration_since(last);
+            if let Some(lag) = elapsed.checked_sub(interval)
+                && lag >= threshold
+            {
+                tracing::warn!(
+                    elapsed_ms = elapsed.as_millis(),
+                    lag_ms = lag.as_millis(),
+                    threshold_ms = threshold.as_millis(),
+                    "Tokio runtime scheduling delay detected"
+                );
+            }
+            last = now;
+        }
+    });
 }
 
 async fn health_handler() -> &'static str {

--- a/pensyve-mcp-gateway/src/main.rs
+++ b/pensyve-mcp-gateway/src/main.rs
@@ -545,8 +545,7 @@ fn positive_millis_value(value: Option<&str>, default: Duration) -> Duration {
     value
         .and_then(|s| s.parse::<u64>().ok())
         .filter(|millis| *millis > 0)
-        .map(Duration::from_millis)
-        .unwrap_or(default)
+        .map_or(default, Duration::from_millis)
 }
 
 async fn health_handler() -> &'static str {

--- a/pensyve-mcp-gateway/src/main.rs
+++ b/pensyve-mcp-gateway/src/main.rs
@@ -393,8 +393,10 @@ async fn async_main(config: GatewayConfig, res: InitResources) -> Result<()> {
     spawn_runtime_stall_watchdog();
 
     // Background consolidation — runs every PENSYVE_CONSOLIDATION_INTERVAL_SECS (default 6h).
+    let consolidation_permits = Arc::new(tokio::sync::Semaphore::new(1));
     tokio::spawn({
         let state = app_state;
+        let consolidation_permits = consolidation_permits.clone();
         async move {
             let interval_secs: u64 = std::env::var("PENSYVE_CONSOLIDATION_INTERVAL_SECS")
                 .ok()
@@ -412,6 +414,11 @@ async fn async_main(config: GatewayConfig, res: InitResources) -> Result<()> {
                         let embedder = ps.embedder.clone();
                         let run_storage = storage.clone();
                         let run_embedder = embedder.clone();
+                        let Ok(_permit) = consolidation_permits.clone().acquire_owned().await
+                        else {
+                            tracing::warn!("Background consolidation semaphore closed");
+                            return;
+                        };
                         // G1/P3a: ConsolidationEngine::run gained `policy`
                         // + `cancel`. The engine performs no network calls
                         // today; pass Disabled (fail-closed) and a fresh

--- a/pensyve-mcp-gateway/src/rate_limit.rs
+++ b/pensyve-mcp-gateway/src/rate_limit.rs
@@ -204,7 +204,7 @@ impl RateLimiter {
                     self.handle_redis_failure(&"redis rate-limit timeout");
                     // Fall through to the in-memory path.
                 }
-            };
+            }
         }
 
         self.check_fallback(tenant_id, limits, now_secs)
@@ -318,7 +318,7 @@ impl RateLimiter {
 
     fn maybe_evict_idle_fallback_buckets(&self, now_secs: u64) {
         let check = self.fallback_sweep_counter.fetch_add(1, Ordering::Relaxed);
-        if check % FALLBACK_EVICT_EVERY_CHECKS == 0 {
+        if check.is_multiple_of(FALLBACK_EVICT_EVERY_CHECKS) {
             self.evict_idle_fallback_buckets(now_secs);
         }
     }

--- a/pensyve-mcp-gateway/src/rate_limit.rs
+++ b/pensyve-mcp-gateway/src/rate_limit.rs
@@ -14,7 +14,7 @@
 //! the cluster is running in degraded mode.
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::task::{Context, Poll};
 use std::time::Duration;
 
@@ -30,6 +30,7 @@ use crate::AppState;
 use crate::auth::AuthContext;
 
 const REDIS_RATE_LIMIT_TIMEOUT: Duration = Duration::from_millis(150);
+const FALLBACK_EVICT_EVERY_CHECKS: u64 = 64;
 
 /// Plan-tier limits, keyed by the `plan` string returned from auth.
 ///
@@ -151,6 +152,7 @@ pub struct RateLimiter {
     /// One-shot flag so the "Redis unavailable, falling back to memory"
     /// warning only fires once per process even under sustained failure.
     fallback_warned: Arc<AtomicBool>,
+    fallback_sweep_counter: Arc<AtomicU64>,
     #[cfg(test)]
     force_redis_error: Arc<AtomicBool>,
 }
@@ -163,6 +165,7 @@ impl RateLimiter {
             fallback: Arc::new(DashMap::new()),
             script: Arc::new(Script::new(RATE_LIMIT_LUA)),
             fallback_warned: Arc::new(AtomicBool::new(false)),
+            fallback_sweep_counter: Arc::new(AtomicU64::new(0)),
             #[cfg(test)]
             force_redis_error: Arc::new(AtomicBool::new(false)),
         }
@@ -275,7 +278,7 @@ impl RateLimiter {
     /// Pure in-memory path. Implements the same sliding-minute semantics
     /// as the Redis script, minus the daily quota (see module docs).
     fn check_fallback(&self, tenant_id: &str, limits: Limits, now_secs: u64) -> CheckOutcome {
-        self.evict_idle_fallback_buckets(now_secs);
+        self.maybe_evict_idle_fallback_buckets(now_secs);
 
         let mut entry = self.fallback.entry(tenant_id.to_string()).or_default();
         let bucket = entry.value_mut();
@@ -310,6 +313,13 @@ impl RateLimiter {
                 let wait = (oldest + 60).saturating_sub(now_secs).max(1);
                 Some(u32::try_from(wait).unwrap_or(60))
             },
+        }
+    }
+
+    fn maybe_evict_idle_fallback_buckets(&self, now_secs: u64) {
+        let check = self.fallback_sweep_counter.fetch_add(1, Ordering::Relaxed);
+        if check % FALLBACK_EVICT_EVERY_CHECKS == 0 {
+            self.evict_idle_fallback_buckets(now_secs);
         }
     }
 
@@ -667,11 +677,10 @@ mod tests {
         assert!(first.allowed);
         assert_eq!(rl.fallback_bucket_count_for_test(), 1);
 
-        let second = rl.check_fallback("tenant_active", limits, 1_061);
-        assert!(second.allowed);
+        rl.evict_idle_fallback_buckets(1_061);
         assert_eq!(
             rl.fallback_bucket_count_for_test(),
-            1,
+            0,
             "idle tenant bucket should be evicted after the sliding window"
         );
     }

--- a/pensyve-mcp-gateway/src/rate_limit.rs
+++ b/pensyve-mcp-gateway/src/rate_limit.rs
@@ -16,6 +16,7 @@
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::task::{Context, Poll};
+use std::time::Duration;
 
 use axum::body::Body;
 use axum::http::{HeaderValue, Request, Response, StatusCode};
@@ -27,6 +28,8 @@ use tower::{Layer, Service};
 
 use crate::AppState;
 use crate::auth::AuthContext;
+
+const REDIS_RATE_LIMIT_TIMEOUT: Duration = Duration::from_millis(150);
 
 /// Plan-tier limits, keyed by the `plan` string returned from auth.
 ///
@@ -131,6 +134,9 @@ impl CheckOutcome {
 struct FallbackBucket {
     /// Unix-second timestamps for the sliding minute window.
     timestamps: Vec<u64>,
+    /// Last request seen for this bucket. Lets the degraded path evict
+    /// idle tenant buckets even when their timestamp vector has gone empty.
+    last_seen: u64,
 }
 
 /// Plan-aware rate limiter. See module docs for the full contract.
@@ -145,6 +151,8 @@ pub struct RateLimiter {
     /// One-shot flag so the "Redis unavailable, falling back to memory"
     /// warning only fires once per process even under sustained failure.
     fallback_warned: Arc<AtomicBool>,
+    #[cfg(test)]
+    force_redis_error: Arc<AtomicBool>,
 }
 
 impl RateLimiter {
@@ -155,6 +163,8 @@ impl RateLimiter {
             fallback: Arc::new(DashMap::new()),
             script: Arc::new(Script::new(RATE_LIMIT_LUA)),
             fallback_warned: Arc::new(AtomicBool::new(false)),
+            #[cfg(test)]
+            force_redis_error: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -169,33 +179,48 @@ impl RateLimiter {
             return CheckOutcome::unlimited(now_secs);
         }
 
+        #[cfg(test)]
+        if self.force_redis_error.load(Ordering::Relaxed) {
+            self.handle_redis_failure(&"forced redis failure");
+            return self.check_fallback(tenant_id, limits, now_secs);
+        }
+
         if let Some(conn) = self.redis.as_ref() {
-            match self.check_redis(conn, tenant_id, limits, now_secs).await {
-                Ok(outcome) => return outcome,
-                Err(e) => {
-                    // Warn once per process, not once per request.
-                    // `swap(true, _)` returns the *previous* value: false
-                    // on the very first failure (which is when we want
-                    // the loud warning), true thereafter (when we drop
-                    // to debug-level so we don't flood the logs).
-                    // Reading `if !swap(...)` matches that mental model
-                    // (negate "have we already warned?") even though
-                    // clippy::if_not_else prefers the inverted form.
-                    #[allow(clippy::if_not_else)]
-                    if !self.fallback_warned.swap(true, Ordering::Relaxed) {
-                        tracing::warn!(
-                            error = %e,
-                            "Rate limiter falling back to in-memory; daily quota NOT enforced"
-                        );
-                    } else {
-                        tracing::debug!(error = %e, "Rate limit Redis call failed; using fallback");
-                    }
+            match tokio::time::timeout(
+                REDIS_RATE_LIMIT_TIMEOUT,
+                self.check_redis(conn, tenant_id, limits, now_secs),
+            )
+            .await
+            {
+                Ok(Ok(outcome)) => return outcome,
+                Ok(Err(e)) => {
+                    self.handle_redis_failure(&e);
                     // Fall through to the in-memory path.
                 }
-            }
+                Err(_) => {
+                    self.handle_redis_failure(&"redis rate-limit timeout");
+                    // Fall through to the in-memory path.
+                }
+            };
         }
 
         self.check_fallback(tenant_id, limits, now_secs)
+    }
+
+    fn handle_redis_failure(&self, error: &dyn std::fmt::Display) {
+        // Warn once per process, not once per request.
+        // `swap(true, _)` returns the *previous* value: false on the
+        // very first failure (which is when we want the loud warning),
+        // true thereafter (when we drop to debug-level so logs stay useful).
+        #[allow(clippy::if_not_else)]
+        if !self.fallback_warned.swap(true, Ordering::Relaxed) {
+            tracing::warn!(
+                error = %error,
+                "Rate limiter falling back to in-memory; daily quota NOT enforced"
+            );
+        } else {
+            tracing::debug!(error = %error, "Rate limit Redis call failed; using fallback");
+        }
     }
 
     /// Redis-backed path. Single Lua call that prunes the sliding window,
@@ -250,10 +275,13 @@ impl RateLimiter {
     /// Pure in-memory path. Implements the same sliding-minute semantics
     /// as the Redis script, minus the daily quota (see module docs).
     fn check_fallback(&self, tenant_id: &str, limits: Limits, now_secs: u64) -> CheckOutcome {
+        self.evict_idle_fallback_buckets(now_secs);
+
         let mut entry = self.fallback.entry(tenant_id.to_string()).or_default();
         let bucket = entry.value_mut();
         let window_start = now_secs.saturating_sub(60);
         bucket.timestamps.retain(|&ts| ts > window_start);
+        bucket.last_seen = now_secs;
 
         let count = bucket.timestamps.len() as u32;
         let allowed = count < limits.rpm;
@@ -283,6 +311,31 @@ impl RateLimiter {
                 Some(u32::try_from(wait).unwrap_or(60))
             },
         }
+    }
+
+    fn evict_idle_fallback_buckets(&self, now_secs: u64) {
+        let window_start = now_secs.saturating_sub(60);
+        self.fallback.retain(|_, bucket| {
+            bucket.timestamps.retain(|&ts| ts > window_start);
+            !bucket.timestamps.is_empty() || bucket.last_seen > window_start
+        });
+    }
+
+    #[cfg(test)]
+    fn new_forced_redis_error_for_test() -> Self {
+        let limiter = Self::new(None);
+        limiter.force_redis_error.store(true, Ordering::Relaxed);
+        limiter
+    }
+
+    #[cfg(test)]
+    fn fallback_warning_emitted_for_test(&self) -> bool {
+        self.fallback_warned.load(Ordering::Relaxed)
+    }
+
+    #[cfg(test)]
+    fn fallback_bucket_count_for_test(&self) -> usize {
+        self.fallback.len()
     }
 }
 
@@ -425,10 +478,7 @@ where
             // before reaching here, so this is mostly belt-and-suspenders.
             let (tenant_id, plan) = req.extensions().get::<AuthContext>().map_or_else(
                 || ("anonymous".to_string(), "free".to_string()),
-                |ctx| {
-                    let tenant = ctx.user_id.clone().unwrap_or_else(|| ctx.key_id.clone());
-                    (tenant, ctx.plan.clone())
-                },
+                |ctx| (quota_bucket_key(ctx), ctx.plan.clone()),
             );
 
             let outcome = state.rate_limiter.check(&tenant_id, &plan).await;
@@ -444,6 +494,13 @@ where
             Ok(response)
         })
     }
+}
+
+fn quota_bucket_key(ctx: &AuthContext) -> String {
+    ctx.tenant_id
+        .clone()
+        .or_else(|| ctx.user_id.clone())
+        .unwrap_or_else(|| ctx.key_id.clone())
 }
 
 /// Build a 429 response with all rate-limit / retry headers populated.
@@ -578,14 +635,64 @@ mod tests {
 
     #[tokio::test]
     async fn test_grace_period_on_redis_failure() {
-        // Redis = None simulates "Redis configured but every call fails".
-        // The limiter must continue serving traffic via the in-memory path
-        // and only emit ONE warning across many requests.
+        // Redis = None forces the degraded in-memory path. The separate
+        // forced-error test below exercises the Redis failure branch.
         let rl = limiter();
         for _ in 0..5 {
             let outcome = rl.check("u_grace", "free").await;
             assert!(outcome.allowed);
         }
+    }
+
+    #[tokio::test]
+    async fn test_redis_error_path_sets_warn_once_and_serves_fallback() {
+        let rl = RateLimiter::new_forced_redis_error_for_test();
+        assert!(!rl.fallback_warning_emitted_for_test());
+
+        for _ in 0..5 {
+            let outcome = rl.check("u_grace_forced", "free").await;
+            assert!(outcome.allowed);
+        }
+
+        assert!(rl.fallback_warning_emitted_for_test());
+        assert_eq!(rl.fallback_bucket_count_for_test(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_fallback_evicts_idle_buckets() {
+        let rl = limiter();
+        let limits = PlanLimits::for_plan("free");
+
+        let first = rl.check_fallback("tenant_idle", limits, 1_000);
+        assert!(first.allowed);
+        assert_eq!(rl.fallback_bucket_count_for_test(), 1);
+
+        let second = rl.check_fallback("tenant_active", limits, 1_061);
+        assert!(second.allowed);
+        assert_eq!(
+            rl.fallback_bucket_count_for_test(),
+            1,
+            "idle tenant bucket should be evicted after the sliding window"
+        );
+    }
+
+    #[test]
+    fn test_quota_bucket_prefers_tenant_then_user_then_key() {
+        let mut ctx = AuthContext {
+            key_id: "key_123".to_string(),
+            tenant_id: Some("tenant_abc".to_string()),
+            user_id: Some("user_123".to_string()),
+            scope: "mcp".to_string(),
+            stripe_customer_id: None,
+            plan: "business".to_string(),
+        };
+        assert_eq!(quota_bucket_key(&ctx), "tenant_abc");
+
+        ctx.tenant_id = None;
+        assert_eq!(quota_bucket_key(&ctx), "user_123");
+
+        ctx.user_id = None;
+        assert_eq!(quota_bucket_key(&ctx), "key_123");
     }
 
     #[tokio::test]

--- a/pensyve-mcp-gateway/src/usage.rs
+++ b/pensyve-mcp-gateway/src/usage.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+use sha2::{Digest, Sha256};
 use tokio::sync::mpsc;
 
 use crate::circuit_breaker::CircuitBreaker;
@@ -385,7 +386,7 @@ impl UsageReporter {
             "Flushing usage to Stripe"
         );
 
-        let mut failed_groups = HashSet::new();
+        let mut failed_groups: HashSet<(&str, OperationTier)> = HashSet::new();
         for ((customer_id, tier), (count, traceparent)) in &aggregated {
             let success = Self::post_meter_event(
                 client,
@@ -397,7 +398,7 @@ impl UsageReporter {
             )
             .await;
             if !success {
-                failed_groups.insert((customer_id.clone(), *tier));
+                failed_groups.insert((customer_id.as_str(), *tier));
                 tracing::error!(
                     customer = customer_id,
                     count,
@@ -410,7 +411,7 @@ impl UsageReporter {
 
     fn events_for_failed_groups(
         events: Vec<UsageEvent>,
-        failed_groups: &HashSet<(String, OperationTier)>,
+        failed_groups: &HashSet<(&str, OperationTier)>,
     ) -> Vec<UsageEvent> {
         events
             .into_iter()
@@ -419,7 +420,7 @@ impl UsageReporter {
                     .stripe_customer_id
                     .as_ref()
                     .is_some_and(|customer_id| {
-                        failed_groups.contains(&(customer_id.clone(), event.tier))
+                        failed_groups.contains(&(customer_id.as_str(), event.tier))
                     })
             })
             .collect()
@@ -506,6 +507,9 @@ impl UsageReporter {
         count: u32,
         traceparent: Option<&str>,
     ) -> bool {
+        let count_value = count.to_string();
+        let idempotency_key =
+            Self::meter_event_idempotency_key(customer_id, tier, count, traceparent);
         for attempt in 0..3 {
             if attempt > 0 {
                 tokio::time::sleep(tokio::time::Duration::from_millis(500 * 2u64.pow(attempt)))
@@ -514,10 +518,11 @@ impl UsageReporter {
             let mut req = client
                 .post("https://api.stripe.com/v1/billing/meter_events")
                 .bearer_auth(api_key)
+                .header("Idempotency-Key", &idempotency_key)
                 .form(&[
                     ("event_name", tier.event_name()),
                     ("payload[stripe_customer_id]", customer_id),
-                    ("payload[value]", &count.to_string()),
+                    ("payload[value]", count_value.as_str()),
                 ]);
             // Phase 23/A: propagate W3C trace context so Stripe's
             // request logs (and our own egress logs) can be correlated
@@ -553,6 +558,26 @@ impl UsageReporter {
             }
         }
         false
+    }
+
+    fn meter_event_idempotency_key(
+        customer_id: &str,
+        tier: OperationTier,
+        count: u32,
+        traceparent: Option<&str>,
+    ) -> String {
+        let mut hasher = Sha256::new();
+        hasher.update(b"pensyve-meter-event-v1\0");
+        hasher.update(customer_id.as_bytes());
+        hasher.update(b"\0");
+        hasher.update(tier.event_name().as_bytes());
+        hasher.update(b"\0");
+        hasher.update(count.to_be_bytes());
+        hasher.update(b"\0");
+        if let Some(traceparent) = traceparent {
+            hasher.update(traceparent.as_bytes());
+        }
+        format!("pensyve-meter-{}", hex::encode(hasher.finalize()))
     }
 }
 
@@ -604,6 +629,32 @@ mod tests {
             OperationTier::Extraction.event_name(),
             "pensyve_extraction_operation"
         );
+    }
+
+    #[test]
+    fn test_meter_event_idempotency_key_stable_for_same_payload() {
+        let a = UsageReporter::meter_event_idempotency_key(
+            "cus_123",
+            OperationTier::Standard,
+            4,
+            Some("00-aaa-bbb-01"),
+        );
+        let b = UsageReporter::meter_event_idempotency_key(
+            "cus_123",
+            OperationTier::Standard,
+            4,
+            Some("00-aaa-bbb-01"),
+        );
+        let c = UsageReporter::meter_event_idempotency_key(
+            "cus_123",
+            OperationTier::Standard,
+            5,
+            Some("00-aaa-bbb-01"),
+        );
+
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+        assert!(a.starts_with("pensyve-meter-"));
     }
 
     #[tokio::test]
@@ -662,7 +713,7 @@ mod tests {
                 traceparent: None,
             },
         ];
-        let failed_groups = HashSet::from([("cus_failed".to_string(), OperationTier::Standard)]);
+        let failed_groups = HashSet::from([("cus_failed", OperationTier::Standard)]);
 
         let requeued = UsageReporter::events_for_failed_groups(events, &failed_groups);
 

--- a/pensyve-mcp-gateway/src/usage.rs
+++ b/pensyve-mcp-gateway/src/usage.rs
@@ -1,5 +1,6 @@
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use tokio::sync::mpsc;
 
@@ -128,7 +129,10 @@ impl UsageReporter {
         buffer_capacity: usize,
     ) {
         // Reuse the HTTP client across all flushes for connection pooling.
-        let client = reqwest::Client::new();
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(5))
+            .build()
+            .expect("usage reporter HTTP client should build");
         let mut batch: Vec<UsageEvent> = Vec::new();
         // Bounded buffer for events received while the breaker is Open.
         // Wrapped in std::sync::Mutex so internal drain helpers can take
@@ -260,9 +264,9 @@ impl UsageReporter {
         // contents would otherwise be silently lost. Take a defensive
         // clone so we can requeue on failure into the same bounded
         // buffer the Open path uses (drop-oldest semantics preserved).
-        let preserved = batch.clone();
-        let success = Self::flush_batch_returning_success(batch, stripe_api_key, client).await;
-        if success {
+        let failed_events =
+            Self::flush_batch_returning_failed_events(batch, stripe_api_key, client).await;
+        if failed_events.is_empty() {
             cb.record_success().await;
             // First successful flush after Open → drain the buffer. We
             // always attempt to drain whenever there are buffered events,
@@ -279,7 +283,7 @@ impl UsageReporter {
             {
                 let mut buf = buffer.lock().expect("usage buffer mutex poisoned");
                 let mut dropped = 0usize;
-                for event in preserved {
+                for event in failed_events {
                     if buf.len() >= buffer_capacity && buf.pop_front().is_some() {
                         dropped += 1;
                     }
@@ -321,24 +325,22 @@ impl UsageReporter {
                 buf.drain(..take).collect()
             };
             let chunk_len = chunk.len();
-            // Keep an untouched copy for the requeue path.
-            // `flush_batch_returning_success` calls `aggregate_batch` which
-            // *drains* its input vec, so by the time the !success branch
-            // runs there's nothing left in the borrowed copy to push back.
-            // Without this clone the failed events would be silently lost.
-            let mut working_copy = chunk.clone();
-            let success =
-                Self::flush_batch_returning_success(&mut working_copy, stripe_api_key, client)
-                    .await;
-            if !success {
-                // Push the original (un-drained) chunk back to the front
-                // so order is preserved on the next drain attempt. Take
-                // care to drop the MutexGuard before .await — std Mutex
-                // guards are !Send and would un-Send the report_loop
-                // future.
+            let mut working_copy = chunk;
+            let failed_events = Self::flush_batch_returning_failed_events(
+                &mut working_copy,
+                stripe_api_key,
+                client,
+            )
+            .await;
+            if !failed_events.is_empty() {
+                // Push only the failed customer/tier groups back to the
+                // front so successful groups are not double-counted on
+                // the next drain attempt. Take care to drop the
+                // MutexGuard before .await — std Mutex guards are !Send
+                // and would un-Send the report_loop future.
                 let remaining = {
                     let mut buf = buffer.lock().expect("usage buffer mutex poisoned");
-                    for event in chunk.into_iter().rev() {
+                    for event in failed_events.into_iter().rev() {
                         buf.push_front(event);
                     }
                     buf.len()
@@ -358,22 +360,23 @@ impl UsageReporter {
     /// Flush a batch and report whether the Stripe call(s) ultimately
     /// succeeded. Used by the circuit-breaker wrapper so we can classify
     /// the outcome.
-    async fn flush_batch_returning_success(
+    async fn flush_batch_returning_failed_events(
         batch: &mut Vec<UsageEvent>,
         stripe_api_key: Option<&str>,
         client: &reqwest::Client,
-    ) -> bool {
+    ) -> Vec<UsageEvent> {
         let Some(api_key) = stripe_api_key else {
             // No Stripe configured — events are intentionally dropped at
             // the source (dev mode). Treat as success so we don't trip
             // the breaker on operator misconfiguration.
             batch.clear();
-            return true;
+            return Vec::new();
         };
 
+        let original = batch.clone();
         let aggregated = Self::aggregate_batch(batch);
         if aggregated.is_empty() {
-            return true;
+            return Vec::new();
         }
 
         tracing::info!(
@@ -382,7 +385,7 @@ impl UsageReporter {
             "Flushing usage to Stripe"
         );
 
-        let mut overall_success = true;
+        let mut failed_groups = HashSet::new();
         for ((customer_id, tier), (count, traceparent)) in &aggregated {
             let success = Self::post_meter_event(
                 client,
@@ -394,7 +397,7 @@ impl UsageReporter {
             )
             .await;
             if !success {
-                overall_success = false;
+                failed_groups.insert((customer_id.clone(), *tier));
                 tracing::error!(
                     customer = customer_id,
                     count,
@@ -402,7 +405,24 @@ impl UsageReporter {
                 );
             }
         }
-        overall_success
+        Self::events_for_failed_groups(original, &failed_groups)
+    }
+
+    fn events_for_failed_groups(
+        events: Vec<UsageEvent>,
+        failed_groups: &HashSet<(String, OperationTier)>,
+    ) -> Vec<UsageEvent> {
+        events
+            .into_iter()
+            .filter(|event| {
+                event
+                    .stripe_customer_id
+                    .as_ref()
+                    .is_some_and(|customer_id| {
+                        failed_groups.contains(&(customer_id.clone(), event.tier))
+                    })
+            })
+            .collect()
     }
 
     /// Legacy flush path — used only when no circuit breaker is attached.
@@ -608,6 +628,48 @@ mod tests {
         // Without a real Stripe key, this just discards.
         UsageReporter::flush_batch(&mut batch, None, &client).await;
         assert!(batch.is_empty());
+    }
+
+    #[test]
+    fn test_partial_stripe_failure_requeues_only_failed_groups() {
+        let events = vec![
+            UsageEvent {
+                key_id: "k_success".into(),
+                stripe_customer_id: Some("cus_success".into()),
+                tier: OperationTier::Standard,
+                count: 3,
+                traceparent: None,
+            },
+            UsageEvent {
+                key_id: "k_failed_a".into(),
+                stripe_customer_id: Some("cus_failed".into()),
+                tier: OperationTier::Standard,
+                count: 7,
+                traceparent: None,
+            },
+            UsageEvent {
+                key_id: "k_failed_b".into(),
+                stripe_customer_id: Some("cus_failed".into()),
+                tier: OperationTier::Standard,
+                count: 2,
+                traceparent: Some("00-aaa-bbb-01".into()),
+            },
+            UsageEvent {
+                key_id: "k_other_tier".into(),
+                stripe_customer_id: Some("cus_failed".into()),
+                tier: OperationTier::Extraction,
+                count: 1,
+                traceparent: None,
+            },
+        ];
+        let failed_groups = HashSet::from([("cus_failed".to_string(), OperationTier::Standard)]);
+
+        let requeued = UsageReporter::events_for_failed_groups(events, &failed_groups);
+
+        assert_eq!(requeued.len(), 2);
+        assert_eq!(requeued[0].key_id, "k_failed_a");
+        assert_eq!(requeued[1].key_id, "k_failed_b");
+        assert_eq!(requeued[1].traceparent.as_deref(), Some("00-aaa-bbb-01"));
     }
 
     /// Phase 23/C: when the circuit breaker is Open, events going


### PR DESCRIPTION
## Summary

- add tenant/account identity to gateway auth context and prefer it for rate-limit quota buckets
- bound degraded-mode rate-limit fallback buckets, add a Redis call timeout, and cover the Redis-error fallback path
- requeue only failed Stripe meter-event groups after partial flush failures
- enforce a single HalfOpen circuit-breaker probe locally and via Redis `SET NX EX` when available
- add runtime-stall watchdog logging, move background consolidation off core Tokio workers, and add a finite Stripe HTTP timeout

## Issues

Fixes #89
Fixes #90
Fixes #91
Fixes #94
Fixes #95
Addresses #107

## Verification

- `cargo test -p pensyve-mcp-gateway`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Reliability & Performance**
  * Redis-coordinated single-probe circuit-breaker ownership with abandoned-probe timeouts, bounded Redis timeouts, consolidation moved to a blocking worker, and a runtime scheduling watchdog

* **Rate Limiting**
  * Safer Redis timeouts, centralized Redis-failure handling, deterministic in-memory fallback with idle-bucket eviction, and quota-key precedence for tenant resolution

* **Auth & Multi-tenant**
  * Consistent tenant identity propagation across auth paths and support for multiple tenant/account identity fields

* **Billing**
  * Short HTTP timeout, stable idempotency keys, and requeueing only failed customer/tier groups on partial Stripe failures

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/major7apps/pensyve/pull/123?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->