### PR TITLE
fix(mcp): make pensyve_forget safe against scope-narrowing mistakes (#217)

### DIFF
--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -241,7 +241,7 @@ The plugin wraps 7 MCP tools exposed by the `pensyve-mcp` binary:
 | `pensyve_observe`       | `episode_id`, `content`, `source_entity`, `about_entity`, `content_type?` | Stored observation object. Primary episodic-capture path used by in-flight memory-woven skills. `source_entity` and `about_entity` are required. |
 | `pensyve_episode_start` | `participants`                         | `episode_id`, `started_at`           |
 | `pensyve_episode_end`   | `episode_id`, `outcome?`               | `memories_created` count             |
-| `pensyve_forget`        | `entity`, `hard_delete?`               | `forgotten_count`                    |
+| `pensyve_forget`        | `entity`                               | `forgotten_count`. Entity-wide, irreversible hard delete; use `pensyve_forget_memory` to delete a single memory by id. |
 | `pensyve_inspect`       | `entity`, `memory_type?`, `limit?`     | Array of memories with stats         |
 
 All tools communicate over MCP. The Cloud server is at `https://mcp.pensyve.com/mcp`. The plugin never bypasses MCP to access storage directly.

--- a/integrations/gemini-extension/GEMINI.md
+++ b/integrations/gemini-extension/GEMINI.md
@@ -452,5 +452,5 @@ Medium-signal items that benefit from user confirmation:
 | `pensyve_observe`       | Record an observation within an active episode | `episode_id`, `content`, `source_entity`, `about_entity`, `content_type?` |
 | `pensyve_episode_start` | Begin tracking a conversation                  | `participants`                                                            |
 | `pensyve_episode_end`   | End episode with outcome summary               | `episode_id`, `outcome?`                                                  |
-| `pensyve_forget`        | Delete all memories for an entity              | `entity`, `hard_delete?`                                                  |
+| `pensyve_forget`        | Delete all memories for an entity (irreversible) | `entity`                                                                |
 | `pensyve_inspect`       | View all memories for an entity                | `entity`, `memory_type?`, `limit?`                                        |

--- a/integrations/gemini-extension/README.md
+++ b/integrations/gemini-extension/README.md
@@ -140,7 +140,7 @@ Gemini CLI has no hook/event surface, so the entire substrate is delivered throu
 | `pensyve_observe`       | `episode_id`, `content`, `source_entity`, `about_entity`, `content_type?` | Stored episodic memory object        |
 | `pensyve_episode_start` | `participants`                                                            | `episode_id`, `started_at`           |
 | `pensyve_episode_end`   | `episode_id`, `outcome?`                                                  | `memories_created` count             |
-| `pensyve_forget`        | `entity`, `hard_delete?`                                                  | `forgotten_count`                    |
+| `pensyve_forget`        | `entity`                                                                  | `forgotten_count`                    |
 | `pensyve_inspect`       | `entity`, `memory_type?`, `limit?`                                        | Array of memories with stats         |
 
 ## Opt-Out

--- a/integrations/hermes/__init__.py
+++ b/integrations/hermes/__init__.py
@@ -258,7 +258,6 @@ FORGET_SCHEMA = {
         "type": "object",
         "properties": {
             "entity": {"type": "string", "description": "Entity to forget."},
-            "hard_delete": {"type": "boolean", "description": "If true, permanently deletes rather than soft-deleting."},
         },
         "required": ["entity"],
     },
@@ -641,10 +640,7 @@ class PensyveMemoryProvider(MemoryProvider):
                 entity = args.get("entity", "")
                 if not entity:
                     return tool_error("Missing required parameter: entity")
-                result = mcp.call_tool("pensyve_forget", {
-                    "entity": entity,
-                    "hard_delete": args.get("hard_delete"),
-                })
+                result = mcp.call_tool("pensyve_forget", {"entity": entity})
                 self._record_success()
                 return json.dumps({"result": f"Memories for '{entity}' deleted.", "details": result})
 

--- a/pensyve-core/src/storage/mod.rs
+++ b/pensyve-core/src/storage/mod.rs
@@ -36,6 +36,12 @@ pub enum StorageError {
 
 pub type StorageResult<T> = Result<T, StorageError>;
 
+fn scoped_delete_not_implemented() -> StorageResult<bool> {
+    Err(StorageError::Context(
+        "storage backend does not implement atomic scoped deletion".to_string(),
+    ))
+}
+
 // ---------------------------------------------------------------------------
 // StorageTrait
 // ---------------------------------------------------------------------------
@@ -294,22 +300,15 @@ pub trait StorageTrait: Send + Sync {
 
     /// Delete a single memory only when it belongs to `namespace_id`.
     ///
-    /// Backends should override this with an atomic namespace-qualified delete.
-    /// The default preserves compatibility for third-party backends while still
-    /// preventing an obvious cross-namespace delete.
+    /// Backends must override this with an atomic namespace-qualified delete.
+    /// The default preserves source compatibility for third-party backends but
+    /// fails closed rather than falling back to an unscoped delete.
     fn delete_memory_by_id_in_namespace(
         &self,
-        id: Uuid,
-        namespace_id: Uuid,
+        _id: Uuid,
+        _namespace_id: Uuid,
     ) -> StorageResult<bool> {
-        let belongs_to_namespace = self
-            .get_all_memories_by_namespace(namespace_id)?
-            .iter()
-            .any(|memory| memory.id() == id);
-        if !belongs_to_namespace {
-            return Ok(false);
-        }
-        self.delete_memory_by_id(id)
+        scoped_delete_not_implemented()
     }
 
     /// Delete all memories in a namespace. Returns the count of deleted memories.
@@ -456,4 +455,17 @@ pub fn memory_matches_scope(
         None => row_user.is_none(),
     };
     agent_match && user_match
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scoped_delete_not_implemented_fails_closed() {
+        let error = scoped_delete_not_implemented().unwrap_err();
+
+        assert!(matches!(error, StorageError::Context(_)));
+        assert!(error.to_string().contains("atomic scoped deletion"));
+    }
 }

--- a/pensyve-core/src/storage/mod.rs
+++ b/pensyve-core/src/storage/mod.rs
@@ -292,6 +292,26 @@ pub trait StorageTrait: Send + Sync {
     /// Delete a single memory by its UUID (episodic, semantic, or procedural).
     fn delete_memory_by_id(&self, id: Uuid) -> StorageResult<bool>;
 
+    /// Delete a single memory only when it belongs to `namespace_id`.
+    ///
+    /// Backends should override this with an atomic namespace-qualified delete.
+    /// The default preserves compatibility for third-party backends while still
+    /// preventing an obvious cross-namespace delete.
+    fn delete_memory_by_id_in_namespace(
+        &self,
+        id: Uuid,
+        namespace_id: Uuid,
+    ) -> StorageResult<bool> {
+        let belongs_to_namespace = self
+            .get_all_memories_by_namespace(namespace_id)?
+            .iter()
+            .any(|memory| memory.id() == id);
+        if !belongs_to_namespace {
+            return Ok(false);
+        }
+        self.delete_memory_by_id(id)
+    }
+
     /// Delete all memories in a namespace. Returns the count of deleted memories.
     fn purge_namespace(&self, namespace_id: Uuid) -> StorageResult<usize> {
         // Default: fall back to loading + deleting one by one.

--- a/pensyve-core/src/storage/postgres.rs
+++ b/pensyve-core/src/storage/postgres.rs
@@ -1517,7 +1517,7 @@ impl StorageTrait for PostgresBackend {
         namespace_id: Uuid,
     ) -> StorageResult<bool> {
         self.block_on(async {
-            let mut conn = self.maybe_scoped_conn().await?;
+            let mut conn = self.scoped_conn(namespace_id).await?;
             let mut transaction = (&mut *conn).begin().await.map_err(sqlx_to_io)?;
             let mut deleted = false;
 

--- a/pensyve-core/src/storage/postgres.rs
+++ b/pensyve-core/src/storage/postgres.rs
@@ -1510,6 +1510,67 @@ impl StorageTrait for PostgresBackend {
         })
     }
 
+    fn delete_memory_by_id_in_namespace(
+        &self,
+        id: Uuid,
+        namespace_id: Uuid,
+    ) -> StorageResult<bool> {
+        self.block_on(async {
+            let mut conn = self.maybe_scoped_conn().await?;
+            let mut deleted = false;
+
+            let result = query::<Postgres>(
+                "DELETE FROM episodic_memories WHERE id = $1 AND namespace_id = $2",
+            )
+            .bind(id)
+            .bind(namespace_id)
+            .execute(&mut *conn)
+            .await
+            .map_err(sqlx_to_io)?;
+            if result.rows_affected() > 0 {
+                deleted = true;
+            }
+
+            let result = query::<Postgres>(
+                "DELETE FROM semantic_memories WHERE id = $1 AND namespace_id = $2",
+            )
+            .bind(id)
+            .bind(namespace_id)
+            .execute(&mut *conn)
+            .await
+            .map_err(sqlx_to_io)?;
+            if result.rows_affected() > 0 {
+                deleted = true;
+            }
+
+            let result = query::<Postgres>(
+                "DELETE FROM procedural_memories WHERE id = $1 AND namespace_id = $2",
+            )
+            .bind(id)
+            .bind(namespace_id)
+            .execute(&mut *conn)
+            .await
+            .map_err(sqlx_to_io)?;
+            if result.rows_affected() > 0 {
+                deleted = true;
+            }
+
+            let result = query::<Postgres>(
+                "DELETE FROM observation_memories WHERE id = $1 AND namespace_id = $2",
+            )
+            .bind(id)
+            .bind(namespace_id)
+            .execute(&mut *conn)
+            .await
+            .map_err(sqlx_to_io)?;
+            if result.rows_affected() > 0 {
+                deleted = true;
+            }
+
+            Ok(deleted)
+        })
+    }
+
     fn update_semantic_content(
         &self,
         id: Uuid,

--- a/pensyve-core/src/storage/postgres.rs
+++ b/pensyve-core/src/storage/postgres.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use std::future::Future;
 
 use chrono::{DateTime, Utc};
+use sqlx_core::acquire::Acquire;
 use sqlx_core::executor::Executor;
 use sqlx_core::from_row::FromRow;
 use sqlx_core::query::query;
@@ -1517,6 +1518,7 @@ impl StorageTrait for PostgresBackend {
     ) -> StorageResult<bool> {
         self.block_on(async {
             let mut conn = self.maybe_scoped_conn().await?;
+            let mut transaction = (&mut *conn).begin().await.map_err(sqlx_to_io)?;
             let mut deleted = false;
 
             let result = query::<Postgres>(
@@ -1524,7 +1526,7 @@ impl StorageTrait for PostgresBackend {
             )
             .bind(id)
             .bind(namespace_id)
-            .execute(&mut *conn)
+            .execute(&mut *transaction)
             .await
             .map_err(sqlx_to_io)?;
             if result.rows_affected() > 0 {
@@ -1536,7 +1538,7 @@ impl StorageTrait for PostgresBackend {
             )
             .bind(id)
             .bind(namespace_id)
-            .execute(&mut *conn)
+            .execute(&mut *transaction)
             .await
             .map_err(sqlx_to_io)?;
             if result.rows_affected() > 0 {
@@ -1548,7 +1550,7 @@ impl StorageTrait for PostgresBackend {
             )
             .bind(id)
             .bind(namespace_id)
-            .execute(&mut *conn)
+            .execute(&mut *transaction)
             .await
             .map_err(sqlx_to_io)?;
             if result.rows_affected() > 0 {
@@ -1560,13 +1562,14 @@ impl StorageTrait for PostgresBackend {
             )
             .bind(id)
             .bind(namespace_id)
-            .execute(&mut *conn)
+            .execute(&mut *transaction)
             .await
             .map_err(sqlx_to_io)?;
             if result.rows_affected() > 0 {
                 deleted = true;
             }
 
+            transaction.commit().await.map_err(sqlx_to_io)?;
             Ok(deleted)
         })
     }

--- a/pensyve-core/src/storage/sqlite.rs
+++ b/pensyve-core/src/storage/sqlite.rs
@@ -702,11 +702,12 @@ fn delete_memory_by_id_with_namespace(
     id: Uuid,
     namespace_id: Option<Uuid>,
 ) -> StorageResult<bool> {
+    let transaction = conn.unchecked_transaction()?;
     let id_str = id.to_string();
     let namespace_id = namespace_id.map(|namespace_id| namespace_id.to_string());
     let mut deleted = false;
 
-    let n = conn.execute(
+    let n = transaction.execute(
         "DELETE FROM episodic_memories
          WHERE id = ?1 AND (?2 IS NULL OR namespace_id = ?2)",
         params![&id_str, namespace_id.as_deref()],
@@ -715,7 +716,7 @@ fn delete_memory_by_id_with_namespace(
         deleted = true;
     }
 
-    let n = conn.execute(
+    let n = transaction.execute(
         "DELETE FROM semantic_memories
          WHERE id = ?1 AND (?2 IS NULL OR namespace_id = ?2)",
         params![&id_str, namespace_id.as_deref()],
@@ -724,7 +725,7 @@ fn delete_memory_by_id_with_namespace(
         deleted = true;
     }
 
-    let n = conn.execute(
+    let n = transaction.execute(
         "DELETE FROM procedural_memories
          WHERE id = ?1 AND (?2 IS NULL OR namespace_id = ?2)",
         params![&id_str, namespace_id.as_deref()],
@@ -733,7 +734,7 @@ fn delete_memory_by_id_with_namespace(
         deleted = true;
     }
 
-    let n = conn.execute(
+    let n = transaction.execute(
         "DELETE FROM observation_memories
          WHERE id = ?1 AND (?2 IS NULL OR namespace_id = ?2)",
         params![&id_str, namespace_id.as_deref()],
@@ -741,12 +742,12 @@ fn delete_memory_by_id_with_namespace(
     if n > 0 {
         deleted = true;
         // Observations are the only memory type represented in the KG tables.
-        conn.execute(
+        transaction.execute(
             "DELETE FROM kg_triples
              WHERE passage_id = ?1 AND (?2 IS NULL OR namespace_id = ?2)",
             params![&id_str, namespace_id.as_deref()],
         )?;
-        conn.execute(
+        transaction.execute(
             "DELETE FROM kg_passage_entities
              WHERE passage_id = ?1
                AND (
@@ -760,13 +761,14 @@ fn delete_memory_by_id_with_namespace(
     }
 
     if deleted {
-        conn.execute(
+        transaction.execute(
             "DELETE FROM memory_fts
              WHERE memory_id = ?1 AND (?2 IS NULL OR namespace_id = ?2)",
             params![&id_str, namespace_id.as_deref()],
         )?;
     }
 
+    transaction.commit()?;
     Ok(deleted)
 }
 
@@ -3949,6 +3951,45 @@ mod tests {
             .unwrap();
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].id(), shared_id);
+    }
+
+    #[test]
+    fn test_delete_memory_by_id_in_namespace_rolls_back_partial_delete() {
+        let (_dir, db) = setup();
+        let ns = make_namespace(&db);
+        let shared_id = Uuid::new_v4();
+
+        let mut episodic = EpisodicMemory::new(
+            ns.id,
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            "must survive rollback",
+        );
+        episodic.id = shared_id;
+        db.save_episodic(&episodic).unwrap();
+
+        let mut semantic = SemanticMemory::new(ns.id, Uuid::new_v4(), "must", "also survive", 0.9);
+        semantic.id = shared_id;
+        db.save_semantic(&semantic).unwrap();
+
+        {
+            let conn = db.conn.lock().unwrap();
+            conn.execute_batch(
+                "CREATE TRIGGER fail_scoped_semantic_delete
+                 BEFORE DELETE ON semantic_memories
+                 BEGIN
+                     SELECT RAISE(ABORT, 'forced rollback');
+                 END;",
+            )
+            .unwrap();
+        }
+
+        let result = db.delete_memory_by_id_in_namespace(shared_id, ns.id);
+
+        assert!(result.is_err());
+        assert!(db.get_episodic(shared_id).unwrap().is_some());
+        assert!(db.get_semantic(shared_id).unwrap().is_some());
     }
 
     #[test]

--- a/pensyve-core/src/storage/sqlite.rs
+++ b/pensyve-core/src/storage/sqlite.rs
@@ -697,6 +697,79 @@ fn str_to_dt(s: &str) -> DateTime<Utc> {
     DateTime::parse_from_rfc3339(s).map_or_else(|_| Utc::now(), |d| d.with_timezone(&Utc))
 }
 
+fn delete_memory_by_id_with_namespace(
+    conn: &Connection,
+    id: Uuid,
+    namespace_id: Option<Uuid>,
+) -> StorageResult<bool> {
+    let id_str = id.to_string();
+    let namespace_id = namespace_id.map(|namespace_id| namespace_id.to_string());
+    let mut deleted = false;
+
+    let n = conn.execute(
+        "DELETE FROM episodic_memories
+         WHERE id = ?1 AND (?2 IS NULL OR namespace_id = ?2)",
+        params![&id_str, namespace_id.as_deref()],
+    )?;
+    if n > 0 {
+        deleted = true;
+    }
+
+    let n = conn.execute(
+        "DELETE FROM semantic_memories
+         WHERE id = ?1 AND (?2 IS NULL OR namespace_id = ?2)",
+        params![&id_str, namespace_id.as_deref()],
+    )?;
+    if n > 0 {
+        deleted = true;
+    }
+
+    let n = conn.execute(
+        "DELETE FROM procedural_memories
+         WHERE id = ?1 AND (?2 IS NULL OR namespace_id = ?2)",
+        params![&id_str, namespace_id.as_deref()],
+    )?;
+    if n > 0 {
+        deleted = true;
+    }
+
+    let n = conn.execute(
+        "DELETE FROM observation_memories
+         WHERE id = ?1 AND (?2 IS NULL OR namespace_id = ?2)",
+        params![&id_str, namespace_id.as_deref()],
+    )?;
+    if n > 0 {
+        deleted = true;
+        // Observations are the only memory type represented in the KG tables.
+        conn.execute(
+            "DELETE FROM kg_triples
+             WHERE passage_id = ?1 AND (?2 IS NULL OR namespace_id = ?2)",
+            params![&id_str, namespace_id.as_deref()],
+        )?;
+        conn.execute(
+            "DELETE FROM kg_passage_entities
+             WHERE passage_id = ?1
+               AND (
+                   ?2 IS NULL
+                   OR entity_id IN (
+                       SELECT id FROM kg_entities WHERE namespace_id = ?2
+                   )
+               )",
+            params![&id_str, namespace_id.as_deref()],
+        )?;
+    }
+
+    if deleted {
+        conn.execute(
+            "DELETE FROM memory_fts
+             WHERE memory_id = ?1 AND (?2 IS NULL OR namespace_id = ?2)",
+            params![&id_str, namespace_id.as_deref()],
+        )?;
+    }
+
+    Ok(deleted)
+}
+
 // ---------------------------------------------------------------------------
 // StorageTrait implementation
 // ---------------------------------------------------------------------------
@@ -2143,65 +2216,16 @@ impl StorageTrait for SqliteBackend {
 
     fn delete_memory_by_id(&self, id: Uuid) -> StorageResult<bool> {
         let conn = lock_conn!(self);
-        let id_str = id.to_string();
+        delete_memory_by_id_with_namespace(&conn, id, None)
+    }
 
-        // Try deleting from each table in order.
-        let mut deleted = false;
-
-        let n = conn.execute(
-            "DELETE FROM episodic_memories WHERE id = ?1",
-            params![&id_str],
-        )?;
-        if n > 0 {
-            deleted = true;
-        }
-
-        let n = conn.execute(
-            "DELETE FROM semantic_memories WHERE id = ?1",
-            params![&id_str],
-        )?;
-        if n > 0 {
-            deleted = true;
-        }
-
-        let n = conn.execute(
-            "DELETE FROM procedural_memories WHERE id = ?1",
-            params![&id_str],
-        )?;
-        if n > 0 {
-            deleted = true;
-        }
-
-        let n = conn.execute(
-            "DELETE FROM observation_memories WHERE id = ?1",
-            params![&id_str],
-        )?;
-        if n > 0 {
-            deleted = true;
-            // Phase 2B cascade (CodeRabbit PR #115 round 2): if the
-            // departing row was an observation, drop its `kg_triples`
-            // and `kg_passage_entities` (both keyed by `passage_id ==
-            // observation.id`). Other memory types do not populate
-            // KG tables so the cascade is observation-only.
-            conn.execute(
-                "DELETE FROM kg_triples WHERE passage_id = ?1",
-                params![&id_str],
-            )?;
-            conn.execute(
-                "DELETE FROM kg_passage_entities WHERE passage_id = ?1",
-                params![&id_str],
-            )?;
-        }
-
-        // Remove from FTS index.
-        if deleted {
-            conn.execute(
-                "DELETE FROM memory_fts WHERE memory_id = ?1",
-                params![&id_str],
-            )?;
-        }
-
-        Ok(deleted)
+    fn delete_memory_by_id_in_namespace(
+        &self,
+        id: Uuid,
+        namespace_id: Uuid,
+    ) -> StorageResult<bool> {
+        let conn = lock_conn!(self);
+        delete_memory_by_id_with_namespace(&conn, id, Some(namespace_id))
     }
 
     fn purge_namespace(&self, namespace_id: Uuid) -> StorageResult<usize> {
@@ -3861,6 +3885,70 @@ mod tests {
         let deleted = db.delete_memory_by_id(obs_id).unwrap();
         assert!(deleted);
         assert!(db.get_observation(obs_id).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_delete_memory_by_id_in_namespace_rejects_foreign_namespace() {
+        let (_dir, db) = setup();
+        let owner_ns = make_namespace(&db);
+        let foreign_ns = Namespace::new("other");
+        db.save_namespace(&foreign_ns).unwrap();
+
+        let obs = ObservationMemory::new(owner_ns.id, Uuid::new_v4(), "x", "y", "z", "content");
+        db.save_observation(&obs).unwrap();
+
+        let deleted = db
+            .delete_memory_by_id_in_namespace(obs.id, foreign_ns.id)
+            .unwrap();
+
+        assert!(!deleted);
+        assert!(db.get_observation(obs.id).unwrap().is_some());
+    }
+
+    #[test]
+    fn test_delete_memory_by_id_in_namespace_deletes_matching_namespace() {
+        let (_dir, db) = setup();
+        let ns = make_namespace(&db);
+        let obs = ObservationMemory::new(ns.id, Uuid::new_v4(), "x", "y", "z", "content");
+        db.save_observation(&obs).unwrap();
+
+        let deleted = db.delete_memory_by_id_in_namespace(obs.id, ns.id).unwrap();
+
+        assert!(deleted);
+        assert!(db.get_observation(obs.id).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_delete_memory_by_id_in_namespace_preserves_foreign_fts_entry() {
+        let (_dir, db) = setup();
+        let owner_ns = make_namespace(&db);
+        let foreign_ns = Namespace::new("other");
+        db.save_namespace(&foreign_ns).unwrap();
+        let shared_id = Uuid::new_v4();
+
+        let mut owner_memory =
+            SemanticMemory::new(owner_ns.id, Uuid::new_v4(), "owns", "local token", 0.9);
+        owner_memory.id = shared_id;
+        db.save_semantic(&owner_memory).unwrap();
+
+        let mut foreign_memory = EpisodicMemory::new(
+            foreign_ns.id,
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            "foreign unique token",
+        );
+        foreign_memory.id = shared_id;
+        db.save_episodic(&foreign_memory).unwrap();
+
+        db.delete_memory_by_id_in_namespace(shared_id, owner_ns.id)
+            .unwrap();
+
+        let hits = db
+            .search_fts("foreign unique token", foreign_ns.id, 10)
+            .unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].id(), shared_id);
     }
 
     #[test]

--- a/pensyve-mcp-gateway/tests/integration_test.rs
+++ b/pensyve-mcp-gateway/tests/integration_test.rs
@@ -195,7 +195,7 @@ async fn test_mcp_tools_list() {
     let text = resp.text().await.unwrap();
     let json: serde_json::Value = serde_json::from_str(&text).expect("parse json");
     let tools = json["result"]["tools"].as_array().expect("tools array");
-    assert_eq!(tools.len(), 9, "Expected 9 tools");
+    assert_eq!(tools.len(), 10, "Expected 10 tools");
 
     // Verify all tool names.
     let tool_names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
@@ -204,10 +204,87 @@ async fn test_mcp_tools_list() {
     assert!(tool_names.contains(&"pensyve_episode_start"));
     assert!(tool_names.contains(&"pensyve_episode_end"));
     assert!(tool_names.contains(&"pensyve_forget"));
+    assert!(tool_names.contains(&"pensyve_forget_memory"));
     assert!(tool_names.contains(&"pensyve_inspect"));
     assert!(tool_names.contains(&"pensyve_status"));
     assert!(tool_names.contains(&"pensyve_account"));
     assert!(tool_names.contains(&"pensyve_observe"));
+
+    ct.cancel();
+}
+
+#[tokio::test]
+async fn test_mcp_forget_memory_rejects_foreign_namespace() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let state = create_test_state(&dir);
+    let foreign_namespace = Namespace::new("foreign");
+    state
+        .storage
+        .save_namespace(&foreign_namespace)
+        .expect("save foreign namespace");
+    let foreign_memory = ObservationMemory::new(
+        foreign_namespace.id,
+        uuid::Uuid::new_v4(),
+        "thing",
+        "foreign",
+        "did",
+        "must survive",
+    );
+    state
+        .storage
+        .save_observation(&foreign_memory)
+        .expect("save foreign memory");
+
+    let (url, ct) = start_test_server(state.clone()).await;
+    let client = reqwest::Client::new();
+    client
+        .post(format!("{url}/mcp"))
+        .header("content-type", "application/json")
+        .header("accept", "application/json, text/event-stream")
+        .body(json_rpc(
+            "initialize",
+            serde_json::json!({
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": { "name": "test", "version": "0.1.0" }
+            }),
+            1,
+        ))
+        .send()
+        .await
+        .expect("init");
+
+    let resp = client
+        .post(format!("{url}/mcp"))
+        .header("content-type", "application/json")
+        .header("accept", "application/json, text/event-stream")
+        .body(json_rpc(
+            "tools/call",
+            serde_json::json!({
+                "name": "pensyve_forget_memory",
+                "arguments": { "memory_id": foreign_memory.id.to_string() }
+            }),
+            2,
+        ))
+        .send()
+        .await
+        .expect("forget foreign memory");
+
+    assert_eq!(resp.status(), 200);
+    let text = resp.text().await.unwrap();
+    let json: serde_json::Value = serde_json::from_str(&text).expect("parse json");
+    let result_text = json["result"]["content"][0]["text"]
+        .as_str()
+        .expect("result text");
+    let result: serde_json::Value = serde_json::from_str(result_text).expect("parse result");
+    assert_eq!(result["deleted"], false);
+    assert!(
+        state
+            .storage
+            .get_observation(foreign_memory.id)
+            .expect("load foreign memory")
+            .is_some()
+    );
 
     ct.cancel();
 }

--- a/pensyve-mcp-tools/src/params.rs
+++ b/pensyve-mcp-tools/src/params.rs
@@ -55,12 +55,22 @@ pub struct ObserveParams {
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
+// Destructive call: reject unknown fields instead of silently dropping them,
+// so a caller passing e.g. `memory_id` (expecting to narrow the scope) gets a
+// hard error rather than an entity-wide delete. See issue #217.
+#[serde(deny_unknown_fields)]
 #[allow(dead_code)] // Fields are read via Deserialize, not direct access
 pub struct ForgetParams {
-    /// The entity whose memories to remove.
+    /// The entity whose memories will ALL be permanently deleted.
     pub entity: String,
-    /// If true, permanently deletes rather than soft-deleting.
-    pub hard_delete: Option<bool>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+#[allow(dead_code)] // Fields are read via Deserialize, not direct access
+pub struct ForgetMemoryParams {
+    /// The id (UUID) of the single memory to permanently delete.
+    pub memory_id: String,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -81,3 +91,34 @@ pub struct StatusParams {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct AccountParams {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Issue #217: an unknown field on a destructive call must be a hard
+    /// error, not silently dropped (the incident caller passed `memory_id`
+    /// expecting to narrow an entity-wide delete to one memory).
+    #[test]
+    fn forget_params_rejects_unknown_fields() {
+        let err = serde_json::from_str::<ForgetParams>(
+            r#"{"entity": "design-tool", "memory_id": "96e8896e-0000-0000-0000-000000000000"}"#,
+        );
+        assert!(err.is_err(), "unknown field must fail deserialization");
+        assert!(err.unwrap_err().to_string().contains("memory_id"));
+    }
+
+    #[test]
+    fn forget_params_accepts_entity_only() {
+        let ok = serde_json::from_str::<ForgetParams>(r#"{"entity": "design-tool"}"#);
+        assert!(ok.is_ok());
+    }
+
+    #[test]
+    fn forget_memory_params_rejects_unknown_fields() {
+        let err = serde_json::from_str::<ForgetMemoryParams>(
+            r#"{"memory_id": "96e8896e-0000-0000-0000-000000000000", "entity": "design-tool"}"#,
+        );
+        assert!(err.is_err(), "unknown field must fail deserialization");
+    }
+}

--- a/pensyve-mcp-tools/src/server.rs
+++ b/pensyve-mcp-tools/src/server.rs
@@ -14,7 +14,8 @@ use pensyve_core::types::{
 };
 
 use crate::params::{
-    AccountParams, EpisodeEndParams, EpisodeStartParams, ForgetParams, InspectParams,
+    AccountParams, EpisodeEndParams, EpisodeStartParams, ForgetMemoryParams, ForgetParams,
+    InspectParams,
     ObserveParams, RecallParams, RememberParams, StatusParams,
 };
 use crate::state::PensyveState;
@@ -531,7 +532,7 @@ impl PensyveMcpServer {
     /// Delete memories for an entity.
     #[tool(
         name = "pensyve_forget",
-        description = "Delete all memories associated with an entity. Returns the count of forgotten memories."
+        description = "PERMANENTLY delete ALL memories associated with an entity — entity-wide and irreversible. To retract a single memory, use pensyve_forget_memory instead. Returns the count of forgotten memories."
     )]
     async fn forget(&self, Parameters(params): Parameters<ForgetParams>) -> Result<String, String> {
         check_scope(&self.scope, "pensyve_forget")?;
@@ -585,6 +586,44 @@ impl PensyveMcpServer {
             "entity": params.entity,
             "entity_id": entity.id.to_string(),
             "forgotten_count": forgotten_count,
+        }))
+        .map_err(|e| format!("Serialization error: {e}"))
+    }
+
+    /// Delete a single memory by id.
+    #[tool(
+        name = "pensyve_forget_memory",
+        description = "Permanently delete ONE memory by its id (as returned by pensyve_inspect or pensyve_recall). The safe, scoped alternative to pensyve_forget. Returns whether a memory was deleted."
+    )]
+    async fn forget_memory(
+        &self,
+        Parameters(params): Parameters<ForgetMemoryParams>,
+    ) -> Result<String, String> {
+        check_scope(&self.scope, "pensyve_forget_memory")?;
+        let state = &self.state;
+
+        let memory_id = uuid::Uuid::parse_str(&params.memory_id)
+            .map_err(|e| format!("Invalid memory_id (expected UUID): {e}"))?;
+
+        let deleted = state
+            .storage
+            .delete_memory_by_id(memory_id)
+            .map_err(|err| format!("Error deleting memory: {err}"))?;
+
+        if deleted {
+            let mut vi = state.vector_index.write().await;
+            let _ = vi.remove(memory_id);
+        }
+
+        let _ = state.storage.log_activity(
+            state.namespace.id,
+            "forget_memory",
+            &serde_json::json!({"memory_id": params.memory_id, "deleted": deleted}),
+        );
+
+        serde_json::to_string(&serde_json::json!({
+            "memory_id": params.memory_id,
+            "deleted": deleted,
         }))
         .map_err(|e| format!("Serialization error: {e}"))
     }

--- a/pensyve-mcp-tools/src/server.rs
+++ b/pensyve-mcp-tools/src/server.rs
@@ -15,8 +15,7 @@ use pensyve_core::types::{
 
 use crate::params::{
     AccountParams, EpisodeEndParams, EpisodeStartParams, ForgetMemoryParams, ForgetParams,
-    InspectParams,
-    ObserveParams, RecallParams, RememberParams, StatusParams,
+    InspectParams, ObserveParams, RecallParams, RememberParams, StatusParams,
 };
 use crate::state::PensyveState;
 
@@ -532,7 +531,9 @@ impl PensyveMcpServer {
     /// Delete memories for an entity.
     #[tool(
         name = "pensyve_forget",
-        description = "PERMANENTLY delete ALL memories associated with an entity — entity-wide and irreversible. To retract a single memory, use pensyve_forget_memory instead. Returns the count of forgotten memories."
+        description = "PERMANENTLY delete ALL memories associated with an entity — entity-wide \
+                       and irreversible. To retract a single memory, use pensyve_forget_memory \
+                       instead. Returns the count of forgotten memories."
     )]
     async fn forget(&self, Parameters(params): Parameters<ForgetParams>) -> Result<String, String> {
         check_scope(&self.scope, "pensyve_forget")?;
@@ -593,7 +594,9 @@ impl PensyveMcpServer {
     /// Delete a single memory by id.
     #[tool(
         name = "pensyve_forget_memory",
-        description = "Permanently delete ONE memory by its id (as returned by pensyve_inspect or pensyve_recall). The safe, scoped alternative to pensyve_forget. Returns whether a memory was deleted."
+        description = "Permanently delete ONE memory by its id (as returned by pensyve_inspect or \
+                       pensyve_recall). The safe, scoped alternative to pensyve_forget. Returns \
+                       whether a memory was deleted."
     )]
     async fn forget_memory(
         &self,
@@ -607,7 +610,7 @@ impl PensyveMcpServer {
 
         let deleted = state
             .storage
-            .delete_memory_by_id(memory_id)
+            .delete_memory_by_id_in_namespace(memory_id, state.namespace.id)
             .map_err(|err| format!("Error deleting memory: {err}"))?;
 
         if deleted {

--- a/pensyve-mcp/README.md
+++ b/pensyve-mcp/README.md
@@ -2,7 +2,7 @@
 
 Model Context Protocol (MCP) server for Pensyve — a universal memory runtime for AI agents.
 
-Exposes 6 memory tools over stdio so any MCP-compatible client (Claude Code, Cursor, Continue, etc.) can store, search, and manage memories backed by a local SQLite database with semantic search.
+Exposes 7 memory tools over stdio so any MCP-compatible client (Claude Code, Cursor, Continue, etc.) can store, search, and manage memories backed by a local SQLite database with semantic search.
 
 ---
 
@@ -244,14 +244,15 @@ Close an open episode and record its outcome. Returns the count of memories extr
 
 ### `pensyve_forget`
 
-Delete all memories associated with a named entity. If the entity does not exist, returns a zero count without error. By default this is a hard delete.
+Delete **all** memories associated with a named entity. This is entity-wide and irreversible (a permanent hard delete). To retract a single memory instead, use `pensyve_forget_memory`. If the entity does not exist, returns a zero count without error.
+
+Unknown parameters are rejected with an error rather than silently ignored.
 
 **Parameters**
 
 | Name          | Type    | Required | Default | Description                                 |
 | ------------- | ------- | -------- | ------- | ------------------------------------------- |
 | `entity`      | string  | yes      | —       | Name of the entity whose memories to remove |
-| `hard_delete` | boolean | no       | `true`  | If `true`, permanently deletes records      |
 
 **Example input**
 
@@ -280,6 +281,37 @@ If the entity is not found:
   "message": "Entity not found"
 }
 ```
+
+---
+
+### `pensyve_forget_memory`
+
+Permanently delete one memory by its id (as returned by `pensyve_recall` or `pensyve_inspect`). The safe, scoped alternative to `pensyve_forget`.
+
+**Parameters**
+
+| Name        | Type   | Required | Default | Description                                    |
+| ----------- | ------ | -------- | ------- | ---------------------------------------------- |
+| `memory_id` | string | yes      | —       | UUID of the single memory to permanently delete |
+
+**Example input**
+
+```json
+{
+  "memory_id": "96e8896e-1c2d-4e5f-8a9b-0c1d2e3f4a5b"
+}
+```
+
+**Example output**
+
+```json
+{
+  "memory_id": "96e8896e-1c2d-4e5f-8a9b-0c1d2e3f4a5b",
+  "deleted": true
+}
+```
+
+`deleted` is `false` when no memory with that id exists in the active namespace.
 
 ---
 


### PR DESCRIPTION
Addresses the incident in #217, where a caller passing `memory_id` to `pensyve_forget` (expecting to narrow the scope to one memory) had the unknown field silently dropped and lost 1,528 memories to an entity-wide hard delete.

This implements three of the four requests from that issue:

## 1. `deny_unknown_fields` on `ForgetParams`
The exact call from the incident now fails fast with a clear error instead of executing an entity-wide delete:
```
{"entity": "design-tool", "memory_id": "96e8896e-…"}
→ failed to deserialize parameters: unknown field `memory_id`, expected `entity`
```

## 2. Remove the inert `hard_delete` parameter
`ForgetParams.hard_delete` was documented ("permanently deletes rather than soft-deleting") but never read anywhere — `forget` unconditionally issues hard SQL DELETEs. The published schema therefore promised a reversibility that does not exist. Per the issue's suggestion ("a documented-but-inert safety switch is worse than none"), this removes the parameter rather than implementing soft-delete; combined with `deny_unknown_fields`, callers still passing it get an explicit error instead of a false sense of safety.

## 3. New `pensyve_forget_memory` tool (memory-scoped deletion)
Exposes the already-existing `delete_memory_by_id` storage path (which handles FTS cleanup and the observation KG cascade) as a separate tool with a disjoint schema, plus vector-index removal and activity logging. This gives agents a supported path for the natural need — retract one wrong fact — that previously forced guessing.

Also updates the `pensyve_forget` description to state explicitly that it is entity-wide and irreversible, and points to the scoped tool.

**Not included:** the two-step confirm-token protocol / pre-delete snapshot from the issue's section 4 — that's a design decision better made by maintainers (happy to follow up if there's an agreed direction).

## Tests
Three new serde regression tests in `params.rs` (unknown-field rejection both directions + happy path); `cargo test -p pensyve-mcp-tools` passes 8/8 on current main. Also wire-tested over MCP stdio against a scratch store: the #217-style call errors, `pensyve_forget_memory` on a nonexistent id returns `{"deleted": false}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)