### PR TITLE
chore: prepare 2.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to Pensyve will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.6.0] - 2026-07-07
+
+Minor release since v2.5.0, headlined by the `SelRoute` query-type classifier (Phase 2A) moving from opt-in to default-on — the behavior change that makes this a minor bump rather than a patch. Also ships tenant-scoped gateway rate limiting/quotas, gateway resilience hardening, a native Codex `/pensyve` command, a documentation decomposition pass, and a UTF-8 panic fix in gateway logging.
+
+### Added
+
+- **Native Codex `/pensyve` command** (`integrations/codex-plugin`) for explicit recall / remember / observe / inspect / status / review / forget workflows, plus a `mention-workflow` skill that treats literal `@pensyve` text as explicit memory intent. Ships as Codex plugin v1.4.1/v1.4.2 (versioned independently of the core crate — see `integrations/codex-plugin/CHANGELOG.md`). Resolves #122.
+- **`docs/SECURITY.md` and `docs/RELIABILITY.md`** — dedicated security (auth, RBAC, `NetworkPolicy`, multi-tenant isolation, PII detection) and reliability (test counts, FSRS guarantees) references, split out of the retired `docs/agent-context.md` alongside an expanded `docs/ARCHITECTURE.md`. Resolves #124.
+
+### Fixed
+
+- **Phase 2A.1 — preference-detection for the `SelRoute` query classifier** (`pensyve-core::retrieval::query_classifier`). Queries like "What is my favorite color?" previously matched the single-session-user pattern (`\bmy\b`) and took a spreading-activation penalty meant for a different question type — there was no preference-specific detector. Added a preference regex (favourite/favorite, prefer/preferred/preferences, like best, go-to) with precedence above single-session-user but below single-session-assistant, so preference queries now route to the identity mask instead. This fix is what unblocked the default-on flip below. Resolves #125.
+- **Gateway resilience hardening** (`pensyve-mcp-gateway`): the auth/Stripe circuit breaker now recovers from abandoned `HalfOpen` probes and mirrors state across gateway instances via Redis instead of waiting out a full cooldown; the usage reporter requeues only the specific customer/tier groups that failed to flush (instead of the whole batch) and applies a bounded HTTP timeout so a slow Stripe call can no longer stall reporting. Part of #123.
+- **UTF-8 panic in the gateway's `/v1/remember` request logging.** Byte-index slicing of the `fact` field for a log preview could panic when the truncation boundary fell inside a multi-byte character (e.g. accented letters), which surfaced to clients as `socket connection closed unexpectedly`. Truncation now walks `chars()` so it always respects character boundaries. Resolves #151.
+
+### Changed
+
+- **`SelRoute` query-type classifier is now default-on** (`pensyve-core::retrieval::query_classifier`). `PENSYVE_SELROUTE` previously required explicit opt-in; it now defaults to enabled, with `PENSYVE_SELROUTE=0` (or `false` / `off` / `no`) to disable and restore the byte-for-byte pre-Phase-2A recall pipeline. SelRoute maps recall queries into the six `IntentRouter` question types and applies a per-route 8-signal RRF mask. The flip follows the Phase 2A.1 fix above and validated positive on Pensyve's internal n=100 validation set: +2.0pp aggregate accuracy and +11.8pp on single-session-preference queries specifically, with zero regressions on other question types. Resolves #126.
+- **Gateway rate limiting and usage quotas are now tenant-scoped** (`pensyve-mcp-gateway`). `AuthContext` carries an optional `tenant_id` (from OAuth claims or the auth-service response body); the rate-limit/quota bucket key now resolves `tenant_id > user_id > key_id`, so multiple API keys under the same tenant share one quota bucket instead of each key getting its own. Part of #123.
+- **Core release version bumped `2.5.0 -> 2.6.0`** across Rust manifests, Python metadata, and Cargo/uv locks; `@pensyve/sdk` moves in lockstep.
+
+### Notes
+
+- **Defaults for G3/G4 and Phase 2B-2E mechanisms (dependency-parse KG, PPR, D-MEM, Vendi rerank) are unchanged** — still opt-in behind their respective env gates. Only SelRoute (Phase 2A) flips to default-on in this release.
+- **`pensyve-python` wheels** follow the same release workflow matrix as v2.5.0: Linux x64, Linux ARM64, macOS ARM64, and Windows x64.
+- **MSRV unchanged** at 1.88.
+
 ## [2.5.0] - 2026-05-24
 
 Feature release since v2.4.0. This cut includes the two G4 public-surface follow-ups plus the Phase 2A-2E algorithm stack: SelRoute query classification, dependency-parse KG materialization, Personalized PageRank retrieval, RPE-gated fast/slow consolidation, and Vendi-Score diversity reranking. The new retrieval and consolidation mechanisms remain opt-in behind env gates unless called through explicit SDK surfaces.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2793,7 +2793,7 @@ dependencies = [
 
 [[package]]
 name = "pensyve-benchmarks"
-version = "2.5.0"
+version = "2.6.0"
 dependencies = [
  "chrono",
  "pensyve-core",
@@ -2808,7 +2808,7 @@ dependencies = [
 
 [[package]]
 name = "pensyve-cli"
-version = "2.5.0"
+version = "2.6.0"
 dependencies = [
  "clap",
  "dirs",
@@ -2819,7 +2819,7 @@ dependencies = [
 
 [[package]]
 name = "pensyve-core"
-version = "2.5.0"
+version = "2.6.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2849,7 +2849,7 @@ dependencies = [
 
 [[package]]
 name = "pensyve-mcp"
-version = "2.5.0"
+version = "2.6.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -2865,7 +2865,7 @@ dependencies = [
 
 [[package]]
 name = "pensyve-mcp-gateway"
-version = "2.5.0"
+version = "2.6.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2897,7 +2897,7 @@ dependencies = [
 
 [[package]]
 name = "pensyve-mcp-tools"
-version = "2.5.0"
+version = "2.6.0"
 dependencies = [
  "pensyve-core",
  "rmcp",
@@ -2912,7 +2912,7 @@ dependencies = [
 
 [[package]]
 name = "pensyve-python"
-version = "2.5.0"
+version = "2.6.0"
 dependencies = [
  "chrono",
  "pensyve-core",

--- a/pensyve-benchmarks/Cargo.toml
+++ b/pensyve-benchmarks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pensyve-benchmarks"
-version = "2.5.0"
+version = "2.6.0"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"
@@ -8,7 +8,7 @@ description = "Evaluation framework for Pensyve memory engine"
 publish = false
 
 [dependencies]
-pensyve-core = { path = "../pensyve-core", version = "2.5.0" }
+pensyve-core = { path = "../pensyve-core", version = "2.6.0" }
 rand = "0.10"
 rand_distr = "0.6"
 serde = { version = "1", features = ["derive"] }

--- a/pensyve-cli/Cargo.toml
+++ b/pensyve-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pensyve-cli"
-version = "2.5.0"
+version = "2.6.0"
 edition = "2024"
 description = "Pensyve command-line interface — universal memory runtime for AI agents"
 rust-version = "1.88"
@@ -14,7 +14,7 @@ name = "pensyve"
 path = "src/main.rs"
 
 [dependencies]
-pensyve-core = { path = "../pensyve-core", version = "2.5.0" }
+pensyve-core = { path = "../pensyve-core", version = "2.6.0" }
 clap = { version = "4", features = ["derive"] }
 serde_json = "1"
 uuid = { version = "1", features = ["v4"] }

--- a/pensyve-core/Cargo.toml
+++ b/pensyve-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pensyve-core"
-version = "2.5.0"
+version = "2.6.0"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/pensyve-mcp-gateway/Cargo.toml
+++ b/pensyve-mcp-gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pensyve-mcp-gateway"
-version = "2.5.0"
+version = "2.6.0"
 edition = "2024"
 description = "Remote MCP gateway for Pensyve Cloud — Streamable HTTP transport"
 rust-version = "1.88"
@@ -18,8 +18,8 @@ name = "pensyve-mcp-gateway"
 path = "src/main.rs"
 
 [dependencies]
-pensyve-core = { path = "../pensyve-core", version = "2.5.0", features = ["postgres", "observation-extraction"] }
-pensyve-mcp-tools = { path = "../pensyve-mcp-tools", version = "2.5.0" }
+pensyve-core = { path = "../pensyve-core", version = "2.6.0", features = ["postgres", "observation-extraction"] }
+pensyve-mcp-tools = { path = "../pensyve-mcp-tools", version = "2.6.0" }
 rmcp = { version = "1.7", features = ["server", "transport-streamable-http-server", "macros"] }
 axum = "0.8"
 tower-http = { version = "0.6", features = ["compression-gzip", "compression-br"] }

--- a/pensyve-mcp-tools/Cargo.toml
+++ b/pensyve-mcp-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pensyve-mcp-tools"
-version = "2.5.0"
+version = "2.6.0"
 edition = "2024"
 description = "Shared MCP tool definitions for Pensyve servers"
 rust-version = "1.88"
@@ -13,7 +13,7 @@ documentation = "https://pensyve.com/docs"
 name = "pensyve_mcp_tools"
 
 [dependencies]
-pensyve-core = { path = "../pensyve-core", version = "2.5.0" }
+pensyve-core = { path = "../pensyve-core", version = "2.6.0" }
 rmcp = { version = "1.7", features = ["server", "macros"] }
 tokio = { version = "1", features = ["full"] }
 # G1/P3a: needed for `CancellationToken::new()` passed to

--- a/pensyve-mcp/Cargo.toml
+++ b/pensyve-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pensyve-mcp"
-version = "2.5.0"
+version = "2.6.0"
 edition = "2024"
 description = "Pensyve MCP server (stdio transport) — universal memory runtime for AI agents"
 rust-version = "1.88"
@@ -14,8 +14,8 @@ name = "pensyve-mcp"
 path = "src/main.rs"
 
 [dependencies]
-pensyve-core = { path = "../pensyve-core", version = "2.5.0" }
-pensyve-mcp-tools = { path = "../pensyve-mcp-tools", version = "2.5.0" }
+pensyve-core = { path = "../pensyve-core", version = "2.6.0" }
+pensyve-mcp-tools = { path = "../pensyve-mcp-tools", version = "2.6.0" }
 rmcp = { version = "1.7", features = ["server", "transport-io", "macros"] }
 tokio = { version = "1", features = ["full"] }
 uuid = { version = "1", features = ["v4"] }

--- a/pensyve-python/Cargo.toml
+++ b/pensyve-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pensyve-python"
-version = "2.5.0"
+version = "2.6.0"
 edition = "2024"
 rust-version = "1.88"
 readme = "README.md"
@@ -15,7 +15,7 @@ name = "pensyve_python"
 crate-type = ["cdylib"]
 
 [dependencies]
-pensyve-core = { path = "../pensyve-core", version = "2.5.0", features = ["observation-extraction"] }
+pensyve-core = { path = "../pensyve-core", version = "2.6.0", features = ["observation-extraction"] }
 pyo3 = { version = "^0.28.3", features = ["extension-module"] }
 uuid = { version = "1", features = ["v4"] }
 chrono = "0.4"

--- a/pensyve-python/pyproject.toml
+++ b/pensyve-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pensyve"
-version = "2.5.0"
+version = "2.6.0"
 description = "Universal memory runtime for AI agents — framework-agnostic, protocol-native, offline-first"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/pensyve-ts/package.json
+++ b/pensyve-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pensyve/sdk",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "Pensyve TypeScript SDK — universal memory runtime for AI agents",
   "type": "module",
   "main": "dist/index.js",

--- a/pensyve-wasm/Cargo.toml
+++ b/pensyve-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pensyve-wasm"
-version = "2.5.0"
+version = "2.6.0"
 edition = "2024"
 
 [workspace]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pensyve"
-version = "2.5.0"
+version = "2.6.0"
 description = "Universal memory runtime for AI agents — framework-agnostic, protocol-native, offline-first"
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -922,7 +922,7 @@ wheels = [
 
 [[package]]
 name = "pensyve"
-version = "2.5.0"
+version = "2.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Prepares the v2.6.0 minor release. Bumps all workspace/crate manifests, `pyproject.toml`/`pensyve-python/pyproject.toml`, and `pensyve-ts/package.json` from `2.5.0` to `2.6.0`, regenerates `Cargo.lock` and `uv.lock`, and adds the `[2.6.0]` CHANGELOG entry. Follows the same manifest-bump pattern used for the v2.5.0 release (`d43fb98`).

Minor (not patch) bump because `SelRoute` (#126) is a default-behavior change: `PENSYVE_SELROUTE` now defaults to enabled (opt-out via `0`/`false`/`off`/`no`) instead of requiring opt-in.

**Included since v2.5.0 (333c702):**
- #122 — Native Codex `/pensyve` command + `mention-workflow` skill
- #123 — Tenant-scoped gateway rate limits/quotas + circuit breaker / usage-reporter resilience hardening
- #124 — Docs decomposition: `docs/SECURITY.md` + `docs/RELIABILITY.md`, retired `docs/agent-context.md`
- #125 — Phase 2A.1 fix: preference-detection for the `SelRoute` query classifier (closes the regression that blocked default-on)
- #126 — `SelRoute` query-type classifier default-on (+2.0pp aggregate / +11.8pp ss-preference on internal n=100 validation, zero regressions)
- #151 — Fix UTF-8 panic in gateway `/v1/remember` logging (char-based truncation instead of byte-index slicing)

**This PR does not merge or tag.** No `v*` tag was created or pushed, so `release.yml`'s publish pipeline was not triggered.

## Validation run locally

- `cargo fmt --all -- --check` — clean, no diff
- `cargo clippy --workspace -- -D warnings` — clean, zero warnings
- `cargo check --workspace` — all 8 workspace crates build at `2.6.0`
- `cargo test -p pensyve-core` — all test binaries green (487 unit tests + all integration suites, 0 failed)
- `uv lock` — regenerated `uv.lock`, single-line version diff (`pensyve v2.5.0 -> v2.6.0`)

Skipped (network/model-download dependent, and version-only changes don't warrant it per task scope): full-workspace `cargo test` (gateway/mcp/python crates need live infra or model downloads), Python (`uv run pytest` / `pyright`), and TypeScript SDK test suites.

## Test plan

- [ ] CI green on this PR (fmt, clippy, full test matrix, build artifacts)
- [ ] Manual review of CHANGELOG wording and PR/issue references
- [ ] Merge only after review — no auto-merge
- [ ] Tag `v2.6.0` and push separately, once merged, to trigger `release.yml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a native `/pensyve` command and expanded workflow support.
  * Introduced new security and reliability documentation.

* **Bug Fixes**
  * Improved search routing accuracy for preference-based queries.
  * Strengthened gateway resilience and recovery behavior.
  * Fixed a logging crash on non-UTF-8 request data.
  * Made usage requeueing more selective with safer timeouts.

* **Changes**
  * Enabled `SelRoute` by default, with an option to restore prior behavior.
  * Updated gateway rate limiting to use tenant-scoped quota buckets.
  * Bumped the release to **2.6.0**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->