### PR TITLE
fix(inspect): entity-scoped observations, MCP parity, procedural write-path docs (#184)

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -462,6 +462,14 @@ curl http://localhost:3000/v1/health
 | `GET`    | `/v1/health`          | Health check             |
 | `GET`    | `/metrics`            | Prometheus metrics       |
 
+### Procedural memories
+
+Core library callers create these with `types::ProceduralMemory::new` and persist them through
+`storage::StorageTrait::save_procedural`. There is no automatic creator in the `consolidation` or
+`observation` pipelines today; consolidation only updates reliability for procedures already
+stored. Procedural memories are namespace-scoped and have no entity linkage, so per-entity inspect
+returns none. There is deliberately no REST write path for procedural memories today.
+
 ### Authentication
 
 Set `PENSYVE_API_KEYS` env var (comma-separated) to enable auth. When unset, all endpoints are open (dev mode).

--- a/pensyve-core/src/storage/mod.rs
+++ b/pensyve-core/src/storage/mod.rs
@@ -148,11 +148,17 @@ pub trait StorageTrait: Send + Sync {
         Ok(None)
     }
 
+    /// Fetch observations linked to an entity by exact, case-sensitive instance string,
+    /// bounded by `limit` (G3 semantics). This deliberately differs from the forget path's
+    /// episode-to-entity join, which may use different matching semantics.
     fn list_observations_by_entity_instance(
         &self,
-        namespace_id: Uuid,
-        instance: &str,
-    ) -> StorageResult<Vec<ObservationMemory>>;
+        _namespace_id: Uuid,
+        _instance: &str,
+        _limit: usize,
+    ) -> StorageResult<Vec<ObservationMemory>> {
+        Ok(Vec::new())
+    }
 
     /// Fetch all observations attached to any of the given episode IDs,
     /// bounded by `limit` (applied after fetch). Used by `recall_grouped` to

--- a/pensyve-core/src/storage/mod.rs
+++ b/pensyve-core/src/storage/mod.rs
@@ -148,6 +148,12 @@ pub trait StorageTrait: Send + Sync {
         Ok(None)
     }
 
+    fn list_observations_by_entity_instance(
+        &self,
+        namespace_id: Uuid,
+        instance: &str,
+    ) -> StorageResult<Vec<ObservationMemory>>;
+
     /// Fetch all observations attached to any of the given episode IDs,
     /// bounded by `limit` (applied after fetch). Used by `recall_grouped` to
     /// attach observations to top-k session groups.

--- a/pensyve-core/src/storage/postgres.rs
+++ b/pensyve-core/src/storage/postgres.rs
@@ -967,6 +967,30 @@ impl StorageTrait for PostgresBackend {
         })
     }
 
