### PR TITLE
chore: PR #162 follow-ups — fork-PR review guard, dimension-aware model choice

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -6,7 +6,12 @@ on:
 
 jobs:
   claude-review:
-    if: github.event.pull_request.draft == false && github.actor != 'dependabot[bot]'
+    # Fork PRs receive neither repo secrets nor `id-token: write` from
+    # GitHub, so the action can only fail there (see PR #162) — skip them.
+    if: >-
+      github.event.pull_request.draft == false &&
+      github.actor != 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/README.md
+++ b/README.md
@@ -396,7 +396,8 @@ Pensyve uses the following environment variables across its components:
 | `PENSYVE_PATH`                | `~/.pensyve/<namespace>` | SQLite database directory                                 |
 | `PENSYVE_NAMESPACE`           | `default`                | Memory namespace name                                     |
 | `RUST_LOG`                    | `pensyve=info`           | Tracing filter (e.g. `debug`, `pensyve=debug,hyper=warn`) |
-| `PENSYVE_ALLOW_MOCK_EMBEDDER` | `false`                  | Fall back to mock embedder if real models unavailable     |
+| `PENSYVE_ALLOW_MOCK_EMBEDDER` | `false`                  | Fall back to mock embedder if real models unavailable (eager startup only, i.e. with `PENSYVE_EAGER_EMBEDDER=1`) |
+| `PENSYVE_EAGER_EMBEDDER`      | `false`                  | Load the ONNX model at startup instead of on first use    |
 
 ### Gateway / REST API
 

--- a/pensyve-core/src/embedding.rs
+++ b/pensyve-core/src/embedding.rs
@@ -141,27 +141,32 @@ pub fn is_model_available_offline(model_name: &str) -> bool {
 }
 
 /// Map a supported model name to its fastembed enum, dimensionality, and
-/// `HuggingFace` model code. Errors on unknown names.
+/// `HuggingFace` model code. Errors on unknown names. Dimensionality is
+/// looked up in [`SUPPORTED_MODELS`] so the registry stays the single
+/// source of truth.
 fn resolve_model(model_name: &str) -> EmbeddingResult<(EmbeddingModel, usize, &'static str)> {
-    match model_name {
-        "Alibaba-NLP/gte-base-en-v1.5" => Ok((
-            EmbeddingModel::GTEBaseENV15,
-            768,
-            "Alibaba-NLP/gte-base-en-v1.5",
-        )),
-        "all-MiniLM-L6-v2" | "sentence-transformers/all-MiniLM-L6-v2" => Ok((
+    let (model, hf_model_code) = match model_name {
+        "Alibaba-NLP/gte-base-en-v1.5" => {
+            (EmbeddingModel::GTEBaseENV15, "Alibaba-NLP/gte-base-en-v1.5")
+        }
+        "all-MiniLM-L6-v2" | "sentence-transformers/all-MiniLM-L6-v2" => (
             EmbeddingModel::AllMiniLML6V2,
-            384,
             "Qdrant/all-MiniLM-L6-v2-onnx",
-        )),
+        ),
         other => {
             let supported: Vec<&str> = SUPPORTED_MODELS.iter().map(|(name, _)| *name).collect();
-            Err(EmbeddingError::ModelLoad(format!(
+            return Err(EmbeddingError::ModelLoad(format!(
                 "Unknown model: '{other}'. Supported: {}",
                 supported.join(", ")
-            )))
+            )));
         }
-    }
+    };
+    let dims = model_dimensions(model_name).ok_or_else(|| {
+        EmbeddingError::ModelLoad(format!(
+            "BUG: model '{model_name}' resolves but is missing from SUPPORTED_MODELS"
+        ))
+    })?;
+    Ok((model, dims, hf_model_code))
 }
 
 /// Build a pool of `pool_size` ONNX sessions for `model`. This is the

