### PR TITLE
fix(gateway): use char-based slicing to prevent UTF-8 panic in remember log

### DIFF
--- a/pensyve-mcp-gateway/src/rest.rs
+++ b/pensyve-mcp-gateway/src/rest.rs
@@ -724,7 +724,7 @@ async fn remember(
     let _ = ps.storage.log_activity(
         ps.namespace.id,
         "remember",
-        &json!({"entity": body.entity, "preview": &body.fact[..body.fact.len().min(50)]}),
+        &json!({"entity": body.entity, "preview": body.fact.chars().take(50).collect::<String>()}),
     );
 
     // Invalidate recall cache for this namespace.


### PR DESCRIPTION
Bug
---
Byte-index slicing `body.fact[..len.min(50)]` in the remember
endpoint panics when the 50th byte falls inside a multi-byte UTF-8
character (e.g. accented chars like `á`, `ñ`, `ü`). This kills the
tokio worker handling the request, drops the HTTP connection, and
causes `socket connection closed unexpectedly` errors in clients.

Repro
-----
POST /v1/remember with a fact containing an accented character
straddling byte position 50, e.g.:

  `[session] Estaba haciendo una pruebecilla. Nada más. Al inicio...`
                                                           ^ byte 50
                                                           splits 'á'

Fix
---
Replace byte-index slice with character-based truncation:

  -  &body.fact[..body.fact.len().min(50)]
  +  body.fact.chars().take(50).collect::<String>()

Only 1 line changed in `pensyve-mcp-gateway/src/rest.rs:727`.

No other unsafe byte slices found in the codebase (the other one at
line 691 is safe because it uses `find(' ')` which returns a valid
UTF-8 boundary for an ASCII char).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed preview text truncation to properly handle non-ASCII characters, ensuring content is truncated by character count rather than byte length for more reliable preview generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->