### PR TITLE
fix: lazy ONNX embedder loading for the MCP stdio server (~2.9 GB -> ~12 MB idle per instance)

### DIFF
--- a/pensyve-core/src/embedding.rs
+++ b/pensyve-core/src/embedding.rs
@@ -96,6 +96,19 @@ enum EmbedderInner {
         pool: Vec<Mutex<TextEmbedding>>,
         next: AtomicUsize,
     },
+    /// Deferred variant: the ONNX session pool (and any load-time HF
+    /// download) is built on the first `embed`/`embed_batch` call instead
+    /// of at construction. `dimensions()` is available immediately because
+    /// dimensionality is a static property of the model name. A failed
+    /// pool build is NOT cached — the next embed call retries.
+    Lazy {
+        model: EmbeddingModel,
+        hf_model_code: &'static str,
+        policy: NetworkPolicy,
+        pool_size: usize,
+        pool: Mutex<Option<Arc<Vec<Mutex<TextEmbedding>>>>>,
+        next: AtomicUsize,
+    },
 }
 
 // ---------------------------------------------------------------------------
@@ -115,6 +128,59 @@ pub fn model_dimensions(model_name: &str) -> Option<usize> {
         .iter()
         .find(|(name, _)| *name == model_name)
         .map(|(_, dims)| *dims)
+}
+
+/// Returns whether a supported model is already present in the local
+/// fastembed cache, i.e. can be loaded without any network I/O. Unknown
+/// model names return `false`.
+///
+/// Useful for callers that want to pick a model without triggering a
+/// download (e.g. the MCP stdio server's lazy startup path).
+pub fn is_model_available_offline(model_name: &str) -> bool {
+    resolve_model(model_name).is_ok_and(|(_, _, hf_model_code)| is_model_cached(hf_model_code))
+}
+
+/// Map a supported model name to its fastembed enum, dimensionality, and
+/// `HuggingFace` model code. Errors on unknown names.
+fn resolve_model(model_name: &str) -> EmbeddingResult<(EmbeddingModel, usize, &'static str)> {
+    match model_name {
+        "Alibaba-NLP/gte-base-en-v1.5" => Ok((
+            EmbeddingModel::GTEBaseENV15,
+            768,
+            "Alibaba-NLP/gte-base-en-v1.5",
+        )),
+        "all-MiniLM-L6-v2" | "sentence-transformers/all-MiniLM-L6-v2" => Ok((
+            EmbeddingModel::AllMiniLML6V2,
+            384,
+            "Qdrant/all-MiniLM-L6-v2-onnx",
+        )),
+        other => {
+            let supported: Vec<&str> = SUPPORTED_MODELS.iter().map(|(name, _)| *name).collect();
+            Err(EmbeddingError::ModelLoad(format!(
+                "Unknown model: '{other}'. Supported: {}",
+                supported.join(", ")
+            )))
+        }
+    }
+}
+
+/// Build a pool of `pool_size` ONNX sessions for `model`. This is the
+/// expensive step (~hundreds of MB of session state per slot for
+/// GTE-base) shared by the eager and lazy construction paths.
+fn build_pool(
+    model: &EmbeddingModel,
+    pool_size: usize,
+) -> EmbeddingResult<Vec<Mutex<TextEmbedding>>> {
+    let mut pool = Vec::with_capacity(pool_size);
+    for i in 0..pool_size {
+        let show_progress = i == 0;
+        let session = TextEmbedding::try_new(
+            InitOptions::new(model.clone()).with_show_download_progress(show_progress),
+        )
+        .map_err(|e| EmbeddingError::ModelLoad(e.to_string()))?;
+        pool.push(Mutex::new(session));
+    }
+    Ok(pool)
 }
 
 // ---------------------------------------------------------------------------
