### PR TITLE
chore: refresh MCP Registry manifest to 2.6.1

### DIFF
--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.major7apps/pensyve",
   "title": "Pensyve",
   "description": "Universal memory runtime for AI agents — episodic, semantic, and procedural memory.",
-  "version": "1.0.4",
+  "version": "2.6.1",
   "repository": {
     "url": "https://github.com/major7apps/pensyve",
     "source": "github"
@@ -27,6 +27,10 @@
     {
       "name": "pensyve_remember",
       "description": "Store a fact about a named entity as semantic memory"
+    },
+    {
+      "name": "pensyve_observe",
+      "description": "Record an observation within an active episode"
     },
     {
       "name": "pensyve_episode_start",

--- a/server.json
+++ b/server.json
@@ -10,15 +10,20 @@
   },
   "websiteUrl": "https://pensyve.com",
   "license": "Apache-2.0",
-  "runtime": {
-    "type": "http",
-    "url": "https://mcp.pensyve.com/mcp",
-    "transport": "streamable-http",
-    "authentication": {
-      "type": "bearer",
-      "environmentVariable": "PENSYVE_API_KEY"
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.pensyve.com/mcp",
+      "headers": [
+        {
+          "name": "Authorization",
+          "description": "Bearer token for authentication, e.g. 'Bearer <PENSYVE_API_KEY>'",
+          "isRequired": true,
+          "isSecret": true
+        }
+      ]
     }
-  },
+  ],
   "tools": [
     {
       "name": "pensyve_recall",


### PR DESCRIPTION
## Summary

The official MCP Registry listing for Pensyve (`io.github.major7apps/pensyve`) has been live since 2026-04-04, but `registry.modelcontextprotocol.io/v0/servers?search=pensyve` still returns `version: 1.0.4` — matching the `server.json` committed at the time of that publish, and well behind the current `2.6.1` release. This was flagged in `pensyve-docs/docs/design-docs/2026-03-27-pensyve-directory-submissions.md` (directory-submissions tracker, section 5).

This PR brings `server.json` current so the next publish reflects reality:

- `version`: `1.0.4` → `2.6.1`
- `tools`: added the missing `pensyve_observe` entry (manifest listed 8 tools; the server actually exposes 9 — verified against `#[tool(name = "...")]` definitions in `pensyve-mcp-tools/src/server.rs`)
- `remotes`: replaced the non-standard `runtime` block with a schema-correct top-level `remotes` entry (`type: streamable-http`, `url`, `headers`). The 2025-12-11 `server.schema.json` (`ServerDetail`) does not define a `runtime` property at all — hosted transports are only recognized under `remotes` (`RemoteTransport` → `StreamableHttpTransport`). The old `runtime` block would have been silently ignored by any spec-compliant registry consumer, meaning the connection endpoint and auth header were never actually surfaced. Caught by the Codex automated review on this PR; verified the fix by validating the full document against the fetched schema with `jsonschema.validate()`.
- `description` and `tags` were checked against `README.md` / `pensyve-python/pyproject.toml` and are still accurate — left unchanged.

## Publish mechanism (for the operator, after merge)

There is **no CI automation** that publishes to the MCP Registry — `.github/workflows/release.yml` publishes to PyPI/npm/crates.io/GitHub Releases but does not touch `server.json` or the registry. Publishing is a manual, local step using the `mcp-publisher` CLI (GitHub device-flow auth):

```bash
# Install mcp-publisher
curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_arm64.tar.gz" | tar xz mcp-publisher
sudo mv mcp-publisher /usr/local/bin/

# Authenticate (GitHub device flow)
mcp-publisher login github

# Validate server.json against the registry schema
mcp-publisher validate

# Publish the update
mcp-publisher publish
```

This PR does **not** run `mcp-publisher publish` — that's an operator action to take after merge.

## Test plan

- [x] `python3 -m json.tool server.json` — valid JSON
- [x] Tool count/names cross-checked against `pensyve-mcp-tools/src/server.rs` (`#[tool(name = "...")]` macros) — 9 tools total
- [x] Version cross-checked against `pensyve-mcp/Cargo.toml`, `pensyve-mcp-tools/Cargo.toml`, and the `v2.6.1` git tag
- [x] Full document validated against the fetched `2025-12-11/server.schema.json` with Python `jsonschema.validate()` — passes
- [x] CI green
- [x] CodeRabbit review addressed (approved, no actionable comments)
- [x] Claude workflow review addressed (LGTM)
- [x] Codex automated review finding addressed (runtime → remotes fix, pushed in 46cf0af)

https://claude.ai/code/session_01RBPnHnTPtEkp1EcaLqfPCU