### PR TITLE
ci: Claude workflows → Opus 4.8 at xhigh effort

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -74,5 +74,6 @@ jobs:
             - Be concise. One sentence per finding is enough.
 
           claude_args: |
-            --model claude-opus-4-6
+            --model claude-opus-4-8
+            --effort xhigh
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,5 +36,6 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
-            --model claude-opus-4-6
+            --model claude-opus-4-8
+            --effort xhigh
             --allowedTools "Edit,Write,Read,Bash(cargo:*),Bash(make:*),Bash(uv:*),Bash(bun:*),Bash(gh:*),mcp__github_inline_comment__create_inline_comment"


### PR DESCRIPTION
Per Seth's directive: all Claude code reviews run on Opus 4.8 at X-High effort.

- `--model claude-opus-4-8` (was `claude-opus-4-6`) in both `claude-code-review.yml` and `claude.yml`
- `--effort xhigh` added (Claude Code CLI flag; values low|medium|high|xhigh|max — verified against code.claude.com CLI reference)

Both flags pass through `claude_args` per the claude-code-action v1 docs.