@@ -157,25 +223,7 @@ impl OnnxEmbedder {
     /// This is the fail-closed-friendly entry point. Callers that want
     /// the v2.1 always-permissive behavior keep using [`Self::new`].
     pub fn new_with_policy(model_name: &str, policy: &NetworkPolicy) -> EmbeddingResult<Self> {
-        let (model_enum, dims, hf_model_code) = match model_name {
-            "Alibaba-NLP/gte-base-en-v1.5" => (
-                EmbeddingModel::GTEBaseENV15,
-                768,
-                "Alibaba-NLP/gte-base-en-v1.5",
-            ),
-            "all-MiniLM-L6-v2" | "sentence-transformers/all-MiniLM-L6-v2" => (
-                EmbeddingModel::AllMiniLML6V2,
-                384,
-                "Qdrant/all-MiniLM-L6-v2-onnx",
-            ),
-            other => {
-                let supported: Vec<&str> = SUPPORTED_MODELS.iter().map(|(name, _)| *name).collect();
-                return Err(EmbeddingError::ModelLoad(format!(
-                    "Unknown model: '{other}'. Supported: {}",
-                    supported.join(", ")
-                )));
-            }
-        };
+        let (model_enum, dims, hf_model_code) = resolve_model(model_name)?;
 
         // Cache pre-check: if the model directory already exists in the
         // fastembed cache, fastembed's `pull_from_hf` short-circuits and
@@ -191,17 +239,7 @@ impl OnnxEmbedder {
             policy.check(&hf_url)?;
         }
 
-        let pool_size = resolve_pool_size();
-
-        let mut pool = Vec::with_capacity(pool_size);
-        for i in 0..pool_size {
-            let show_progress = i == 0;
-            let model = TextEmbedding::try_new(
-                InitOptions::new(model_enum.clone()).with_show_download_progress(show_progress),
-            )
-            .map_err(|e| EmbeddingError::ModelLoad(e.to_string()))?;
-            pool.push(Mutex::new(model));
-        }
+        let pool = build_pool(&model_enum, resolve_pool_size())?;
 
         Ok(Self {
             dimensions: dims,
@@ -210,6 +248,92 @@ impl OnnxEmbedder {
                 next: AtomicUsize::new(0),
             },
         })
+    }
+
+    /// Create a lazy ONNX-backed embedder: the model name is validated and
+    /// dimensionality resolved immediately, but the ONNX session pool (and
+    /// any load-time `HuggingFace` download) is deferred until the first
+    /// `embed`/`embed_batch` call.
+    ///
+    /// Intended for per-session processes like the MCP stdio server, where
+    /// many concurrent instances may exist but most never embed anything —
+    /// an idle lazy embedder holds no ONNX session memory at all.
+    ///
+    /// The [`NetworkPolicy`] is captured at construction and enforced at
+    /// first load, mirroring [`Self::new_with_policy`]: an uncached model
+    /// under [`NetworkPolicy::Disabled`] surfaces
+    /// [`EmbeddingError::Network`] — just at first use instead of startup.
+    /// A failed load is not cached; subsequent calls retry.
+    ///
+    /// Equivalent to `new_lazy_with_options(model_name,
+    /// &NetworkPolicy::Permissive, resolved pool size)`.
+    pub fn new_lazy(model_name: &str) -> EmbeddingResult<Self> {
+        Self::new_lazy_with_options(model_name, &NetworkPolicy::Permissive, resolve_pool_size())
+    }
+
+    /// Lazy constructor with an explicit [`NetworkPolicy`] and pool size.
+    ///
+    /// `pool_size` is taken explicitly (rather than from
+    /// `PENSYVE_EMBEDDING_POOL_SIZE`) so single-client callers like the MCP
+    /// stdio server can default to 1 session instead of the CPU-derived
+    /// default meant for multi-threaded harnesses.
+    pub fn new_lazy_with_options(
+        model_name: &str,
+        policy: &NetworkPolicy,
+        pool_size: usize,
+    ) -> EmbeddingResult<Self> {
+        let (model_enum, dims, hf_model_code) = resolve_model(model_name)?;
+        Ok(Self {
+            dimensions: dims,
+            inner: EmbedderInner::Lazy {
+                model: model_enum,
+                hf_model_code,
+                policy: policy.clone(),
+                pool_size: pool_size.max(1),
+                pool: Mutex::new(None),
+                next: AtomicUsize::new(0),
+            },
+        })
+    }
+
+    /// Get the session pool of a `Lazy` embedder, building it on first use.
+    /// The mutex guard is held across the build so concurrent first calls
+    /// serialize instead of double-loading. Errors are returned without
+    /// being cached so a transient failure (e.g. download denied/offline)
+    /// is retried on the next call.
+    fn ensure_lazy_pool(&self) -> EmbeddingResult<Arc<Vec<Mutex<TextEmbedding>>>> {
+        let EmbedderInner::Lazy {
+            model,
+            hf_model_code,
+            policy,
+            pool_size,
+            pool,
+            ..
+        } = &self.inner
+        else {
+            return Err(EmbeddingError::Inference(
+                "ensure_lazy_pool called on non-lazy embedder".into(),
+            ));
+        };
+
+        let mut guard = pool
+            .lock()
+            .map_err(|e| EmbeddingError::Inference(format!("Lock poisoned: {e}")))?;
+        if let Some(existing) = guard.as_ref() {
+            return Ok(Arc::clone(existing));
+        }
+
+        // Same load-time network gating as `new_with_policy`, deferred to
+        // first use.
+        if !is_model_cached(hf_model_code) {
+            let hf_url = format!("https://huggingface.co/{hf_model_code}");
+            policy.check(&hf_url)?;
+        }
+
+        tracing::info!("Lazily loading ONNX embedder (pool_size={pool_size})");
+        let built = Arc::new(build_pool(model, *pool_size)?);
+        *guard = Some(Arc::clone(&built));
+        Ok(built)
     }
 
     /// Cached variant of [`Self::new`]. Returns an `Arc<OnnxEmbedder>` shared
@@ -272,18 +396,10 @@ impl OnnxEmbedder {
     pub fn embed(&self, text: &str) -> EmbeddingResult<Vec<f32>> {
         match &self.inner {
             EmbedderInner::Mock => Ok(mock_embed(text, self.dimensions)),
-            EmbedderInner::Real { pool, next } => {
-                let idx = next.fetch_add(1, Ordering::Relaxed) % pool.len();
-                let mut model = pool[idx]
-                    .lock()
-                    .map_err(|e| EmbeddingError::Inference(format!("Lock poisoned: {e}")))?;
-                let embeddings = model
-                    .embed(vec![text], None)
-                    .map_err(|e| EmbeddingError::Inference(e.to_string()))?;
-                embeddings
-                    .into_iter()
-                    .next()
-                    .ok_or_else(|| EmbeddingError::Inference("No embedding returned".into()))
+            EmbedderInner::Real { pool, next } => embed_one_in_pool(pool, next, text),
+            EmbedderInner::Lazy { next, .. } => {
+                let pool = self.ensure_lazy_pool()?;
+                embed_one_in_pool(&pool, next, text)
             }
         }
     }
@@ -295,14 +411,10 @@ impl OnnxEmbedder {
                 .iter()
                 .map(|t| Ok(mock_embed(t, self.dimensions)))
                 .collect(),
-            EmbedderInner::Real { pool, next } => {
-                let idx = next.fetch_add(1, Ordering::Relaxed) % pool.len();
-                let mut model = pool[idx]
-                    .lock()
-                    .map_err(|e| EmbeddingError::Inference(format!("Lock poisoned: {e}")))?;
-                model
-                    .embed(texts, None)
-                    .map_err(|e| EmbeddingError::Inference(e.to_string()))
+            EmbedderInner::Real { pool, next } => embed_batch_in_pool(pool, next, texts),
+            EmbedderInner::Lazy { next, .. } => {
+                let pool = self.ensure_lazy_pool()?;
+                embed_batch_in_pool(&pool, next, texts)
             }
         }
     }
@@ -311,6 +423,44 @@ impl OnnxEmbedder {
     pub fn dimensions(&self) -> usize {
         self.dimensions
     }
+}
+
+// ---------------------------------------------------------------------------
+// Pool embedding internals (shared by Real and Lazy variants)
+// ---------------------------------------------------------------------------
+
+/// Embed one text on the next round-robin slot of `pool`.
+fn embed_one_in_pool(
+    pool: &[Mutex<TextEmbedding>],
+    next: &AtomicUsize,
+    text: &str,
+) -> EmbeddingResult<Vec<f32>> {
+    let idx = next.fetch_add(1, Ordering::Relaxed) % pool.len();
+    let mut model = pool[idx]
+        .lock()
+        .map_err(|e| EmbeddingError::Inference(format!("Lock poisoned: {e}")))?;
+    let embeddings = model
+        .embed(vec![text], None)
+        .map_err(|e| EmbeddingError::Inference(e.to_string()))?;
+    embeddings
+        .into_iter()
+        .next()
+        .ok_or_else(|| EmbeddingError::Inference("No embedding returned".into()))
+}
+
+/// Embed a batch of texts on the next round-robin slot of `pool`.
+fn embed_batch_in_pool(
+    pool: &[Mutex<TextEmbedding>],
+    next: &AtomicUsize,
+    texts: &[&str],
+) -> EmbeddingResult<Vec<Vec<f32>>> {
+    let idx = next.fetch_add(1, Ordering::Relaxed) % pool.len();
+    let mut model = pool[idx]
+        .lock()
+        .map_err(|e| EmbeddingError::Inference(format!("Lock poisoned: {e}")))?;
+    model
+        .embed(texts, None)
+        .map_err(|e| EmbeddingError::Inference(e.to_string()))
 }
 
 // ---------------------------------------------------------------------------
@@ -505,6 +655,40 @@ mod tests {
             assert_eq!(emb.len(), 384);
         }
     }
+
+    // -----------------------------------------------------------------------
+    // Lazy embedder tests (offline-safe — construction never loads ONNX)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_lazy_unknown_model_errors_at_construction() {
+        let result = OnnxEmbedder::new_lazy("nonexistent-model");
+        assert!(result.is_err());
+        assert!(result.err().unwrap().to_string().contains("Unknown model"));
+    }
+
+    #[test]
+    fn test_lazy_dimensions_available_without_load() {
+        // Construction must not touch ONNX or the network, yet dimensions
+        // are already correct.
+        let gte = OnnxEmbedder::new_lazy("Alibaba-NLP/gte-base-en-v1.5").unwrap();
+        assert_eq!(gte.dimensions(), 768);
+        let mini = OnnxEmbedder::new_lazy("all-MiniLM-L6-v2").unwrap();
+        assert_eq!(mini.dimensions(), 384);
+    }
+
+    #[test]
+    fn test_lazy_pool_size_clamped_to_one() {
+        // pool_size 0 would panic on `% pool.len()` — must clamp to 1.
+        let embedder =
+            OnnxEmbedder::new_lazy_with_options("all-MiniLM-L6-v2", &NetworkPolicy::Permissive, 0)
+                .unwrap();
+        assert_eq!(embedder.dimensions(), 384);
+    }
+
+    // The Disabled-policy-at-first-use behavior is covered in
+    // `tests/test_no_network_invariants.rs`, which owns the serialized
+    // `FASTEMBED_CACHE_DIR` env-var guard needed to force an uncached model.
 
     // -----------------------------------------------------------------------
     // Model registry tests

--- a/pensyve-core/tests/test_no_network_invariants.rs
+++ b/pensyve-core/tests/test_no_network_invariants.rs
@@ -390,6 +390,73 @@ fn onnx_embedder_constructor_under_disabled_with_cached_model_succeeds() {
     );
 }
 
