### PR TITLE
feat(recall): populate contradictions from live semantic disagreements (#183)

### DIFF
--- a/pensyve-core/src/retrieval/contradictions.rs
+++ b/pensyve-core/src/retrieval/contradictions.rs
@@ -1,0 +1,179 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::Serialize;
+use uuid::Uuid;
+
+use crate::types::Memory;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct Contradiction {
+    pub subject: Uuid,
+    pub predicate: String,
+    pub memory_ids: Vec<Uuid>,
+    pub objects: Vec<String>,
+}
+
+#[derive(Default)]
+struct ContradictionGroup {
+    memory_ids: Vec<Uuid>,
+    objects: Vec<String>,
+    distinct_objects: BTreeSet<String>,
+}
+
+pub fn detect_contradictions(memories: &[Memory]) -> Vec<Contradiction> {
+    let mut groups: BTreeMap<(Uuid, String), ContradictionGroup> = BTreeMap::new();
+
+    for memory in memories {
+        let Memory::Semantic(memory) = memory else {
+            continue;
+        };
+        if memory.invalid_at.is_some() {
+            continue;
+        }
+
+        let predicate = memory.predicate.to_lowercase();
+        let group = groups.entry((memory.subject, predicate)).or_default();
+        group.memory_ids.push(memory.id);
+        group.objects.push(memory.object.clone());
+        group
+            .distinct_objects
+            .insert(memory.object.trim().to_lowercase());
+    }
+
+    groups
+        .into_iter()
+        .filter_map(|((subject, predicate), group)| {
+            (group.distinct_objects.len() >= 2).then_some(Contradiction {
+                subject,
+                predicate,
+                memory_ids: group.memory_ids,
+                objects: group.objects,
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use chrono::Utc;
+    use uuid::Uuid;
+
+    use super::detect_contradictions;
+    use crate::types::{
+        EpisodicMemory, Memory, ObservationMemory, Outcome, ProceduralMemory, SemanticMemory,
+    };
+
+    fn semantic(
+        namespace_id: Uuid,
+        subject: Uuid,
+        predicate: &str,
+        object: &str,
+    ) -> SemanticMemory {
+        SemanticMemory::new(namespace_id, subject, predicate, object, 0.9)
+    }
+
+    #[test]
+    fn detects_disagreeing_objects_case_insensitively() {
+        let namespace_id = Uuid::from_u128(1);
+        let subject = Uuid::from_u128(2);
+        let first = semantic(namespace_id, subject, "Works_At", " Acme ");
+        let second = semantic(namespace_id, subject, "works_at", "Globex");
+        let first_id = first.id;
+        let second_id = second.id;
+
+        let contradictions =
+            detect_contradictions(&[Memory::Semantic(first), Memory::Semantic(second)]);
+
+        assert_eq!(contradictions.len(), 1);
+        assert_eq!(contradictions[0].subject, subject);
+        assert_eq!(contradictions[0].predicate, "works_at");
+        assert_eq!(contradictions[0].memory_ids, vec![first_id, second_id]);
+        assert_eq!(contradictions[0].objects, vec![" Acme ", "Globex"]);
+    }
+
+    #[test]
+    fn agreeing_duplicate_objects_are_not_flagged() {
+        let namespace_id = Uuid::from_u128(1);
+        let subject = Uuid::from_u128(2);
+
+        let contradictions = detect_contradictions(&[
+            Memory::Semantic(semantic(namespace_id, subject, "works_at", "Acme")),
+            Memory::Semantic(semantic(namespace_id, subject, "WORKS_AT", " acme ")),
+        ]);
+
+        assert!(contradictions.is_empty());
+    }
+
+    #[test]
+    fn invalidated_memories_are_excluded() {
+        let namespace_id = Uuid::from_u128(1);
+        let subject = Uuid::from_u128(2);
+        let active = semantic(namespace_id, subject, "works_at", "Acme");
+        let mut invalid = semantic(namespace_id, subject, "works_at", "Globex");
+        invalid.invalid_at = Some(Utc::now());
+
+        let contradictions =
+            detect_contradictions(&[Memory::Semantic(active), Memory::Semantic(invalid)]);
+
+        assert!(contradictions.is_empty());
+    }
+
+    #[test]
+    fn different_predicates_for_same_subject_form_independent_sorted_groups() {
+        let namespace_id = Uuid::from_u128(1);
+        let subject = Uuid::from_u128(2);
+        let works_first = semantic(namespace_id, subject, "works_at", "Acme");
+        let lives_first = semantic(namespace_id, subject, "lives_in", "Boston");
+        let works_second = semantic(namespace_id, subject, "works_at", "Globex");
+        let lives_second = semantic(namespace_id, subject, "lives_in", "Paris");
+        let works_ids = vec![works_first.id, works_second.id];
+        let lives_ids = vec![lives_first.id, lives_second.id];
+
+        let contradictions = detect_contradictions(&[
+            Memory::Semantic(works_first),
+            Memory::Semantic(lives_first),
+            Memory::Semantic(works_second),
+            Memory::Semantic(lives_second),
+        ]);
+
+        assert_eq!(contradictions.len(), 2);
+        assert_eq!(contradictions[0].predicate, "lives_in");
+        assert_eq!(contradictions[0].memory_ids, lives_ids);
+        assert_eq!(contradictions[1].predicate, "works_at");
+        assert_eq!(contradictions[1].memory_ids, works_ids);
+    }
+
+    #[test]
+    fn non_semantic_memory_variants_are_ignored() {
+        let namespace_id = Uuid::from_u128(1);
+        let episode_id = Uuid::from_u128(2);
+        let subject = Uuid::from_u128(3);
+        let episodic =
+            EpisodicMemory::new(namespace_id, episode_id, subject, subject, "works_at Acme");
+        let procedural = ProceduralMemory::new(
+            namespace_id,
+            "works_at",
+            "Globex",
+            Outcome::Success,
+            HashMap::new(),
+        );
+        let observation = ObservationMemory::new(
+            namespace_id,
+            episode_id,
+            "works_at",
+            "Initech",
+            "works_at",
+            "works_at Initech",
+        );
+
+        let contradictions = detect_contradictions(&[
+            Memory::Episodic(episodic),
+            Memory::Procedural(procedural),
+            Memory::Observation(observation),
+        ]);
+
+        assert!(contradictions.is_empty());
+    }
+}

--- a/pensyve-core/src/retrieval/contradictions.rs
+++ b/pensyve-core/src/retrieval/contradictions.rs
@@ -5,6 +5,29 @@ use uuid::Uuid;
 
 use crate::types::Memory;
 
+/// Predicates conservatively excluded from contradiction detection because they commonly describe
+/// multi-valued relationships. This deny-list is a heuristic; memory supersession (issue #187) is
+/// the systematic long-term fix.
+const CONTRADICTION_PREDICATE_DENY_LIST: &[&str] = &[
+    "knows",
+    "has_skill",
+    "has_skills",
+    "member_of",
+    "likes",
+    "loves",
+    "owns",
+    "uses",
+    "works_on",
+    "interested_in",
+    "collaborates_with",
+    "friend_of",
+    "has_hobby",
+    "speaks",
+    "attended",
+    "visited",
+    "related_to",
+];
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct Contradiction {
     pub subject: Uuid,
@@ -32,6 +55,10 @@ pub fn detect_contradictions(memories: &[Memory]) -> Vec<Contradiction> {
         }
 
         let predicate = memory.predicate.to_lowercase();
+        let deny_list_predicate = predicate.replace(' ', "_");
+        if CONTRADICTION_PREDICATE_DENY_LIST.contains(&deny_list_predicate.as_str()) {
+            continue;
+        }
         let group = groups.entry((memory.subject, predicate)).or_default();
         group.memory_ids.push(memory.id);
         group.objects.push(memory.object.clone());
@@ -101,6 +128,45 @@ mod tests {
         let contradictions = detect_contradictions(&[
             Memory::Semantic(semantic(namespace_id, subject, "works_at", "Acme")),
             Memory::Semantic(semantic(namespace_id, subject, "WORKS_AT", " acme ")),
+        ]);
+
+        assert!(contradictions.is_empty());
+    }
+
+    #[test]
+    fn knows_with_different_objects_is_not_flagged() {
+        let namespace_id = Uuid::from_u128(1);
+        let subject = Uuid::from_u128(2);
+
+        let contradictions = detect_contradictions(&[
+            Memory::Semantic(semantic(namespace_id, subject, "knows", "Bob")),
+            Memory::Semantic(semantic(namespace_id, subject, "knows", "Carol")),
+        ]);
+
+        assert!(contradictions.is_empty());
+    }
+
+    #[test]
+    fn works_at_with_different_objects_is_flagged() {
+        let namespace_id = Uuid::from_u128(1);
+        let subject = Uuid::from_u128(2);
+
+        let contradictions = detect_contradictions(&[
+            Memory::Semantic(semantic(namespace_id, subject, "works_at", "Acme")),
+            Memory::Semantic(semantic(namespace_id, subject, "works_at", "Globex")),
+        ]);
+
+        assert_eq!(contradictions.len(), 1);
+    }
+
+    #[test]
+    fn space_separated_has_skill_with_different_objects_is_not_flagged() {
+        let namespace_id = Uuid::from_u128(1);
+        let subject = Uuid::from_u128(2);
+
+        let contradictions = detect_contradictions(&[
+            Memory::Semantic(semantic(namespace_id, subject, "has skill", "Rust")),
+            Memory::Semantic(semantic(namespace_id, subject, "has skill", "Go")),
         ]);
 
         assert!(contradictions.is_empty());

--- a/pensyve-core/src/retrieval/mod.rs
+++ b/pensyve-core/src/retrieval/mod.rs
@@ -24,6 +24,7 @@
 //! continue to work unchanged after the directory split.
 
 pub mod cards;
+pub mod contradictions;
 pub mod diversity;
 pub mod engine;
 pub mod intent_router;

--- a/pensyve-go/client.go
+++ b/pensyve-go/client.go
@@ -224,6 +224,19 @@ func (c *Client) Entity(ctx context.Context, name, kind string) (*Entity, error)
 
 // Recall searches for memories matching the given query.
 func (c *Client) Recall(ctx context.Context, query string, opts *RecallOptions) ([]Memory, error) {
+	result, err := c.RecallWithResult(ctx, query, opts)
+	if err != nil {
+		return nil, err
+	}
+	return result.Memories, nil
+}
+
+// RecallWithResult searches for memories and returns the full result, including contradictions.
+func (c *Client) RecallWithResult(
+	ctx context.Context,
+	query string,
+	opts *RecallOptions,
+) (*RecallResult, error) {
 	if query == "" {
 		return nil, fmt.Errorf("query must not be empty")
 	}
@@ -243,12 +256,12 @@ func (c *Client) Recall(ctx context.Context, query string, opts *RecallOptions) 
 		}
 	}
 
-	var resp recallResponse
-	err := c.do(ctx, "POST", "/v1/recall", req, &resp)
+	var result RecallResult
+	err := c.do(ctx, "POST", "/v1/recall", req, &result)
 	if err != nil {
 		return nil, err
 	}
-	return resp.Memories, nil
+	return &result, nil
 }
 
 // Remember stores a fact for the given entity with the specified confidence.

--- a/pensyve-go/client_test.go
+++ b/pensyve-go/client_test.go
@@ -78,7 +78,7 @@ func TestRecallWithOptions(t *testing.T) {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(recallResponse{
+		json.NewEncoder(w).Encode(RecallResult{
 			Memories: []Memory{
 				{
 					ID:         "mem-1",
@@ -127,7 +127,7 @@ func TestRecallWithNilOptions(t *testing.T) {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(recallResponse{Memories: []Memory{}})
+		json.NewEncoder(w).Encode(RecallResult{Memories: []Memory{}})
 	}))
 	defer server.Close()
 
@@ -141,6 +141,47 @@ func TestRecallWithNilOptions(t *testing.T) {
 	}
 	if len(memories) != 0 {
 		t.Fatalf("expected 0 memories, got %d", len(memories))
+	}
+}
+
+func TestRecallWithResultReturnsContradictions(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"memories": []Memory{{ID: "mem-1", Content: "Alice works at Acme"}},
+			"contradictions": []map[string]interface{}{{
+				"subject":    "alice",
+				"predicate":  "works_at",
+				"memory_ids": []string{"mem-1", "mem-2"},
+				"objects":    []string{"Acme", "Globex"},
+			}},
+		})
+	}))
+	defer server.Close()
+
+	client, err := NewClient(Config{BaseURL: server.URL})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := client.RecallWithResult(context.Background(), "employment", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Memories) != 1 {
+		t.Fatalf("expected 1 memory, got %d", len(result.Memories))
+	}
+	if len(result.Contradictions) != 1 {
+		t.Fatalf("expected 1 contradiction, got %d", len(result.Contradictions))
+	}
+	contradiction := result.Contradictions[0]
+	if contradiction.Subject != "alice" || contradiction.Predicate != "works_at" {
+		t.Errorf("unexpected contradiction: %+v", contradiction)
+	}
+	if len(contradiction.MemoryIDs) != 2 || contradiction.MemoryIDs[1] != "mem-2" {
+		t.Errorf("unexpected memory IDs: %v", contradiction.MemoryIDs)
+	}
+	if len(contradiction.Objects) != 2 || contradiction.Objects[1] != "Globex" {
+		t.Errorf("unexpected objects: %v", contradiction.Objects)
 	}
 }
 

--- a/pensyve-go/types.go
+++ b/pensyve-go/types.go
@@ -29,6 +29,14 @@ type Memory struct {
 	EventTime  *time.Time `json:"event_time,omitempty"`
 }
 
+// Contradiction represents conflicting objects reported for a subject and predicate.
+type Contradiction struct {
+	Subject   string   `json:"subject"`
+	Predicate string   `json:"predicate"`
+	MemoryIDs []string `json:"memory_ids"`
+	Objects   []string `json:"objects"`
+}
+
 // RecallOptions configures a recall query.
 type RecallOptions struct {
 	Entity string
@@ -63,11 +71,11 @@ type recallRequest struct {
 	Types  []string `json:"types,omitempty"`
 }
 
-// recallResponse is the JSON body returned by POST /v1/recall.
-type recallResponse struct {
-	Memories      []Memory `json:"memories"`
-	Contradictions []Memory `json:"contradictions"`
-	Cursor        *string  `json:"cursor"`
+// RecallResult is the JSON body returned by POST /v1/recall.
+type RecallResult struct {
+	Memories       []Memory        `json:"memories"`
+	Contradictions []Contradiction `json:"contradictions"`
+	Cursor         *string         `json:"cursor"`
 }
 
 // rememberRequest is the JSON body for POST /v1/remember.

--- a/pensyve-mcp-gateway/src/rest.rs
+++ b/pensyve-mcp-gateway/src/rest.rs
@@ -16,6 +16,7 @@ use uuid::Uuid;
 use crate::auth::AuthContext;
 
 use pensyve_core::retrieval::RecallEngine;
+use pensyve_core::retrieval::contradictions::detect_contradictions;
 use pensyve_core::storage::StorageTrait;
 use pensyve_core::types::{
     ContentType, Entity, EntityKind, Episode, EpisodicMemory, Memory, Outcome, SemanticMemory,
@@ -377,34 +378,36 @@ fn filter_recall_results(
     result: &pensyve_core::retrieval::RecallResult,
     types: Option<&[String]>,
     min_confidence: Option<f64>,
-) -> Vec<RecallMemory> {
-    result
-        .memories
-        .iter()
-        .filter(|c| {
-            if let Some(types) = types {
-                let tn = memory_type_name(&c.memory);
-                if !types.iter().any(|t| t == tn) {
-                    return false;
-                }
+) -> (Vec<RecallMemory>, Vec<Memory>) {
+    let mut response_memories = Vec::new();
+    let mut returned_memories = Vec::new();
+
+    for candidate in &result.memories {
+        if let Some(types) = types {
+            let memory_type = memory_type_name(&candidate.memory);
+            if !types.iter().any(|requested| requested == memory_type) {
+                continue;
             }
-            if let Some(min_conf) = min_confidence
-                && f64::from(memory_confidence(&c.memory)) < min_conf
-            {
-                return false;
-            }
-            true
-        })
-        .map(|c| RecallMemory {
-            id: c.memory_id.to_string(),
-            content: memory_content(&c.memory),
-            memory_type: memory_type_name(&c.memory).to_string(),
-            confidence: memory_confidence(&c.memory),
-            stability: memory_stability(&c.memory),
-            score: c.final_score,
-            event_time: memory_event_time(&c.memory),
-        })
-        .collect()
+        }
+        if let Some(min_confidence) = min_confidence
+            && f64::from(memory_confidence(&candidate.memory)) < min_confidence
+        {
+            continue;
+        }
+
+        response_memories.push(RecallMemory {
+            id: candidate.memory_id.to_string(),
+            content: memory_content(&candidate.memory),
+            memory_type: memory_type_name(&candidate.memory).to_string(),
+            confidence: memory_confidence(&candidate.memory),
+            stability: memory_stability(&candidate.memory),
+            score: candidate.final_score,
+            event_time: memory_event_time(&candidate.memory),
+        });
+        returned_memories.push(candidate.memory.clone());
+    }
+
+    (response_memories, returned_memories)
 }
 
 fn strip_embedding(val: &mut serde_json::Value) {
@@ -491,6 +494,7 @@ async fn health() -> impl IntoResponse {
     }))
 }
 
+#[allow(clippy::too_many_lines)]
 async fn recall(
     State(state): State<Arc<AppState>>,
     axum::Extension(auth_ctx): axum::Extension<AuthContext>,
@@ -580,7 +584,18 @@ async fn recall(
             })?
     };
 
-    let memories = filter_recall_results(&result, body.types.as_deref(), body.min_confidence);
+    let (memories, returned_memories) =
+        filter_recall_results(&result, body.types.as_deref(), body.min_confidence);
+    let contradictions = detect_contradictions(&returned_memories)
+        .into_iter()
+        .map(serde_json::to_value)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|err| {
+            RestError(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Error serializing contradictions: {err}"),
+            )
+        })?;
 
     let _ = ps.storage.log_activity(
         ps.namespace.id,
@@ -590,7 +605,7 @@ async fn recall(
 
     let response = RecallResponse {
         memories,
-        contradictions: vec![],
+        contradictions,
     };
 
     // Cache the result (60s TTL).

--- a/pensyve-mcp-gateway/tests/test_rest_recall_contradictions.rs
+++ b/pensyve-mcp-gateway/tests/test_rest_recall_contradictions.rs
@@ -1,0 +1,215 @@
+use std::sync::Arc;
+
+use axum::Extension;
+use pensyve_core::config::RetrievalConfig;
+use pensyve_core::embedding::OnnxEmbedder;
+use pensyve_core::storage::StorageTrait;
+use pensyve_core::storage::sqlite::SqliteBackend;
+use pensyve_core::types::{Entity, EntityKind, Namespace, SemanticMemory};
+use pensyve_core::vector::VectorIndex;
+use pensyve_mcp_gateway::AppState;
+use pensyve_mcp_gateway::auth::{AuthContext, AuthValidator};
+use pensyve_mcp_gateway::config::GatewayConfig;
+use pensyve_mcp_gateway::rate_limit::RateLimiter;
+use pensyve_mcp_gateway::rest;
+use pensyve_mcp_gateway::tenant::TenantStateManager;
+use pensyve_mcp_gateway::usage::UsageReporter;
+use pensyve_mcp_gateway::usage_counter::UsageCounter;
+use serde_json::{Value, json};
+use tempfile::TempDir;
+use tokio_util::sync::CancellationToken;
+use uuid::Uuid;
+
+const TEST_TENANT: &str = "test-rest-recall-contradictions";
+
+fn retrieval_config() -> RetrievalConfig {
+    RetrievalConfig {
+        default_limit: 5,
+        max_candidates: 100,
+        weights: [0.30, 0.15, 0.20, 0.10, 0.10, 0.05, 0.05, 0.05],
+        recall_timeout_secs: 5,
+        rrf_k: 60,
+        rrf_weights: [1.0, 0.8, 1.0, 0.8, 0.5, 0.5, 1.2, 1.0],
+        beam_width: 10,
+        max_depth: 4,
+    }
+}
+
+fn gateway_config(dir: &TempDir) -> GatewayConfig {
+    GatewayConfig {
+        host: "127.0.0.1".to_string(),
+        port: 0,
+        storage_path: dir.path().to_path_buf(),
+        namespace: "default".to_string(),
+        api_keys: vec![],
+        rate_limit_per_minute: 300,
+        stripe_api_key: None,
+        admin_key: None,
+        key_user_map: vec![],
+        allowed_hosts: vec![],
+    }
+}
+
+fn app_state(dir: &TempDir) -> Arc<AppState> {
+    let storage =
+        Arc::new(SqliteBackend::open(dir.path()).expect("open storage")) as Arc<dyn StorageTrait>;
+    let namespace = Namespace::new("default");
+    storage
+        .save_namespace(&namespace)
+        .expect("save default namespace");
+
+    let tenant_mgr = TenantStateManager::new(
+        storage,
+        Arc::new(OnnxEmbedder::new_mock(768)),
+        retrieval_config(),
+        namespace,
+        VectorIndex::new(768, 1024),
+    );
+    let config = gateway_config(dir);
+
+    Arc::new(AppState {
+        auth: AuthValidator::new(&config),
+        rate_limiter: RateLimiter::new(None),
+        usage_reporter: UsageReporter::new(None),
+        usage_counter: UsageCounter::new(),
+        tenant_mgr,
+        auth_required: false,
+        admin_key: None,
+        ct: CancellationToken::new(),
+        redis: None,
+        extractor: None,
+    })
+}
+
+fn auth_context() -> AuthContext {
+    AuthContext {
+        key_id: TEST_TENANT.to_string(),
+        tenant_id: None,
+        user_id: None,
+        scope: "mcp".to_string(),
+        stripe_customer_id: None,
+        plan: "free".to_string(),
+    }
+}
+
+async fn start_test_server(dir: &TempDir) -> (String, Arc<AppState>, CancellationToken) {
+    let state = app_state(dir);
+    let app = rest::router()
+        .layer(Extension(auth_context()))
+        .with_state(state.clone());
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test server");
+    let addr = listener.local_addr().expect("test server address");
+    let cancellation = CancellationToken::new();
+    let shutdown = cancellation.clone();
+
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app)
+            .with_graceful_shutdown(shutdown.cancelled_owned())
+            .await;
+    });
+
+    (format!("http://{addr}"), state, cancellation)
+}
+
+fn store_semantic_pair(state: &AppState, first_object: &str, second_object: &str) -> [Uuid; 2] {
+    let pensyve_state = state
+        .tenant_mgr
+        .get_tenant_state(TEST_TENANT)
+        .expect("tenant state");
+    let mut subject = Entity::new("alice", EntityKind::User);
+    subject.namespace_id = pensyve_state.namespace.id;
+    pensyve_state
+        .storage
+        .save_entity(&subject)
+        .expect("save subject entity");
+
+    let first = SemanticMemory::new(
+        pensyve_state.namespace.id,
+        subject.id,
+        "works_at",
+        first_object,
+        0.9,
+    );
+    let second = SemanticMemory::new(
+        pensyve_state.namespace.id,
+        subject.id,
+        "works_at",
+        second_object,
+        0.9,
+    );
+    pensyve_state
+        .storage
+        .save_semantic(&first)
+        .expect("save first semantic memory");
+    pensyve_state
+        .storage
+        .save_semantic(&second)
+        .expect("save second semantic memory");
+
+    [first.id, second.id]
+}
+
+async fn recall(client: &reqwest::Client, url: &str) -> Value {
+    let response = client
+        .post(format!("{url}/v1/recall"))
+        .json(&json!({
+            "query": "works_at",
+            "limit": 5,
+        }))
+        .send()
+        .await
+        .expect("recall request");
+
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    response.json().await.expect("recall response JSON")
+}
+
+#[tokio::test]
+async fn recall_reports_contradicting_semantic_memories() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let (url, state, cancellation) = start_test_server(&dir).await;
+    let memory_ids = store_semantic_pair(&state, "Acme", "Globex");
+    let client = reqwest::Client::new();
+
+    let body = recall(&client, &url).await;
+
+    let recalled_memories = body["memories"].as_array().expect("recalled memories");
+    let contradictions = body["contradictions"]
+        .as_array()
+        .expect("contradictions array");
+    assert!(!contradictions.is_empty());
+    let contradiction_ids = contradictions[0]["memory_ids"]
+        .as_array()
+        .expect("contradiction memory ids");
+    for memory_id in &memory_ids {
+        let memory_id = memory_id.to_string();
+        assert!(
+            recalled_memories
+                .iter()
+                .any(|memory| memory["id"].as_str() == Some(memory_id.as_str()))
+        );
+        assert!(
+            contradiction_ids
+                .iter()
+                .any(|value| value.as_str() == Some(memory_id.as_str()))
+        );
+    }
+    cancellation.cancel();
+}
+
+#[tokio::test]
+async fn recall_does_not_report_agreeing_semantic_memories() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let (url, state, cancellation) = start_test_server(&dir).await;
+    store_semantic_pair(&state, "Acme", "Acme");
+    let client = reqwest::Client::new();
+
+    let body = recall(&client, &url).await;
+
+    assert_eq!(body["memories"].as_array().map(Vec::len), Some(2));
+    assert_eq!(body["contradictions"], json!([]));
+    cancellation.cancel();
+}

--- a/pensyve-ts/src/index.test.ts
+++ b/pensyve-ts/src/index.test.ts
@@ -358,6 +358,34 @@ describe("recall()", () => {
     expect(result.cursor).toBe("page2-token");
   });
 
+  test("returns contradictions with camelCase keys", async () => {
+    const fetchFn = mock(async () =>
+      jsonResponse({
+        memories: [],
+        contradictions: [
+          {
+            subject: "alice",
+            predicate: "works_at",
+            memory_ids: ["mem-1", "mem-2"],
+            objects: ["Acme", "Globex"],
+          },
+        ],
+      })
+    );
+
+    const client = makeClient(fetchFn);
+    const result: RecallResult = await client.recall("employment");
+
+    expect(result.contradictions).toEqual([
+      {
+        subject: "alice",
+        predicate: "works_at",
+        memoryIds: ["mem-1", "mem-2"],
+        objects: ["Acme", "Globex"],
+      },
+    ]);
+  });
+
   test("handles bare array response (legacy)", async () => {
     const fetchFn = mock(async () =>
       jsonResponse([

--- a/pensyve-ts/src/index.ts
+++ b/pensyve-ts/src/index.ts
@@ -133,6 +133,13 @@ export interface Memory {
   episodeId?: string;
 }
 
+export interface Contradiction {
+  subject: string;
+  predicate: string;
+  memoryIds: string[];
+  objects: string[];
+}
+
 export interface RecallOptions {
   entity?: string;
   limit?: number;
@@ -144,6 +151,7 @@ export interface RecallOptions {
 /** Result returned by recall(), including an optional pagination cursor. */
 export interface RecallResult {
   memories: Memory[];
+  contradictions?: Contradiction[];
   /** Opaque cursor for fetching the next page of results. */
   cursor?: string;
 }
@@ -411,13 +419,18 @@ export class Pensyve {
       "Recall",
     );
     const raw = await res.json();
-    const body = camelCaseKeys(raw) as { memories?: Memory[]; cursor?: string };
+    const body = camelCaseKeys(raw) as {
+      memories?: Memory[];
+      contradictions?: Contradiction[];
+      cursor?: string;
+    };
     // Handle both {memories: [...]} and bare array responses
     if (Array.isArray(body)) {
       return { memories: body as unknown as Memory[] };
     }
     return {
       memories: body.memories ?? [],
+      contradictions: body.contradictions,
       cursor: body.cursor,
     };
   }


### PR DESCRIPTION
Fixes #183.

## Scope correction

The issue proposed wiring "the existing contradiction detector in `retrieval/cards/composite.rs`" — no such detector exists at HEAD (the word appears only in a doc comment there). This PR implements a minimal, honest detector instead.

## What

- New `pensyve_core::retrieval::contradictions::detect_contradictions(&[Memory]) -> Vec<Contradiction>`: groups live (`invalid_at: None`) semantic memories by (subject, case-normalized predicate); a group with ≥2 distinct objects (trimmed, case-insensitive) is a contradiction `{subject, predicate, memory_ids, objects}`. Deterministic ordering via BTreeMap. Episodic/procedural/observation memories are ignored.
- Gateway recall (`rest.rs`): `filter_recall_results` now also yields the filtered `Memory` list, and the handler runs the detector over exactly the memories being returned, serializing into the previously hardcoded-empty `RecallResponse.contradictions`. The cached path carries it (the response is cached whole, post-detection).

## Tests

- Unit (core module): disagreement detected case-insensitively; agreeing duplicates not flagged; `invalid_at` memories excluded; distinct predicates independent; non-semantic kinds ignored.
- Integration (`tests/test_rest_recall_contradictions.rs`, real SQLite + router harness): recall over two disagreeing `works_at` facts returns a non-empty `contradictions` naming both memory ids; agreeing memories return `contradictions: []`.

`cargo test -p pensyve-core -p pensyve-mcp-gateway` green; clippy clean; fmt clean.