### PR TITLE
chore: prepare 2.6.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to Pensyve will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.6.1] - 2026-07-12
+
+Patch release: CI/release-pipeline fixes and a full dependency refresh. No functional changes to the memory runtime.
+
+### Fixed
+
+- **Lint failure on Rust 1.97** — removed a redundant `&` in a `format!` argument in `pensyve-mcp-gateway` auth that tripped the new `useless_borrows_in_formatting` clippy lint, which broke every CI run under `-D warnings` once the stable toolchain moved to 1.97. (#163)
+- **Release workflow "Package Codex plugin" job** — `integrations/codex-plugin/scripts/lint-mcp-refs.sh` shelled out to `rg`, which is not installed on GitHub-hosted runners; every tagged release since v2.1.0 failed there, skipping the GitHub Release step (registry publishes were unaffected). The script now uses portable `grep -E`. (#163)
+
+### Changed
+
+- **Dependency refresh across all ecosystems** (#164): sqlx-core/sqlx-postgres 0.8.6 → 0.9.0, phf 0.11 → 0.13, rusqlite 0.39 → 0.40, fastembed → 5.17.2, redis → 1.3.0, plus uuid/regex/chrono/serde_json patch bumps and a full `cargo update`; eslint → 10.7.0 and typescript-eslint → 8.63.0 (TypeScript stays on 6.x until typescript-eslint supports 7.x); `uv lock --upgrade` for the Python tree (llama-cpp-python 0.3.34, pyright 1.1.411, huggingface-hub 1.23.0, ruff 0.15.21, pytest-asyncio 1.4.0); actions/checkout → v7 and actions/cache → v6.
+
 ## [2.6.0] - 2026-07-07
 
 Minor release since v2.5.0, headlined by the `SelRoute` query-type classifier (Phase 2A) moving from opt-in to default-on — the behavior change that makes this a minor bump rather than a patch. Also ships tenant-scoped gateway rate limiting/quotas, gateway resilience hardening, a native Codex `/pensyve` command, a documentation decomposition pass, and a UTF-8 panic fix in gateway logging.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2733,7 +2733,7 @@ dependencies = [
 
 [[package]]
 name = "pensyve-benchmarks"
-version = "2.6.0"
+version = "2.6.1"
 dependencies = [
  "chrono",
  "pensyve-core",
@@ -2748,7 +2748,7 @@ dependencies = [
 
 [[package]]
 name = "pensyve-cli"
-version = "2.6.0"
+version = "2.6.1"
 dependencies = [
  "clap",
  "dirs",
@@ -2759,7 +2759,7 @@ dependencies = [
 
 [[package]]
 name = "pensyve-core"
-version = "2.6.0"
+version = "2.6.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2789,7 +2789,7 @@ dependencies = [
 
 [[package]]
 name = "pensyve-mcp"
-version = "2.6.0"
+version = "2.6.1"
 dependencies = [
  "anyhow",
  "dirs",
@@ -2805,7 +2805,7 @@ dependencies = [
 
 [[package]]
 name = "pensyve-mcp-gateway"
-version = "2.6.0"
+version = "2.6.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -2837,7 +2837,7 @@ dependencies = [
 
 [[package]]
 name = "pensyve-mcp-tools"
-version = "2.6.0"
+version = "2.6.1"
 dependencies = [
  "pensyve-core",
  "rmcp",
@@ -2852,7 +2852,7 @@ dependencies = [
 
 [[package]]
 name = "pensyve-python"
-version = "2.6.0"
+version = "2.6.1"
 dependencies = [
  "chrono",
  "pensyve-core",

--- a/pensyve-benchmarks/Cargo.toml
+++ b/pensyve-benchmarks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pensyve-benchmarks"
-version = "2.6.0"
+version = "2.6.1"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"
@@ -8,7 +8,7 @@ description = "Evaluation framework for Pensyve memory engine"
 publish = false
 
 [dependencies]
-pensyve-core = { path = "../pensyve-core", version = "2.6.0" }
+pensyve-core = { path = "../pensyve-core", version = "2.6.1" }
 rand = "0.10"
 rand_distr = "0.6"
 serde = { version = "1", features = ["derive"] }

--- a/pensyve-cli/Cargo.toml
+++ b/pensyve-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pensyve-cli"
-version = "2.6.0"
+version = "2.6.1"
 edition = "2024"
 description = "Pensyve command-line interface — universal memory runtime for AI agents"
 rust-version = "1.88"
@@ -14,7 +14,7 @@ name = "pensyve"
 path = "src/main.rs"
 
 [dependencies]
-pensyve-core = { path = "../pensyve-core", version = "2.6.0" }
+pensyve-core = { path = "../pensyve-core", version = "2.6.1" }
 clap = { version = "4", features = ["derive"] }
 serde_json = "1"
 uuid = { version = "1", features = ["v4"] }

--- a/pensyve-core/Cargo.toml
+++ b/pensyve-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pensyve-core"
-version = "2.6.0"
+version = "2.6.1"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/pensyve-mcp-gateway/Cargo.toml
+++ b/pensyve-mcp-gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pensyve-mcp-gateway"
-version = "2.6.0"
+version = "2.6.1"
 edition = "2024"
 description = "Remote MCP gateway for Pensyve Cloud — Streamable HTTP transport"
 rust-version = "1.88"
@@ -18,8 +18,8 @@ name = "pensyve-mcp-gateway"
 path = "src/main.rs"
 
 [dependencies]
-pensyve-core = { path = "../pensyve-core", version = "2.6.0", features = ["postgres", "observation-extraction"] }
-pensyve-mcp-tools = { path = "../pensyve-mcp-tools", version = "2.6.0" }
+pensyve-core = { path = "../pensyve-core", version = "2.6.1", features = ["postgres", "observation-extraction"] }
+pensyve-mcp-tools = { path = "../pensyve-mcp-tools", version = "2.6.1" }
 rmcp = { version = "1.7", features = ["server", "transport-streamable-http-server", "macros"] }
 axum = "0.8"
 tower-http = { version = "0.6", features = ["compression-gzip", "compression-br"] }

--- a/pensyve-mcp-tools/Cargo.toml
+++ b/pensyve-mcp-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pensyve-mcp-tools"
-version = "2.6.0"
+version = "2.6.1"
 edition = "2024"
 description = "Shared MCP tool definitions for Pensyve servers"
 rust-version = "1.88"
@@ -13,7 +13,7 @@ documentation = "https://pensyve.com/docs"
 name = "pensyve_mcp_tools"
 
 [dependencies]
-pensyve-core = { path = "../pensyve-core", version = "2.6.0" }
+pensyve-core = { path = "../pensyve-core", version = "2.6.1" }
 rmcp = { version = "1.7", features = ["server", "macros"] }
 tokio = { version = "1", features = ["full"] }
 # G1/P3a: needed for `CancellationToken::new()` passed to

--- a/pensyve-mcp/Cargo.toml
+++ b/pensyve-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pensyve-mcp"
-version = "2.6.0"
+version = "2.6.1"
 edition = "2024"
 description = "Pensyve MCP server (stdio transport) — universal memory runtime for AI agents"
 rust-version = "1.88"
@@ -14,8 +14,8 @@ name = "pensyve-mcp"
 path = "src/main.rs"
 
 [dependencies]
-pensyve-core = { path = "../pensyve-core", version = "2.6.0" }
-pensyve-mcp-tools = { path = "../pensyve-mcp-tools", version = "2.6.0" }
+pensyve-core = { path = "../pensyve-core", version = "2.6.1" }
+pensyve-mcp-tools = { path = "../pensyve-mcp-tools", version = "2.6.1" }
 rmcp = { version = "1.7", features = ["server", "transport-io", "macros"] }
 tokio = { version = "1", features = ["full"] }
 uuid = { version = "1", features = ["v4"] }

--- a/pensyve-python/Cargo.toml
+++ b/pensyve-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pensyve-python"
-version = "2.6.0"
+version = "2.6.1"
 edition = "2024"
 rust-version = "1.88"
 readme = "README.md"
@@ -15,7 +15,7 @@ name = "pensyve_python"
 crate-type = ["cdylib"]
 
 [dependencies]
-pensyve-core = { path = "../pensyve-core", version = "2.6.0", features = ["observation-extraction"] }
+pensyve-core = { path = "../pensyve-core", version = "2.6.1", features = ["observation-extraction"] }
 pyo3 = { version = "^0.28.3", features = ["extension-module"] }
 uuid = { version = "1", features = ["v4"] }
 chrono = "0.4"

--- a/pensyve-python/pyproject.toml
+++ b/pensyve-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pensyve"
-version = "2.6.0"
+version = "2.6.1"
 description = "Universal memory runtime for AI agents — framework-agnostic, protocol-native, offline-first"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/pensyve-ts/package.json
+++ b/pensyve-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pensyve/sdk",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Pensyve TypeScript SDK — universal memory runtime for AI agents",
   "type": "module",
   "main": "dist/index.js",

--- a/pensyve-wasm/Cargo.toml
+++ b/pensyve-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pensyve-wasm"
-version = "2.6.0"
+version = "2.6.1"
 edition = "2024"
 
 [workspace]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pensyve"
-version = "2.6.0"
+version = "2.6.1"
 description = "Universal memory runtime for AI agents — framework-agnostic, protocol-native, offline-first"
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -929,7 +929,7 @@ wheels = [
 
 [[package]]
 name = "pensyve"
-version = "2.6.0"
+version = "2.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
Version bump 2.6.0 → 2.6.1 across all manifests (mirrors the 2.6.0 prep in #159) plus CHANGELOG entry.

Patch release contents:
- CI/release fixes from #163 (clippy 1.97 lint; `rg`-free codex-plugin lint script — this is what unblocks the Release workflow's "Package Codex plugin" job, which has failed on every tag since v2.1.0)
- Consolidated dependency refresh from #164

After merge: tag `v2.6.1` from main to trigger the Release workflow end-to-end (registries + Codex plugin package + GitHub Release).

## Verification
- `cargo check --workspace` clean at 2.6.1
- No `2.6.0` references remain in any manifest
- Cargo.lock + uv.lock regenerated