+/// **Invariant I4.OnnxEmbedder.lazy-disabled-uncached**: a *lazy*
+/// embedder (`new_lazy_with_options`) constructed under
+/// `NetworkPolicy::Disabled` for an uncached model MUST succeed at
+/// construction (nothing is loaded yet) and MUST surface
+/// `EmbeddingError::Network` at the first `embed()` call — the same
+/// policy gate as the eager constructor, deferred to first use. A
+/// denied load MUST NOT leave a partial-download artifact and MUST NOT
+/// be cached as a permanent failure (the pool stays unbuilt, so a later
+/// call under a permissive environment can retry).
+///
+/// Mechanical proof:
+///   1. Point `FASTEMBED_CACHE_DIR` at a fresh tempdir — guarantees the
+///      model is NOT cached.
+///   2. `new_lazy_with_options(<model>, &Disabled, 1)` returns `Ok` and
+///      reports the correct dimensionality without loading anything.
+///   3. `embed("hello")` returns `Err(EmbeddingError::Network(_))`.
+///   4. The cache tempdir has no `models--*` subdirectory.
+#[test]
+fn onnx_embedder_lazy_under_disabled_with_uncached_model_errors_at_first_use() {
+    let _ = real_cache_dir();
+    let _serial = cache_env_lock().lock().expect("env lock poisoned");
+
+    let cache_tempdir = TempDir::new().expect("tempdir for empty fastembed cache");
+    let _guard = FastembedCacheGuard::set(cache_tempdir.path());
+
+    let embedder = OnnxEmbedder::new_lazy_with_options(
+        "Alibaba-NLP/gte-base-en-v1.5",
+        &NetworkPolicy::Disabled,
+        1,
+    )
+    .expect("lazy construction must succeed without loading the model");
+    assert_eq!(
+        embedder.dimensions(),
+        768,
+        "dimensions must be available before the model is loaded"
+    );
+
+    match embedder.embed("hello") {
+        Err(EmbeddingError::Network(msg)) => {
+            assert!(
+                msg.contains("Disabled") || msg.contains("not permitted"),
+                "expected Disabled-policy error message, got: {msg}"
+            );
+        }
+        Err(other) => panic!(
+            "expected EmbeddingError::Network at first use for uncached model \
+             under Disabled, got {other:?}"
+        ),
+        Ok(_) => panic!(
+            "lazy embed succeeded under Disabled with empty cache — \
+             the deferred load-time policy gate did not fire"
+        ),
+    }
+
+    // No partial download artifact: the policy gate fires BEFORE
+    // fastembed's `pull_from_hf` is invoked, even on the lazy path.
+    let entries: Vec<_> = std::fs::read_dir(cache_tempdir.path())
+        .expect("read tempdir")
+        .filter_map(Result::ok)
+        .filter(|e| e.file_name().to_string_lossy().starts_with("models--"))
+        .collect();
+    assert!(
+        entries.is_empty(),
+        "expected no model subdirectory after denied lazy load, found: {entries:?}"
+    );
+}
+
 // -------------------------------------------------------------------------
 // FASTEMBED_CACHE_DIR env-var guard
 // -------------------------------------------------------------------------

