### PR TITLE
fix(env): canonicalize bare DATABASE_URL/REDIS_URL in .env.example and docs (#188)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,13 +20,15 @@ PENSYVE_AUTH_ENABLED=false
 # Database (managed service — Postgres)
 # NOTE: the gateway reads the bare name DATABASE_URL (not PENSYVE_DATABASE_URL).
 # Setting the wrong name silently falls back to SQLite and in-memory usage counters.
-DATABASE_URL=              # postgres://user:pass@host:5432/pensyve
+# Example: postgres://user:pass@host:5432/pensyve
+DATABASE_URL=""
 
 # Redis (managed service — caching, rate limiting, quota enforcement)
 # NOTE: the gateway reads the bare name REDIS_URL (not PENSYVE_REDIS_URL).
 # Setting the wrong name silently disables the Redis-backed rate limiter and
 # daily quota enforcement (falls back to per-instance in-memory limits).
-REDIS_URL=                 # redis://host:6379/0
+# Example: redis://host:6379/0
+REDIS_URL=""
 
 # Observability
 PENSYVE_LOG_LEVEL=info

--- a/.env.example
+++ b/.env.example
@@ -18,10 +18,15 @@ PENSYVE_API_KEY=
 PENSYVE_AUTH_ENABLED=false
 
 # Database (managed service — Postgres)
-PENSYVE_DATABASE_URL=      # postgres://user:pass@host:5432/pensyve
+# NOTE: the gateway reads the bare name DATABASE_URL (not PENSYVE_DATABASE_URL).
+# Setting the wrong name silently falls back to SQLite and in-memory usage counters.
+DATABASE_URL=              # postgres://user:pass@host:5432/pensyve
 
-# Redis (managed service — episode state)
-PENSYVE_REDIS_URL=         # redis://host:6379/0
+# Redis (managed service — caching, rate limiting, quota enforcement)
+# NOTE: the gateway reads the bare name REDIS_URL (not PENSYVE_REDIS_URL).
+# Setting the wrong name silently disables the Redis-backed rate limiter and
+# daily quota enforcement (falls back to per-instance in-memory limits).
+REDIS_URL=                 # redis://host:6379/0
 
 # Observability
 PENSYVE_LOG_LEVEL=info

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,8 +91,8 @@ Python env setup: `uv sync --extra dev && uv run maturin develop --manifest-path
 | `PENSYVE_API_KEYS` | (unset) | Comma-separated API keys for auth |
 | `PENSYVE_TIER2_ENABLED` | `false` | Enable LLM-based Tier 2 extraction |
 | `PENSYVE_TIER2_MODEL_PATH` | (unset) | Path to GGUF model for Tier 2 |
-| `PENSYVE_DATABASE_URL` | (unset) | Postgres connection string (optional) |
-| `PENSYVE_REDIS_URL` | (unset) | Redis URL for episode state (optional) |
+| `DATABASE_URL` | (unset) | Postgres connection string (optional) |
+| `REDIS_URL` | (unset) | Redis URL for episode state (optional) |
 
 ## When in doubt
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,7 @@ Python env setup: `uv sync --extra dev && uv run maturin develop --manifest-path
 | `PENSYVE_TIER2_ENABLED` | `false` | Enable LLM-based Tier 2 extraction |
 | `PENSYVE_TIER2_MODEL_PATH` | (unset) | Path to GGUF model for Tier 2 |
 | `DATABASE_URL` | (unset) | Postgres connection string (optional) |
-| `REDIS_URL` | (unset) | Redis URL for episode state (optional) |
+| `REDIS_URL` | (unset) | Redis for caching, rate limiting, and daily quota enforcement (optional) |
 
 ## When in doubt
 

--- a/README.md
+++ b/README.md
@@ -415,8 +415,8 @@ Pensyve uses the following environment variables across its components:
 | ---------------------- | ----------------------- | ----------------------------- |
 | `PENSYVE_API_KEY`      | _(none)_                | Cloud API key for remote mode |
 | `PENSYVE_REMOTE_URL`   | `http://localhost:8000` | Remote server URL             |
-| `PENSYVE_DATABASE_URL` | _(none)_                | Postgres connection string    |
-| `PENSYVE_REDIS_URL`    | _(none)_                | Redis URL for episode state   |
+| `DATABASE_URL` | _(none)_                | Postgres connection string    |
+| `REDIS_URL`    | _(none)_                | Redis URL for episode state   |
 
 ### Quotas (managed service)
 

--- a/README.md
+++ b/README.md
@@ -416,7 +416,7 @@ Pensyve uses the following environment variables across its components:
 | `PENSYVE_API_KEY`      | _(none)_                | Cloud API key for remote mode |
 | `PENSYVE_REMOTE_URL`   | `http://localhost:8000` | Remote server URL             |
 | `DATABASE_URL` | _(none)_                | Postgres connection string    |
-| `REDIS_URL`    | _(none)_                | Redis URL for episode state   |
+| `REDIS_URL`    | _(none)_                | Redis for caching, rate limiting, daily quotas |
 
 ### Quotas (managed service)
 

--- a/docs/RELIABILITY.md
+++ b/docs/RELIABILITY.md
@@ -81,7 +81,7 @@ Typical recall latency for a full pipeline (embed + retrieve + rerank):
 
 - **p50**: ~3 seconds (includes embedding generation, multi-signal retrieval, cross-encoder reranking)
 - Dominated by embedding and reranking; pure retrieval logic is sub-millisecond
-- Optional Redis cache (`PENSYVE_REDIS_URL`) reduces repeat queries to single-digit milliseconds
+- Optional Redis cache (`REDIS_URL`) reduces repeat queries to single-digit milliseconds
 
 ### Storage Efficiency
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -89,5 +89,5 @@ tracks operations per (user, month, tier) for billing and abuse prevention.
 
 - ONNX embeddings via `fastembed` (no external API calls in offline mode).
 - Optional Postgres backend is feature-gated; SQLite is the default.
-- Optional Redis cache is feature-gated (`REDIS_URL`).
+- Optional Redis cache is environment-gated: enabled when `REDIS_URL` is set.
 - Go SDK uses standard library only; no third-party dependencies.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -89,5 +89,5 @@ tracks operations per (user, month, tier) for billing and abuse prevention.
 
 - ONNX embeddings via `fastembed` (no external API calls in offline mode).
 - Optional Postgres backend is feature-gated; SQLite is the default.
-- Optional Redis cache is feature-gated (`PENSYVE_REDIS_URL`).
+- Optional Redis cache is feature-gated (`REDIS_URL`).
 - Go SDK uses standard library only; no third-party dependencies.


### PR DESCRIPTION
Fixes #188.

The gateway reads the bare names — `DATABASE_URL` (main.rs:46, storage backend selection + Neon usage counters) and `REDIS_URL` (cache.rs:15, plus the Redis-backed rate limiter/quota) — but `.env.example`, README, AGENTS.md, SECURITY.md, and RELIABILITY.md documented `PENSYVE_`-prefixed variants. Copying the example verbatim silently produced: SQLite fallback instead of Postgres, in-memory usage counters, and **disabled Redis-backed rate limiting and daily quota enforcement** (per-instance in-memory fallback) — the quota-enforcement consequence is now called out inline in `.env.example`.

All five doc sites canonicalized to the bare names. Copy/docs only; no code change.