### PR TITLE
feat(retrieval): default-on SelRoute query-type classifier

### DIFF
--- a/pensyve-core/src/extraction/dep_parse.rs
+++ b/pensyve-core/src/extraction/dep_parse.rs
@@ -240,9 +240,9 @@ static PRONOUN_SUBJECTS: phf::Set<&'static str> = phf::phf_set! {
 
 /// Check whether the `PENSYVE_DEP_PARSE` env-var gate is enabled.
 ///
-/// Reads once via `OnceLock` (matches the Phase 2A `SelRoute` pattern in
-/// [`crate::retrieval::query_classifier::selroute_enabled`]). Accepted
-/// truthy values (case-insensitive): `"1"`, `"true"`, `"on"`, `"yes"`.
+/// Reads once via `OnceLock`. Default-off (unlike `SelRoute` which is
+/// default-on). Accepted truthy values (case-insensitive): `"1"`,
+/// `"true"`, `"on"`, `"yes"`.
 #[must_use]
 pub fn dep_parse_enabled() -> bool {
     static DEP_PARSE: OnceLock<bool> = OnceLock::new();

--- a/pensyve-core/src/retrieval/engine.rs
+++ b/pensyve-core/src/retrieval/engine.rs
@@ -648,12 +648,12 @@ impl<'a> RecallEngine<'a> {
             self.gather_candidates(query, namespace_id, max_candidates)?
         };
 
-        // Phase 2A SelRoute: optional question-type classification +
-        // per-route RRF weight mask. Strictly gated behind the
-        // `PENSYVE_SELROUTE` env-var (read once via OnceLock — see
-        // `query_classifier::selroute_enabled`); when the gate is off
-        // the entire block is bypassed and the recall path is
-        // byte-for-byte identical to pre-Phase-2A behavior.
+        // Phase 2A SelRoute: question-type classification + per-route
+        // RRF weight mask. Enabled by default; set `PENSYVE_SELROUTE=0`
+        // to disable (read once via OnceLock — see
+        // `query_classifier::selroute_enabled`). When disabled, the
+        // entire block is bypassed and the recall path is byte-for-byte
+        // identical to pre-Phase-2A behavior.
         //
         // This block runs BEFORE the zero-candidate early return so
         // `selroute_classified` / `selroute_fallback_count` /

--- a/pensyve-core/src/retrieval/query_classifier.rs
+++ b/pensyve-core/src/retrieval/query_classifier.rs
@@ -421,23 +421,22 @@ pub fn selroute_metric_index(question_type: &str) -> Option<usize> {
     }
 }
 
-/// Check whether the `SelRoute` env-var gate is enabled.
+/// Check whether the `SelRoute` query-type classifier is enabled.
+///
+/// **Default-on** since Phase 2A.1 validated `SelRoute` as net positive
+/// (+2.0pp aggregate, +11.8pp ss-preference, zero regressions).
 ///
 /// Reads `PENSYVE_SELROUTE` once via `OnceLock` — env-var changes
-/// post-init are NOT picked up. This matches the existing `IntentRouter`
-/// pattern of caching env reads at construction (`MultiSessionCard::g3_mode`,
-/// `KBudget::from_env`).
-///
-/// Accepted truthy values (case-insensitive): `"1"`, `"true"`, `"on"`,
-/// `"yes"`. Anything else — including unset — disables `SelRoute`.
+/// post-init are NOT picked up. Set `PENSYVE_SELROUTE=0` to disable.
 #[must_use]
 pub fn selroute_enabled() -> bool {
     static SELROUTE: OnceLock<bool> = OnceLock::new();
     *SELROUTE.get_or_init(|| {
-        std::env::var("PENSYVE_SELROUTE").is_ok_and(|v| {
-            let lower = v.trim().to_ascii_lowercase();
-            matches!(lower.as_str(), "1" | "true" | "on" | "yes")
-        })
+        std::env::var("PENSYVE_SELROUTE")
+            .map_or(true, |v| {
+                let lower = v.trim().to_ascii_lowercase();
+                !matches!(lower.as_str(), "0" | "false" | "off" | "no")
+            })
     })
 }
 

--- a/pensyve-core/src/retrieval/query_classifier.rs
+++ b/pensyve-core/src/retrieval/query_classifier.rs
@@ -431,11 +431,10 @@ pub fn selroute_metric_index(question_type: &str) -> Option<usize> {
 pub fn selroute_enabled() -> bool {
     static SELROUTE: OnceLock<bool> = OnceLock::new();
     *SELROUTE.get_or_init(|| {
-        std::env::var("PENSYVE_SELROUTE")
-            .map_or(true, |v| {
-                let lower = v.trim().to_ascii_lowercase();
-                !matches!(lower.as_str(), "0" | "false" | "off" | "no")
-            })
+        std::env::var("PENSYVE_SELROUTE").map_or(true, |v| {
+            let lower = v.trim().to_ascii_lowercase();
+            !matches!(lower.as_str(), "0" | "false" | "off" | "no")
+        })
     })
 }
 

--- a/pensyve-core/src/retrieval/query_classifier.rs
+++ b/pensyve-core/src/retrieval/query_classifier.rs
@@ -33,10 +33,9 @@
 //!
 //! The Phase 2A integration in `engine.rs` is wrapped behind a
 //! `PENSYVE_SELROUTE` env-var gate read once at process start via
-//! `OnceLock`. When unset / `0` / `false`, the recall pipeline is
-//! byte-for-byte identical to pre-Phase-2A behavior — this is a hard
-//! requirement for the Phase 2 rollout (the orchestrator A/B's the gate
-//! against the v2.2 baseline).
+//! `OnceLock`. **`SelRoute` is enabled by default**; set
+//! `PENSYVE_SELROUTE=0` (or `false` / `off` / `no`) to disable and
+//! restore the byte-for-byte pre-Phase-2A recall pipeline.
 //!
 //! ## Per-route RRF mask rationale (Phase 2A + 2C)
 //!


### PR DESCRIPTION
## Summary

- Flip `selroute_enabled()` default from opt-in (`PENSYVE_SELROUTE=1`) to opt-out (`PENSYVE_SELROUTE=0`)
- SelRoute validated positive in Phase 2A.1: **+2.0pp aggregate**, **+11.8pp ss-preference**, zero regressions
- D-MEM/Vendi regressions are orthogonal (only in `all-five` config), not affected by this change

## Test plan

- [x] `cargo test --workspace` — 818 tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [ ] Verify SelRoute active by default (no env var set → classification runs)
- [ ] Verify opt-out works (`PENSYVE_SELROUTE=0` → classification skipped)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Changed a critical configuration’s default from disabled to enabled; it can still be disabled by setting the option to 0, false, off, or no (case-insensitive, whitespace-trimmed).
  * When disabled, the related classification/weight-mask block is fully bypassed.

* **Documentation**
  * Updated docs to reflect the default-enabled behavior and list the disable values.
  * Clarified that a related configuration remains default-off in its documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/major7apps/pensyve/pull/126?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->