--- a/pensyve-core/src/observation.rs
+++ b/pensyve-core/src/observation.rs
@@ -1934,7 +1934,6 @@ mod batched_localllm {
     mod tests {
         use super::*;
         use crate::network_policy::NetworkPolicy;
-        use std::sync::atomic::{AtomicUsize, Ordering};
         use std::time::Duration;
         use wiremock::matchers::{method, path};
         use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -2097,41 +2096,35 @@ mod batched_localllm {
 
         #[tokio::test]
         async fn batched_fans_out_concurrent_calls() {
-            // Observe peak in-flight concurrency by holding each request
-            // open for ~150ms while counting active calls. The semaphore
-            // caps the number of futures that can call `inner.extract`
-            // concurrently — with max_concurrency=4 and 8 episodes,
-            // wiremock should see at least 2 in-flight requests at peak
-            // (lower bound is loose to tolerate scheduler/runtime
-            // variance — what we're really asserting is "more than one
-            // request is in flight", proving fan-out happened).
+            // Observe peak in-flight concurrency by recording each
+            // request's ARRIVAL TIMESTAMP and computing interval overlap
+            // post-hoc: request i is in flight over
+            // [arrival_i, arrival_i + delay) (the response is held open
+            // for `delay`). This measurement is race-free — an earlier
+            // version counted with a live atomic decremented by a spawned
+            // `sleep(delay)` task, which had zero margin against the
+            // permit-release boundary: under loaded CI runners, lagging
+            // decrements overlapped fresh arrivals and the "peak"
+            // overshot the semaphore limit (observed 6 with 4 permits)
+            // even though clamping worked correctly.
             //
-            // Mechanism: a background tokio task per request increments
-            // on arrival and decrements AFTER the response delay has
-            // elapsed. wiremock's `respond_with` closure is synchronous
-            // (it must return a `ResponseTemplate`), so the decrement
-            // can't live inside it directly without firing before the
-            // delayed response goes out the wire. Spawning a fire-and-
-            // forget task that sleeps the same duration as the response
-            // delay gives a faithful picture of concurrent request
-            // lifetimes.
+            // With timestamps the upper bound is exact: a same-permit
+            // successor can only arrive after its predecessor's response
+            // was delivered, i.e. strictly after arrival + delay, so its
+            // interval never overlaps — peak overlap > max_concurrency
+            // is possible only if the semaphore genuinely over-admits.
             let server = MockServer::start().await;
-            let in_flight = Arc::new(AtomicUsize::new(0));
-            let peak = Arc::new(AtomicUsize::new(0));
+            let arrivals = Arc::new(std::sync::Mutex::new(Vec::<std::time::Instant>::new()));
             let delay = Duration::from_millis(150);
-            let in_flight_resp = in_flight.clone();
-            let peak_resp = peak.clone();
+            let arrivals_resp = arrivals.clone();
 
             Mock::given(method("POST"))
                 .and(path("/v1/chat/completions"))
                 .respond_with(move |_req: &wiremock::Request| {
-                    let cur = in_flight_resp.fetch_add(1, Ordering::SeqCst) + 1;
-                    peak_resp.fetch_max(cur, Ordering::SeqCst);
-                    let in_flight_task = in_flight_resp.clone();
-                    tokio::spawn(async move {
-                        tokio::time::sleep(delay).await;
-                        in_flight_task.fetch_sub(1, Ordering::SeqCst);
-                    });
+                    arrivals_resp
+                        .lock()
+                        .expect("arrivals lock")
+                        .push(std::time::Instant::now());
                     ResponseTemplate::new(200)
                         .set_body_json(openai_response_body("[]"))
                         .set_delay(delay)
@@ -2162,7 +2155,20 @@ mod batched_localllm {
                 .expect("ok");
             assert_eq!(out.len(), 8);
 
-            let observed_peak = peak.load(Ordering::SeqCst);
+            // Peak overlap of the [arrival, arrival + delay) intervals.
+            // n = 8, so the quadratic sweep is fine.
+            let arrivals = arrivals.lock().expect("arrivals lock");
+            assert_eq!(arrivals.len(), 8, "every episode must reach the mock");
+            let observed_peak = arrivals
+                .iter()
+                .map(|t| {
+                    arrivals
+                        .iter()
+                        .filter(|o| **o <= *t && *t < **o + delay)
+                        .count()
+                })
+                .max()
+                .unwrap_or(0);
             assert!(
                 (2..=4).contains(&observed_peak),
                 "observed peak concurrency {observed_peak} should be in [2, 4] \

--- a/pensyve-mcp/src/main.rs
+++ b/pensyve-mcp/src/main.rs
@@ -4,7 +4,6 @@ use std::sync::Arc;
 use anyhow::Result;
 use rmcp::ServiceExt;
 use tokio::sync::RwLock;
-use uuid::Uuid;
 
 use pensyve_core::config::RetrievalConfig;
 use pensyve_core::embedding::{OnnxEmbedder, is_model_available_offline};
@@ -53,30 +52,33 @@ fn resolve_stdio_pool_size() -> usize {
 /// most of which never embed anything; eager loading multiplied ~2.9 GB
 /// per process and has caused system-wide memory exhaustion.
 ///
-/// Model choice mirrors the eager fallback chain without any load: prefer
-/// GTE if it is already in the fastembed cache, else `MiniLM` if cached,
-/// else GTE (downloaded on first use).
+/// Model choice: if the namespace already holds embeddings, the model whose
+/// dimensionality matches them wins outright — picking anything else would
+/// silently drop every stored vector from the index at load. Otherwise
+/// mirror the eager fallback chain without any load: prefer GTE if it is
+/// already in the fastembed cache, else `MiniLM` if cached, else GTE
+/// (downloaded on first use).
 ///
 /// `PENSYVE_EAGER_EMBEDDER=1` restores the pre-lazy behavior: load (and
 /// if necessary download) the model at startup, falling back
 /// GTE → `MiniLM` → mock exactly as before.
-fn build_embedder() -> anyhow::Result<OnnxEmbedder> {
-    const GTE: &str = "Alibaba-NLP/gte-base-en-v1.5";
-    const MINILM: &str = "all-MiniLM-L6-v2";
-
+fn build_embedder(stored_dims: Option<usize>) -> anyhow::Result<OnnxEmbedder> {
     if std::env::var("PENSYVE_EAGER_EMBEDDER").is_ok() {
         return build_eager_embedder();
     }
 
-    let model_name = if is_model_available_offline(GTE) {
-        GTE
-    } else if is_model_available_offline(MINILM) {
-        MINILM
-    } else {
-        // Neither model cached: stay lazy on the preferred model; the
-        // download happens on the first embedding tool call.
-        GTE
-    };
+    if std::env::var("PENSYVE_ALLOW_MOCK_EMBEDDER").is_ok() {
+        tracing::warn!(
+            "PENSYVE_ALLOW_MOCK_EMBEDDER has no effect on the default lazy path; \
+             it only applies with PENSYVE_EAGER_EMBEDDER=1"
+        );
+    }
+
+    let model_name = choose_lazy_model(
+        stored_dims,
+        is_model_available_offline(GTE),
+        is_model_available_offline(MINILM),
+    );
 
     let embedder = OnnxEmbedder::new_lazy_with_options(
         model_name,
@@ -89,6 +91,48 @@ fn build_embedder() -> anyhow::Result<OnnxEmbedder> {
         embedder.dimensions()
     );
     Ok(embedder)
+}
+
+const GTE: &str = "Alibaba-NLP/gte-base-en-v1.5";
+const MINILM: &str = "all-MiniLM-L6-v2";
+
+/// Pick the lazy model for the stdio server.
+///
+/// Precedence:
+/// 1. Existing embeddings' dimensionality (768 → GTE, 384 → `MiniLM`) —
+///    even for an uncached model, matching the eager path's willingness to
+///    download rather than orphan the stored vectors.
+/// 2. Whichever preferred model is already cached (GTE, then `MiniLM`).
+/// 3. GTE, downloaded lazily on first use.
+fn choose_lazy_model(
+    stored_dims: Option<usize>,
+    gte_cached: bool,
+    minilm_cached: bool,
+) -> &'static str {
+    match stored_dims {
+        Some(768) => GTE,
+        Some(384) => MINILM,
+        Some(other) => {
+            tracing::warn!(
+                "Existing embeddings have unrecognized dimensionality {other}; \
+                 falling back to cache-preference model choice"
+            );
+            cache_preferred_model(gte_cached, minilm_cached)
+        }
+        None => cache_preferred_model(gte_cached, minilm_cached),
+    }
+}
+
+fn cache_preferred_model(gte_cached: bool, minilm_cached: bool) -> &'static str {
+    if gte_cached {
+        GTE
+    } else if minilm_cached {
+        MINILM
+    } else {
+        // Neither model cached: stay lazy on the preferred model; the
+        // download happens on the first embedding tool call.
+        GTE
+    }
 }
 
 /// Pre-lazy startup behavior: try GTE (768d), then `MiniLM` (384d), then mock.
@@ -122,53 +166,52 @@ fn build_eager_embedder() -> anyhow::Result<OnnxEmbedder> {
     }
 }
 
-fn load_vector_index(
-    storage: &dyn StorageTrait,
-    namespace_id: Uuid,
-    dimensions: usize,
-) -> VectorIndex {
+/// Dimensionality of the namespace's existing embeddings, from the first
+/// non-observation memory with a non-empty embedding. `None` for a fresh
+/// namespace. Drives model choice in `build_embedder` so we never pick a
+/// model that orphans the stored vectors.
+fn stored_embedding_dims(memories: &[pensyve_core::types::Memory]) -> Option<usize> {
+    memories
+        .iter()
+        .filter(|m| !matches!(m, pensyve_core::types::Memory::Observation(_)))
+        .map(|m| m.embedding().len())
+        .find(|&len| len > 0)
+}
+
+fn build_vector_index(memories: &[pensyve_core::types::Memory], dimensions: usize) -> VectorIndex {
     let mut index = VectorIndex::new(dimensions, 1024);
 
-    match storage.get_all_memories_by_namespace(namespace_id) {
-        Ok(memories) => {
-            let mut loaded = 0usize;
-            for memory in &memories {
-                // Observations are recall-time enrichment — they attach to
-                // top-k session groups via `recall_grouped::attach_observations_to_groups`
-                // and MUST NOT enter the RRF candidate pool.
-                if matches!(memory, pensyve_core::types::Memory::Observation(_)) {
-                    continue;
-                }
-                let embedding = memory.embedding();
-                if !embedding.is_empty() {
-                    let result = match memory {
-                        pensyve_core::types::Memory::Semantic(s) => {
-                            index.add_with_entity(memory.id(), embedding, s.subject)
-                        }
-                        pensyve_core::types::Memory::Episodic(e) => {
-                            index.add_with_entity(memory.id(), embedding, e.about_entity)
-                        }
-                        pensyve_core::types::Memory::Procedural(_) => {
-                            index.add(memory.id(), embedding)
-                        }
-                        pensyve_core::types::Memory::Observation(_) => unreachable!(),
-                    };
-                    if let Err(e) = result {
-                        tracing::warn!("Skipping memory in index load: {e}");
-                    } else {
-                        loaded += 1;
-                    }
-                }
-            }
-            tracing::info!(
-                "Loaded {loaded}/{} memories into vector index",
-                memories.len()
-            );
+    let mut loaded = 0usize;
+    for memory in memories {
+        // Observations are recall-time enrichment — they attach to
+        // top-k session groups via `recall_grouped::attach_observations_to_groups`
+        // and MUST NOT enter the RRF candidate pool.
+        if matches!(memory, pensyve_core::types::Memory::Observation(_)) {
+            continue;
         }
-        Err(e) => {
-            tracing::warn!("Failed to load memories for vector index: {e}");
+        let embedding = memory.embedding();
+        if !embedding.is_empty() {
+            let result = match memory {
+                pensyve_core::types::Memory::Semantic(s) => {
+                    index.add_with_entity(memory.id(), embedding, s.subject)
+                }
+                pensyve_core::types::Memory::Episodic(e) => {
+                    index.add_with_entity(memory.id(), embedding, e.about_entity)
+                }
+                pensyve_core::types::Memory::Procedural(_) => index.add(memory.id(), embedding),
+                pensyve_core::types::Memory::Observation(_) => unreachable!(),
+            };
+            if let Err(e) = result {
+                tracing::warn!("Skipping memory in index load: {e}");
+            } else {
+                loaded += 1;
+            }
         }
     }
+    tracing::info!(
+        "Loaded {loaded}/{} memories into vector index",
+        memories.len()
+    );
 
     index
 }
@@ -204,13 +247,22 @@ async fn main() -> Result<()> {
         Err(e) => return Err(anyhow::anyhow!("Storage error: {e}")),
     };
 
+    // Fetch memories once: they drive both the embedder's model choice
+    // (existing embedding dimensionality wins) and the vector index build.
+    let memories = storage
+        .get_all_memories_by_namespace(namespace.id)
+        .unwrap_or_else(|e| {
+            tracing::warn!("Failed to load memories for vector index: {e}");
+            Vec::new()
+        });
+
     // Initialize embedder — lazy by default (see `build_embedder`).
-    let embedder = build_embedder()?;
+    let embedder = build_embedder(stored_embedding_dims(&memories))?;
 
     let dimensions = embedder.dimensions();
 
     // Load existing embeddings into the vector index.
-    let vector_index = load_vector_index(&storage, namespace.id, dimensions);
+    let vector_index = build_vector_index(&memories, dimensions);
 
     let retrieval_config = RetrievalConfig {
         default_limit: 5,
@@ -247,4 +299,52 @@ async fn main() -> Result<()> {
 
     tracing::info!("pensyve-mcp shut down");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pensyve_core::types::{Memory, SemanticMemory};
+    use uuid::Uuid;
+
+    #[test]
+    fn stored_dims_win_over_cache_state() {
+        // Existing 768-d embeddings force GTE even when only MiniLM is
+        // cached — anything else orphans the stored vectors at index load.
+        assert_eq!(choose_lazy_model(Some(768), false, true), GTE);
+        assert_eq!(choose_lazy_model(Some(384), true, false), MINILM);
+    }
+
+    #[test]
+    fn fresh_namespace_prefers_cached_model() {
+        assert_eq!(choose_lazy_model(None, true, true), GTE);
+        assert_eq!(choose_lazy_model(None, false, true), MINILM);
+        assert_eq!(choose_lazy_model(None, false, false), GTE);
+    }
+
+    #[test]
+    fn unrecognized_dims_fall_back_to_cache_preference() {
+        assert_eq!(choose_lazy_model(Some(512), false, true), MINILM);
+        assert_eq!(choose_lazy_model(Some(512), false, false), GTE);
+    }
+
+    #[test]
+    fn stored_embedding_dims_finds_first_nonempty() {
+        let ns = Uuid::new_v4();
+        let entity = Uuid::new_v4();
+        let mut without = SemanticMemory::new(ns, entity, "likes", "rust", 0.9);
+        without.embedding = vec![];
+        let mut with = SemanticMemory::new(ns, entity, "likes", "onnx", 0.9);
+        with.embedding = vec![0.0; 768];
+
+        assert_eq!(stored_embedding_dims(&[]), None);
+        assert_eq!(
+            stored_embedding_dims(&[Memory::Semantic(without.clone())]),
+            None
+        );
+        assert_eq!(
+            stored_embedding_dims(&[Memory::Semantic(without), Memory::Semantic(with)]),
+            Some(768)
+        );
+    }
 }

--- a/pensyve-mcp/src/main.rs
+++ b/pensyve-mcp/src/main.rs
@@ -63,8 +63,8 @@ fn resolve_stdio_pool_size() -> usize {
 /// if necessary download) the model at startup, falling back
 /// GTE → `MiniLM` → mock exactly as before.
 fn build_embedder(stored_dims: Option<usize>) -> anyhow::Result<OnnxEmbedder> {
-    if std::env::var("PENSYVE_EAGER_EMBEDDER").is_ok() {
-        return build_eager_embedder();
+    if eager_embedder_enabled() {
+        return build_eager_embedder(stored_dims);
     }
 
     if std::env::var("PENSYVE_ALLOW_MOCK_EMBEDDER").is_ok() {
@@ -95,6 +95,18 @@ fn build_embedder(stored_dims: Option<usize>) -> anyhow::Result<OnnxEmbedder> {
 
 const GTE: &str = "Alibaba-NLP/gte-base-en-v1.5";
 const MINILM: &str = "all-MiniLM-L6-v2";
+
+/// Whether `PENSYVE_EAGER_EMBEDDER` is set to an enabled value. Falsy
+/// values (`0`, `false`, `off`, `no`, empty) leave the default lazy path
+/// active, matching the `PENSYVE_SELROUTE` truthiness convention.
+fn eager_embedder_enabled() -> bool {
+    std::env::var("PENSYVE_EAGER_EMBEDDER").is_ok_and(|v| flag_is_truthy(&v))
+}
+
+fn flag_is_truthy(value: &str) -> bool {
+    let lower = value.trim().to_ascii_lowercase();
+    !matches!(lower.as_str(), "" | "0" | "false" | "off" | "no")
+}
 
 /// Pick the lazy model for the stdio server.
 ///
@@ -135,29 +147,49 @@ fn cache_preferred_model(gte_cached: bool, minilm_cached: bool) -> &'static str 
     }
 }
 
-/// Pre-lazy startup behavior: try GTE (768d), then `MiniLM` (384d), then mock.
-fn build_eager_embedder() -> anyhow::Result<OnnxEmbedder> {
-    match OnnxEmbedder::new("Alibaba-NLP/gte-base-en-v1.5") {
+/// Try order for the eager path: existing embeddings' dimensionality
+/// promotes the matching model to first choice (384 → `MiniLM` before
+/// GTE); otherwise the pre-lazy GTE → `MiniLM` order applies.
+fn eager_model_order(stored_dims: Option<usize>) -> [&'static str; 2] {
+    match stored_dims {
+        Some(384) => [MINILM, GTE],
+        _ => [GTE, MINILM],
+    }
+}
+
+/// Pre-lazy startup behavior: load a model at startup (downloading if
+/// needed), falling back to mock when permitted. Try order honors
+/// existing embeddings' dimensionality — see `eager_model_order`.
+fn build_eager_embedder(stored_dims: Option<usize>) -> anyhow::Result<OnnxEmbedder> {
+    let [first, second] = eager_model_order(stored_dims);
+    match OnnxEmbedder::new(first) {
         Ok(e) => {
-            tracing::info!("Using real ONNX embedder (Alibaba-NLP/gte-base-en-v1.5, 768 dims)");
+            tracing::info!(
+                "Using real ONNX embedder ({first}, {} dims)",
+                e.dimensions()
+            );
             Ok(e)
         }
-        Err(gte_err) => {
-            tracing::warn!("GTE model unavailable ({gte_err}), trying all-MiniLM-L6-v2 fallback");
-            match OnnxEmbedder::new("all-MiniLM-L6-v2") {
+        Err(first_err) => {
+            tracing::warn!("{first} unavailable ({first_err}), trying {second} fallback");
+            match OnnxEmbedder::new(second) {
                 Ok(e) => {
-                    tracing::info!("Using fallback ONNX embedder (all-MiniLM-L6-v2, 384 dims)");
+                    tracing::info!(
+                        "Using fallback ONNX embedder ({second}, {} dims)",
+                        e.dimensions()
+                    );
                     Ok(e)
                 }
-                Err(mini_err) => {
+                Err(second_err) => {
                     if std::env::var("PENSYVE_ALLOW_MOCK_EMBEDDER").is_ok() {
+                        let mock_dims = stored_dims.unwrap_or(768);
                         tracing::warn!(
-                            "ONNX embedders unavailable ({mini_err}), falling back to mock (768 dims)"
+                            "ONNX embedders unavailable ({second_err}), falling back to mock ({mock_dims} dims)"
                         );
-                        Ok(OnnxEmbedder::new_mock(768))
+                        Ok(OnnxEmbedder::new_mock(mock_dims))
                     } else {
                         Err(anyhow::anyhow!(
-                            "No ONNX model available. Set PENSYVE_ALLOW_MOCK_EMBEDDER=1 to use mock. Error: {mini_err}"
+                            "No ONNX model available. Set PENSYVE_ALLOW_MOCK_EMBEDDER=1 to use mock. Error: {second_err}"
                         ))
                     }
                 }
@@ -320,6 +352,23 @@ mod tests {
         assert_eq!(choose_lazy_model(None, true, true), GTE);
         assert_eq!(choose_lazy_model(None, false, true), MINILM);
         assert_eq!(choose_lazy_model(None, false, false), GTE);
+    }
+
+    #[test]
+    fn falsy_flag_values_stay_lazy() {
+        for v in ["0", "false", "off", "no", "", " FALSE "] {
+            assert!(!flag_is_truthy(v), "{v:?} must be falsy");
+        }
+        for v in ["1", "true", "yes", "on"] {
+            assert!(flag_is_truthy(v), "{v:?} must be truthy");
+        }
+    }
+
+    #[test]
+    fn eager_order_honors_stored_dims() {
+        assert_eq!(eager_model_order(Some(384)), [MINILM, GTE]);
+        assert_eq!(eager_model_order(Some(768)), [GTE, MINILM]);
+        assert_eq!(eager_model_order(None), [GTE, MINILM]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
The four nits identified in the deep-dive review of #162, none blocking that merge:

1. **CI: skip claude-review on fork PRs.** Fork `pull_request` runs receive neither repo secrets nor `id-token: write` from GitHub, so the job structurally fails on every external contribution (as it did twice on #162 — no token rotation can fix it). The job now skips when the head repo isn't this repo.
2. **Dimension-aware model choice** (`pensyve-mcp`): if the namespace already holds embeddings, the model matching their dimensionality (768 → GTE, 384 → MiniLM) wins outright over fastembed-cache presence. Previously a 768-d database on a machine with only MiniLM cached would silently drop **all** stored vectors from the index at load (per-memory warns only).
3. **`PENSYVE_ALLOW_MOCK_EMBEDDER` clarity**: startup warn when it's set on the lazy path (where it has no effect), plus README rows for it and `PENSYVE_EAGER_EMBEDDER`.
4. **`resolve_model` dedup** (`pensyve-core`): dimensionality now comes from `SUPPORTED_MODELS` instead of duplicated literals.

## Verification
- `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings` — clean
- pensyve-core: 24 embedding tests + 6 no-network invariant tests pass
- pensyve-mcp: 13 integration + 4 new unit tests pass (`choose_lazy_model` precedence, `stored_embedding_dims`)