--- a/pensyve-mcp/src/main.rs
+++ b/pensyve-mcp/src/main.rs
@@ -7,7 +7,8 @@ use tokio::sync::RwLock;
 use uuid::Uuid;
 
 use pensyve_core::config::RetrievalConfig;
-use pensyve_core::embedding::OnnxEmbedder;
+use pensyve_core::embedding::{OnnxEmbedder, is_model_available_offline};
+use pensyve_core::network_policy::NetworkPolicy;
 use pensyve_core::storage::StorageTrait;
 use pensyve_core::storage::sqlite::SqliteBackend;
 use pensyve_core::types::Namespace;
@@ -28,6 +29,97 @@ fn resolve_storage_path() -> PathBuf {
 
 fn resolve_namespace() -> String {
     std::env::var("PENSYVE_NAMESPACE").unwrap_or_else(|_| "default".to_string())
+}
+
+/// Pool size for the stdio server's embedder. This server has exactly one
+/// client and serves tool calls serially, so one ONNX session is enough;
+/// the CPU-derived default in pensyve-core (up to 4 sessions ≈ 4× the
+/// resident memory) is meant for multi-threaded harnesses.
+/// `PENSYVE_EMBEDDING_POOL_SIZE` still overrides.
+fn resolve_stdio_pool_size() -> usize {
+    std::env::var("PENSYVE_EMBEDDING_POOL_SIZE")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|&n| n > 0)
+        .unwrap_or(1)
+}
+
+/// Build the embedder for the stdio server.
+///
+/// Default path: a *lazy* embedder — model name validated and dimensions
+/// resolved at startup, but the ONNX session pool (hundreds of MB per
+/// slot) is only built on the first tool call that needs an embedding.
+/// Agent harnesses routinely hold many concurrent pensyve-mcp processes,
+/// most of which never embed anything; eager loading multiplied ~2.9 GB
+/// per process and has caused system-wide memory exhaustion.
+///
+/// Model choice mirrors the eager fallback chain without any load: prefer
+/// GTE if it is already in the fastembed cache, else `MiniLM` if cached,
+/// else GTE (downloaded on first use).
+///
+/// `PENSYVE_EAGER_EMBEDDER=1` restores the pre-lazy behavior: load (and
+/// if necessary download) the model at startup, falling back
+/// GTE → `MiniLM` → mock exactly as before.
+fn build_embedder() -> anyhow::Result<OnnxEmbedder> {
+    const GTE: &str = "Alibaba-NLP/gte-base-en-v1.5";
+    const MINILM: &str = "all-MiniLM-L6-v2";
+
+    if std::env::var("PENSYVE_EAGER_EMBEDDER").is_ok() {
+        return build_eager_embedder();
+    }
+
+    let model_name = if is_model_available_offline(GTE) {
+        GTE
+    } else if is_model_available_offline(MINILM) {
+        MINILM
+    } else {
+        // Neither model cached: stay lazy on the preferred model; the
+        // download happens on the first embedding tool call.
+        GTE
+    };
+
+    let embedder = OnnxEmbedder::new_lazy_with_options(
+        model_name,
+        &NetworkPolicy::Permissive,
+        resolve_stdio_pool_size(),
+    )
+    .map_err(|e| anyhow::anyhow!("Failed to prepare embedder: {e}"))?;
+    tracing::info!(
+        "Using lazy ONNX embedder ({model_name}, {} dims) — model loads on first use",
+        embedder.dimensions()
+    );
+    Ok(embedder)
+}
+
+/// Pre-lazy startup behavior: try GTE (768d), then `MiniLM` (384d), then mock.
+fn build_eager_embedder() -> anyhow::Result<OnnxEmbedder> {
+    match OnnxEmbedder::new("Alibaba-NLP/gte-base-en-v1.5") {
+        Ok(e) => {
+            tracing::info!("Using real ONNX embedder (Alibaba-NLP/gte-base-en-v1.5, 768 dims)");
+            Ok(e)
+        }
+        Err(gte_err) => {
+            tracing::warn!("GTE model unavailable ({gte_err}), trying all-MiniLM-L6-v2 fallback");
+            match OnnxEmbedder::new("all-MiniLM-L6-v2") {
+                Ok(e) => {
+                    tracing::info!("Using fallback ONNX embedder (all-MiniLM-L6-v2, 384 dims)");
+                    Ok(e)
+                }
+                Err(mini_err) => {
+                    if std::env::var("PENSYVE_ALLOW_MOCK_EMBEDDER").is_ok() {
+                        tracing::warn!(
+                            "ONNX embedders unavailable ({mini_err}), falling back to mock (768 dims)"
+                        );
+                        Ok(OnnxEmbedder::new_mock(768))
+                    } else {
+                        Err(anyhow::anyhow!(
+                            "No ONNX model available. Set PENSYVE_ALLOW_MOCK_EMBEDDER=1 to use mock. Error: {mini_err}"
+                        ))
+                    }
+                }
+            }
+        }
+    }
 }
 
 fn load_vector_index(
@@ -112,34 +204,8 @@ async fn main() -> Result<()> {
         Err(e) => return Err(anyhow::anyhow!("Storage error: {e}")),
     };
 
-    // Initialize embedder: try GTE (768d) first, then MiniLM (384d), then mock.
-    let embedder = match OnnxEmbedder::new("Alibaba-NLP/gte-base-en-v1.5") {
-        Ok(e) => {
-            tracing::info!("Using real ONNX embedder (Alibaba-NLP/gte-base-en-v1.5, 768 dims)");
-            e
-        }
-        Err(gte_err) => {
-            tracing::warn!("GTE model unavailable ({gte_err}), trying all-MiniLM-L6-v2 fallback");
-            match OnnxEmbedder::new("all-MiniLM-L6-v2") {
-                Ok(e) => {
-                    tracing::info!("Using fallback ONNX embedder (all-MiniLM-L6-v2, 384 dims)");
-                    e
-                }
-                Err(mini_err) => {
-                    if std::env::var("PENSYVE_ALLOW_MOCK_EMBEDDER").is_ok() {
-                        tracing::warn!(
-                            "ONNX embedders unavailable ({mini_err}), falling back to mock (768 dims)"
-                        );
-                        OnnxEmbedder::new_mock(768)
-                    } else {
-                        return Err(anyhow::anyhow!(
-                            "No ONNX model available. Set PENSYVE_ALLOW_MOCK_EMBEDDER=1 to use mock. Error: {mini_err}"
-                        ));
-                    }
-                }
-            }
-        }
-    };
+    // Initialize embedder — lazy by default (see `build_embedder`).
+    let embedder = build_embedder()?;
 
     let dimensions = embedder.dimensions();
 


### PR DESCRIPTION
## Problem

Every `pensyve-mcp` stdio process eagerly builds a pool of `min(cores, 4)` ONNX sessions at startup — about **2.9 GB resident** for GTE-base — even if no memory tool is ever called.

MCP clients spawn one stdio server per session, and agent harnesses (Claude Code, Codex, Cursor) routinely run many sessions at once. The footprint multiplies fast: on my 48 GB M-series MacBook Pro I observed **21 concurrent idle instances holding 49.2 GB resident**, which exhausted physical memory, froze userspace, and ended in a macOS `watchdog timeout` kernel panic (three crashes in one week before I traced it).

This also conflicts with the documented design goal in `docs/RELIABILITY.md` principle 3: *"Small footprint — Under 300 MB total (binary + ONNX models)."*

## Fix

Two changes, no public API breakage:

1. **`pensyve-core`: lazy embedder variant.** `OnnxEmbedder::new_lazy` / `new_lazy_with_options` validate the model name and resolve dimensionality at construction, but defer building the session pool (and any load-time HF download) to the first `embed`/`embed_batch` call. The `NetworkPolicy` gate fires at first load exactly as `new_with_policy` fires it at construction; a failed load is not cached, so subsequent calls retry. Shared helpers (`resolve_model`, `build_pool`, `embed_*_in_pool`) keep the eager and lazy paths from drifting. Also exposes `is_model_available_offline()` so callers can pick a model by fastembed-cache presence without triggering a download.

2. **`pensyve-mcp`: lazy by default, pool size 1.** The stdio server has exactly one client and serves tool calls serially, so one session replaces the CPU-derived pool of 4. Model choice mirrors the old fallback preference without loading anything (GTE if cached, else MiniLM if cached, else lazy GTE). Escape hatches: `PENSYVE_EMBEDDING_POOL_SIZE` still overrides the pool size, and `PENSYVE_EAGER_EMBEDDER=1` restores the previous eager startup including the GTE → MiniLM → mock fallback chain.

## Measurements

Driving the server over stdio (initialize → `pensyve_recall`), models pre-cached, Apple Silicon:

| | before | after |
|---|---|---|
| RSS idle (post-initialize) | 2,804 MB | **12 MB** |
| RSS after first recall | 2,807 MB | 990 MB |
| recall result | ok | ok |

Worst-case observed fleet (21 idle instances): 49.2 GB → ~0.25 GB.

## Tests

- Offline-safe unit tests: unknown model errors at construction; dimensions available without load; pool size clamped to ≥1.
- New invariant test in `tests/test_no_network_invariants.rs` using the existing `FastembedCacheGuard`: lazy + `Disabled` + uncached model constructs fine, errors with `EmbeddingError::Network` at first use, and leaves no partial-download artifact.
- `cargo fmt --all`, `cargo clippy --all-targets -p pensyve-core -p pensyve-mcp -- -D warnings`, and `cargo test -p pensyve-core` all pass. (One pre-existing failure unrelated to this change: `i5_long_running_consolidation_cancels_within_budget` is timing-sensitive and fails identically on an untouched `main` checkout on fast machines — the consolidation completes before the cancel can interpose.)

## Trade-off

The first embedding-dependent tool call in a session pays a one-time model load (~1–2 s with a warm disk cache). Given the documented recall p50 of ~3 s, this doesn't change the latency class, and every subsequent call is unchanged. Sessions that never touch memory tools — the overwhelming majority in multi-agent fleets — now cost ~12 MB instead of ~2.9 GB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)