### PR TITLE
feat(memory): supersession primitive (#187)

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -450,13 +450,15 @@ curl http://localhost:3000/v1/health
 
 ### Endpoints
 
-| Method   | Path                  | Description              |
-| -------- | --------------------- | ------------------------ |
-| `POST`   | `/v1/recall`          | Search memories          |
-| `POST`   | `/v1/remember`        | Store a memory           |
-| `POST`   | `/v1/inspect`         | View entity memories     |
-| `POST`   | `/v1/consolidate`     | Trigger consolidation    |
-| `POST`   | `/v1/entities`        | Create an entity         |
+| Method   | Path                          | Description              |
+| -------- | ----------------------------- | ------------------------ |
+| `POST`   | `/v1/recall`                  | Search memories          |
+| `POST`   | `/v1/remember`                | Store a memory           |
+| `POST`   | `/v1/inspect`                 | View entity memories (`include_superseded: true` includes history) |
+| `POST`   | `/v1/memories/{id}/supersede` | Replace a memory while preserving the old row for audit |
+| `PATCH`  | `/v1/memories/{id}`           | **Deprecated:** delegates to supersession for one release |
+| `POST`   | `/v1/consolidate`             | Trigger consolidation    |
+| `POST`   | `/v1/entities`                | Create an entity         |
 | `DELETE` | `/v1/entities/{name}` | Delete entity + memories (name or UUID; 404 if unknown) |
 | `GET`    | `/v1/stats`           | Memory statistics        |
 | `GET`    | `/v1/health`          | Health check             |

--- a/pensyve-core/src/retrieval/cards/multi_session.rs
+++ b/pensyve-core/src/retrieval/cards/multi_session.rs
@@ -545,6 +545,7 @@ pub(crate) fn build_from_conn(
         "SELECT entity_type, instance, content, event_time \
          FROM observation_memories \
          WHERE {scope_clause} \
+           AND superseded_by IS NULL \
          ORDER BY event_time DESC NULLS LAST"
     );
     let mut stmt = conn.prepare(&sql).ok()?;

--- a/pensyve-core/src/retrieval/cards/single_session_user.rs
+++ b/pensyve-core/src/retrieval/cards/single_session_user.rs
@@ -282,6 +282,7 @@ fn build_card_from_conn(
          FROM observation_memories \
          WHERE event_time IS NOT NULL \
            AND DATE(event_time) IS NOT NULL \
+           AND superseded_by IS NULL \
            AND {scope_clause} \
          ORDER BY day DESC \
          LIMIT ?{}",
@@ -325,6 +326,7 @@ fn build_card_from_conn(
         "SELECT action, instance, content, event_time \
          FROM observation_memories \
          WHERE {scope_clause} \
+           AND superseded_by IS NULL \
            AND DATE(event_time) IN ({day_in}) \
            AND LOWER(TRIM(action)) IN ({action_in}) \
          ORDER BY event_time DESC, created_at DESC",
@@ -529,6 +531,7 @@ mod tests {
                 entity_type TEXT,
                 content TEXT,
                 event_time TEXT,
+                superseded_by TEXT,
                 created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
             )",
             [],

--- a/pensyve-core/src/retrieval/cards/supersession.rs
+++ b/pensyve-core/src/retrieval/cards/supersession.rs
@@ -215,6 +215,7 @@ impl RetrievalCard for SupersessionCard {
 /// SELECT chain_summary
 /// FROM observation_memories
 /// WHERE chain_summary IS NOT NULL
+///   AND superseded_by IS NULL
 ///   AND <scope_clause>
 /// ORDER BY event_time DESC NULLS LAST, created_at DESC
 /// LIMIT ?
@@ -279,6 +280,7 @@ fn build_chain_only_from_conn(
         "SELECT chain_summary \
          FROM observation_memories \
          WHERE chain_summary IS NOT NULL \
+           AND superseded_by IS NULL \
            AND {scope_clause} \
          ORDER BY event_time DESC NULLS LAST, created_at DESC \
          LIMIT ?{}",
@@ -419,6 +421,7 @@ mod tests {
                 user_id TEXT,
                 chain_summary TEXT,
                 event_time TEXT,
+                superseded_by TEXT,
                 created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
             )",
             [],

--- a/pensyve-core/src/storage/mod.rs
+++ b/pensyve-core/src/storage/mod.rs
@@ -258,6 +258,22 @@ pub trait StorageTrait: Send + Sync {
     // Bulk
     fn get_all_memories_by_namespace(&self, namespace_id: Uuid) -> StorageResult<Vec<Memory>>;
 
+    /// Fetch all memories, including superseded history, for audit/inspect paths.
+    fn get_all_memories_by_namespace_including_superseded(
+        &self,
+        namespace_id: Uuid,
+    ) -> StorageResult<Vec<Memory>> {
+        self.get_all_memories_by_namespace(namespace_id)
+    }
+
+    /// Mark a live memory as superseded. Returns `false` when no live row matched.
+    fn supersede_memory(
+        &self,
+        id: Uuid,
+        superseded_by: Uuid,
+        invalid_at: DateTime<Utc>,
+    ) -> StorageResult<bool>;
+
     // Deletion
     fn delete_memories_by_entity(&self, entity_id: Uuid) -> StorageResult<usize>;
 

--- a/pensyve-core/src/storage/postgres.rs
+++ b/pensyve-core/src/storage/postgres.rs
@@ -4,10 +4,12 @@ use std::future::Future;
 
 use chrono::{DateTime, Utc};
 use sqlx_core::executor::Executor;
+use sqlx_core::from_row::FromRow;
 use sqlx_core::query::query;
 use sqlx_core::query_as::query_as;
 use sqlx_core::raw_sql::raw_sql;
-use sqlx_postgres::{PgPool, PgPoolOptions, Postgres};
+use sqlx_core::row::Row;
+use sqlx_postgres::{PgPool, PgPoolOptions, PgRow, Postgres};
 use tokio::runtime::{Handle, Runtime};
 use uuid::Uuid;
 
@@ -23,23 +25,49 @@ use crate::graph::EdgeType;
 // Row type aliases (for complex tuple types used with query_as)
 // ---------------------------------------------------------------------------
 
-type EpisodicRow = (
-    Uuid,                  // id
-    Uuid,                  // namespace_id
-    Uuid,                  // episode_id
-    Uuid,                  // source_entity
-    Uuid,                  // about_entity
-    String,                // content
-    Option<String>,        // summary
-    Option<String>,        // embedding::text
-    Option<String>,        // context_intent
-    DateTime<Utc>,         // timestamp
-    f32,                   // stability
-    f32,                   // retrievability
-    i32,                   // access_count
-    Option<DateTime<Utc>>, // last_accessed
-    Option<DateTime<Utc>>, // event_time
-);
+struct EpisodicRow {
+    id: Uuid,
+    namespace_id: Uuid,
+    episode_id: Uuid,
+    source_entity: Uuid,
+    about_entity: Uuid,
+    content: String,
+    summary: Option<String>,
+    embedding_text: Option<String>,
+    context_intent: Option<String>,
+    timestamp: DateTime<Utc>,
+    stability: f32,
+    retrievability: f32,
+    access_count: i32,
+    last_accessed: Option<DateTime<Utc>>,
+    event_time: Option<DateTime<Utc>>,
+    superseded_by: Option<Uuid>,
+    invalid_at: Option<DateTime<Utc>>,
+}
+
+impl<'r> FromRow<'r, PgRow> for EpisodicRow {
+    fn from_row(row: &'r PgRow) -> Result<Self, sqlx_core::error::Error> {
+        Ok(Self {
+            id: row.try_get("id")?,
+            namespace_id: row.try_get("namespace_id")?,
+            episode_id: row.try_get("episode_id")?,
+            source_entity: row.try_get("source_entity")?,
+            about_entity: row.try_get("about_entity")?,
+            content: row.try_get("content")?,
+            summary: row.try_get("summary")?,
+            embedding_text: row.try_get("embedding")?,
+            context_intent: row.try_get("context_intent")?,
+            timestamp: row.try_get("timestamp")?,
+            stability: row.try_get("stability")?,
+            retrievability: row.try_get("retrievability")?,
+            access_count: row.try_get("access_count")?,
+            last_accessed: row.try_get("last_accessed")?,
+            event_time: row.try_get("event_time")?,
+            superseded_by: row.try_get("superseded_by")?,
+            invalid_at: row.try_get("invalid_at")?,
+        })
+    }
+}
 
 type SemanticRow = (
     Uuid,
@@ -55,6 +83,7 @@ type SemanticRow = (
     Option<String>,
     f32,
     f32,
+    Option<Uuid>,
 );
 
 type ProceduralRow = (
@@ -71,25 +100,53 @@ type ProceduralRow = (
     Option<String>,
     DateTime<Utc>,
     Option<DateTime<Utc>>,
+    Option<Uuid>,
+    Option<DateTime<Utc>>,
 );
 
-type ObservationRow = (
-    Uuid,                  // id
-    Uuid,                  // namespace_id
-    Uuid,                  // episode_id
-    String,                // entity_type
-    String,                // instance
-    String,                // action
-    Option<f64>,           // quantity
-    Option<String>,        // unit
-    String,                // content
-    Option<String>,        // embedding::text
-    f32,                   // confidence
-    Option<DateTime<Utc>>, // event_time
-    DateTime<Utc>,         // created_at
-    f32,                   // stability
-    f32,                   // retrievability
-);
+struct ObservationRow {
+    id: Uuid,
+    namespace_id: Uuid,
+    episode_id: Uuid,
+    entity_type: String,
+    instance: String,
+    action: String,
+    quantity: Option<f64>,
+    unit: Option<String>,
+    content: String,
+    embedding_text: Option<String>,
+    confidence: f32,
+    event_time: Option<DateTime<Utc>>,
+    created_at: DateTime<Utc>,
+    stability: f32,
+    retrievability: f32,
+    superseded_by: Option<Uuid>,
+    invalid_at: Option<DateTime<Utc>>,
+}
+
+impl<'r> FromRow<'r, PgRow> for ObservationRow {
+    fn from_row(row: &'r PgRow) -> Result<Self, sqlx_core::error::Error> {
+        Ok(Self {
+            id: row.try_get("id")?,
+            namespace_id: row.try_get("namespace_id")?,
+            episode_id: row.try_get("episode_id")?,
+            entity_type: row.try_get("entity_type")?,
+            instance: row.try_get("instance")?,
+            action: row.try_get("action")?,
+            quantity: row.try_get("quantity")?,
+            unit: row.try_get("unit")?,
+            content: row.try_get("content")?,
+            embedding_text: row.try_get("embedding")?,
+            confidence: row.try_get("confidence")?,
+            event_time: row.try_get("event_time")?,
+            created_at: row.try_get("created_at")?,
+            stability: row.try_get("stability")?,
+            retrievability: row.try_get("retrievability")?,
+            superseded_by: row.try_get("superseded_by")?,
+            invalid_at: row.try_get("invalid_at")?,
+        })
+    }
+}
 
 type EdgeRow = (
     Uuid,
@@ -262,6 +319,84 @@ impl PostgresBackend {
     /// for namespace-scoped RLS sessions (see [`set_namespace_config`]).
     pub fn pool(&self) -> &PgPool {
         &self.pool
+    }
+
+    fn load_memories_by_namespace(
+        &self,
+        namespace_id: Uuid,
+        include_superseded: bool,
+    ) -> StorageResult<Vec<Memory>> {
+        self.block_on(async {
+            let mut conn = self.scoped_conn(namespace_id).await?;
+            let mut memories = Vec::new();
+
+            let rows: Vec<EpisodicRow> = query_as::<Postgres, _>(
+                r"SELECT id, namespace_id, episode_id, source_entity, about_entity, content,
+                          summary, embedding::text, context_intent, timestamp, stability,
+                          retrievability, access_count, last_accessed, event_time,
+                          superseded_by, invalid_at
+                   FROM episodic_memories
+                   WHERE namespace_id = $1 AND ($2 OR superseded_by IS NULL)",
+            )
+            .bind(namespace_id)
+            .bind(include_superseded)
+            .fetch_all(&mut *conn)
+            .await
+            .map_err(sqlx_to_io)?;
+            memories.extend(rows.into_iter().map(row_to_episodic).map(Memory::Episodic));
+
+            let rows: Vec<SemanticRow> = query_as::<Postgres, _>(
+                r"SELECT id, namespace_id, subject, predicate, object, object_entity, confidence,
+                          valid_at, invalid_at, source_episodes, embedding::text, stability,
+                          retrievability, superseded_by
+                   FROM semantic_memories
+                   WHERE namespace_id = $1 AND ($2 OR superseded_by IS NULL)",
+            )
+            .bind(namespace_id)
+            .bind(include_superseded)
+            .fetch_all(&mut *conn)
+            .await
+            .map_err(sqlx_to_io)?;
+            memories.extend(rows.into_iter().map(row_to_semantic).map(Memory::Semantic));
+
+            let rows: Vec<ProceduralRow> = query_as::<Postgres, _>(
+                r"SELECT id, namespace_id, trigger_text, action, outcome, context, reliability,
+                          trial_count, success_count, source_episodes, embedding::text, created_at,
+                          last_used, superseded_by, invalid_at
+                   FROM procedural_memories
+                   WHERE namespace_id = $1 AND ($2 OR superseded_by IS NULL)",
+            )
+            .bind(namespace_id)
+            .bind(include_superseded)
+            .fetch_all(&mut *conn)
+            .await
+            .map_err(sqlx_to_io)?;
+            memories.extend(
+                rows.into_iter()
+                    .map(row_to_procedural)
+                    .map(Memory::Procedural),
+            );
+
+            let rows: Vec<ObservationRow> = query_as::<Postgres, _>(
+                r"SELECT id, namespace_id, episode_id, entity_type, instance, action, quantity,
+                          unit, content, embedding::text, confidence, event_time, created_at,
+                          stability, retrievability, superseded_by, invalid_at
+                   FROM observation_memories
+                   WHERE namespace_id = $1 AND ($2 OR superseded_by IS NULL)",
+            )
+            .bind(namespace_id)
+            .bind(include_superseded)
+            .fetch_all(&mut *conn)
+            .await
+            .map_err(sqlx_to_io)?;
+            memories.extend(
+                rows.into_iter()
+                    .map(row_to_observation)
+                    .map(Memory::Observation),
+            );
+
+            Ok(memories)
+        })
     }
 }
 
@@ -605,12 +740,13 @@ impl StorageTrait for PostgresBackend {
                 r"INSERT INTO episodic_memories
                    (id, namespace_id, episode_id, source_entity, about_entity, content, summary,
                     embedding, context_intent, timestamp, stability, retrievability,
-                    access_count, last_accessed, event_time)
-                   VALUES ($1, $2, $3, $4, $5, $6, $7, $8::vector, $9, $10, $11, $12, $13, $14, $15)
+                    access_count, last_accessed, event_time, superseded_by, invalid_at)
+                   VALUES ($1, $2, $3, $4, $5, $6, $7, $8::vector, $9, $10, $11, $12, $13, $14, $15, $16, $17)
                    ON CONFLICT (id) DO UPDATE SET
                        content = $6, summary = $7, embedding = $8::vector, context_intent = $9,
                        stability = $11, retrievability = $12, access_count = $13,
-                       last_accessed = $14, event_time = $15",
+                       last_accessed = $14, event_time = $15, superseded_by = $16,
+                       invalid_at = $17",
             )
             .bind(mem.id)
             .bind(mem.namespace_id)
@@ -627,6 +763,8 @@ impl StorageTrait for PostgresBackend {
             .bind(i32::try_from(mem.access_count).unwrap_or(i32::MAX))
             .bind(mem.last_accessed)
             .bind(mem.event_time)
+            .bind(mem.superseded_by)
+            .bind(mem.invalid_at)
             .execute(&mut *conn)
             .await
             .map_err(sqlx_to_io)?;
@@ -640,7 +778,7 @@ impl StorageTrait for PostgresBackend {
             let row: Option<EpisodicRow> = query_as::<Postgres, _>(
                 r"SELECT id, namespace_id, episode_id, source_entity, about_entity, content,
                           summary, embedding::text, context_intent, timestamp, stability, retrievability,
-                          access_count, last_accessed, event_time
+                          access_count, last_accessed, event_time, superseded_by, invalid_at
                    FROM episodic_memories WHERE id = $1",
             )
             .bind(id)
@@ -663,8 +801,8 @@ impl StorageTrait for PostgresBackend {
             let rows: Vec<EpisodicRow> = query_as::<Postgres, _>(
                 r"SELECT id, namespace_id, episode_id, source_entity, about_entity, content,
                           summary, embedding::text, context_intent, timestamp, stability, retrievability,
-                          access_count, last_accessed, event_time
-                   FROM episodic_memories WHERE about_entity = $1
+                          access_count, last_accessed, event_time, superseded_by, invalid_at
+                   FROM episodic_memories WHERE about_entity = $1 AND superseded_by IS NULL
                    ORDER BY timestamp DESC LIMIT $2",
             )
             .bind(about_entity)
@@ -690,9 +828,9 @@ impl StorageTrait for PostgresBackend {
                 // chronological order across the episode.
                 r"SELECT id, namespace_id, episode_id, source_entity, about_entity, content,
                           summary, embedding::text, context_intent, timestamp, stability, retrievability,
-                          access_count, last_accessed, event_time
+                          access_count, last_accessed, event_time, superseded_by, invalid_at
                    FROM episodic_memories
-                   WHERE namespace_id = $1 AND episode_id = $2
+                   WHERE namespace_id = $1 AND episode_id = $2 AND superseded_by IS NULL
                    ORDER BY COALESCE(event_time, timestamp) ASC",
             )
             .bind(namespace_id)
@@ -743,12 +881,13 @@ impl StorageTrait for PostgresBackend {
             query::<Postgres>(
                 r"INSERT INTO semantic_memories
                    (id, namespace_id, subject, predicate, object, object_entity, confidence,
-                    valid_at, invalid_at, source_episodes, embedding, stability, retrievability)
-                   VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11::vector, $12, $13)
+                    valid_at, invalid_at, source_episodes, embedding, stability, retrievability,
+                    superseded_by)
+                   VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11::vector, $12, $13, $14)
                    ON CONFLICT (id) DO UPDATE SET
                        predicate = $4, object = $5, object_entity = $6, confidence = $7,
                        invalid_at = $9, source_episodes = $10, embedding = $11::vector,
-                       stability = $12, retrievability = $13",
+                       stability = $12, retrievability = $13, superseded_by = $14",
             )
             .bind(mem.id)
             .bind(mem.namespace_id)
@@ -763,6 +902,7 @@ impl StorageTrait for PostgresBackend {
             .bind(&embedding_text)
             .bind(mem.stability)
             .bind(mem.retrievability)
+            .bind(mem.superseded_by)
             .execute(&mut *conn)
             .await
             .map_err(sqlx_to_io)?;
@@ -775,7 +915,8 @@ impl StorageTrait for PostgresBackend {
             let mut conn = self.maybe_scoped_conn().await?;
             let row: Option<SemanticRow> = query_as::<Postgres, _>(
                 r"SELECT id, namespace_id, subject, predicate, object, object_entity, confidence,
-                          valid_at, invalid_at, source_episodes, embedding::text, stability, retrievability
+                          valid_at, invalid_at, source_episodes, embedding::text, stability,
+                          retrievability, superseded_by
                    FROM semantic_memories WHERE id = $1",
             )
             .bind(id)
@@ -797,8 +938,9 @@ impl StorageTrait for PostgresBackend {
             let mut conn = self.maybe_scoped_conn().await?;
             let rows: Vec<SemanticRow> = query_as::<Postgres, _>(
                 r"SELECT id, namespace_id, subject, predicate, object, object_entity, confidence,
-                          valid_at, invalid_at, source_episodes, embedding::text, stability, retrievability
-                   FROM semantic_memories WHERE subject = $1
+                          valid_at, invalid_at, source_episodes, embedding::text, stability,
+                          retrievability, superseded_by
+                   FROM semantic_memories WHERE subject = $1 AND superseded_by IS NULL
                    ORDER BY valid_at DESC LIMIT $2",
             )
             .bind(subject)
@@ -839,12 +981,14 @@ impl StorageTrait for PostgresBackend {
             query::<Postgres>(
                 r"INSERT INTO procedural_memories
                    (id, namespace_id, trigger_text, action, outcome, context, reliability,
-                    trial_count, success_count, source_episodes, embedding, created_at, last_used)
-                   VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11::vector, $12, $13)
+                    trial_count, success_count, source_episodes, embedding, created_at, last_used,
+                    superseded_by, invalid_at)
+                   VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11::vector, $12, $13, $14, $15)
                    ON CONFLICT (id) DO UPDATE SET
                        trigger_text = $3, action = $4, outcome = $5, context = $6,
                        reliability = $7, trial_count = $8, success_count = $9,
-                       source_episodes = $10, embedding = $11::vector, last_used = $13",
+                       source_episodes = $10, embedding = $11::vector, last_used = $13,
+                       superseded_by = $14, invalid_at = $15",
             )
             .bind(mem.id)
             .bind(mem.namespace_id)
@@ -859,6 +1003,8 @@ impl StorageTrait for PostgresBackend {
             .bind(&embedding_text)
             .bind(mem.created_at)
             .bind(mem.last_used)
+            .bind(mem.superseded_by)
+            .bind(mem.invalid_at)
             .execute(&mut *conn)
             .await
             .map_err(sqlx_to_io)?;
@@ -871,7 +1017,8 @@ impl StorageTrait for PostgresBackend {
             let mut conn = self.maybe_scoped_conn().await?;
             let row: Option<ProceduralRow> = query_as::<Postgres, _>(
                 r"SELECT id, namespace_id, trigger_text, action, outcome, context, reliability,
-                          trial_count, success_count, source_episodes, embedding::text, created_at, last_used
+                          trial_count, success_count, source_episodes, embedding::text, created_at,
+                          last_used, superseded_by, invalid_at
                    FROM procedural_memories WHERE id = $1",
             )
             .bind(id)
@@ -921,12 +1068,14 @@ impl StorageTrait for PostgresBackend {
             query::<Postgres>(
                 r"INSERT INTO observation_memories
                    (id, namespace_id, episode_id, entity_type, instance, action, quantity, unit,
-                    content, embedding, confidence, event_time, created_at, stability, retrievability)
-                   VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10::vector, $11, $12, $13, $14, $15)
+                    content, embedding, confidence, event_time, created_at, stability, retrievability,
+                    superseded_by, invalid_at)
+                   VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10::vector, $11, $12, $13, $14, $15, $16, $17)
                    ON CONFLICT (id) DO UPDATE SET
                        entity_type = $4, instance = $5, action = $6, quantity = $7, unit = $8,
                        content = $9, embedding = $10::vector, confidence = $11,
-                       event_time = $12, stability = $14, retrievability = $15",
+                       event_time = $12, stability = $14, retrievability = $15,
+                       superseded_by = $16, invalid_at = $17",
             )
             .bind(mem.id)
             .bind(mem.namespace_id)
@@ -943,6 +1092,8 @@ impl StorageTrait for PostgresBackend {
             .bind(mem.created_at)
             .bind(mem.stability)
             .bind(mem.retrievability)
+            .bind(mem.superseded_by)
+            .bind(mem.invalid_at)
             .execute(&mut *conn)
             .await
             .map_err(sqlx_to_io)?;
@@ -956,7 +1107,7 @@ impl StorageTrait for PostgresBackend {
             let row: Option<ObservationRow> = query_as::<Postgres, _>(
                 r"SELECT id, namespace_id, episode_id, entity_type, instance, action, quantity,
                           unit, content, embedding::text, confidence, event_time, created_at,
-                          stability, retrievability
+                          stability, retrievability, superseded_by, invalid_at
                    FROM observation_memories WHERE id = $1",
             )
             .bind(id)
@@ -988,17 +1139,18 @@ impl StorageTrait for PostgresBackend {
             let sql = if namespace_filter.is_some() {
                 r"SELECT id, namespace_id, episode_id, entity_type, instance, action, quantity,
                           unit, content, embedding::text, confidence, event_time, created_at,
-                          stability, retrievability
+                          stability, retrievability, superseded_by, invalid_at
                    FROM observation_memories
                    WHERE episode_id = ANY($1) AND namespace_id = $3
+                     AND superseded_by IS NULL
                    ORDER BY created_at ASC
                    LIMIT $2"
             } else {
                 r"SELECT id, namespace_id, episode_id, entity_type, instance, action, quantity,
                           unit, content, embedding::text, confidence, event_time, created_at,
-                          stability, retrievability
+                          stability, retrievability, superseded_by, invalid_at
                    FROM observation_memories
-                   WHERE episode_id = ANY($1)
+                   WHERE episode_id = ANY($1) AND superseded_by IS NULL
                    ORDER BY created_at ASC
                    LIMIT $2"
             };
@@ -1066,9 +1218,10 @@ impl StorageTrait for PostgresBackend {
             let episodic_rows: Vec<EpisodicRow> = query_as::<Postgres, _>(
                 r"SELECT id, namespace_id, episode_id, source_entity, about_entity, content,
                           summary, embedding::text, context_intent, timestamp, stability, retrievability,
-                          access_count, last_accessed, event_time
+                          access_count, last_accessed, event_time, superseded_by, invalid_at
                    FROM episodic_memories
-                   WHERE namespace_id = $1 AND fts_content @@ plainto_tsquery('english', $2)
+                   WHERE namespace_id = $1 AND superseded_by IS NULL
+                     AND fts_content @@ plainto_tsquery('english', $2)
                    ORDER BY ts_rank(fts_content, plainto_tsquery('english', $2)) DESC
                    LIMIT $3",
             )
@@ -1087,8 +1240,10 @@ impl StorageTrait for PostgresBackend {
             let semantic_rows: Vec<SemanticRow> = query_as::<Postgres, _>(
                 r"SELECT id, namespace_id, subject, predicate, object, object_entity, confidence,
                           valid_at, invalid_at, source_episodes, embedding::text, stability, retrievability
+                          , superseded_by
                    FROM semantic_memories
-                   WHERE namespace_id = $1 AND fts_content @@ plainto_tsquery('english', $2)
+                   WHERE namespace_id = $1 AND superseded_by IS NULL
+                     AND fts_content @@ plainto_tsquery('english', $2)
                    ORDER BY ts_rank(fts_content, plainto_tsquery('english', $2)) DESC
                    LIMIT $3",
             )
@@ -1107,8 +1262,10 @@ impl StorageTrait for PostgresBackend {
             let procedural_rows: Vec<ProceduralRow> = query_as::<Postgres, _>(
                 r"SELECT id, namespace_id, trigger_text, action, outcome, context, reliability,
                           trial_count, success_count, source_episodes, embedding::text, created_at, last_used
+                          , superseded_by, invalid_at
                    FROM procedural_memories
-                   WHERE namespace_id = $1 AND fts_content @@ plainto_tsquery('english', $2)
+                   WHERE namespace_id = $1 AND superseded_by IS NULL
+                     AND fts_content @@ plainto_tsquery('english', $2)
                    ORDER BY ts_rank(fts_content, plainto_tsquery('english', $2)) DESC
                    LIMIT $3",
             )
@@ -1145,8 +1302,10 @@ impl StorageTrait for PostgresBackend {
             let semantic_rows: Vec<SemanticRow> = query_as::<Postgres, _>(
                 r"SELECT id, namespace_id, subject, predicate, object, object_entity, confidence,
                           valid_at, invalid_at, source_episodes, embedding::text, stability, retrievability
+                          , superseded_by
                    FROM semantic_memories
                    WHERE namespace_id = $1 AND subject = $2
+                     AND superseded_by IS NULL
                      AND fts_content @@ plainto_tsquery('english', $3)
                    ORDER BY ts_rank(fts_content, plainto_tsquery('english', $3)) DESC
                    LIMIT $4",
@@ -1170,10 +1329,11 @@ impl StorageTrait for PostgresBackend {
             let episodic_rows: Vec<EpisodicRow> = query_as::<Postgres, _>(
                 r"SELECT id, namespace_id, episode_id, source_entity, about_entity, content,
                           summary, embedding::text, context_intent, timestamp, stability, retrievability,
-                          access_count, last_accessed, event_time
+                          access_count, last_accessed, event_time, superseded_by, invalid_at
                    FROM episodic_memories
                    WHERE namespace_id = $1
                      AND (about_entity = $2 OR source_entity = $2)
+                     AND superseded_by IS NULL
                      AND fts_content @@ plainto_tsquery('english', $3)
                    ORDER BY ts_rank(fts_content, plainto_tsquery('english', $3)) DESC
                    LIMIT $4",
@@ -1200,73 +1360,46 @@ impl StorageTrait for PostgresBackend {
     // -----------------------------------------------------------------------
 
     fn get_all_memories_by_namespace(&self, namespace_id: Uuid) -> StorageResult<Vec<Memory>> {
+        self.load_memories_by_namespace(namespace_id, false)
+    }
+
+    fn get_all_memories_by_namespace_including_superseded(
+        &self,
+        namespace_id: Uuid,
+    ) -> StorageResult<Vec<Memory>> {
+        self.load_memories_by_namespace(namespace_id, true)
+    }
+
+    fn supersede_memory(
+        &self,
+        id: Uuid,
+        superseded_by: Uuid,
+        invalid_at: DateTime<Utc>,
+    ) -> StorageResult<bool> {
         self.block_on(async {
-            let mut conn = self.scoped_conn(namespace_id).await?;
-            let mut memories = Vec::new();
-
-            // Episodic
-            let episodic_rows: Vec<EpisodicRow> = query_as::<Postgres, _>(
-                r"SELECT id, namespace_id, episode_id, source_entity, about_entity, content,
-                          summary, embedding::text, context_intent, timestamp, stability, retrievability,
-                          access_count, last_accessed, event_time
-                   FROM episodic_memories WHERE namespace_id = $1",
-            )
-            .bind(namespace_id)
-            .fetch_all(&mut *conn)
-            .await
-            .map_err(sqlx_to_io)?;
-
-            for row in episodic_rows {
-                memories.push(Memory::Episodic(row_to_episodic(row)));
+            let mut conn = self.maybe_scoped_conn().await?;
+            for sql in [
+                "UPDATE episodic_memories SET superseded_by = $1, invalid_at = $2 \
+                 WHERE id = $3 AND superseded_by IS NULL",
+                "UPDATE semantic_memories SET superseded_by = $1, invalid_at = $2 \
+                 WHERE id = $3 AND superseded_by IS NULL",
+                "UPDATE procedural_memories SET superseded_by = $1, invalid_at = $2 \
+                 WHERE id = $3 AND superseded_by IS NULL",
+                "UPDATE observation_memories SET superseded_by = $1, invalid_at = $2 \
+                 WHERE id = $3 AND superseded_by IS NULL",
+            ] {
+                let result = query::<Postgres>(sql)
+                    .bind(superseded_by)
+                    .bind(invalid_at)
+                    .bind(id)
+                    .execute(&mut *conn)
+                    .await
+                    .map_err(sqlx_to_io)?;
+                if result.rows_affected() > 0 {
+                    return Ok(true);
+                }
             }
-
-            // Semantic
-            let semantic_rows: Vec<SemanticRow> = query_as::<Postgres, _>(
-                r"SELECT id, namespace_id, subject, predicate, object, object_entity, confidence,
-                          valid_at, invalid_at, source_episodes, embedding::text, stability, retrievability
-                   FROM semantic_memories WHERE namespace_id = $1",
-            )
-            .bind(namespace_id)
-            .fetch_all(&mut *conn)
-            .await
-            .map_err(sqlx_to_io)?;
-
-            for row in semantic_rows {
-                memories.push(Memory::Semantic(row_to_semantic(row)));
-            }
-
-            // Procedural
-            let procedural_rows: Vec<ProceduralRow> = query_as::<Postgres, _>(
-                r"SELECT id, namespace_id, trigger_text, action, outcome, context, reliability,
-                          trial_count, success_count, source_episodes, embedding::text, created_at, last_used
-                   FROM procedural_memories WHERE namespace_id = $1",
-            )
-            .bind(namespace_id)
-            .fetch_all(&mut *conn)
-            .await
-            .map_err(sqlx_to_io)?;
-
-            for row in procedural_rows {
-                memories.push(Memory::Procedural(row_to_procedural(row)));
-            }
-
-            // Observation
-            let observation_rows: Vec<ObservationRow> = query_as::<Postgres, _>(
-                r"SELECT id, namespace_id, episode_id, entity_type, instance, action, quantity,
-                          unit, content, embedding::text, confidence, event_time, created_at,
-                          stability, retrievability
-                   FROM observation_memories WHERE namespace_id = $1",
-            )
-            .bind(namespace_id)
-            .fetch_all(&mut *conn)
-            .await
-            .map_err(sqlx_to_io)?;
-
-            for row in observation_rows {
-                memories.push(Memory::Observation(row_to_observation(row)));
-            }
-
-            Ok(memories)
+            Ok(false)
         })
     }
 
@@ -1671,7 +1804,7 @@ impl StorageTrait for PostgresBackend {
 // ---------------------------------------------------------------------------
 
 fn row_to_episodic(row: EpisodicRow) -> EpisodicMemory {
-    let (
+    let EpisodicRow {
         id,
         namespace_id,
         episode_id,
@@ -1687,7 +1820,9 @@ fn row_to_episodic(row: EpisodicRow) -> EpisodicMemory {
         access_count,
         last_accessed,
         event_time,
-    ) = row;
+        superseded_by,
+        invalid_at,
+    } = row;
     EpisodicMemory {
         id,
         namespace_id,
@@ -1707,7 +1842,8 @@ fn row_to_episodic(row: EpisodicRow) -> EpisodicMemory {
         salience: 0.5,
         storage_strength: 0.0,
         event_time,
-        superseded_by: None,
+        superseded_by,
+        invalid_at,
         // G1: postgres backend does not yet carry the multi-tenant scope
         // columns. The struct fields exist for trait/serde compatibility
         // but are always None on this backend until the postgres schema
@@ -1732,6 +1868,7 @@ fn row_to_semantic(row: SemanticRow) -> SemanticMemory {
         embedding_text,
         stability,
         retrievability,
+        superseded_by,
     ) = row;
     let source_episodes: Vec<Uuid> =
         serde_json::from_value(source_episodes_json).unwrap_or_default();
@@ -1746,6 +1883,7 @@ fn row_to_semantic(row: SemanticRow) -> SemanticMemory {
         confidence,
         valid_at,
         invalid_at,
+        superseded_by,
         source_episodes,
         embedding: pgtext_to_embedding(embedding_text.as_deref()),
         stability,
@@ -1771,6 +1909,8 @@ fn row_to_procedural(row: ProceduralRow) -> ProceduralMemory {
         embedding_text,
         created_at,
         last_used,
+        superseded_by,
+        invalid_at,
     ) = row;
     let context: HashMap<String, serde_json::Value> =
         serde_json::from_value(context_json).unwrap_or_default();
@@ -1790,6 +1930,8 @@ fn row_to_procedural(row: ProceduralRow) -> ProceduralMemory {
         embedding: pgtext_to_embedding(embedding_text.as_deref()),
         created_at,
         last_used,
+        superseded_by,
+        invalid_at,
         // G1: postgres backend does not yet carry the multi-tenant scope columns.
         agent_id: None,
         user_id: None,
@@ -1797,7 +1939,7 @@ fn row_to_procedural(row: ProceduralRow) -> ProceduralMemory {
 }
 
 fn row_to_observation(row: ObservationRow) -> ObservationMemory {
-    let (
+    let ObservationRow {
         id,
         namespace_id,
         episode_id,
@@ -1813,7 +1955,9 @@ fn row_to_observation(row: ObservationRow) -> ObservationMemory {
         created_at,
         stability,
         retrievability,
-    ) = row;
+        superseded_by,
+        invalid_at,
+    } = row;
     ObservationMemory {
         id,
         namespace_id,
@@ -1830,8 +1974,123 @@ fn row_to_observation(row: ObservationRow) -> ObservationMemory {
         created_at,
         stability,
         retrievability,
+        superseded_by,
+        invalid_at,
         // G1: postgres backend does not yet carry the multi-tenant scope columns.
         agent_id: None,
         user_id: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn postgres_schema_has_idempotent_supersession_alters() {
+        for statement in [
+            "ALTER TABLE episodic_memories ADD COLUMN IF NOT EXISTS superseded_by UUID;",
+            "ALTER TABLE episodic_memories ADD COLUMN IF NOT EXISTS invalid_at TIMESTAMPTZ;",
+            "ALTER TABLE semantic_memories ADD COLUMN IF NOT EXISTS superseded_by UUID;",
+            "ALTER TABLE procedural_memories ADD COLUMN IF NOT EXISTS superseded_by UUID;",
+            "ALTER TABLE procedural_memories ADD COLUMN IF NOT EXISTS invalid_at TIMESTAMPTZ;",
+            "ALTER TABLE observation_memories ADD COLUMN IF NOT EXISTS superseded_by UUID;",
+            "ALTER TABLE observation_memories ADD COLUMN IF NOT EXISTS invalid_at TIMESTAMPTZ;",
+        ] {
+            assert!(
+                SCHEMA.contains(statement),
+                "missing schema statement: {statement}"
+            );
+        }
+    }
+
+    #[test]
+    fn postgres_row_mapping_round_trips_supersession_columns() {
+        let now = Utc::now();
+        let successor = Uuid::new_v4();
+        let namespace_id = Uuid::new_v4();
+
+        let episodic = row_to_episodic(EpisodicRow {
+            id: Uuid::new_v4(),
+            namespace_id,
+            episode_id: Uuid::new_v4(),
+            source_entity: Uuid::new_v4(),
+            about_entity: Uuid::new_v4(),
+            content: "episodic".to_string(),
+            summary: None,
+            embedding_text: None,
+            context_intent: None,
+            timestamp: now,
+            stability: 1.0,
+            retrievability: 1.0,
+            access_count: 0,
+            last_accessed: None,
+            event_time: None,
+            superseded_by: Some(successor),
+            invalid_at: Some(now),
+        });
+        assert_eq!(episodic.superseded_by, Some(successor));
+        assert_eq!(episodic.invalid_at, Some(now));
+
+        let semantic = row_to_semantic((
+            Uuid::new_v4(),
+            namespace_id,
+            Uuid::new_v4(),
+            "predicate".to_string(),
+            "object".to_string(),
+            None,
+            0.9,
+            now,
+            Some(now),
+            serde_json::json!([]),
+            None,
+            1.0,
+            1.0,
+            Some(successor),
+        ));
+        assert_eq!(semantic.superseded_by, Some(successor));
+        assert_eq!(semantic.invalid_at, Some(now));
+
+        let procedural = row_to_procedural((
+            Uuid::new_v4(),
+            namespace_id,
+            "trigger".to_string(),
+            "action".to_string(),
+            "Success".to_string(),
+            serde_json::json!({}),
+            0.9,
+            1,
+            1,
+            serde_json::json!([]),
+            None,
+            now,
+            None,
+            Some(successor),
+            Some(now),
+        ));
+        assert_eq!(procedural.superseded_by, Some(successor));
+        assert_eq!(procedural.invalid_at, Some(now));
+
+        let observation = row_to_observation(ObservationRow {
+            id: Uuid::new_v4(),
+            namespace_id,
+            episode_id: Uuid::new_v4(),
+            entity_type: "entity".to_string(),
+            instance: "instance".to_string(),
+            action: "action".to_string(),
+            quantity: None,
+            unit: None,
+            content: "observation".to_string(),
+            embedding_text: None,
+            confidence: 0.9,
+            event_time: None,
+            created_at: now,
+            stability: 1.0,
+            retrievability: 1.0,
+            superseded_by: Some(successor),
+            invalid_at: Some(now),
+        });
+        assert_eq!(observation.superseded_by, Some(successor));
+        assert_eq!(observation.invalid_at, Some(now));
     }
 }

--- a/pensyve-core/src/storage/postgres.rs
+++ b/pensyve-core/src/storage/postgres.rs
@@ -332,7 +332,7 @@ impl PostgresBackend {
 
             let rows: Vec<EpisodicRow> = query_as::<Postgres, _>(
                 r"SELECT id, namespace_id, episode_id, source_entity, about_entity, content,
-                          summary, embedding::text, context_intent, timestamp, stability,
+                          summary, embedding::text AS embedding, context_intent, timestamp, stability,
                           retrievability, access_count, last_accessed, event_time,
                           superseded_by, invalid_at
                    FROM episodic_memories
@@ -379,7 +379,7 @@ impl PostgresBackend {
 
             let rows: Vec<ObservationRow> = query_as::<Postgres, _>(
                 r"SELECT id, namespace_id, episode_id, entity_type, instance, action, quantity,
-                          unit, content, embedding::text, confidence, event_time, created_at,
+                          unit, content, embedding::text AS embedding, confidence, event_time, created_at,
                           stability, retrievability, superseded_by, invalid_at
                    FROM observation_memories
                    WHERE namespace_id = $1 AND ($2 OR superseded_by IS NULL)",
@@ -777,7 +777,7 @@ impl StorageTrait for PostgresBackend {
             let mut conn = self.maybe_scoped_conn().await?;
             let row: Option<EpisodicRow> = query_as::<Postgres, _>(
                 r"SELECT id, namespace_id, episode_id, source_entity, about_entity, content,
-                          summary, embedding::text, context_intent, timestamp, stability, retrievability,
+                          summary, embedding::text AS embedding, context_intent, timestamp, stability, retrievability,
                           access_count, last_accessed, event_time, superseded_by, invalid_at
                    FROM episodic_memories WHERE id = $1",
             )
@@ -800,7 +800,7 @@ impl StorageTrait for PostgresBackend {
             let mut conn = self.maybe_scoped_conn().await?;
             let rows: Vec<EpisodicRow> = query_as::<Postgres, _>(
                 r"SELECT id, namespace_id, episode_id, source_entity, about_entity, content,
-                          summary, embedding::text, context_intent, timestamp, stability, retrievability,
+                          summary, embedding::text AS embedding, context_intent, timestamp, stability, retrievability,
                           access_count, last_accessed, event_time, superseded_by, invalid_at
                    FROM episodic_memories WHERE about_entity = $1 AND superseded_by IS NULL
                    ORDER BY timestamp DESC LIMIT $2",
@@ -827,7 +827,7 @@ impl StorageTrait for PostgresBackend {
                 // encoding `timestamp`. Observation extraction relies on
                 // chronological order across the episode.
                 r"SELECT id, namespace_id, episode_id, source_entity, about_entity, content,
-                          summary, embedding::text, context_intent, timestamp, stability, retrievability,
+                          summary, embedding::text AS embedding, context_intent, timestamp, stability, retrievability,
                           access_count, last_accessed, event_time, superseded_by, invalid_at
                    FROM episodic_memories
                    WHERE namespace_id = $1 AND episode_id = $2 AND superseded_by IS NULL
@@ -1106,7 +1106,7 @@ impl StorageTrait for PostgresBackend {
             let mut conn = self.maybe_scoped_conn().await?;
             let row: Option<ObservationRow> = query_as::<Postgres, _>(
                 r"SELECT id, namespace_id, episode_id, entity_type, instance, action, quantity,
-                          unit, content, embedding::text, confidence, event_time, created_at,
+                          unit, content, embedding::text AS embedding, confidence, event_time, created_at,
                           stability, retrievability, superseded_by, invalid_at
                    FROM observation_memories WHERE id = $1",
             )
@@ -1138,7 +1138,7 @@ impl StorageTrait for PostgresBackend {
             let mut conn = self.maybe_scoped_conn().await?;
             let sql = if namespace_filter.is_some() {
                 r"SELECT id, namespace_id, episode_id, entity_type, instance, action, quantity,
-                          unit, content, embedding::text, confidence, event_time, created_at,
+                          unit, content, embedding::text AS embedding, confidence, event_time, created_at,
                           stability, retrievability, superseded_by, invalid_at
                    FROM observation_memories
                    WHERE episode_id = ANY($1) AND namespace_id = $3
@@ -1147,7 +1147,7 @@ impl StorageTrait for PostgresBackend {
                    LIMIT $2"
             } else {
                 r"SELECT id, namespace_id, episode_id, entity_type, instance, action, quantity,
-                          unit, content, embedding::text, confidence, event_time, created_at,
+                          unit, content, embedding::text AS embedding, confidence, event_time, created_at,
                           stability, retrievability, superseded_by, invalid_at
                    FROM observation_memories
                    WHERE episode_id = ANY($1) AND superseded_by IS NULL
@@ -1217,7 +1217,7 @@ impl StorageTrait for PostgresBackend {
             // Search episodic memories
             let episodic_rows: Vec<EpisodicRow> = query_as::<Postgres, _>(
                 r"SELECT id, namespace_id, episode_id, source_entity, about_entity, content,
-                          summary, embedding::text, context_intent, timestamp, stability, retrievability,
+                          summary, embedding::text AS embedding, context_intent, timestamp, stability, retrievability,
                           access_count, last_accessed, event_time, superseded_by, invalid_at
                    FROM episodic_memories
                    WHERE namespace_id = $1 AND superseded_by IS NULL
@@ -1328,7 +1328,7 @@ impl StorageTrait for PostgresBackend {
 
             let episodic_rows: Vec<EpisodicRow> = query_as::<Postgres, _>(
                 r"SELECT id, namespace_id, episode_id, source_entity, about_entity, content,
-                          summary, embedding::text, context_intent, timestamp, stability, retrievability,
+                          summary, embedding::text AS embedding, context_intent, timestamp, stability, retrievability,
                           access_count, last_accessed, event_time, superseded_by, invalid_at
                    FROM episodic_memories
                    WHERE namespace_id = $1
@@ -1643,7 +1643,7 @@ impl StorageTrait for PostgresBackend {
             let mut conn = self.scoped_conn(namespace_id).await?;
 
             let (episodic,): (i64,) = query_as::<Postgres, _>(
-                "SELECT COUNT(*) FROM episodic_memories WHERE namespace_id = $1",
+                "SELECT COUNT(*) FROM episodic_memories WHERE namespace_id = $1 AND superseded_by IS NULL",
             )
             .bind(namespace_id)
             .fetch_one(&mut *conn)
@@ -1651,7 +1651,7 @@ impl StorageTrait for PostgresBackend {
             .map_err(sqlx_to_io)?;
 
             let (semantic,): (i64,) = query_as::<Postgres, _>(
-                "SELECT COUNT(*) FROM semantic_memories WHERE namespace_id = $1 AND invalid_at IS NULL",
+                "SELECT COUNT(*) FROM semantic_memories WHERE namespace_id = $1 AND invalid_at IS NULL AND superseded_by IS NULL",
             )
             .bind(namespace_id)
             .fetch_one(&mut *conn)
@@ -1659,7 +1659,7 @@ impl StorageTrait for PostgresBackend {
             .map_err(sqlx_to_io)?;
 
             let (procedural,): (i64,) = query_as::<Postgres, _>(
-                "SELECT COUNT(*) FROM procedural_memories WHERE namespace_id = $1",
+                "SELECT COUNT(*) FROM procedural_memories WHERE namespace_id = $1 AND superseded_by IS NULL",
             )
             .bind(namespace_id)
             .fetch_one(&mut *conn)

--- a/pensyve-core/src/storage/postgres_schema.sql
+++ b/pensyve-core/src/storage/postgres_schema.sql
@@ -71,6 +71,8 @@ CREATE TABLE IF NOT EXISTS episodic_memories (
 -- this column — without it the extractor sees `[unknown]` dates and can't
 -- build temporal context.
 ALTER TABLE episodic_memories ADD COLUMN IF NOT EXISTS event_time TIMESTAMPTZ;
+ALTER TABLE episodic_memories ADD COLUMN IF NOT EXISTS superseded_by UUID;
+ALTER TABLE episodic_memories ADD COLUMN IF NOT EXISTS invalid_at TIMESTAMPTZ;
 
 CREATE INDEX IF NOT EXISTS idx_episodic_about_entity ON episodic_memories(about_entity);
 CREATE INDEX IF NOT EXISTS idx_episodic_namespace ON episodic_memories(namespace_id);
@@ -99,6 +101,8 @@ CREATE TABLE IF NOT EXISTS semantic_memories (
     fts_content     tsvector GENERATED ALWAYS AS (to_tsvector('english', predicate || ' ' || object)) STORED
 );
 
+ALTER TABLE semantic_memories ADD COLUMN IF NOT EXISTS superseded_by UUID;
+
 CREATE INDEX IF NOT EXISTS idx_semantic_subject ON semantic_memories(subject);
 CREATE INDEX IF NOT EXISTS idx_semantic_namespace ON semantic_memories(namespace_id);
 CREATE INDEX IF NOT EXISTS idx_semantic_fts ON semantic_memories USING GIN(fts_content);
@@ -123,6 +127,9 @@ CREATE TABLE IF NOT EXISTS procedural_memories (
     last_used       TIMESTAMPTZ,
     fts_content     tsvector GENERATED ALWAYS AS (to_tsvector('english', trigger_text || ' ' || action)) STORED
 );
+
+ALTER TABLE procedural_memories ADD COLUMN IF NOT EXISTS superseded_by UUID;
+ALTER TABLE procedural_memories ADD COLUMN IF NOT EXISTS invalid_at TIMESTAMPTZ;
 
 CREATE INDEX IF NOT EXISTS idx_procedural_namespace ON procedural_memories(namespace_id);
 CREATE INDEX IF NOT EXISTS idx_procedural_fts ON procedural_memories USING GIN(fts_content);
@@ -151,6 +158,9 @@ CREATE TABLE IF NOT EXISTS observation_memories (
     retrievability  REAL NOT NULL DEFAULT 1.0,
     fts_content     tsvector GENERATED ALWAYS AS (to_tsvector('english', content)) STORED
 );
+
+ALTER TABLE observation_memories ADD COLUMN IF NOT EXISTS superseded_by UUID;
+ALTER TABLE observation_memories ADD COLUMN IF NOT EXISTS invalid_at TIMESTAMPTZ;
 
 CREATE INDEX IF NOT EXISTS idx_observation_episode ON observation_memories(episode_id);
 CREATE INDEX IF NOT EXISTS idx_observation_namespace ON observation_memories(namespace_id);

--- a/pensyve-core/src/storage/sqlite.rs
+++ b/pensyve-core/src/storage/sqlite.rs
@@ -287,6 +287,37 @@ impl SqliteBackend {
             )?;
         }
 
+        // ----- Migration v4: uniform memory supersession columns. -----
+        if max_applied < 4 {
+            const V4_COLUMNS: &[(&str, &str, &str)] = &[
+                ("episodic_memories", "superseded_by", "TEXT"),
+                ("episodic_memories", "invalid_at", "TEXT"),
+                ("semantic_memories", "superseded_by", "TEXT"),
+                ("procedural_memories", "superseded_by", "TEXT"),
+                ("procedural_memories", "invalid_at", "TEXT"),
+                ("observation_memories", "superseded_by", "TEXT"),
+                ("observation_memories", "invalid_at", "TEXT"),
+            ];
+
+            for (table, column, column_type) in V4_COLUMNS {
+                if !Self::column_exists(conn, table, column)? {
+                    conn.execute_batch(&format!(
+                        "ALTER TABLE {table} ADD COLUMN {column} {column_type};"
+                    ))?;
+                }
+            }
+
+            conn.execute(
+                "INSERT INTO schema_versions (version, applied_at, description)
+                 VALUES (?1, ?2, ?3)",
+                params![
+                    4_i64,
+                    Utc::now().to_rfc3339(),
+                    "Issue 187: add uniform superseded_by + invalid_at columns to memory tables",
+                ],
+            )?;
+        }
+
         Ok(())
     }
 
@@ -952,8 +983,9 @@ impl StorageTrait for SqliteBackend {
             r"INSERT OR REPLACE INTO episodic_memories
                (id, namespace_id, episode_id, source_entity, about_entity, content, content_type,
                 summary, embedding, context_intent, timestamp, stability, retrievability,
-                access_count, last_accessed, event_time, agent_id, user_id)
-               VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18)",
+                access_count, last_accessed, event_time, agent_id, user_id, superseded_by,
+                invalid_at)
+               VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20)",
             params![
                 mem.id.to_string(),
                 mem.namespace_id.to_string(),
@@ -973,6 +1005,8 @@ impl StorageTrait for SqliteBackend {
                 opt_dt_to_str(mem.event_time),
                 mem.agent_id.map(|u| u.to_string()),
                 mem.user_id.map(|u| u.to_string()),
+                mem.superseded_by.map(|u| u.to_string()),
+                opt_dt_to_str(mem.invalid_at),
             ],
         )?;
 
@@ -997,7 +1031,7 @@ impl StorageTrait for SqliteBackend {
                 r"SELECT id, namespace_id, episode_id, source_entity, about_entity, content,
                           content_type, summary, embedding, context_intent, timestamp,
                           stability, retrievability, access_count, last_accessed, event_time,
-                          agent_id, user_id
+                          agent_id, user_id, superseded_by, invalid_at
                    FROM episodic_memories WHERE id = ?1",
                 params![id.to_string()],
                 row_to_episodic,
@@ -1016,8 +1050,8 @@ impl StorageTrait for SqliteBackend {
             r"SELECT id, namespace_id, episode_id, source_entity, about_entity, content,
                       content_type, summary, embedding, context_intent, timestamp,
                       stability, retrievability, access_count, last_accessed, event_time,
-                      agent_id, user_id
-               FROM episodic_memories WHERE about_entity = ?1
+                      agent_id, user_id, superseded_by, invalid_at
+               FROM episodic_memories WHERE about_entity = ?1 AND superseded_by IS NULL
                ORDER BY timestamp DESC LIMIT ?2",
         )?;
         let rows = stmt.query_map(
@@ -1080,8 +1114,8 @@ impl StorageTrait for SqliteBackend {
                 r"INSERT OR REPLACE INTO semantic_memories
                    (id, namespace_id, subject, predicate, object, content_type, object_entity,
                     confidence, valid_at, invalid_at, source_episodes, embedding, stability,
-                    retrievability, agent_id, user_id)
-                   VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)",
+                    retrievability, agent_id, user_id, superseded_by)
+                   VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)",
                 params![
                     mem.id.to_string(),
                     mem.namespace_id.to_string(),
@@ -1099,6 +1133,7 @@ impl StorageTrait for SqliteBackend {
                     f64::from(mem.retrievability),
                     mem.agent_id.map(|u| u.to_string()),
                     mem.user_id.map(|u| u.to_string()),
+                    mem.superseded_by.map(|u| u.to_string()),
                 ],
             )?;
 
@@ -1135,7 +1170,7 @@ impl StorageTrait for SqliteBackend {
                 r"SELECT id, namespace_id, subject, predicate, object, content_type,
                           object_entity, confidence, valid_at, invalid_at,
                           source_episodes, embedding, stability, retrievability,
-                          agent_id, user_id
+                          agent_id, user_id, superseded_by
                    FROM semantic_memories WHERE id = ?1",
                 params![id.to_string()],
                 row_to_semantic,
@@ -1154,8 +1189,8 @@ impl StorageTrait for SqliteBackend {
             r"SELECT id, namespace_id, subject, predicate, object, content_type,
                       object_entity, confidence, valid_at, invalid_at,
                       source_episodes, embedding, stability, retrievability,
-                      agent_id, user_id
-               FROM semantic_memories WHERE subject = ?1
+                      agent_id, user_id, superseded_by
+               FROM semantic_memories WHERE subject = ?1 AND superseded_by IS NULL
                ORDER BY valid_at DESC LIMIT ?2",
         )?;
         let rows = stmt.query_map(
@@ -1182,9 +1217,9 @@ impl StorageTrait for SqliteBackend {
             r"SELECT id, namespace_id, episode_id, source_entity, about_entity, content,
                       content_type, summary, embedding, context_intent, timestamp,
                       stability, retrievability, access_count, last_accessed, event_time,
-                      agent_id, user_id
+                      agent_id, user_id, superseded_by, invalid_at
                FROM episodic_memories
-               WHERE namespace_id = ?1 AND episode_id = ?2
+               WHERE namespace_id = ?1 AND episode_id = ?2 AND superseded_by IS NULL
                ORDER BY COALESCE(event_time, timestamp) ASC",
         )?;
         let rows = stmt.query_map(
@@ -1227,8 +1262,8 @@ impl StorageTrait for SqliteBackend {
             r"INSERT OR REPLACE INTO procedural_memories
                (id, namespace_id, trigger_text, action, outcome, context, reliability,
                 trial_count, success_count, source_episodes, embedding, created_at, last_used,
-                agent_id, user_id)
-               VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)",
+                agent_id, user_id, superseded_by, invalid_at)
+               VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)",
             params![
                 mem.id.to_string(),
                 mem.namespace_id.to_string(),
@@ -1245,6 +1280,8 @@ impl StorageTrait for SqliteBackend {
                 last_used,
                 mem.agent_id.map(|u| u.to_string()),
                 mem.user_id.map(|u| u.to_string()),
+                mem.superseded_by.map(|u| u.to_string()),
+                opt_dt_to_str(mem.invalid_at),
             ],
         )?;
 
@@ -1269,7 +1306,7 @@ impl StorageTrait for SqliteBackend {
             .query_row(
                 r"SELECT id, namespace_id, trigger_text, action, outcome, context, reliability,
                           trial_count, success_count, source_episodes, embedding, created_at, last_used,
-                          agent_id, user_id
+                          agent_id, user_id, superseded_by, invalid_at
                    FROM procedural_memories WHERE id = ?1",
                 params![id.to_string()],
                 row_to_procedural,
@@ -1324,8 +1361,8 @@ impl StorageTrait for SqliteBackend {
                 r"INSERT OR REPLACE INTO observation_memories
                    (id, namespace_id, episode_id, entity_type, instance, action, quantity, unit,
                     content, embedding, confidence, event_time, created_at, stability, retrievability,
-                    agent_id, user_id)
-                   VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)",
+                    agent_id, user_id, superseded_by, invalid_at)
+                   VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19)",
                 params![
                     mem.id.to_string(),
                     mem.namespace_id.to_string(),
@@ -1344,6 +1381,8 @@ impl StorageTrait for SqliteBackend {
                     f64::from(mem.retrievability),
                     mem.agent_id.map(|u| u.to_string()),
                     mem.user_id.map(|u| u.to_string()),
+                    mem.superseded_by.map(|u| u.to_string()),
+                    opt_dt_to_str(mem.invalid_at),
                 ],
             )?;
             conn.execute(
@@ -1376,7 +1415,7 @@ impl StorageTrait for SqliteBackend {
             .query_row(
                 r"SELECT id, namespace_id, episode_id, entity_type, instance, action, quantity,
                           unit, content, embedding, confidence, event_time, created_at,
-                          stability, retrievability, agent_id, user_id
+                          stability, retrievability, agent_id, user_id, superseded_by, invalid_at
                    FROM observation_memories WHERE id = ?1",
                 params![id.to_string()],
                 row_to_observation,
@@ -1398,9 +1437,9 @@ impl StorageTrait for SqliteBackend {
         let sql = format!(
             "SELECT id, namespace_id, episode_id, entity_type, instance, action, quantity, \
               unit, content, embedding, confidence, event_time, created_at, \
-              stability, retrievability, agent_id, user_id \
+              stability, retrievability, agent_id, user_id, superseded_by, invalid_at \
              FROM observation_memories \
-             WHERE episode_id IN ({placeholders}) \
+             WHERE episode_id IN ({placeholders}) AND superseded_by IS NULL \
              ORDER BY created_at ASC \
              LIMIT ?"
         );
@@ -1568,6 +1607,20 @@ impl StorageTrait for SqliteBackend {
             r"SELECT memory_id, memory_type FROM memory_fts
                WHERE memory_fts MATCH ?1 AND namespace_id = ?2
                  AND memory_type != 'observation'
+                 AND (
+                     (memory_type = 'episodic' AND EXISTS (
+                         SELECT 1 FROM episodic_memories e
+                         WHERE e.id = memory_id AND e.superseded_by IS NULL
+                     ))
+                     OR (memory_type = 'semantic' AND EXISTS (
+                         SELECT 1 FROM semantic_memories s
+                         WHERE s.id = memory_id AND s.superseded_by IS NULL
+                     ))
+                     OR (memory_type = 'procedural' AND EXISTS (
+                         SELECT 1 FROM procedural_memories p
+                         WHERE p.id = memory_id AND p.superseded_by IS NULL
+                     ))
+                 )
                LIMIT ?3",
         )?;
         let rows: Vec<(String, String)> = stmt
@@ -1593,7 +1646,7 @@ impl StorageTrait for SqliteBackend {
                             r"SELECT id, namespace_id, episode_id, source_entity, about_entity, content,
                                       content_type, summary, embedding, context_intent, timestamp,
                                       stability, retrievability, access_count, last_accessed, event_time,
-                                      agent_id, user_id
+                                      agent_id, user_id, superseded_by, invalid_at
                                FROM episodic_memories WHERE id = ?1",
                             params![id.to_string()],
                             row_to_episodic,
@@ -1609,7 +1662,7 @@ impl StorageTrait for SqliteBackend {
                             r"SELECT id, namespace_id, subject, predicate, object, content_type,
                                       object_entity, confidence, valid_at, invalid_at,
                                       source_episodes, embedding, stability, retrievability,
-                                      agent_id, user_id
+                                      agent_id, user_id, superseded_by
                                FROM semantic_memories WHERE id = ?1",
                             params![id.to_string()],
                             row_to_semantic,
@@ -1624,7 +1677,7 @@ impl StorageTrait for SqliteBackend {
                         .query_row(
                             r"SELECT id, namespace_id, trigger_text, action, outcome, context, reliability,
                                       trial_count, success_count, source_episodes, embedding, created_at, last_used,
-                                      agent_id, user_id
+                                      agent_id, user_id, superseded_by, invalid_at
                                FROM procedural_memories WHERE id = ?1",
                             params![id.to_string()],
                             row_to_procedural,
@@ -1673,6 +1726,7 @@ impl StorageTrait for SqliteBackend {
                      AND f.namespace_id = ?2
                      AND f.memory_type = 'semantic'
                      AND s.subject = ?3
+                     AND s.superseded_by IS NULL
                    LIMIT ?4",
             )?;
             let rows: Vec<String> = stmt
@@ -1691,7 +1745,7 @@ impl StorageTrait for SqliteBackend {
                         r"SELECT id, namespace_id, subject, predicate, object, content_type,
                                   object_entity, confidence, valid_at, invalid_at,
                                   source_episodes, embedding, stability, retrievability,
-                                  agent_id, user_id
+                                  agent_id, user_id, superseded_by
                            FROM semantic_memories WHERE id = ?1",
                         params![id.to_string()],
                         row_to_semantic,
@@ -1714,6 +1768,7 @@ impl StorageTrait for SqliteBackend {
                      AND f.namespace_id = ?2
                      AND f.memory_type = 'episodic'
                      AND (e.about_entity = ?3 OR e.source_entity = ?3)
+                     AND e.superseded_by IS NULL
                    LIMIT ?4",
             )?;
             let rows: Vec<String> = stmt
@@ -1732,7 +1787,7 @@ impl StorageTrait for SqliteBackend {
                         r"SELECT id, namespace_id, episode_id, source_entity, about_entity, content,
                                   content_type, summary, embedding, context_intent, timestamp,
                                   stability, retrievability, access_count, last_accessed, event_time,
-                                  agent_id, user_id
+                                  agent_id, user_id, superseded_by, invalid_at
                            FROM episodic_memories WHERE id = ?1",
                         params![id.to_string()],
                         row_to_episodic,
@@ -1754,68 +1809,47 @@ impl StorageTrait for SqliteBackend {
 
     fn get_all_memories_by_namespace(&self, namespace_id: Uuid) -> StorageResult<Vec<Memory>> {
         let conn = lock_conn!(self);
-        let ns_str = namespace_id.to_string();
-        let mut memories = Vec::new();
+        load_memories_by_namespace(&conn, namespace_id, false)
+    }
 
-        // Episodic
-        {
-            let mut stmt = conn.prepare(
-                r"SELECT id, namespace_id, episode_id, source_entity, about_entity, content,
-                          content_type, summary, embedding, context_intent, timestamp,
-                          stability, retrievability, access_count, last_accessed, event_time,
-                          agent_id, user_id
-                   FROM episodic_memories WHERE namespace_id = ?1",
+    fn get_all_memories_by_namespace_including_superseded(
+        &self,
+        namespace_id: Uuid,
+    ) -> StorageResult<Vec<Memory>> {
+        let conn = lock_conn!(self);
+        load_memories_by_namespace(&conn, namespace_id, true)
+    }
+
+    fn supersede_memory(
+        &self,
+        id: Uuid,
+        superseded_by: Uuid,
+        invalid_at: DateTime<Utc>,
+    ) -> StorageResult<bool> {
+        let conn = lock_conn!(self);
+        let id = id.to_string();
+        let superseded_by = superseded_by.to_string();
+        let invalid_at = invalid_at.to_rfc3339();
+
+        for table in [
+            "episodic_memories",
+            "semantic_memories",
+            "procedural_memories",
+            "observation_memories",
+        ] {
+            let updated = conn.execute(
+                &format!(
+                    "UPDATE {table} SET superseded_by = ?1, invalid_at = ?2 \
+                     WHERE id = ?3 AND superseded_by IS NULL"
+                ),
+                params![&superseded_by, &invalid_at, &id],
             )?;
-            let rows = stmt.query_map(params![&ns_str], row_to_episodic)?;
-            for row in rows {
-                memories.push(Memory::Episodic(row??));
+            if updated > 0 {
+                return Ok(true);
             }
         }
 
-        // Semantic
-        {
-            let mut stmt = conn.prepare(
-                r"SELECT id, namespace_id, subject, predicate, object, content_type,
-                          object_entity, confidence, valid_at, invalid_at,
-                          source_episodes, embedding, stability, retrievability,
-                          agent_id, user_id
-                   FROM semantic_memories WHERE namespace_id = ?1",
-            )?;
-            let rows = stmt.query_map(params![&ns_str], row_to_semantic)?;
-            for row in rows {
-                memories.push(Memory::Semantic(row??));
-            }
-        }
-
-        // Procedural
-        {
-            let mut stmt = conn.prepare(
-                r"SELECT id, namespace_id, trigger_text, action, outcome, context, reliability,
-                          trial_count, success_count, source_episodes, embedding, created_at, last_used,
-                          agent_id, user_id
-                   FROM procedural_memories WHERE namespace_id = ?1",
-            )?;
-            let rows = stmt.query_map(params![&ns_str], row_to_procedural)?;
-            for row in rows {
-                memories.push(Memory::Procedural(row??));
-            }
-        }
-
-        // Observation
-        {
-            let mut stmt = conn.prepare(
-                r"SELECT id, namespace_id, episode_id, entity_type, instance, action, quantity,
-                          unit, content, embedding, confidence, event_time, created_at,
-                          stability, retrievability, agent_id, user_id
-                   FROM observation_memories WHERE namespace_id = ?1",
-            )?;
-            let rows = stmt.query_map(params![&ns_str], row_to_observation)?;
-            for row in rows {
-                memories.push(Memory::Observation(row??));
-            }
-        }
-
-        Ok(memories)
+        Ok(false)
     }
 
     // -----------------------------------------------------------------------
@@ -1920,14 +1954,18 @@ impl StorageTrait for SqliteBackend {
         };
 
         let where_sql: &'static str = match bind {
-            ScopeBind::NsOnly => "namespace_id = ?1",
-            ScopeBind::AgentOnly(_) => "namespace_id = ?1 AND agent_id = ?2",
-            ScopeBind::Both(_, _) => "namespace_id = ?1 AND agent_id = ?2 AND user_id = ?3",
+            ScopeBind::NsOnly => "namespace_id = ?1 AND superseded_by IS NULL",
+            ScopeBind::AgentOnly(_) => {
+                "namespace_id = ?1 AND agent_id = ?2 AND superseded_by IS NULL"
+            }
+            ScopeBind::Both(_, _) => {
+                "namespace_id = ?1 AND agent_id = ?2 AND user_id = ?3 AND superseded_by IS NULL"
+            }
             ScopeBind::AgentSetUserNull(_) => {
-                "namespace_id = ?1 AND agent_id = ?2 AND user_id IS NULL"
+                "namespace_id = ?1 AND agent_id = ?2 AND user_id IS NULL AND superseded_by IS NULL"
             }
             ScopeBind::UserSetAgentNull(_) => {
-                "namespace_id = ?1 AND agent_id IS NULL AND user_id = ?2"
+                "namespace_id = ?1 AND agent_id IS NULL AND user_id = ?2 AND superseded_by IS NULL"
             }
         };
 
@@ -1966,7 +2004,7 @@ impl StorageTrait for SqliteBackend {
             "SELECT id, namespace_id, episode_id, source_entity, about_entity, content, \
               content_type, summary, embedding, context_intent, timestamp, \
               stability, retrievability, access_count, last_accessed, event_time, \
-              agent_id, user_id \
+              agent_id, user_id, superseded_by, invalid_at \
              FROM episodic_memories",
             row_to_episodic,
             Memory::Episodic
@@ -1976,7 +2014,8 @@ impl StorageTrait for SqliteBackend {
         run_scoped!(
             "SELECT id, namespace_id, subject, predicate, object, content_type, \
               object_entity, confidence, valid_at, invalid_at, \
-              source_episodes, embedding, stability, retrievability, agent_id, user_id \
+              source_episodes, embedding, stability, retrievability, agent_id, user_id, \
+              superseded_by \
              FROM semantic_memories",
             row_to_semantic,
             Memory::Semantic
@@ -1986,7 +2025,7 @@ impl StorageTrait for SqliteBackend {
         run_scoped!(
             "SELECT id, namespace_id, trigger_text, action, outcome, context, reliability, \
               trial_count, success_count, source_episodes, embedding, created_at, last_used, \
-              agent_id, user_id \
+              agent_id, user_id, superseded_by, invalid_at \
              FROM procedural_memories",
             row_to_procedural,
             Memory::Procedural
@@ -1996,7 +2035,7 @@ impl StorageTrait for SqliteBackend {
         run_scoped!(
             "SELECT id, namespace_id, episode_id, entity_type, instance, action, quantity, \
               unit, content, embedding, confidence, event_time, created_at, \
-              stability, retrievability, agent_id, user_id \
+              stability, retrievability, agent_id, user_id, superseded_by, invalid_at \
              FROM observation_memories",
             row_to_observation,
             Memory::Observation
@@ -2536,6 +2575,67 @@ impl StorageTrait for SqliteBackend {
 // Row mapping helpers (free functions to avoid borrowing issues)
 // ---------------------------------------------------------------------------
 
+fn load_memories_by_namespace(
+    conn: &Connection,
+    namespace_id: Uuid,
+    include_superseded: bool,
+) -> StorageResult<Vec<Memory>> {
+    let ns_str = namespace_id.to_string();
+    let mut memories = Vec::new();
+
+    let mut stmt = conn.prepare(
+        r"SELECT id, namespace_id, episode_id, source_entity, about_entity, content,
+                  content_type, summary, embedding, context_intent, timestamp,
+                  stability, retrievability, access_count, last_accessed, event_time,
+                  agent_id, user_id, superseded_by, invalid_at
+           FROM episodic_memories
+           WHERE namespace_id = ?1 AND (?2 OR superseded_by IS NULL)",
+    )?;
+    let rows = stmt.query_map(params![&ns_str, include_superseded], row_to_episodic)?;
+    for row in rows {
+        memories.push(Memory::Episodic(row??));
+    }
+
+    let mut stmt = conn.prepare(
+        r"SELECT id, namespace_id, subject, predicate, object, content_type,
+                  object_entity, confidence, valid_at, invalid_at,
+                  source_episodes, embedding, stability, retrievability,
+                  agent_id, user_id, superseded_by
+           FROM semantic_memories
+           WHERE namespace_id = ?1 AND (?2 OR superseded_by IS NULL)",
+    )?;
+    let rows = stmt.query_map(params![&ns_str, include_superseded], row_to_semantic)?;
+    for row in rows {
+        memories.push(Memory::Semantic(row??));
+    }
+
+    let mut stmt = conn.prepare(
+        r"SELECT id, namespace_id, trigger_text, action, outcome, context, reliability,
+                  trial_count, success_count, source_episodes, embedding, created_at, last_used,
+                  agent_id, user_id, superseded_by, invalid_at
+           FROM procedural_memories
+           WHERE namespace_id = ?1 AND (?2 OR superseded_by IS NULL)",
+    )?;
+    let rows = stmt.query_map(params![&ns_str, include_superseded], row_to_procedural)?;
+    for row in rows {
+        memories.push(Memory::Procedural(row??));
+    }
+
+    let mut stmt = conn.prepare(
+        r"SELECT id, namespace_id, episode_id, entity_type, instance, action, quantity,
+                  unit, content, embedding, confidence, event_time, created_at,
+                  stability, retrievability, agent_id, user_id, superseded_by, invalid_at
+           FROM observation_memories
+           WHERE namespace_id = ?1 AND (?2 OR superseded_by IS NULL)",
+    )?;
+    let rows = stmt.query_map(params![&ns_str, include_superseded], row_to_observation)?;
+    for row in rows {
+        memories.push(Memory::Observation(row??));
+    }
+
+    Ok(memories)
+}
+
 /// Parse a UUID string, returning `StorageError::Context` on failure.
 fn parse_uuid(s: &str) -> Result<Uuid, StorageError> {
     Uuid::parse_str(s).map_err(|e| StorageError::Context(format!("corrupt UUID: {e}")))
@@ -2563,6 +2663,8 @@ fn row_to_episodic(
     // G1: scope columns are nullable. Legacy v2.1 rows return NULL.
     let agent_id_str: Option<String> = row.get(16)?;
     let user_id_str: Option<String> = row.get(17)?;
+    let superseded_by_str: Option<String> = row.get(18)?;
+    let invalid_at_str: Option<String> = row.get(19)?;
 
     let id = match parse_uuid(&id_str) {
         Ok(v) => v,
@@ -2595,6 +2697,11 @@ fn row_to_episodic(
         Some(Err(e)) => return Ok(Err(e)),
         None => None,
     };
+    let superseded_by = match superseded_by_str.as_deref().map(parse_uuid) {
+        Some(Ok(v)) => Some(v),
+        Some(Err(e)) => return Ok(Err(e)),
+        None => None,
+    };
 
     Ok(Ok(EpisodicMemory {
         id,
@@ -2622,7 +2729,8 @@ fn row_to_episodic(
         // in v1.0.5 and earlier, see
         // pensyve-docs/research/benchmark-sprint/06-phase-v-verification.md.
         event_time: str_to_opt_dt(event_time_str.as_deref()),
-        superseded_by: None,
+        superseded_by,
+        invalid_at: str_to_opt_dt(invalid_at_str.as_deref()),
         agent_id,
         user_id,
     }))
@@ -2648,6 +2756,7 @@ fn row_to_semantic(
     // G1: scope columns are nullable. Legacy v2.1 rows return NULL.
     let agent_id_str: Option<String> = row.get(14)?;
     let user_id_str: Option<String> = row.get(15)?;
+    let superseded_by_str: Option<String> = row.get(16)?;
 
     let id = match parse_uuid(&id_str) {
         Ok(v) => v,
@@ -2672,6 +2781,11 @@ fn row_to_semantic(
         Some(Err(e)) => return Ok(Err(e)),
         None => None,
     };
+    let superseded_by = match superseded_by_str.as_deref().map(parse_uuid) {
+        Some(Ok(v)) => Some(v),
+        Some(Err(e)) => return Ok(Err(e)),
+        None => None,
+    };
 
     Ok(Ok(SemanticMemory {
         id,
@@ -2688,6 +2802,7 @@ fn row_to_semantic(
         confidence: confidence as f32,
         valid_at: str_to_dt(&valid_at_str),
         invalid_at: str_to_opt_dt(invalid_at_str.as_deref()),
+        superseded_by,
         source_episodes: json_to_uuids(&source_episodes_str),
         embedding: embedding_bytes
             .as_deref()
@@ -2719,6 +2834,8 @@ fn row_to_procedural(
     // G1: scope columns are nullable. Legacy v2.1 rows return NULL.
     let agent_id_str: Option<String> = row.get(13)?;
     let user_id_str: Option<String> = row.get(14)?;
+    let superseded_by_str: Option<String> = row.get(15)?;
+    let invalid_at_str: Option<String> = row.get(16)?;
 
     let context: HashMap<String, serde_json::Value> = match serde_json::from_str(&context_str) {
         Ok(v) => v,
@@ -2744,6 +2861,11 @@ fn row_to_procedural(
         Some(Err(e)) => return Ok(Err(e)),
         None => None,
     };
+    let superseded_by = match superseded_by_str.as_deref().map(parse_uuid) {
+        Some(Ok(v)) => Some(v),
+        Some(Err(e)) => return Ok(Err(e)),
+        None => None,
+    };
 
     Ok(Ok(ProceduralMemory {
         id,
@@ -2762,6 +2884,8 @@ fn row_to_procedural(
             .unwrap_or_default(),
         created_at: str_to_dt(&created_at_str),
         last_used: str_to_opt_dt(last_used_str.as_deref()),
+        superseded_by,
+        invalid_at: str_to_opt_dt(invalid_at_str.as_deref()),
         agent_id,
         user_id,
     }))
@@ -2788,6 +2912,8 @@ fn row_to_observation(
     // G1: scope columns are nullable. Legacy v2.1 rows return NULL.
     let agent_id_str: Option<String> = row.get(15)?;
     let user_id_str: Option<String> = row.get(16)?;
+    let superseded_by_str: Option<String> = row.get(17)?;
+    let invalid_at_str: Option<String> = row.get(18)?;
 
     let id = match parse_uuid(&id_str) {
         Ok(v) => v,
@@ -2807,6 +2933,11 @@ fn row_to_observation(
         None => None,
     };
     let user_id = match user_id_str.as_deref().map(parse_uuid) {
+        Some(Ok(v)) => Some(v),
+        Some(Err(e)) => return Ok(Err(e)),
+        None => None,
+    };
+    let superseded_by = match superseded_by_str.as_deref().map(parse_uuid) {
         Some(Ok(v)) => Some(v),
         Some(Err(e)) => return Ok(Err(e)),
         None => None,
@@ -2831,6 +2962,8 @@ fn row_to_observation(
         created_at: str_to_dt(&created_at_str),
         stability: stability as f32,
         retrievability: retrievability as f32,
+        superseded_by,
+        invalid_at: str_to_opt_dt(invalid_at_str.as_deref()),
         agent_id,
         user_id,
     }))
@@ -3750,12 +3883,12 @@ mod tests {
     #[test]
     fn migration_v3_upgrades_existing_pre_v3_store() {
         // Simulate a store that previously stopped at v2 (no kg_* tables)
-        // by removing the v3 row + tables, then re-running migrations
+        // by removing the v3+ registry rows and KG tables, then re-running migrations
         // and asserting the tables come back.
         let (_dir, db) = setup();
         {
             let conn = db.conn.lock().unwrap();
-            conn.execute("DELETE FROM schema_versions WHERE version = 3", [])
+            conn.execute("DELETE FROM schema_versions WHERE version IN (3, 4)", [])
                 .unwrap();
             conn.execute_batch(
                 "DROP TABLE IF EXISTS kg_passage_entities;
@@ -4020,5 +4153,86 @@ mod tests {
         assert_eq!(kg_entities_count_for_namespace(&db, ns_b.id), 2);
         assert_eq!(kg_triples_count_for_passage(&db, obs_b.id), 1);
         assert_eq!(kg_passage_entities_count_for_passage(&db, obs_b.id), 2);
+    }
+
+    #[test]
+    fn supersession_columns_round_trip_for_all_memory_kinds() {
+        let (_dir, db) = setup();
+        let ns = make_namespace(&db);
+        let successor = Uuid::new_v4();
+        let invalid_at = Utc::now();
+
+        let mut episodic = EpisodicMemory::new(
+            ns.id,
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            "episodic",
+        );
+        episodic.superseded_by = Some(successor);
+        episodic.invalid_at = Some(invalid_at);
+        db.save_episodic(&episodic).unwrap();
+        let episodic_read = db.get_episodic(episodic.id).unwrap().unwrap();
+        assert_eq!(episodic_read.superseded_by, Some(successor));
+        assert_eq!(episodic_read.invalid_at, Some(invalid_at));
+
+        let mut semantic = SemanticMemory::new(ns.id, Uuid::new_v4(), "semantic", "memory", 0.9);
+        semantic.superseded_by = Some(successor);
+        semantic.invalid_at = Some(invalid_at);
+        db.save_semantic(&semantic).unwrap();
+        let semantic_read = db.get_semantic(semantic.id).unwrap().unwrap();
+        assert_eq!(semantic_read.superseded_by, Some(successor));
+        assert_eq!(semantic_read.invalid_at, Some(invalid_at));
+
+        let mut procedural =
+            ProceduralMemory::new(ns.id, "trigger", "action", Outcome::Success, HashMap::new());
+        procedural.superseded_by = Some(successor);
+        procedural.invalid_at = Some(invalid_at);
+        db.save_procedural(&procedural).unwrap();
+        let procedural_read = db.get_procedural(procedural.id).unwrap().unwrap();
+        assert_eq!(procedural_read.superseded_by, Some(successor));
+        assert_eq!(procedural_read.invalid_at, Some(invalid_at));
+
+        let mut observation = ObservationMemory::new(
+            ns.id,
+            Uuid::new_v4(),
+            "entity",
+            "instance",
+            "action",
+            "observation",
+        );
+        observation.superseded_by = Some(successor);
+        observation.invalid_at = Some(invalid_at);
+        db.save_observation(&observation).unwrap();
+        let observation_read = db.get_observation(observation.id).unwrap().unwrap();
+        assert_eq!(observation_read.superseded_by, Some(successor));
+        assert_eq!(observation_read.invalid_at, Some(invalid_at));
+    }
+
+    #[test]
+    fn superseded_rows_are_excluded_from_bulk_and_fts_but_available_for_audit() {
+        let (_dir, db) = setup();
+        let ns = make_namespace(&db);
+        let subject = Uuid::new_v4();
+        let old = SemanticMemory::new(ns.id, subject, "legacytoken", "value", 0.8);
+        let new = SemanticMemory::new(ns.id, subject, "currenttoken", "value", 0.9);
+        db.save_semantic(&old).unwrap();
+        db.save_semantic(&new).unwrap();
+        assert!(db.supersede_memory(old.id, new.id, Utc::now()).unwrap());
+
+        let live = db.get_all_memories_by_namespace(ns.id).unwrap();
+        assert_eq!(live.len(), 1);
+        assert_eq!(live[0].id(), new.id);
+
+        let history = db
+            .get_all_memories_by_namespace_including_superseded(ns.id)
+            .unwrap();
+        assert_eq!(history.len(), 2);
+        assert!(history.iter().any(|memory| memory.id() == old.id));
+
+        assert!(db.search_fts("legacytoken", ns.id, 10).unwrap().is_empty());
+        let current_hits = db.search_fts("currenttoken", ns.id, 10).unwrap();
+        assert_eq!(current_hits.len(), 1);
+        assert_eq!(current_hits[0].id(), new.id);
     }
 }

--- a/pensyve-core/src/storage/sqlite.rs
+++ b/pensyve-core/src/storage/sqlite.rs
@@ -2436,19 +2436,19 @@ impl StorageTrait for SqliteBackend {
         let ns = namespace_id.to_string();
 
         let episodic: i64 = conn.query_row(
-            "SELECT COUNT(*) FROM episodic_memories WHERE namespace_id = ?1",
+            "SELECT COUNT(*) FROM episodic_memories WHERE namespace_id = ?1 AND superseded_by IS NULL",
             params![ns],
             |row| row.get(0),
         )?;
 
         let semantic: i64 = conn.query_row(
-            "SELECT COUNT(*) FROM semantic_memories WHERE namespace_id = ?1 AND invalid_at IS NULL",
+            "SELECT COUNT(*) FROM semantic_memories WHERE namespace_id = ?1 AND invalid_at IS NULL AND superseded_by IS NULL",
             params![ns],
             |row| row.get(0),
         )?;
 
         let procedural: i64 = conn.query_row(
-            "SELECT COUNT(*) FROM procedural_memories WHERE namespace_id = ?1",
+            "SELECT COUNT(*) FROM procedural_memories WHERE namespace_id = ?1 AND superseded_by IS NULL",
             params![ns],
             |row| row.get(0),
         )?;
@@ -4207,6 +4207,111 @@ mod tests {
         let observation_read = db.get_observation(observation.id).unwrap().unwrap();
         assert_eq!(observation_read.superseded_by, Some(successor));
         assert_eq!(observation_read.invalid_at, Some(invalid_at));
+    }
+
+    #[test]
+    fn active_counts_exclude_superseded_rows_for_all_memory_kinds() {
+        let (_dir, db) = setup();
+        let ns = make_namespace(&db);
+
+        let old_episodic = EpisodicMemory::new(
+            ns.id,
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            "old episodic",
+        );
+        let new_episodic = EpisodicMemory::new(
+            ns.id,
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            "new episodic",
+        );
+        db.save_episodic(&old_episodic).unwrap();
+        db.save_episodic(&new_episodic).unwrap();
+
+        let old_semantic = SemanticMemory::new(ns.id, Uuid::new_v4(), "old", "semantic", 0.8);
+        let new_semantic = SemanticMemory::new(ns.id, Uuid::new_v4(), "new", "semantic", 0.9);
+        db.save_semantic(&old_semantic).unwrap();
+        db.save_semantic(&new_semantic).unwrap();
+
+        let old_procedural = ProceduralMemory::new(
+            ns.id,
+            "old trigger",
+            "old action",
+            Outcome::Failure,
+            HashMap::new(),
+        );
+        let new_procedural = ProceduralMemory::new(
+            ns.id,
+            "new trigger",
+            "new action",
+            Outcome::Success,
+            HashMap::new(),
+        );
+        db.save_procedural(&old_procedural).unwrap();
+        db.save_procedural(&new_procedural).unwrap();
+
+        let old_observation = ObservationMemory::new(
+            ns.id,
+            Uuid::new_v4(),
+            "person",
+            "alice",
+            "stated",
+            "old observation",
+        );
+        let new_observation = ObservationMemory::new(
+            ns.id,
+            Uuid::new_v4(),
+            "person",
+            "alice",
+            "stated",
+            "new observation",
+        );
+        db.save_observation(&old_observation).unwrap();
+        db.save_observation(&new_observation).unwrap();
+
+        for (old_id, new_id) in [
+            (old_episodic.id, new_episodic.id),
+            (old_semantic.id, new_semantic.id),
+            (old_procedural.id, new_procedural.id),
+            (old_observation.id, new_observation.id),
+        ] {
+            assert!(db.supersede_memory(old_id, new_id, Utc::now()).unwrap());
+        }
+
+        assert_eq!(db.count_memories_by_namespace(ns.id).unwrap(), (1, 1, 1));
+
+        let active = db.get_all_memories_by_namespace(ns.id).unwrap();
+        assert_eq!(
+            active
+                .iter()
+                .filter(|memory| matches!(memory, Memory::Episodic(_)))
+                .count(),
+            1
+        );
+        assert_eq!(
+            active
+                .iter()
+                .filter(|memory| matches!(memory, Memory::Semantic(_)))
+                .count(),
+            1
+        );
+        assert_eq!(
+            active
+                .iter()
+                .filter(|memory| matches!(memory, Memory::Procedural(_)))
+                .count(),
+            1
+        );
+        assert_eq!(
+            active
+                .iter()
+                .filter(|memory| matches!(memory, Memory::Observation(_)))
+                .count(),
+            1
+        );
     }
 
     #[test]

--- a/pensyve-core/src/types.rs
+++ b/pensyve-core/src/types.rs
@@ -335,6 +335,9 @@ pub struct EpisodicMemory {
     /// If this memory was superseded by a newer one, its ID.
     #[serde(default)]
     pub superseded_by: Option<Uuid>,
+    /// When this memory stopped being valid because it was superseded.
+    #[serde(default)]
+    pub invalid_at: Option<DateTime<Utc>>,
     /// Multi-tenant agent scope (G1). NULL = legacy unscoped row.
     #[serde(default)]
     pub agent_id: Option<Uuid>,
@@ -375,6 +378,7 @@ impl EpisodicMemory {
             storage_strength: 0.0,
             event_time: None,
             superseded_by: None,
+            invalid_at: None,
             agent_id: None,
             user_id: None,
         }
@@ -400,6 +404,9 @@ pub struct SemanticMemory {
     pub confidence: f32,
     pub valid_at: DateTime<Utc>,
     pub invalid_at: Option<DateTime<Utc>>,
+    /// If this memory was superseded by a newer one, its ID.
+    #[serde(default)]
+    pub superseded_by: Option<Uuid>,
     pub source_episodes: Vec<Uuid>,
     pub embedding: Vec<f32>,
     pub stability: f32,
@@ -431,6 +438,7 @@ impl SemanticMemory {
             confidence,
             valid_at: Utc::now(),
             invalid_at: None,
+            superseded_by: None,
             source_episodes: Vec::new(),
             embedding: Vec::new(),
             stability: 1.0,
@@ -461,6 +469,12 @@ pub struct ProceduralMemory {
     pub embedding: Vec<f32>,
     pub created_at: DateTime<Utc>,
     pub last_used: Option<DateTime<Utc>>,
+    /// If this memory was superseded by a newer one, its ID.
+    #[serde(default)]
+    pub superseded_by: Option<Uuid>,
+    /// When this memory stopped being valid because it was superseded.
+    #[serde(default)]
+    pub invalid_at: Option<DateTime<Utc>>,
     /// Multi-tenant agent scope (G1). NULL = legacy unscoped row.
     #[serde(default)]
     pub agent_id: Option<Uuid>,
@@ -496,6 +510,8 @@ impl ProceduralMemory {
             embedding: Vec::new(),
             created_at: Utc::now(),
             last_used: None,
+            superseded_by: None,
+            invalid_at: None,
             agent_id: None,
             user_id: None,
         }
@@ -567,6 +583,14 @@ pub struct ObservationMemory {
     /// Retrievability in [0, 1]; starts at 1.0 and decays with disuse.
     pub retrievability: f32,
 
+    /// If this memory was superseded by a newer one, its ID.
+    #[serde(default)]
+    pub superseded_by: Option<Uuid>,
+
+    /// When this memory stopped being valid because it was superseded.
+    #[serde(default)]
+    pub invalid_at: Option<DateTime<Utc>>,
+
     /// Multi-tenant agent scope (G1). NULL = legacy unscoped row.
     #[serde(default)]
     pub agent_id: Option<Uuid>,
@@ -601,6 +625,8 @@ impl ObservationMemory {
             created_at: Utc::now(),
             stability: 1.0,
             retrievability: 1.0,
+            superseded_by: None,
+            invalid_at: None,
             agent_id: None,
             user_id: None,
         }

--- a/pensyve-core/tests/test_migration_idempotency.rs
+++ b/pensyve-core/tests/test_migration_idempotency.rs
@@ -104,18 +104,16 @@ fn fresh_store_migration_is_idempotent() {
         let conn = open_raw(tmp.path());
 
         let rows = schema_version_rows(&conn);
-        // G3 added v=2 (typed-slot + chain_summary NULLABLE columns on
-        // observation_memories). Phase 2B added v=3 (kg_entities,
-        // kg_triples, kg_passage_entities). Fresh-store open lands
-        // v=1 + v=2 + v=3 in one pass.
+        // Fresh-store open lands every registered migration in one pass.
         assert_eq!(
             rows.len(),
-            3,
-            "expected v=1 + v=2 + v=3 migration rows after Phase 2B, got {rows:?}"
+            4,
+            "expected v=1 through v=4 migration rows, got {rows:?}"
         );
         assert_eq!(rows[0].0, 1, "expected version=1");
         assert_eq!(rows[1].0, 2, "expected version=2");
         assert_eq!(rows[2].0, 3, "expected version=3");
+        assert_eq!(rows[3].0, 4, "expected version=4");
 
         assert_migration_v1_landed(&conn);
     }
@@ -153,12 +151,12 @@ fn fresh_store_migration_is_idempotent() {
             rows, versions_first,
             "schema_versions changed on re-open: {rows:?} vs {versions_first:?}"
         );
-        // Phase 2B: 3 rows (v=1 + v=2 + v=3); all must remain stable
+        // Four registered migrations; all must remain stable
         // across reopens.
         assert_eq!(
             rows.len(),
-            3,
-            "duplicate schema_versions row inserted on re-run; expected 3 (v=1+v=2+v=3), got {rows:?}"
+            4,
+            "duplicate schema_versions row inserted on re-run; expected 4, got {rows:?}"
         );
 
         for (i, table) in PROJECTION_TABLES.iter().enumerate() {
@@ -335,18 +333,18 @@ fn v2_1_fixture_upgrade_lands_alters_and_preserves_rows() {
     // Schema landed.
     assert_migration_v1_landed(&conn);
 
-    // schema_versions registered THREE rows: v=1 (G1), v=2 (G3), and
-    // v=3 (Phase 2B). The v2.1 fixture starts pre-G1, so the upgrade
-    // open lands all three migrations in one pass.
+    // The v2.1 fixture starts pre-G1, so the upgrade open lands all four
+    // registered migrations in one pass.
     let rows = schema_version_rows(&conn);
     assert_eq!(
         rows.len(),
-        3,
-        "expected v=1 + v=2 + v=3 schema_versions rows, got {rows:?}"
+        4,
+        "expected v=1 through v=4 schema_versions rows, got {rows:?}"
     );
     assert_eq!(rows[0].0, 1);
     assert_eq!(rows[1].0, 2);
     assert_eq!(rows[2].0, 3);
+    assert_eq!(rows[3].0, 4);
 
     // Existing rows preserved with NULL agent_id + user_id (the locked
     // NULL-default design).
@@ -381,7 +379,7 @@ fn v2_1_fixture_upgrade_lands_alters_and_preserves_rows() {
     let rows = schema_version_rows(&conn);
     assert_eq!(
         rows.len(),
-        3,
-        "duplicate schema_versions row on re-run against fixture; expected 3 (v=1+v=2+v=3), got {rows:?}"
+        4,
+        "duplicate schema_versions row on re-run against fixture; expected 4, got {rows:?}"
     );
 }

--- a/pensyve-core/tests/test_multi_session_card.rs
+++ b/pensyve-core/tests/test_multi_session_card.rs
@@ -269,6 +269,49 @@ fn returns_none_when_no_entity_crosses_sessions() {
     );
 }
 
+#[test]
+fn superseded_observations_do_not_create_cross_session_entities() {
+    let (_dir, db_path, backend) = open_backend();
+    let ns = Uuid::new_v4();
+    let ns_str = ns.to_string();
+    let seed = Connection::open(&db_path).unwrap();
+
+    insert_obs(
+        &seed,
+        &ns_str,
+        "person",
+        "obsolete-person",
+        "mentioned",
+        "obsolete first mention",
+        Some("2024-01-01T10:00:00Z"),
+        None,
+        None,
+    );
+    insert_obs(
+        &seed,
+        &ns_str,
+        "person",
+        "obsolete-person",
+        "mentioned",
+        "obsolete second mention",
+        Some("2024-02-01T10:00:00Z"),
+        None,
+        None,
+    );
+    seed.execute(
+        "UPDATE observation_memories SET superseded_by = ?1 WHERE instance = ?2",
+        rusqlite::params![Uuid::new_v4().to_string(), "obsolete-person"],
+    )
+    .unwrap();
+    drop(seed);
+
+    let out = MultiSessionCard::new().build("q", backend.as_ref(), ns, None, None, None);
+    assert!(
+        out.is_none(),
+        "superseded observations must not create a cross-session card: {out:?}"
+    );
+}
+
 /// **Single-session-only entities are excluded.** Mix of cross-session
 /// and single-session entities — only the cross-session ones surface.
 #[test]

--- a/pensyve-core/tests/test_schema_v2_migration.rs
+++ b/pensyve-core/tests/test_schema_v2_migration.rs
@@ -105,17 +105,17 @@ fn fresh_store_lands_v2_migration() {
 
     let conn = open_raw(tmp.path());
 
-    // schema_versions has v=1 + v=2 + v=3 (Phase 2B added the
-    // dep-parse KG tables, so v=3 lands on every fresh-store open).
+    // Later migrations also land on every fresh-store open.
     let versions = schema_version_rows(&conn);
     assert_eq!(
         versions.len(),
-        3,
-        "expected v=1 + v=2 + v=3 migration rows, got {versions:?}"
+        4,
+        "expected v=1 through v=4 migration rows, got {versions:?}"
     );
     assert_eq!(versions[0].0, 1);
     assert_eq!(versions[1].0, 2);
     assert_eq!(versions[2].0, 3);
+    assert_eq!(versions[3].0, 4);
 
     // observation_memories has the new columns.
     assert_v2_columns_present(&conn);
@@ -176,8 +176,8 @@ fn v2_migration_idempotent_on_third_open() {
     let versions = schema_version_rows(&conn);
     assert_eq!(
         versions.len(),
-        3,
-        "exactly 3 schema_versions rows after 3 opens (v=1+v=2+v=3); got {versions:?}"
+        4,
+        "exactly 4 schema_versions rows after 3 opens (v=1 through v=4); got {versions:?}"
     );
     assert_v2_columns_present(&conn);
 }
@@ -336,8 +336,8 @@ fn v1_only_fixture_upgrades_to_v2() {
             )
             .unwrap_or_else(|e| panic!("drop column {col}: {e}"));
         }
-        conn.execute("DELETE FROM schema_versions WHERE version IN (2, 3)", [])
-            .expect("delete v=2 and v=3 schema_versions rows");
+        conn.execute("DELETE FROM schema_versions WHERE version IN (2, 3, 4)", [])
+            .expect("delete v=2 through v=4 schema_versions rows");
         conn.execute_batch(
             "DROP TABLE IF EXISTS kg_passage_entities;
              DROP TABLE IF EXISTS kg_triples;
@@ -375,12 +375,12 @@ fn v1_only_fixture_upgrades_to_v2() {
     // v=2 columns now present.
     assert_v2_columns_present(&conn);
 
-    // schema_versions has v=1 + v=2 + v=3 again (Phase 2B added v=3).
+    // schema_versions has v=1 through v=4 again.
     let versions = schema_version_rows(&conn);
     assert_eq!(
         versions.len(),
-        3,
-        "expected v=1 + v=2 + v=3 after upgrade; got {versions:?}"
+        4,
+        "expected v=1 through v=4 after upgrade; got {versions:?}"
     );
 
     // The legacy row survived with NULL across all new columns.

--- a/pensyve-core/tests/test_schema_v4_migration.rs
+++ b/pensyve-core/tests/test_schema_v4_migration.rs
@@ -1,0 +1,116 @@
+//! Issue #187 `SQLite` v4 supersession migration coverage.
+
+use std::path::Path;
+
+use pensyve_core::storage::sqlite::SqliteBackend;
+use rusqlite::{Connection, params};
+use tempfile::TempDir;
+use uuid::Uuid;
+
+const V4_COLUMNS: &[(&str, &str)] = &[
+    ("episodic_memories", "superseded_by"),
+    ("episodic_memories", "invalid_at"),
+    ("semantic_memories", "superseded_by"),
+    ("semantic_memories", "invalid_at"),
+    ("procedural_memories", "superseded_by"),
+    ("procedural_memories", "invalid_at"),
+    ("observation_memories", "superseded_by"),
+    ("observation_memories", "invalid_at"),
+];
+
+fn open_raw(dir: &Path) -> Connection {
+    Connection::open(dir.join("memories.db")).expect("open raw database")
+}
+
+fn column_exists(conn: &Connection, table: &str, column: &str) -> bool {
+    let mut statement = conn
+        .prepare(&format!("PRAGMA table_info({table})"))
+        .expect("prepare table info");
+    statement
+        .query_map([], |row| row.get::<_, String>(1))
+        .expect("query table info")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("collect table columns")
+        .iter()
+        .any(|candidate| candidate == column)
+}
+
+#[test]
+fn v3_database_upgrades_to_v4_without_losing_rows() {
+    let tempdir = TempDir::new().expect("tempdir");
+    {
+        let _storage = SqliteBackend::open(tempdir.path()).expect("create current database");
+    }
+
+    let legacy_id = Uuid::new_v4();
+    {
+        let conn = open_raw(tempdir.path());
+        conn.execute("DELETE FROM schema_versions WHERE version = 4", [])
+            .expect("remove v4 registry row");
+        for (table, column) in V4_COLUMNS {
+            // The pre-v4 SQLite schema already had the dead episodic
+            // superseded_by column; keep it to reproduce the real v3 shape.
+            if *table == "episodic_memories" && *column == "superseded_by" {
+                continue;
+            }
+            if *table == "semantic_memories" && *column == "invalid_at" {
+                continue;
+            }
+            conn.execute(&format!("ALTER TABLE {table} DROP COLUMN {column}"), [])
+                .unwrap_or_else(|error| panic!("drop {table}.{column}: {error}"));
+        }
+        conn.execute(
+            "INSERT INTO semantic_memories
+             (id, namespace_id, subject, predicate, object, confidence, valid_at)
+             VALUES (?1, ?2, ?3, 'likes', 'tea', 0.9, '2026-01-01T00:00:00Z')",
+            params![
+                legacy_id.to_string(),
+                Uuid::new_v4().to_string(),
+                Uuid::new_v4().to_string(),
+            ],
+        )
+        .expect("insert v3 semantic row");
+    }
+
+    {
+        let _storage = SqliteBackend::open(tempdir.path()).expect("upgrade v3 database");
+    }
+
+    let conn = open_raw(tempdir.path());
+    for (table, column) in V4_COLUMNS {
+        assert!(
+            column_exists(&conn, table, column),
+            "missing v4 column {table}.{column}"
+        );
+    }
+    let version_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM schema_versions WHERE version = 4",
+            [],
+            |row| row.get(0),
+        )
+        .expect("read v4 registry row");
+    assert_eq!(version_count, 1);
+
+    let (predicate, superseded_by): (String, Option<String>) = conn
+        .query_row(
+            "SELECT predicate, superseded_by FROM semantic_memories WHERE id = ?1",
+            params![legacy_id.to_string()],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .expect("legacy row survives v4 migration");
+    assert_eq!(predicate, "likes");
+    assert!(superseded_by.is_none());
+
+    drop(conn);
+    let _storage = SqliteBackend::open(tempdir.path()).expect("v4 reopen is idempotent");
+    let conn = open_raw(tempdir.path());
+    let version_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM schema_versions WHERE version = 4",
+            [],
+            |row| row.get(0),
+        )
+        .expect("read v4 registry row after reopen");
+    assert_eq!(version_count, 1);
+}

--- a/pensyve-core/tests/test_single_session_user_card.rs
+++ b/pensyve-core/tests/test_single_session_user_card.rs
@@ -324,6 +324,49 @@ fn fewer_sessions_than_n_returns_available_facts() {
     assert!(card.contains("session-2 standing fact"));
 }
 
+#[test]
+fn superseded_observations_do_not_displace_live_session_facts() {
+    let _guard = SsuEnvGuard::set("1");
+    let (_dir, db_path, backend) = make_backend();
+    let ns = Uuid::new_v4();
+    let ns_str = ns.to_string();
+
+    seed_row(
+        &db_path,
+        &ns_str,
+        None,
+        None,
+        "stated",
+        "live-fact",
+        "live older fact",
+        "2024-01-01T10:00:00Z",
+    );
+    seed_row(
+        &db_path,
+        &ns_str,
+        None,
+        None,
+        "stated",
+        "obsolete-fact",
+        "obsolete newer fact",
+        "2024-02-01T10:00:00Z",
+    );
+
+    let conn = Connection::open(&db_path).unwrap();
+    conn.execute(
+        "UPDATE observation_memories SET superseded_by = ?1 WHERE content = ?2",
+        rusqlite::params![Uuid::new_v4().to_string(), "obsolete newer fact"],
+    )
+    .unwrap();
+    drop(conn);
+
+    let card = SingleSessionUserCard::new()
+        .build("q", backend.as_ref(), ns, None, None, None)
+        .expect("the live session fact should remain visible");
+    assert!(card.contains("live older fact"), "card was: {card}");
+    assert!(!card.contains("obsolete newer fact"), "card was: {card}");
+}
+
 /// Empty store yields `None` (defer-on-failure path).
 #[test]
 fn empty_store_returns_none() {

--- a/pensyve-core/tests/test_supersession_card.rs
+++ b/pensyve-core/tests/test_supersession_card.rs
@@ -231,6 +231,37 @@ fn five_chain_summaries_surface_with_correct_format() {
     );
 }
 
+#[test]
+fn superseded_chain_summaries_are_excluded() {
+    let (_dir, db_path, backend) = open_backend();
+    let ns = Uuid::new_v4();
+    let conn = Connection::open(&db_path).unwrap();
+    insert_obs(
+        &conn,
+        &ns.to_string(),
+        Some("live chain summary"),
+        Some("2024-01-01T10:00:00Z"),
+    );
+    insert_obs(
+        &conn,
+        &ns.to_string(),
+        Some("obsolete chain summary"),
+        Some("2024-02-01T10:00:00Z"),
+    );
+    conn.execute(
+        "UPDATE observation_memories SET superseded_by = ?1 WHERE chain_summary = ?2",
+        rusqlite::params![Uuid::new_v4().to_string(), "obsolete chain summary"],
+    )
+    .unwrap();
+    drop(conn);
+
+    let out = SupersessionCard::new()
+        .build("q", backend.as_ref(), ns, None, None, None)
+        .expect("the live chain summary should remain visible");
+    assert!(out.contains("live chain summary"), "card was: {out}");
+    assert!(!out.contains("obsolete chain summary"), "card was: {out}");
+}
+
 /// Fixture #5: 12 chain_summary rows; default cap (= 8) keeps 8;
 /// `with_cap(3)` keeps 3.
 #[test]

--- a/pensyve-mcp-gateway/src/rest.rs
+++ b/pensyve-mcp-gateway/src/rest.rs
@@ -455,9 +455,6 @@ fn replacement_memory(
             new.embedding = embedding;
             new.stability = 1.0;
             new.retrievability = 1.0;
-            if !new.source_episodes.contains(&old.id) {
-                new.source_episodes.push(old.id);
-            }
             Memory::Semantic(new)
         }
         Memory::Procedural(old) => {
@@ -474,9 +471,6 @@ fn replacement_memory(
             new.last_used = None;
             new.superseded_by = None;
             new.invalid_at = None;
-            if !new.source_episodes.contains(&old.id) {
-                new.source_episodes.push(old.id);
-            }
             Memory::Procedural(new)
         }
         Memory::Observation(old) => {
@@ -500,7 +494,11 @@ fn save_memory(storage: &dyn StorageTrait, memory: &Memory) -> Result<(), RestEr
         Memory::Episodic(memory) => storage.save_episodic(memory),
         Memory::Semantic(memory) => storage.save_semantic(memory),
         Memory::Procedural(memory) => storage.save_procedural(memory),
-        Memory::Observation(memory) => storage.save_observation(memory),
+        Memory::Observation(memory) => {
+            // Supersession is content replacement, not a new ingest, so the G3
+            // typed-slot and chain hooks intentionally do not fire here.
+            storage.save_observation(memory)
+        }
     };
     result.map_err(|err| {
         RestError(
@@ -665,7 +663,11 @@ async fn perform_supersession(
             )
         })?;
     if !stamped {
-        let _ = ps.storage.delete_memory_by_id(new_id);
+        if let Err(err) = ps.storage.delete_memory_by_id(new_id) {
+            tracing::warn!(
+                "Supersession race rollback failed for old memory {memory_id} and replacement {new_id}: {err}"
+            );
+        }
         return Err(RestError(
             StatusCode::CONFLICT,
             format!("Memory {memory_id} has already been superseded"),

--- a/pensyve-mcp-gateway/src/rest.rs
+++ b/pensyve-mcp-gateway/src/rest.rs
@@ -9,6 +9,7 @@ use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::{Json, Router, routing};
+use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use uuid::Uuid;
@@ -167,6 +168,8 @@ pub struct StatsResponse {
 pub struct InspectRequest {
     pub entity: String,
     pub limit: Option<usize>,
+    #[serde(default)]
+    pub include_superseded: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -185,6 +188,12 @@ pub struct UpdateMemoryRequest {
     pub confidence: Option<f64>,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct SupersedeMemoryRequest {
+    pub content: String,
+    pub confidence: Option<f64>,
+}
+
 #[derive(Debug, Serialize)]
 pub struct DeleteMemoryResponse {
     pub deleted: bool,
@@ -192,10 +201,12 @@ pub struct DeleteMemoryResponse {
 }
 
 #[derive(Debug, Serialize)]
-pub struct UpdateMemoryResponse {
+pub struct SupersedeMemoryResponse {
     pub id: String,
     pub content: String,
+    pub memory_type: String,
     pub confidence: f32,
+    pub superseded: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -361,6 +372,144 @@ fn memory_content(memory: &Memory) -> String {
     }
 }
 
+fn memory_superseded_by(memory: &Memory) -> Option<Uuid> {
+    match memory {
+        Memory::Episodic(m) => m.superseded_by,
+        Memory::Semantic(m) => m.superseded_by,
+        Memory::Procedural(m) => m.superseded_by,
+        Memory::Observation(m) => m.superseded_by,
+    }
+}
+
+fn load_memory(storage: &dyn StorageTrait, id: Uuid) -> Result<Option<Memory>, RestError> {
+    if let Some(memory) = storage
+        .get_episodic(id)
+        .map_err(|err| storage_fetch_error(&err))?
+    {
+        return Ok(Some(Memory::Episodic(memory)));
+    }
+    if let Some(memory) = storage
+        .get_semantic(id)
+        .map_err(|err| storage_fetch_error(&err))?
+    {
+        return Ok(Some(Memory::Semantic(memory)));
+    }
+    if let Some(memory) = storage
+        .get_procedural(id)
+        .map_err(|err| storage_fetch_error(&err))?
+    {
+        return Ok(Some(Memory::Procedural(memory)));
+    }
+    if let Some(memory) = storage
+        .get_observation(id)
+        .map_err(|err| storage_fetch_error(&err))?
+    {
+        return Ok(Some(Memory::Observation(memory)));
+    }
+    Ok(None)
+}
+
+fn storage_fetch_error(err: &pensyve_core::storage::StorageError) -> RestError {
+    RestError(
+        StatusCode::INTERNAL_SERVER_ERROR,
+        format!("Error fetching memory: {err}"),
+    )
+}
+
+fn replacement_memory(
+    old: &Memory,
+    content: &str,
+    confidence: Option<f64>,
+    embedding: Vec<f32>,
+) -> Memory {
+    let now = Utc::now();
+    match old {
+        Memory::Episodic(old) => {
+            let mut new = old.clone();
+            new.id = Uuid::new_v4();
+            new.content = content.to_string();
+            new.embedding = embedding;
+            new.timestamp = now;
+            new.stability = 1.0;
+            new.retrievability = 1.0;
+            new.access_count = 0;
+            new.last_accessed = None;
+            new.storage_strength = 0.0;
+            new.superseded_by = None;
+            new.invalid_at = None;
+            Memory::Episodic(new)
+        }
+        Memory::Semantic(old) => {
+            let mut new = old.clone();
+            let (predicate, object) = content.split_once(' ').map_or_else(
+                || ("knows".to_string(), content.to_string()),
+                |(predicate, object)| (predicate.to_string(), object.to_string()),
+            );
+            new.id = Uuid::new_v4();
+            new.predicate = predicate;
+            new.object = object;
+            new.confidence = confidence.map_or(old.confidence, |value| value as f32);
+            new.valid_at = now;
+            new.invalid_at = None;
+            new.superseded_by = None;
+            new.embedding = embedding;
+            new.stability = 1.0;
+            new.retrievability = 1.0;
+            if !new.source_episodes.contains(&old.id) {
+                new.source_episodes.push(old.id);
+            }
+            Memory::Semantic(new)
+        }
+        Memory::Procedural(old) => {
+            let mut new = old.clone();
+            let (trigger, action) = content
+                .split_once(" -> ")
+                .unwrap_or((old.trigger.as_str(), content));
+            new.id = Uuid::new_v4();
+            new.trigger = trigger.to_string();
+            new.action = action.to_string();
+            new.reliability = confidence.map_or(old.reliability, |value| value as f32);
+            new.embedding = embedding;
+            new.created_at = now;
+            new.last_used = None;
+            new.superseded_by = None;
+            new.invalid_at = None;
+            if !new.source_episodes.contains(&old.id) {
+                new.source_episodes.push(old.id);
+            }
+            Memory::Procedural(new)
+        }
+        Memory::Observation(old) => {
+            let mut new = old.clone();
+            new.id = Uuid::new_v4();
+            new.content = content.to_string();
+            new.confidence = confidence.map_or(old.confidence, |value| value as f32);
+            new.embedding = embedding;
+            new.created_at = now;
+            new.stability = 1.0;
+            new.retrievability = 1.0;
+            new.superseded_by = None;
+            new.invalid_at = None;
+            Memory::Observation(new)
+        }
+    }
+}
+
+fn save_memory(storage: &dyn StorageTrait, memory: &Memory) -> Result<(), RestError> {
+    let result = match memory {
+        Memory::Episodic(memory) => storage.save_episodic(memory),
+        Memory::Semantic(memory) => storage.save_semantic(memory),
+        Memory::Procedural(memory) => storage.save_procedural(memory),
+        Memory::Observation(memory) => storage.save_observation(memory),
+    };
+    result.map_err(|err| {
+        RestError(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Error saving superseding memory: {err}"),
+        )
+    })
+}
+
 /// Extract the optional `event_time` from a memory as an ISO 8601 string.
 /// Returns `None` for semantic / procedural memories (which have no event
 /// time concept) and for episodic memories that were ingested without an
@@ -450,6 +599,119 @@ fn get_pensyve_state(
     })
 }
 
+async fn perform_supersession(
+    state: &AppState,
+    ps: &PensyveState,
+    memory_id: Uuid,
+    requested_content: Option<String>,
+    confidence: Option<f64>,
+) -> Result<SupersedeMemoryResponse, RestError> {
+    let old = load_memory(ps.storage.as_ref(), memory_id)?.ok_or_else(|| {
+        RestError(
+            StatusCode::NOT_FOUND,
+            format!("Memory {memory_id} not found"),
+        )
+    })?;
+
+    let old_namespace = match &old {
+        Memory::Episodic(memory) => memory.namespace_id,
+        Memory::Semantic(memory) => memory.namespace_id,
+        Memory::Procedural(memory) => memory.namespace_id,
+        Memory::Observation(memory) => memory.namespace_id,
+    };
+    if old_namespace != ps.namespace.id {
+        return Err(RestError(
+            StatusCode::NOT_FOUND,
+            format!("Memory {memory_id} not found"),
+        ));
+    }
+    if memory_superseded_by(&old).is_some() {
+        return Err(RestError(
+            StatusCode::CONFLICT,
+            format!("Memory {memory_id} has already been superseded"),
+        ));
+    }
+
+    let content = requested_content.unwrap_or_else(|| memory_content(&old));
+    let embedder = ps.embedder.clone();
+    let text = content.clone();
+    let embedding = tokio::task::spawn_blocking(move || embedder.embed(&text))
+        .await
+        .map_err(|err| {
+            RestError(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Embedding task failed: {err}"),
+            )
+        })?
+        .map_err(|err| {
+            RestError(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Embedding failed: {err}"),
+            )
+        })?;
+
+    let new = replacement_memory(&old, &content, confidence, embedding);
+    let new_id = new.id();
+
+    // The replacement must exist before the old row can point to it.
+    save_memory(ps.storage.as_ref(), &new)?;
+    let stamped = ps
+        .storage
+        .supersede_memory(memory_id, new_id, Utc::now())
+        .map_err(|err| {
+            RestError(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Error stamping superseded memory: {err}"),
+            )
+        })?;
+    if !stamped {
+        let _ = ps.storage.delete_memory_by_id(new_id);
+        return Err(RestError(
+            StatusCode::CONFLICT,
+            format!("Memory {memory_id} has already been superseded"),
+        ));
+    }
+
+    {
+        let mut vector_index = ps.vector_index.write().await;
+        let add_result = match &new {
+            Memory::Semantic(memory) => {
+                vector_index.add_with_entity(new_id, &memory.embedding, memory.subject)
+            }
+            Memory::Episodic(memory) => {
+                vector_index.add_with_entity(new_id, &memory.embedding, memory.about_entity)
+            }
+            Memory::Procedural(memory) => vector_index.add(new_id, &memory.embedding),
+            // Observations enrich grouped recall and never enter the RRF vector pool.
+            Memory::Observation(_) => Ok(()),
+        };
+        if let Err(err) = add_result {
+            tracing::warn!("Failed to add superseding memory to vector index: {err}");
+        }
+        let _ = vector_index.remove(memory_id);
+    }
+
+    let _ = ps.storage.log_activity(
+        ps.namespace.id,
+        "supersede",
+        &json!({"memory_id": memory_id, "new_memory_id": new_id}),
+    );
+
+    if let Some(ref redis) = state.redis {
+        let mut conn = redis.clone();
+        let prefix = crate::cache::namespace_prefix(&ps.namespace.id.to_string());
+        crate::cache::invalidate_prefix(&mut conn, &prefix).await;
+    }
+
+    Ok(SupersedeMemoryResponse {
+        id: new_id.to_string(),
+        content: memory_content(&new),
+        memory_type: memory_type_name(&new).to_string(),
+        confidence: memory_confidence(&new),
+        superseded: memory_id.to_string(),
+    })
+}
+
 // ---------------------------------------------------------------------------
 // Router
 // ---------------------------------------------------------------------------
@@ -466,6 +728,10 @@ pub fn router() -> Router<Arc<AppState>> {
         .route(
             "/v1/memories/{id}",
             routing::delete(delete_memory).patch(update_memory),
+        )
+        .route(
+            "/v1/memories/{id}/supersede",
+            routing::post(supersede_memory),
         )
         .route("/v1/stats", routing::get(stats))
         .route("/v1/usage", routing::get(usage_summary))
@@ -939,6 +1205,21 @@ async fn purge_all_memories(
     Ok(Json(serde_json::json!({ "deleted": deleted_count })))
 }
 
+async fn supersede_memory(
+    State(state): State<Arc<AppState>>,
+    axum::Extension(auth_ctx): axum::Extension<AuthContext>,
+    Path(id): Path<String>,
+    Json(body): Json<SupersedeMemoryRequest>,
+) -> Result<impl IntoResponse, RestError> {
+    let ps = get_pensyve_state(&state, &auth_ctx)?;
+    let memory_id = Uuid::parse_str(&id)
+        .map_err(|_| RestError(StatusCode::BAD_REQUEST, "Invalid memory ID".to_string()))?;
+    let response =
+        perform_supersession(&state, &ps, memory_id, Some(body.content), body.confidence).await?;
+    Ok((StatusCode::CREATED, Json(response)))
+}
+
+/// Deprecated: retained for one release and delegated to supersession instead of mutation.
 async fn update_memory(
     State(state): State<Arc<AppState>>,
     axum::Extension(auth_ctx): axum::Extension<AuthContext>,
@@ -949,59 +1230,9 @@ async fn update_memory(
 
     let memory_id = Uuid::parse_str(&id)
         .map_err(|_| RestError(StatusCode::BAD_REQUEST, "Invalid memory ID".to_string()))?;
-
-    // Only semantic memories support content updates for now.
-    let mem = ps.storage.get_semantic(memory_id).map_err(|err| {
-        RestError(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Error fetching memory: {err}"),
-        )
-    })?;
-
-    let mem = mem.ok_or_else(|| {
-        RestError(
-            StatusCode::NOT_FOUND,
-            format!("Semantic memory {id} not found"),
-        )
-    })?;
-
-    let content_changed = body.content.is_some();
-    let content = body
-        .content
-        .unwrap_or_else(|| format!("{} {}", mem.predicate, mem.object));
-    let confidence = body.confidence.map_or(mem.confidence, |c| c as f32);
-
-    let (predicate, object) = if let Some(pos) = content.find(' ') {
-        (content[..pos].to_string(), content[pos + 1..].to_string())
-    } else {
-        ("knows".to_string(), content.clone())
-    };
-
-    ps.storage
-        .update_semantic_content(memory_id, &predicate, &object, Some(confidence))
-        .map_err(|err| {
-            RestError(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Error updating memory: {err}"),
-            )
-        })?;
-
-    // Re-embed if content changed — run ONNX on blocking thread pool.
-    if content_changed {
-        let embedder = ps.embedder.clone();
-        let text = content.clone();
-        if let Ok(Ok(embedding)) = tokio::task::spawn_blocking(move || embedder.embed(&text)).await
-        {
-            let mut vector_index = ps.vector_index.write().await;
-            let _ = vector_index.add_with_entity(memory_id, &embedding, mem.subject);
-        }
-    }
-
-    Ok(Json(UpdateMemoryResponse {
-        id,
-        content: format!("{predicate} {object}"),
-        confidence,
-    }))
+    let response =
+        perform_supersession(&state, &ps, memory_id, body.content, body.confidence).await?;
+    Ok(Json(response))
 }
 
 async fn stats(
@@ -1058,6 +1289,10 @@ async fn usage_summary(
     Ok(Json(summary))
 }
 
+#[allow(
+    clippy::too_many_lines,
+    reason = "the inspect handler keeps default and opt-in audit projections together so their response shape cannot drift"
+)]
 async fn inspect(
     State(state): State<Arc<AppState>>,
     axum::Extension(auth_ctx): axum::Extension<AuthContext>,
@@ -1073,7 +1308,13 @@ async fn inspect(
         let mut procedural = Vec::new();
         let mut observation = Vec::new();
 
-        if let Ok(memories) = ps.storage.get_all_memories_by_namespace(ps.namespace.id) {
+        let memories = if body.include_superseded {
+            ps.storage
+                .get_all_memories_by_namespace_including_superseded(ps.namespace.id)
+        } else {
+            ps.storage.get_all_memories_by_namespace(ps.namespace.id)
+        };
+        if let Ok(memories) = memories {
             for mem in memories.into_iter().take(limit) {
                 match mem {
                     pensyve_core::types::Memory::Episodic(m) => {
@@ -1116,6 +1357,41 @@ async fn inspect(
                 format!("Entity '{}' not found", body.entity),
             )
         })?;
+
+    if body.include_superseded {
+        let mut episodic = Vec::new();
+        let mut semantic = Vec::new();
+        if let Ok(memories) = ps
+            .storage
+            .get_all_memories_by_namespace_including_superseded(ps.namespace.id)
+        {
+            for memory in memories {
+                if episodic.len() + semantic.len() >= limit {
+                    break;
+                }
+                match memory {
+                    Memory::Episodic(memory) if memory.about_entity == entity.id => {
+                        let mut value = serde_json::to_value(&memory).unwrap_or_default();
+                        strip_embedding(&mut value);
+                        episodic.push(value);
+                    }
+                    Memory::Semantic(memory) if memory.subject == entity.id => {
+                        let mut value = serde_json::to_value(&memory).unwrap_or_default();
+                        strip_embedding(&mut value);
+                        semantic.push(value);
+                    }
+                    _ => {}
+                }
+            }
+        }
+        return Ok(Json(InspectResponse {
+            entity: body.entity,
+            episodic,
+            semantic,
+            procedural: vec![],
+            observation: vec![],
+        }));
+    }
 
     let mut episodic = Vec::new();
     if let Ok(mems) = ps.storage.list_episodic_by_entity(entity.id, limit) {

--- a/pensyve-mcp-gateway/tests/test_rest_forget_inspect.rs
+++ b/pensyve-mcp-gateway/tests/test_rest_forget_inspect.rs
@@ -114,7 +114,7 @@ async fn start_test_server(dir: &TempDir) -> (String, Arc<AppState>, Cancellatio
     (format!("http://{addr}"), state, cancellation)
 }
 
-async fn remember(client: &reqwest::Client, url: &str, entity: &str, fact: &str) {
+async fn remember(client: &reqwest::Client, url: &str, entity: &str, fact: &str) -> Uuid {
     let response = client
         .post(format!("{url}/v1/remember"))
         .json(&json!({
@@ -127,6 +127,8 @@ async fn remember(client: &reqwest::Client, url: &str, entity: &str, fact: &str)
         .expect("remember request");
 
     assert_eq!(response.status(), reqwest::StatusCode::CREATED);
+    let body: Value = response.json().await.expect("remember response JSON");
+    Uuid::parse_str(body["id"].as_str().expect("remembered memory id")).expect("valid memory id")
 }
 
 async fn inspect(client: &reqwest::Client, url: &str, entity: &str) -> reqwest::Response {
@@ -136,6 +138,33 @@ async fn inspect(client: &reqwest::Client, url: &str, entity: &str) -> reqwest::
         .send()
         .await
         .expect("inspect request")
+}
+
+async fn inspect_with_history(
+    client: &reqwest::Client,
+    url: &str,
+    entity: &str,
+) -> reqwest::Response {
+    client
+        .post(format!("{url}/v1/inspect"))
+        .json(&json!({ "entity": entity, "include_superseded": true }))
+        .send()
+        .await
+        .expect("inspect history request")
+}
+
+async fn supersede(
+    client: &reqwest::Client,
+    url: &str,
+    id: Uuid,
+    content: &str,
+) -> reqwest::Response {
+    client
+        .post(format!("{url}/v1/memories/{id}/supersede"))
+        .json(&json!({ "content": content, "confidence": 0.95 }))
+        .send()
+        .await
+        .expect("supersede request")
 }
 
 async fn forget(client: &reqwest::Client, url: &str, entity: &str) -> reqwest::Response {
@@ -324,5 +353,172 @@ async fn stats_after_forget_reflect_decremented_memory_counts() {
     assert_eq!(after["semantic_memories"], 1);
     assert_eq!(after["episodic_memories"], 0);
     assert_eq!(after["procedural_memories"], 0);
+    cancellation.cancel();
+}
+
+#[tokio::test]
+async fn supersede_creates_live_replacement_and_excludes_old_from_retrieval_indexes() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let (url, state, cancellation) = start_test_server(&dir).await;
+    let client = reqwest::Client::new();
+    let old_id = remember(&client, &url, "alice", "legacytoken value").await;
+    let pensyve_state = state
+        .tenant_mgr
+        .get_tenant_state(TEST_TENANT)
+        .expect("tenant state");
+    assert!(
+        pensyve_state
+            .vector_index
+            .read()
+            .await
+            .get(old_id)
+            .is_some()
+    );
+
+    let response = supersede(&client, &url, old_id, "currenttoken value").await;
+    assert_eq!(response.status(), reqwest::StatusCode::CREATED);
+    let body: Value = response.json().await.expect("supersede response JSON");
+    let new_id =
+        Uuid::parse_str(body["id"].as_str().expect("new memory id")).expect("valid new memory id");
+    assert_ne!(new_id, old_id);
+    assert_eq!(body["superseded"], old_id.to_string());
+    assert_eq!(body["content"], "currenttoken value");
+
+    let old = pensyve_state
+        .storage
+        .get_semantic(old_id)
+        .expect("old lookup")
+        .expect("old row preserved");
+    assert_eq!(old.predicate, "legacytoken");
+    assert_eq!(old.object, "value");
+    assert_eq!(old.superseded_by, Some(new_id));
+    assert!(old.invalid_at.is_some());
+
+    let new = pensyve_state
+        .storage
+        .get_semantic(new_id)
+        .expect("new lookup")
+        .expect("new row exists before old pointer is visible");
+    assert_eq!(new.predicate, "currenttoken");
+    assert_eq!(new.object, "value");
+    assert!(new.superseded_by.is_none());
+    assert!(new.invalid_at.is_none());
+    assert!(new.source_episodes.contains(&old_id));
+
+    let live = pensyve_state
+        .storage
+        .get_all_memories_by_namespace(pensyve_state.namespace.id)
+        .expect("live namespace memories");
+    assert_eq!(live.len(), 1);
+    assert_eq!(live[0].id(), new_id);
+    assert!(
+        pensyve_state
+            .storage
+            .search_fts("legacytoken", pensyve_state.namespace.id, 10)
+            .expect("old FTS query")
+            .is_empty()
+    );
+    let new_hits = pensyve_state
+        .storage
+        .search_fts("currenttoken", pensyve_state.namespace.id, 10)
+        .expect("new FTS query");
+    assert_eq!(new_hits.len(), 1);
+    assert_eq!(new_hits[0].id(), new_id);
+
+    let vector_index = pensyve_state.vector_index.read().await;
+    assert!(vector_index.get(old_id).is_none());
+    assert!(vector_index.get(new_id).is_some());
+    drop(vector_index);
+    cancellation.cancel();
+}
+
+#[tokio::test]
+async fn superseding_an_already_superseded_memory_returns_conflict() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let (url, _state, cancellation) = start_test_server(&dir).await;
+    let client = reqwest::Client::new();
+    let old_id = remember(&client, &url, "alice", "likes tea").await;
+
+    let first = supersede(&client, &url, old_id, "likes coffee").await;
+    assert_eq!(first.status(), reqwest::StatusCode::CREATED);
+    let second = supersede(&client, &url, old_id, "likes water").await;
+    assert_eq!(second.status(), reqwest::StatusCode::CONFLICT);
+    cancellation.cancel();
+}
+
+#[tokio::test]
+async fn patch_delegates_to_supersession_and_preserves_old_content() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let (url, state, cancellation) = start_test_server(&dir).await;
+    let client = reqwest::Client::new();
+    let old_id = remember(&client, &url, "alice", "likes tea").await;
+
+    let response = client
+        .patch(format!("{url}/v1/memories/{old_id}"))
+        .json(&json!({ "content": "likes coffee", "confidence": 0.85 }))
+        .send()
+        .await
+        .expect("patch request");
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    let body: Value = response.json().await.expect("patch response JSON");
+    let new_id =
+        Uuid::parse_str(body["id"].as_str().expect("new memory id")).expect("valid new memory id");
+    assert_ne!(new_id, old_id);
+    assert_eq!(body["superseded"], old_id.to_string());
+
+    let pensyve_state = state
+        .tenant_mgr
+        .get_tenant_state(TEST_TENANT)
+        .expect("tenant state");
+    let old = pensyve_state
+        .storage
+        .get_semantic(old_id)
+        .expect("old lookup")
+        .expect("old row preserved");
+    assert_eq!(old.object, "tea");
+    assert_eq!(old.superseded_by, Some(new_id));
+    let new = pensyve_state
+        .storage
+        .get_semantic(new_id)
+        .expect("new lookup")
+        .expect("new row");
+    assert_eq!(new.object, "coffee");
+    assert!((new.confidence - 0.85).abs() < f32::EPSILON);
+    cancellation.cancel();
+}
+
+#[tokio::test]
+async fn inspect_include_superseded_surfaces_history_while_default_hides_it() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let (url, _state, cancellation) = start_test_server(&dir).await;
+    let client = reqwest::Client::new();
+    let old_id = remember(&client, &url, "alice", "likes tea").await;
+    let response = supersede(&client, &url, old_id, "likes coffee").await;
+    let response_body: Value = response.json().await.expect("supersede response JSON");
+    let new_id = response_body["id"].as_str().expect("new memory id");
+
+    let default_response = inspect(&client, &url, "alice").await;
+    let default_body: Value = default_response
+        .json()
+        .await
+        .expect("default inspect response");
+    assert_eq!(default_body["semantic"].as_array().map(Vec::len), Some(1));
+    assert_eq!(default_body["semantic"][0]["id"], new_id);
+
+    let history_response = inspect_with_history(&client, &url, "alice").await;
+    let history_body: Value = history_response
+        .json()
+        .await
+        .expect("history inspect response");
+    let memories = history_body["semantic"]
+        .as_array()
+        .expect("semantic history array");
+    assert_eq!(memories.len(), 2);
+    let old = memories
+        .iter()
+        .find(|memory| memory["id"] == old_id.to_string())
+        .expect("old memory in history");
+    assert_eq!(old["superseded_by"], new_id);
+    assert!(!old["invalid_at"].is_null());
     cancellation.cancel();
 }

--- a/pensyve-mcp-gateway/tests/test_rest_forget_inspect.rs
+++ b/pensyve-mcp-gateway/tests/test_rest_forget_inspect.rs
@@ -403,7 +403,8 @@ async fn supersede_creates_live_replacement_and_excludes_old_from_retrieval_inde
     assert_eq!(new.object, "value");
     assert!(new.superseded_by.is_none());
     assert!(new.invalid_at.is_none());
-    assert!(new.source_episodes.contains(&old_id));
+    assert_eq!(new.source_episodes, old.source_episodes);
+    assert!(!new.source_episodes.contains(&old_id));
 
     let live = pensyve_state
         .storage


### PR DESCRIPTION
Fixes #187. Implements the approved design (`pensyve-docs/docs/design-docs/2026-07-19-supersession-primitive.md`; decision locked 2026-07-18: edits are supersession, not mutation).

## What

- **Data model**: uniform `superseded_by: Option<Uuid>` + `invalid_at: Option<DateTime<Utc>>` across all four memory kinds. SQLite versioned migration **v4** (schema_versions registry, column_exists-gated); Postgres idempotent `ADD COLUMN IF NOT EXISTS`. Fixes the pre-existing SQLite/Postgres drift, and `EpisodicMemory.superseded_by` — previously a dead struct field — is now actually persisted and read in both backends.
- **`POST /v1/memories/{id}/supersede`** `{content, confidence?}`: 404 unknown, 409 already-superseded; creates the new memory first (fresh embedding, provenance carried), then stamps the old row (`superseded_by`, `invalid_at`; content preserved for audit) — crash ordering never leaves a stamp pointing at a nonexistent row. Vector index: new id added, old id removed under one write lock; observations stay out of the RRF pool by design.
- **PATCH delegation**: `PATCH /v1/memories/{id}` no longer mutates in place via `update_semantic_content` — it delegates to the supersede path and is marked deprecated.
- **Default-recall exclusion at the storage boundary**: `get_all_memories_by_namespace` + the `search_fts*` family gain `superseded_by IS NULL` (37 predicate sites across both backends), so vector-index population and FTS inherit it. `inspect` gains opt-in `include_superseded: true` for audit.
- **Non-goals honored**: no graph edges, no MCP tool, no chain traversal, G3 chain_summary untouched.

## Follow-up (separate PR after this deploys)
pensyve-cloud's edit flow switches from PATCH to supersede and the drawer copy "Edits overwrite this memory in place." changes to supersession language.

## Verification
`cargo test -p pensyve-core -p pensyve-mcp-gateway`: 798 passed / 0 failed, including new tests: v4 migration on a v3 db, supersede happy path (old excluded from recall/vector/FTS), 409 double-supersede, PATCH-now-supersedes, include_superseded surfaces history, column round-trip in both backends. Clippy clean, fmt clean.