### PR TITLE
fix(ci): unbreak lint on clippy 1.97 and release packaging on GitHub runners

### DIFF
--- a/integrations/codex-plugin/scripts/lint-mcp-refs.sh
+++ b/integrations/codex-plugin/scripts/lint-mcp-refs.sh
@@ -121,7 +121,7 @@ echo ""
 # Check 4: provenance tag format — every proactive/auto-capture tag uses [<origin>/<trigger>/<tier>]
 echo "Check 4: provenance tag format"
 VALID_PROVENANCE_RE='\[(proactive|auto-capture)/(in-flight|stop|pre-compact|curator|user)/(tier-1|tier-2|residual/tier-1|residual/tier-2|open-question)\]'
-if rg -n '\[(proactive|auto-capture)' "${MCP_REF_FILES[@]}" | rg -v "$VALID_PROVENANCE_RE"; then
+if grep -nE '\[(proactive|auto-capture)' "${MCP_REF_FILES[@]}" | grep -vE "$VALID_PROVENANCE_RE"; then
   echo "  FAIL: some provenance tags do not match [<origin>/<trigger>/<tier>] format"
   EXIT_CODE=1
 else
@@ -131,7 +131,7 @@ echo ""
 
 # Check 5: procedural memory convention — [procedural] prefix is used in observe content
 echo "Check 5: procedural convention uses [procedural] prefix in pensyve_observe content"
-if ! rg -q '\[procedural\]' "${MCP_REF_FILES[@]}"; then
+if ! grep -qE '\[procedural\]' "${MCP_REF_FILES[@]}"; then
   echo "  WARN: no [procedural] prefix usage found in configured plugin surfaces."
 else
   echo "  PASS"
@@ -142,7 +142,7 @@ echo ""
 echo "Check 6: @-mention workflow documents current Codex dispatch limitation"
 MISSING_MENTION_DOC=0
 for file in "${MENTION_DOC_FILES[@]}"; do
-  if rg -qi 'true @-mention dispatch is not currently exposed|Codex does not currently expose true @-mention dispatch' "$file"; then
+  if grep -qiE 'true @-mention dispatch is not currently exposed|Codex does not currently expose true @-mention dispatch' "$file"; then
     echo "  PASS: $file"
   else
     echo "  FAIL: $file"

--- a/pensyve-mcp-gateway/src/auth.rs
+++ b/pensyve-mcp-gateway/src/auth.rs
@@ -163,7 +163,7 @@ impl AuthValidator {
             .or_else(|| claims.account_id.filter(|s| !s.is_empty()));
 
         Some(AuthContext {
-            key_id: format!("oauth:{}", &claims.client_id),
+            key_id: format!("oauth:{}", claims.client_id),
             tenant_id,
             user_id: Some(claims.sub),
             scope: claims.scope.unwrap_or_else(|| "mcp".to_string()),


### PR DESCRIPTION
## Summary
Two independent CI breakages, both diagnosed from run logs:

1. **Lint job fails on every run since the stable toolchain moved to Rust 1.97** (2026-07-07). The new clippy lint `useless_borrows_in_formatting` fires on a redundant `&` in `pensyve-mcp-gateway/src/auth.rs:166` and `-D warnings` turns it into an error. This is why the dependabot PRs (#157, #160, #161) show red — they're innocent.
2. **Release workflow "Package Codex plugin" job has failed on every tag since v2.1.0**: `integrations/codex-plugin/scripts/lint-mcp-refs.sh` shells out to `rg`, which is not installed on GitHub-hosted runners (`rg: command not found`). Check 6 requires a positive match, so it always FAILs there. Replaced the three `rg` usages with portable `grep -E` equivalents.

## Verification
- `cargo clippy --workspace -- -D warnings` — clean on rustc 1.97.0 (was failing before the fix)
- `cargo fmt --all -- --check` — clean
- `cargo test -p pensyve-mcp-gateway --all-targets` — 127 passed
- `env PATH=/usr/bin:/bin bash integrations/codex-plugin/scripts/lint-mcp-refs.sh` — all checks PASS with no `rg` on PATH (simulates the runner)

Note: v2.6.0 artifacts published fine to crates.io/npm/PyPI; only the Codex plugin packaging + GitHub Release steps were skipped. After this merges we can re-run the failed jobs on the v2.6.0 tag.