+    fn list_observations_by_entity_instance(
+        &self,
+        namespace_id: Uuid,
+        instance: &str,
+    ) -> StorageResult<Vec<ObservationMemory>> {
+        self.block_on(async {
+            let mut conn = self.scoped_conn(namespace_id).await?;
+            let rows: Vec<ObservationRow> = query_as::<Postgres, _>(
+                r"SELECT id, namespace_id, episode_id, entity_type, instance, action, quantity,
+                          unit, content, embedding::text, confidence, event_time, created_at,
+                          stability, retrievability
+                   FROM observation_memories
+                   WHERE namespace_id = $1 AND LOWER(instance) = LOWER($2)
+                   ORDER BY created_at DESC",
+            )
+            .bind(namespace_id)
+            .bind(instance)
+            .fetch_all(&mut *conn)
+            .await
+            .map_err(sqlx_to_io)?;
+            Ok(rows.into_iter().map(row_to_observation).collect())
+        })
+    }
+
     fn list_observations_by_episode_ids(
         &self,
         episode_ids: &[Uuid],

--- a/pensyve-core/src/storage/postgres.rs
+++ b/pensyve-core/src/storage/postgres.rs
@@ -271,6 +271,13 @@ impl PostgresBackend {
 
 const SCHEMA: &str = include_str!("postgres_schema.sql");
 
+const LIST_OBSERVATIONS_BY_ENTITY_INSTANCE_SQL: &str = r"SELECT id, namespace_id, episode_id, entity_type, instance, action, quantity,
+             unit, content, embedding::text, confidence, event_time, created_at,
+             stability, retrievability
+      FROM observation_memories
+      WHERE namespace_id = $1 AND instance = $2
+      ORDER BY created_at DESC LIMIT $3";
+
 // ---------------------------------------------------------------------------
 // Error helpers
 // ---------------------------------------------------------------------------
@@ -971,22 +978,19 @@ impl StorageTrait for PostgresBackend {
         &self,
         namespace_id: Uuid,
         instance: &str,
+        limit: usize,
     ) -> StorageResult<Vec<ObservationMemory>> {
+        let limit_i64 = i64::try_from(limit).unwrap_or(i64::MAX);
         self.block_on(async {
             let mut conn = self.scoped_conn(namespace_id).await?;
-            let rows: Vec<ObservationRow> = query_as::<Postgres, _>(
-                r"SELECT id, namespace_id, episode_id, entity_type, instance, action, quantity,
-                          unit, content, embedding::text, confidence, event_time, created_at,
-                          stability, retrievability
-                   FROM observation_memories
-                   WHERE namespace_id = $1 AND LOWER(instance) = LOWER($2)
-                   ORDER BY created_at DESC",
-            )
-            .bind(namespace_id)
-            .bind(instance)
-            .fetch_all(&mut *conn)
-            .await
-            .map_err(sqlx_to_io)?;
+            let rows: Vec<ObservationRow> =
+                query_as::<Postgres, _>(LIST_OBSERVATIONS_BY_ENTITY_INSTANCE_SQL)
+                    .bind(namespace_id)
+                    .bind(instance)
+                    .bind(limit_i64)
+                    .fetch_all(&mut *conn)
+                    .await
+                    .map_err(sqlx_to_io)?;
             Ok(rows.into_iter().map(row_to_observation).collect())
         })
     }
@@ -1857,5 +1861,70 @@ fn row_to_observation(row: ObservationRow) -> ObservationMemory {
         // G1: postgres backend does not yet carry the multi-tenant scope columns.
         agent_id: None,
         user_id: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::{Connection, params};
+    use uuid::Uuid;
+
+    use super::LIST_OBSERVATIONS_BY_ENTITY_INSTANCE_SQL;
+
+    fn run_observation_instance_query(
+        instances: &[&str],
+        requested: &str,
+        limit: usize,
+    ) -> Vec<String> {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE observation_memories (
+                namespace_id TEXT NOT NULL,
+                instance TEXT NOT NULL,
+                created_at INTEGER NOT NULL
+            );",
+        )
+        .unwrap();
+
+        let namespace_id = Uuid::new_v4().to_string();
+        for (created_at, instance) in instances.iter().enumerate() {
+            conn.execute(
+                "INSERT INTO observation_memories (namespace_id, instance, created_at)
+                 VALUES (?1, ?2, ?3)",
+                params![namespace_id, instance, i64::try_from(created_at).unwrap()],
+            )
+            .unwrap();
+        }
+
+        let query_tail = LIST_OBSERVATIONS_BY_ENTITY_INSTANCE_SQL
+            .split_once("FROM observation_memories")
+            .unwrap()
+            .1;
+        let sql = format!("SELECT instance FROM observation_memories {query_tail}");
+        let mut stmt = conn.prepare(&sql).unwrap();
+        stmt.query_map(
+            params![namespace_id, requested, i64::try_from(limit).unwrap()],
+            |row| row.get(0),
+        )
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap()
+    }
+
+    #[test]
+    fn list_observations_by_entity_instance_uses_exact_case_match() {
+        assert!(LIST_OBSERVATIONS_BY_ENTITY_INSTANCE_SQL.contains("instance = $2"));
+        assert!(!LIST_OBSERVATIONS_BY_ENTITY_INSTANCE_SQL.contains("LOWER(instance)"));
+        let instances = run_observation_instance_query(&["Alice", "alice"], "alice", 10);
+        assert_eq!(instances, ["alice"]);
+    }
+
+    #[test]
+    fn list_observations_by_entity_instance_pushes_limit_into_query() {
+        assert!(
+            LIST_OBSERVATIONS_BY_ENTITY_INSTANCE_SQL.contains("ORDER BY created_at DESC LIMIT $3")
+        );
+        let instances = run_observation_instance_query(&["alice", "alice", "alice"], "alice", 2);
+        assert_eq!(instances.len(), 2);
     }
 }

--- a/pensyve-core/src/storage/postgres.rs
+++ b/pensyve-core/src/storage/postgres.rs
@@ -271,9 +271,9 @@ impl PostgresBackend {
 
 const SCHEMA: &str = include_str!("postgres_schema.sql");
 
-const LIST_OBSERVATIONS_BY_ENTITY_INSTANCE_SQL: &str = r"SELECT id, namespace_id, episode_id, entity_type, instance, action, quantity,
-             unit, content, embedding::text, confidence, event_time, created_at,
-             stability, retrievability
+const LIST_OBSERVATIONS_BY_ENTITY_INSTANCE_SQL: &str = r"SELECT id, namespace_id, episode_id, entity_type, instance, action,
+             quantity, unit, content, embedding::text, confidence, event_time,
+             created_at, stability, retrievability
       FROM observation_memories
       WHERE namespace_id = $1 AND instance = $2
       ORDER BY created_at DESC LIMIT $3";

--- a/pensyve-core/src/storage/sqlite.rs
+++ b/pensyve-core/src/storage/sqlite.rs
@@ -1389,6 +1389,7 @@ impl StorageTrait for SqliteBackend {
         &self,
         namespace_id: Uuid,
         instance: &str,
+        limit: usize,
     ) -> StorageResult<Vec<ObservationMemory>> {
         let conn = lock_conn!(self);
         let mut stmt = conn.prepare(
@@ -1396,11 +1397,15 @@ impl StorageTrait for SqliteBackend {
                       unit, content, embedding, confidence, event_time, created_at,
                       stability, retrievability, agent_id, user_id
                FROM observation_memories
-               WHERE namespace_id = ?1 AND LOWER(instance) = LOWER(?2)
-               ORDER BY created_at DESC",
+               WHERE namespace_id = ?1 AND instance = ?2
+               ORDER BY created_at DESC LIMIT ?3",
         )?;
         let rows = stmt.query_map(
-            params![namespace_id.to_string(), instance],
+            params![
+                namespace_id.to_string(),
+                instance,
+                i64::try_from(limit).unwrap_or(i64::MAX)
+            ],
             row_to_observation,
         )?;
         let mut out = Vec::new();
@@ -3570,7 +3575,7 @@ mod tests {
 
         for (namespace_id, instance) in [
             (ns.id, "Alice"),
-            (ns.id, "ALICE"),
+            (ns.id, "alice"),
             (ns.id, "Bob"),
             (other_ns.id, "alice"),
         ] {
@@ -3586,14 +3591,37 @@ mod tests {
         }
 
         let fetched = db
-            .list_observations_by_entity_instance(ns.id, "alice")
+            .list_observations_by_entity_instance(ns.id, "alice", 10)
             .unwrap();
-        assert_eq!(fetched.len(), 2);
+        assert_eq!(fetched.len(), 1);
         assert!(
             fetched
                 .iter()
-                .all(|obs| obs.namespace_id == ns.id && obs.instance.eq_ignore_ascii_case("alice"))
+                .all(|obs| obs.namespace_id == ns.id && obs.instance == "alice")
         );
+    }
+
+    #[test]
+    fn test_observations_list_by_entity_instance_respects_limit() {
+        let (_dir, db) = setup();
+        let ns = make_namespace(&db);
+
+        for content in ["first", "second", "third"] {
+            let obs = ObservationMemory::new(
+                ns.id,
+                Uuid::new_v4(),
+                "person",
+                "alice",
+                "mentioned",
+                content,
+            );
+            db.save_observation(&obs).unwrap();
+        }
+
+        let fetched = db
+            .list_observations_by_entity_instance(ns.id, "alice", 2)
+            .unwrap();
+        assert_eq!(fetched.len(), 2);
     }
 
     #[test]

--- a/pensyve-core/src/storage/sqlite.rs
+++ b/pensyve-core/src/storage/sqlite.rs
@@ -1385,6 +1385,31 @@ impl StorageTrait for SqliteBackend {
         result.transpose()
     }
 
+    fn list_observations_by_entity_instance(
+        &self,
+        namespace_id: Uuid,
+        instance: &str,
+    ) -> StorageResult<Vec<ObservationMemory>> {
+        let conn = lock_conn!(self);
+        let mut stmt = conn.prepare(
+            r"SELECT id, namespace_id, episode_id, entity_type, instance, action, quantity,
+                      unit, content, embedding, confidence, event_time, created_at,
+                      stability, retrievability, agent_id, user_id
+               FROM observation_memories
+               WHERE namespace_id = ?1 AND LOWER(instance) = LOWER(?2)
+               ORDER BY created_at DESC",
+        )?;
+        let rows = stmt.query_map(
+            params![namespace_id.to_string(), instance],
+            row_to_observation,
+        )?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row??);
+        }
+        Ok(out)
+    }
+
     fn list_observations_by_episode_ids(
         &self,
         episode_ids: &[Uuid],
@@ -3534,6 +3559,41 @@ mod tests {
         assert!(instances.contains("Elden Ring"));
         assert!(instances.contains("Dune"));
         assert!(!instances.contains("off-topic"));
+    }
+
+    #[test]
+    fn test_observations_list_by_entity_instance() {
+        let (_dir, db) = setup();
+        let ns = make_namespace(&db);
+        let other_ns = Namespace::new("other");
+        db.save_namespace(&other_ns).unwrap();
+
+        for (namespace_id, instance) in [
+            (ns.id, "Alice"),
+            (ns.id, "ALICE"),
+            (ns.id, "Bob"),
+            (other_ns.id, "alice"),
+        ] {
+            let obs = ObservationMemory::new(
+                namespace_id,
+                Uuid::new_v4(),
+                "person",
+                instance,
+                "mentioned",
+                instance,
+            );
+            db.save_observation(&obs).unwrap();
+        }
+
+        let fetched = db
+            .list_observations_by_entity_instance(ns.id, "alice")
+            .unwrap();
+        assert_eq!(fetched.len(), 2);
+        assert!(
+            fetched
+                .iter()
+                .all(|obs| obs.namespace_id == ns.id && obs.instance.eq_ignore_ascii_case("alice"))
+        );
     }
 
     #[test]

--- a/pensyve-mcp-gateway/src/rest.rs
+++ b/pensyve-mcp-gateway/src/rest.rs
@@ -1141,11 +1141,13 @@ async fn inspect(
     let remaining = limit.saturating_sub(episodic.len() + semantic.len());
     let mut observation = Vec::new();
     if remaining > 0
-        && let Ok(mems) = ps
-            .storage
-            .list_observations_by_entity_instance(ps.namespace.id, &entity.name)
+        && let Ok(mems) = ps.storage.list_observations_by_entity_instance(
+            ps.namespace.id,
+            &entity.name,
+            remaining,
+        )
     {
-        for mem in mems.into_iter().take(remaining) {
+        for mem in mems {
             let mut val = serde_json::to_value(&mem).unwrap_or_default();
             strip_embedding(&mut val);
             observation.push(val);

--- a/pensyve-mcp-gateway/src/rest.rs
+++ b/pensyve-mcp-gateway/src/rest.rs
@@ -1138,12 +1138,27 @@ async fn inspect(
         }
     }
 
+    let remaining = limit.saturating_sub(episodic.len() + semantic.len());
+    let mut observation = Vec::new();
+    if remaining > 0
+        && let Ok(mems) = ps
+            .storage
+            .list_observations_by_entity_instance(ps.namespace.id, &entity.name)
+    {
+        for mem in mems.into_iter().take(remaining) {
+            let mut val = serde_json::to_value(&mem).unwrap_or_default();
+            strip_embedding(&mut val);
+            observation.push(val);
+        }
+    }
+
     Ok(Json(InspectResponse {
         entity: body.entity,
         episodic,
         semantic,
+        // Procedural memories are namespace-scoped and have no entity linkage.
         procedural: vec![],
-        observation: vec![],
+        observation,
     }))
 }
 

--- a/pensyve-mcp-gateway/tests/integration_test.rs
+++ b/pensyve-mcp-gateway/tests/integration_test.rs
@@ -5,7 +5,7 @@ use pensyve_core::config::RetrievalConfig;
 use pensyve_core::embedding::OnnxEmbedder;
 use pensyve_core::storage::StorageTrait;
 use pensyve_core::storage::sqlite::SqliteBackend;
-use pensyve_core::types::Namespace;
+use pensyve_core::types::{Namespace, ObservationMemory, Outcome, ProceduralMemory};
 use pensyve_core::vector::VectorIndex;
 use pensyve_mcp_tools::{PensyveMcpServer, PensyveState};
 use rmcp::transport::streamable_http_server::{
@@ -410,7 +410,7 @@ async fn test_mcp_invalid_method_returns_error() {
 async fn test_mcp_forget_and_inspect() {
     let dir = tempfile::tempdir().expect("tempdir");
     let state = create_test_state(&dir);
-    let (url, ct) = start_test_server(state).await;
+    let (url, ct) = start_test_server(state.clone()).await;
 
     let client = reqwest::Client::new();
 
@@ -522,6 +522,99 @@ async fn test_mcp_forget_and_inspect() {
     let content_text = json["result"]["content"][0]["text"].as_str().unwrap();
     let inspect_data: serde_json::Value = serde_json::from_str(content_text).unwrap();
     assert_eq!(inspect_data["memory_count"], 0);
+
+    let mut observation = ObservationMemory::new(
+        state.namespace.id,
+        uuid::Uuid::new_v4(),
+        "person",
+        "BOB",
+        "mentioned",
+        "Bob was mentioned",
+    );
+    observation.embedding = vec![0.1, 0.2];
+    state
+        .storage
+        .save_observation(&observation)
+        .expect("save observation");
+    let procedural = ProceduralMemory::new(
+        state.namespace.id,
+        "on timeout",
+        "retry",
+        Outcome::Success,
+        std::collections::HashMap::new(),
+    );
+    state
+        .storage
+        .save_procedural(&procedural)
+        .expect("save procedural");
+
+    // Entity mode includes instance-matched observations and excludes procedures.
+    let resp = client
+        .post(format!("{url}/mcp"))
+        .header("content-type", "application/json")
+        .header("accept", "application/json, text/event-stream")
+        .body(json_rpc(
+            "tools/call",
+            serde_json::json!({
+                "name": "pensyve_inspect",
+                "arguments": { "entity": "bob", "memory_type": "observation" }
+            }),
+            13,
+        ))
+        .send()
+        .await
+        .expect("inspect observation filter");
+    let text = resp.text().await.unwrap();
+    let json: serde_json::Value = serde_json::from_str(&text).expect("parse");
+    let content_text = json["result"]["content"][0]["text"].as_str().unwrap();
+    let inspect_data: serde_json::Value = serde_json::from_str(content_text).unwrap();
+    assert_eq!(inspect_data["memory_count"], 1);
+    assert_eq!(inspect_data["memories"][0]["_type"], "observation");
+    assert!(inspect_data["memories"][0].get("embedding").is_none());
+
+    let resp = client
+        .post(format!("{url}/mcp"))
+        .header("content-type", "application/json")
+        .header("accept", "application/json, text/event-stream")
+        .body(json_rpc(
+            "tools/call",
+            serde_json::json!({
+                "name": "pensyve_inspect",
+                "arguments": { "entity": "bob", "memory_type": "procedural" }
+            }),
+            14,
+        ))
+        .send()
+        .await
+        .expect("inspect entity procedural filter");
+    let text = resp.text().await.unwrap();
+    let json: serde_json::Value = serde_json::from_str(&text).expect("parse");
+    let content_text = json["result"]["content"][0]["text"].as_str().unwrap();
+    let inspect_data: serde_json::Value = serde_json::from_str(content_text).unwrap();
+    assert_eq!(inspect_data["memory_count"], 0);
+
+    // Empty entity is whole-namespace mode, where procedural is meaningful.
+    let resp = client
+        .post(format!("{url}/mcp"))
+        .header("content-type", "application/json")
+        .header("accept", "application/json, text/event-stream")
+        .body(json_rpc(
+            "tools/call",
+            serde_json::json!({
+                "name": "pensyve_inspect",
+                "arguments": { "entity": "", "memory_type": "procedural" }
+            }),
+            15,
+        ))
+        .send()
+        .await
+        .expect("inspect namespace procedural filter");
+    let text = resp.text().await.unwrap();
+    let json: serde_json::Value = serde_json::from_str(&text).expect("parse");
+    let content_text = json["result"]["content"][0]["text"].as_str().unwrap();
+    let inspect_data: serde_json::Value = serde_json::from_str(content_text).unwrap();
+    assert_eq!(inspect_data["memory_count"], 1);
+    assert_eq!(inspect_data["memories"][0]["_type"], "procedural");
 
     ct.cancel();
 }

--- a/pensyve-mcp-gateway/tests/integration_test.rs
+++ b/pensyve-mcp-gateway/tests/integration_test.rs
@@ -527,7 +527,7 @@ async fn test_mcp_forget_and_inspect() {
         state.namespace.id,
         uuid::Uuid::new_v4(),
         "person",
-        "BOB",
+        "bob",
         "mentioned",
         "Bob was mentioned",
     );

--- a/pensyve-mcp-gateway/tests/test_rest_forget_inspect.rs
+++ b/pensyve-mcp-gateway/tests/test_rest_forget_inspect.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use axum::Extension;
@@ -5,7 +6,10 @@ use pensyve_core::config::RetrievalConfig;
 use pensyve_core::embedding::OnnxEmbedder;
 use pensyve_core::storage::StorageTrait;
 use pensyve_core::storage::sqlite::SqliteBackend;
-use pensyve_core::types::{Entity, EntityKind, Namespace, SemanticMemory};
+use pensyve_core::types::{
+    Entity, EntityKind, EpisodicMemory, Namespace, ObservationMemory, Outcome, ProceduralMemory,
+    SemanticMemory,
+};
 use pensyve_core::vector::VectorIndex;
 use pensyve_mcp_gateway::AppState;
 use pensyve_mcp_gateway::auth::{AuthContext, AuthValidator};
@@ -238,6 +242,133 @@ async fn inspect_by_entity_uuid_returns_memories() {
     assert_eq!(body["semantic"].as_array().map(Vec::len), Some(1));
     assert_eq!(body["semantic"][0]["predicate"], "likes");
     assert_eq!(body["semantic"][0]["object"], "tea");
+    cancellation.cancel();
+}
+
+#[tokio::test]
+async fn inspect_by_entity_returns_instance_matched_observations_and_no_procedural() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let (url, state, cancellation) = start_test_server(&dir).await;
+    let client = reqwest::Client::new();
+    remember(&client, &url, "alice", "likes tea").await;
+
+    let pensyve_state = state
+        .tenant_mgr
+        .get_tenant_state(TEST_TENANT)
+        .expect("tenant state");
+    let mut matching = ObservationMemory::new(
+        pensyve_state.namespace.id,
+        Uuid::new_v4(),
+        "person",
+        "ALICE",
+        "mentioned",
+        "Alice was mentioned",
+    );
+    matching.embedding = vec![0.1, 0.2];
+    pensyve_state
+        .storage
+        .save_observation(&matching)
+        .expect("save matching observation");
+    let other = ObservationMemory::new(
+        pensyve_state.namespace.id,
+        Uuid::new_v4(),
+        "person",
+        "bob",
+        "mentioned",
+        "Bob was mentioned",
+    );
+    pensyve_state
+        .storage
+        .save_observation(&other)
+        .expect("save other observation");
+    let procedural = ProceduralMemory::new(
+        pensyve_state.namespace.id,
+        "on timeout",
+        "retry",
+        Outcome::Success,
+        HashMap::new(),
+    );
+    pensyve_state
+        .storage
+        .save_procedural(&procedural)
+        .expect("save procedural memory");
+
+    let response = inspect(&client, &url, "alice").await;
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    let body: Value = response.json().await.expect("inspect response JSON");
+    assert_eq!(body["observation"].as_array().map(Vec::len), Some(1));
+    assert_eq!(body["observation"][0]["id"], matching.id.to_string());
+    assert!(body["observation"][0].get("embedding").is_none());
+    assert_eq!(body["procedural"], json!([]));
+    cancellation.cancel();
+}
+
+#[tokio::test]
+async fn inspect_browse_mode_returns_all_memory_kinds_without_embeddings() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let (url, state, cancellation) = start_test_server(&dir).await;
+    let client = reqwest::Client::new();
+    remember(&client, &url, "alice", "likes tea").await;
+
+    let pensyve_state = state
+        .tenant_mgr
+        .get_tenant_state(TEST_TENANT)
+        .expect("tenant state");
+    let alice_id = pensyve_state
+        .storage
+        .get_entity_by_name("alice", pensyve_state.namespace.id)
+        .expect("entity lookup")
+        .expect("alice exists")
+        .id;
+    let mut episodic = EpisodicMemory::new(
+        pensyve_state.namespace.id,
+        Uuid::new_v4(),
+        alice_id,
+        alice_id,
+        "Alice likes tea",
+    );
+    episodic.embedding = vec![0.1, 0.2];
+    pensyve_state
+        .storage
+        .save_episodic(&episodic)
+        .expect("save episodic memory");
+    let mut procedural = ProceduralMemory::new(
+        pensyve_state.namespace.id,
+        "when brewing tea",
+        "warm the pot",
+        Outcome::Success,
+        HashMap::new(),
+    );
+    procedural.embedding = vec![0.1, 0.2];
+    pensyve_state
+        .storage
+        .save_procedural(&procedural)
+        .expect("save procedural memory");
+    let mut observation = ObservationMemory::new(
+        pensyve_state.namespace.id,
+        Uuid::new_v4(),
+        "person",
+        "alice",
+        "mentioned",
+        "Alice was mentioned",
+    );
+    observation.embedding = vec![0.1, 0.2];
+    pensyve_state
+        .storage
+        .save_observation(&observation)
+        .expect("save observation memory");
+
+    let response = inspect(&client, &url, "").await;
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    let body: Value = response.json().await.expect("inspect response JSON");
+    for memory_type in ["episodic", "semantic", "procedural", "observation"] {
+        assert_eq!(
+            body[memory_type].as_array().map(Vec::len),
+            Some(1),
+            "browse should return one {memory_type} memory"
+        );
+        assert!(body[memory_type][0].get("embedding").is_none());
+    }
     cancellation.cancel();
 }
 

--- a/pensyve-mcp-gateway/tests/test_rest_forget_inspect.rs
+++ b/pensyve-mcp-gateway/tests/test_rest_forget_inspect.rs
@@ -260,7 +260,7 @@ async fn inspect_by_entity_returns_instance_matched_observations_and_no_procedur
         pensyve_state.namespace.id,
         Uuid::new_v4(),
         "person",
-        "ALICE",
+        "alice",
         "mentioned",
         "Alice was mentioned",
     );

--- a/pensyve-mcp-tools/src/params.rs
+++ b/pensyve-mcp-tools/src/params.rs
@@ -65,9 +65,9 @@ pub struct ForgetParams {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct InspectParams {
-    /// The entity to inspect.
+    /// The entity to inspect. Empty means the whole namespace.
     pub entity: String,
-    /// Memory type filter: "episodic", "semantic", or "procedural".
+    /// Memory type filter: "episodic", "semantic", "procedural", or "observation".
     pub memory_type: Option<String>,
     /// Maximum number of memories to return.
     pub limit: Option<u32>,

--- a/pensyve-mcp-tools/src/server.rs
+++ b/pensyve-mcp-tools/src/server.rs
@@ -693,12 +693,13 @@ impl PensyveMcpServer {
 
         let remaining = limit.saturating_sub(memories.len());
         if remaining > 0 && (type_filter.is_none() || type_filter == Some("observation")) {
-            match state
-                .storage
-                .list_observations_by_entity_instance(state.namespace.id, &entity.name)
-            {
+            match state.storage.list_observations_by_entity_instance(
+                state.namespace.id,
+                &entity.name,
+                remaining,
+            ) {
                 Ok(observations) => {
-                    for mem in observations.into_iter().take(remaining) {
+                    for mem in observations {
                         let mut val = serde_json::to_value(&mem).unwrap_or_default();
                         strip_embedding(&mut val);
                         if let serde_json::Value::Object(ref mut map) = val {

--- a/pensyve-mcp-tools/src/server.rs
+++ b/pensyve-mcp-tools/src/server.rs
@@ -592,7 +592,7 @@ impl PensyveMcpServer {
     /// View all memories for an entity.
     #[tool(
         name = "pensyve_inspect",
-        description = "View all memories stored for an entity, optionally filtered by type. Returns an array of memory objects with stats."
+        description = "View memories stored for an entity, or the whole namespace when entity is empty, optionally filtered by type. Returns an array of memory objects with stats."
     )]
     async fn inspect(
         &self,
@@ -601,6 +601,43 @@ impl PensyveMcpServer {
         check_scope(&self.scope, "pensyve_inspect")?;
         let state = &self.state;
         let limit = params.limit.unwrap_or(20).clamp(1, 100) as usize;
+        let type_filter = params.memory_type.as_deref();
+
+        if params.entity.is_empty() {
+            let stored = state
+                .storage
+                .get_all_memories_by_namespace(state.namespace.id)
+                .map_err(|err| format!("Error listing memories: {err}"))?;
+            let mut memories = Vec::new();
+            for memory in stored {
+                let type_name = memory_type_name(&memory);
+                if type_filter.is_some_and(|filter| filter != type_name) {
+                    continue;
+                }
+                let mut val = match memory {
+                    Memory::Episodic(mem) => serde_json::to_value(mem),
+                    Memory::Semantic(mem) => serde_json::to_value(mem),
+                    Memory::Procedural(mem) => serde_json::to_value(mem),
+                    Memory::Observation(mem) => serde_json::to_value(mem),
+                }
+                .unwrap_or_default();
+                strip_embedding(&mut val);
+                if let serde_json::Value::Object(ref mut map) = val {
+                    map.insert("_type".to_string(), serde_json::json!(type_name));
+                }
+                memories.push(val);
+                if memories.len() == limit {
+                    break;
+                }
+            }
+
+            return serde_json::to_string(&serde_json::json!({
+                "entity": "",
+                "memory_count": memories.len(),
+                "memories": memories,
+            }))
+            .map_err(|e| format!("Serialization error: {e}"));
+        }
 
         let entity = match state
             .storage
@@ -618,7 +655,6 @@ impl PensyveMcpServer {
             Err(err) => return Err(format!("Error looking up entity: {err}")),
         };
 
-        let type_filter = params.memory_type.as_deref();
         let mut memories: Vec<serde_json::Value> = Vec::new();
         let mut remaining = limit;
 
@@ -652,6 +688,26 @@ impl PensyveMcpServer {
                     }
                 }
                 Err(err) => tracing::warn!("Failed to list semantic memories: {err}"),
+            }
+        }
+
+        let remaining = limit.saturating_sub(memories.len());
+        if remaining > 0 && (type_filter.is_none() || type_filter == Some("observation")) {
+            match state
+                .storage
+                .list_observations_by_entity_instance(state.namespace.id, &entity.name)
+            {
+                Ok(observations) => {
+                    for mem in observations.into_iter().take(remaining) {
+                        let mut val = serde_json::to_value(&mem).unwrap_or_default();
+                        strip_embedding(&mut val);
+                        if let serde_json::Value::Object(ref mut map) = val {
+                            map.insert("_type".to_string(), serde_json::json!("observation"));
+                        }
+                        memories.push(val);
+                    }
+                }
+                Err(err) => tracing::warn!("Failed to list observation memories: {err}"),
             }
         }
 


### PR DESCRIPTION
Fixes #184.

## What

- **Per-entity REST inspect** now returns the entity's observation memories via a new SQL-level `StorageTrait::list_observations_by_entity_instance(namespace_id, instance)` (SQLite + Postgres, styled after `list_semantic_by_entity`), matched by exact instance string (G3 chain-lookup semantics; revised from case-insensitive during review), embeddings stripped, bounded by the request limit.
- **`procedural: []` stays** in the per-entity branch — deliberately. `ProceduralMemory` is namespace-scoped with no entity linkage (types.rs), so an empty per-entity list is semantically correct; the hardcoding was only a bug for observations. A code comment now says so.
- **MCP inspect tool parity** (`pensyve-mcp-tools`): entity-scoped inspect returns episodic, semantic, and instance-matched observations; type filters accept `procedural`/`observation` alongside the existing values.
- **Docs**: new "Procedural memories" section in GETTING_STARTED.md documenting the verified write-path story — procedural memories are created only by library callers via `ProceduralMemory::new` + `save_procedural`; no pipeline auto-creates them today (consolidation only updates reliability on existing rows); namespace-scoped, no entity linkage, and deliberately no REST write path.

## Tests

REST integration tests extended (instance-matched observations returned per-entity; procedural empty; browse mode still returns all four kinds), storage-layer tests for the new method in both backends, MCP inspect test extended. `cargo test -p pensyve-core -p pensyve-mcp-gateway -p pensyve-mcp-tools` green; clippy clean; fmt clean.