### PR TITLE
fix(deps): pin fastembed to 5.17.2 — 5.17.3 breaks cached-model resolution (offline regression)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1261,9 +1261,9 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastembed"
-version = "5.17.3"
+version = "5.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c8600c9ec79b51d60c19911fe14eac04fe9c2895e87d2a3e80e2213d645a32"
+checksum = "545e4fb17fc48768ff36c2a3854aa5b0b809d0ed595ab5530fa8ac94f31bd0ea"
 dependencies = [
  "anyhow",
  "hf-hub",

--- a/pensyve-core/Cargo.toml
+++ b/pensyve-core/Cargo.toml
@@ -24,7 +24,9 @@ chrono = { version = "0.4", features = ["serde"] }
 thiserror = "2"
 dirs = "6"
 regex = "1"
-fastembed = "^5.13"
+# Pinned to 5.17.2: 5.17.3 breaks cached-model resolution for existing model
+# caches (offline-first regression); see the tracking issue for details.
+fastembed = "=5.17.2"
 petgraph = "0.8"
 # Phase 2B: compile-time predicate-verb lexicon for the shallow dependency
 # parser (`extraction::dep_parse`). `phf::Map` keys are interned at build


### PR DESCRIPTION
## Summary

Dependabot PR #173 bumped `fastembed` 5.17.2 → 5.17.3. On a machine with a pre-existing model cache, `cargo test -p pensyve-core --test test_no_network_invariants` fails 2/6 at main (`4d917f4`):

- `onnx_embedder_per_call_inference_makes_no_network_calls`: panic `MiniLM embedder should construct from cache: ModelLoad("Failed to retrieve model.onnx")`
- `reranker_does_not_make_network_calls`: panic `BGE reranker should construct from cache: ModelLoad("Failed to retrieve model file: onnx/model.onnx")`

The same test suite passes 6/6 at the pre-bump SHA `c61d60b` on the same machine with the same cache. So 5.17.3 changed cached-model resolution behavior.

This breaks Pensyve's offline-first guarantee for existing deployments: an offline install that upgrades `pensyve` loses its cached models with no network available to re-download them. GitHub CI did not catch this because CI runners have no pre-seeded model cache — the invariant tests that would exercise cache-hit paths currently only run meaningfully on machines with a cache already populated.

This PR pins `fastembed` back to `=5.17.2` in `pensyve-core/Cargo.toml` and updates `Cargo.lock` accordingly. Reverts the fastembed portion of #173.

## Root cause (best-effort, time-boxed)

The only change between v5.17.2 and v5.17.3 upstream is `chore(deps): update candle-core requirement from 0.10.2 to 0.11.0` ([fastembed-rs#270](https://github.com/Anush008/fastembed-rs/pull/270), [compare](https://github.com/Anush008/fastembed-rs/compare/v5.17.2...v5.17.3)).

**Correction from review:** `candle-core` does not actually appear in this repo's `Cargo.lock` — fastembed resolves here via the `ort` (ONNX Runtime) + `hf-hub` backend, and candle is never compiled into our build. So the candle-core bump can't be the direct mechanism of the regression for us; it's a dead-end lead. No other transitive dependency (including `hf-hub`, which owns cache-path resolution) changed version in our lockfile between the two fastembed versions either. The exact mechanism was not identified within the time-box for this fix — the follow-up issue redirects the investigation to `hf-hub` cache-path resolution / fastembed's Cargo feature unification rather than candle.

## Test results

`cargo test -p pensyve-core --test test_no_network_invariants` with fastembed pinned to `5.17.2`:

```
running 6 tests
test onnx_embedder_constructor_under_disabled_with_uncached_model_returns_error ... ok
test peer_card_uses_only_readonly_sqlite_no_network ... ok
test onnx_embedder_constructor_under_disabled_with_cached_model_succeeds ... ok
test onnx_embedder_lazy_under_disabled_with_uncached_model_errors_at_first_use ... ok
test onnx_embedder_per_call_inference_makes_no_network_calls ... ok
test reranker_does_not_make_network_calls ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 34.09s
```

`make test` (full workspace `cargo test` across all crates + `uv run pytest tests/python/`): **PASS** — 0 failed across every `cargo test` binary in the workspace; `121 passed in 24.03s` for the Python SDK suite.

## Follow-up

Filed a follow-up issue to track re-adopting `fastembed` >5.17.2 with a proper model-cache migration path, and to close the CI gap (no-network invariant tests need a pre-seeded model cache on runners to be meaningful). See #191.

https://claude.ai/code/session_01RBPnHnTPtEkp1EcaLqfPCU
