### PR TITLE
fix(test): serialize dmem ring-buffer gauge writes under ROUTING_COUNTER_LOCK

### DIFF
--- a/pensyve-core/src/consolidation/dmem.rs
+++ b/pensyve-core/src/consolidation/dmem.rs
@@ -547,7 +547,11 @@ mod tests {
         assert_eq!(route, DMemRoute::FastBuffer);
         assert_eq!(gate.ring_buffer_len(), 1);
         // Drain before drop to satisfy the debug-only Drop
-        // assertion (CodeRabbit PR #117 round 3).
+        // assertion (CodeRabbit PR #117 round 3). Hold
+        // ROUTING_COUNTER_LOCK: drain stores 0 into the shared
+        // `dmem_ring_buffer_size` gauge and would otherwise race
+        // the gauge-snapshot test.
+        let _guard = test_locks::ROUTING_COUNTER_LOCK.lock().unwrap();
         let _ = gate.drain_ring_buffer();
     }
 
@@ -558,6 +562,10 @@ mod tests {
         // `dmem_ring_buffer_evictions` counter. Without the lock,
         // the eviction-counter snapshot tests would race with this
         // test's mutations. CodeRabbit PR #117 round 2.
+        // Also hold ROUTING_COUNTER_LOCK (acquired first — keep the
+        // ROUTING -> EVICTION order everywhere): the drain below
+        // stores 0 into the shared `dmem_ring_buffer_size` gauge.
+        let _routing_guard = test_locks::ROUTING_COUNTER_LOCK.lock().unwrap();
         let _guard = test_locks::EVICTION_COUNTER_LOCK.lock().unwrap();
         let mut gate = DMemGate::new(0.35, 0.5, 3);
         let low_score = RpeScore {
@@ -584,7 +592,10 @@ mod tests {
         // typed-slot enrichment. Operators get a signal via the
         // `dmem_ring_buffer_evictions` counter. This test pushes
         // `capacity + 1` observations and asserts the counter went
-        // up by exactly 1.
+        // up by exactly 1. ROUTING_COUNTER_LOCK is acquired first
+        // (ROUTING -> EVICTION order): the drain below stores 0 into
+        // the shared `dmem_ring_buffer_size` gauge.
+        let _routing_guard = ROUTING_COUNTER_LOCK.lock().unwrap();
         let _guard = EVICTION_COUNTER_LOCK.lock().unwrap();
         let metrics = crate::observability::metrics();
         let before = metrics.dmem_ring_buffer_evictions.load(Ordering::Relaxed);
@@ -621,6 +632,9 @@ mod tests {
         // Symmetric negative case: under capacity, no eviction
         // counter increment should fire (load-bearing for the
         // "operator sees only real evictions" contract).
+        // ROUTING_COUNTER_LOCK acquired first (ROUTING -> EVICTION
+        // order): the drain below writes the shared gauge.
+        let _routing_guard = ROUTING_COUNTER_LOCK.lock().unwrap();
         let _guard = EVICTION_COUNTER_LOCK.lock().unwrap();
         let metrics = crate::observability::metrics();
         let before = metrics.dmem_ring_buffer_evictions.load(Ordering::Relaxed);
@@ -647,6 +661,10 @@ mod tests {
 
     #[test]
     fn drain_returns_all_and_empties_buffer() {
+        // Hold ROUTING_COUNTER_LOCK: drain stores 0 into the shared
+        // `dmem_ring_buffer_size` gauge and would otherwise race the
+        // gauge-snapshot test.
+        let _guard = ROUTING_COUNTER_LOCK.lock().unwrap();
         let mut gate = DMemGate::new(0.35, 0.5, 8);
         let low_score = RpeScore {
             surprise: 0.0,
@@ -739,6 +757,8 @@ mod tests {
         // "bought" is not in TYPED_SLOT_TRIGGER_ACTIONS → no override.
         let route = gate.route(Uuid::new_v4(), &below_threshold, Some("bought"));
         assert_eq!(route, DMemRoute::FastBuffer);
+        // Locked drain: stores 0 into the shared gauge.
+        let _guard = ROUTING_COUNTER_LOCK.lock().unwrap();
         let _ = gate.drain_ring_buffer();
     }
 
@@ -752,6 +772,8 @@ mod tests {
         };
         let route = gate.route(Uuid::new_v4(), &below_threshold, None);
         assert_eq!(route, DMemRoute::FastBuffer);
+        // Locked drain: stores 0 into the shared gauge.
+        let _guard = ROUTING_COUNTER_LOCK.lock().unwrap();
         let _ = gate.drain_ring_buffer();
     }
 
@@ -797,6 +819,8 @@ mod tests {
                 "threshold=1.0 must route combined<1.0 fast (combined={combined})"
             );
         }
+        // Locked drain: stores 0 into the shared gauge.
+        let _guard = ROUTING_COUNTER_LOCK.lock().unwrap();
         let _ = gate.drain_ring_buffer();
     }
 
@@ -808,6 +832,9 @@ mod tests {
         // observation; we clamp to 1 to make the failure mode at
         // least observable (every fast route evicts the previous).
         // Hold EVICTION_COUNTER_LOCK — this test fires evictions.
+        // ROUTING_COUNTER_LOCK acquired first (ROUTING -> EVICTION
+        // order): the drain below writes the shared gauge.
+        let _routing_guard = test_locks::ROUTING_COUNTER_LOCK.lock().unwrap();
         let _guard = test_locks::EVICTION_COUNTER_LOCK.lock().unwrap();
         let gate = DMemGate::new(0.35, 0.5, 0);
         let mut g = gate;

--- a/pensyve-core/src/consolidation/mod.rs
+++ b/pensyve-core/src/consolidation/mod.rs
@@ -1940,6 +1940,9 @@ mod tests {
             "realistic chat fixture should route ≥ 60% fast; got {fast}/10 = {fast_rate}"
         );
         // Drain before drop (CodeRabbit PR #117 round 3 Drop guard).
+        // Locked: drain stores 0 into the shared `dmem_ring_buffer_size`
+        // gauge and would otherwise race the gauge-snapshot test.
+        let _guard = dmem::test_locks::ROUTING_COUNTER_LOCK.lock().unwrap();
         let _ = gate.drain_ring_buffer();
     }
 
@@ -1985,7 +1988,11 @@ mod tests {
         // Drain and replay dep-parse against each. Use
         // `run_dep_parse_hook_inner` directly to bypass the
         // `PENSYVE_DEP_PARSE` env-flag check.
-        let drained = gate.drain_ring_buffer();
+        let drained = {
+            // Locked: drain stores 0 into the shared gauge.
+            let _guard = dmem::test_locks::ROUTING_COUNTER_LOCK.lock().unwrap();
+            gate.drain_ring_buffer()
+        };
         assert_eq!(drained.len(), 3);
         let conn = rusqlite::Connection::open(storage.db_path().unwrap()).unwrap();
         for (id, content) in drained.iter().zip(observation_contents.iter()) {
@@ -2081,6 +2088,8 @@ mod tests {
              counter went from {dep_parse_before} → {dep_parse_after}"
         );
         // Drain before drop (CodeRabbit PR #117 round 3 Drop guard).
+        // Locked: drain stores 0 into the shared gauge.
+        let _guard = dmem::test_locks::ROUTING_COUNTER_LOCK.lock().unwrap();
         let _ = gate.drain_ring_buffer();
     }
 }


### PR DESCRIPTION
## Summary
Root-causes and fixes the flaky `consolidation::dmem::tests::drain_resets_ring_buffer_size_gauge_to_zero` test that failed on main's Rust Tests job after the #165 merge (and previously on #157's CI run on 2026-07-02).

**Root cause:** the test holds `ROUTING_COUNTER_LOCK` while asserting the global `dmem_ring_buffer_size` gauge equals 3, but 12 other tests (9 in `dmem.rs`, 3 in `mod.rs`) call `drain_ring_buffer()` — which stores 0 into that same global gauge — without the lock. Under parallel test execution, an unlocked drain landing between the locked test's `record_route` calls and its assertion clobbers the gauge. The failing assertion then unwinds past `DMemGate`'s debug-only `Drop` guard (buffer still holds 3 IDs), producing the observed panic-in-destructor abort.

**Fix:** all gauge-writing tests now hold `ROUTING_COUNTER_LOCK` for the write. Tests that also need `EVICTION_COUNTER_LOCK` acquire ROUTING first, keeping a single global lock order (no deadlock).

Integration tests (`tests/test_gate_wiring.rs`) run in a separate process with separate metric globals, so they can't race the unit-test gauge — left untouched.

## Verification
- `cargo test -p pensyve-core --lib` — 487 passed
- 30 consecutive full-suite runs — 0 failures, no deadlocks
- `cargo clippy -p pensyve-core --all-targets -- -D warnings` — clean
- `cargo fmt` — clean