### PR TITLE
fix(consolidation): make episodic→semantic promotion idempotent

### DIFF
--- a/pensyve-core/src/consolidation/mod.rs
+++ b/pensyve-core/src/consolidation/mod.rs
@@ -48,7 +48,7 @@
 pub mod dmem;
 pub mod typed_slots;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::time::{Duration, Instant};
 
 use chrono::Utc;
@@ -225,14 +225,23 @@ impl ConsolidationEngine {
         // Fetch all memories for this namespace to identify episodic ones.
         let all_memories = storage.get_all_memories_by_namespace(namespace_id)?;
 
-        // Partition episodic memories, grouped by about_entity.
+        // Partition episodic memories, grouped by about_entity. In the same
+        // sweep, record every promotion this namespace already holds so a
+        // re-run cannot mint a second copy of it.
         let mut episodic_by_entity: HashMap<Uuid, Vec<EpisodicMemory>> = HashMap::new();
+        let mut already_promoted: HashSet<(Uuid, String)> = HashSet::new();
         for mem in all_memories {
-            if let Memory::Episodic(em) = mem {
-                episodic_by_entity
-                    .entry(em.about_entity)
-                    .or_default()
-                    .push(em);
+            match mem {
+                Memory::Episodic(em) => {
+                    episodic_by_entity
+                        .entry(em.about_entity)
+                        .or_default()
+                        .push(em);
+                }
+                Memory::Semantic(sm) if sm.predicate == "mentioned" => {
+                    already_promoted.insert((sm.subject, sm.object));
+                }
+                _ => {}
             }
         }
 
@@ -310,6 +319,17 @@ impl ConsolidationEngine {
                 let most_recent = &memories[most_recent_idx];
                 let cluster_size = cluster.len();
                 let about_entity = most_recent.about_entity;
+
+                // Idempotency guard: this job re-derives clusters from scratch
+                // on every run, and the (entity, content) pair it would write
+                // is fully determined by that cluster. Without this check a
+                // stable cluster is re-promoted once per run — an episode_end
+                // hook firing per session turns that into unbounded duplicate
+                // growth in semantic memory.
+                if !already_promoted.insert((about_entity, most_recent.content.clone())) {
+                    continue;
+                }
+
                 let confidence = (cluster_size as f32 * 0.3).min(1.0);
                 let source_episodes: Vec<Uuid> = cluster
                     .iter()

--- a/pensyve-core/tests/test_consolidation_idempotency.rs
+++ b/pensyve-core/tests/test_consolidation_idempotency.rs
@@ -136,6 +136,12 @@ fn guard_does_not_collapse_distinct_entities() {
 
 /// A genuinely new cluster still promotes after earlier runs have populated
 /// the namespace — the guard suppresses duplicates, not new knowledge.
+///
+/// The second cluster is deliberately filed under the *same* entity as the
+/// first. That pins the content half of the key: a guard keyed on
+/// `about_entity` alone would treat this entity as already promoted and skip
+/// it, so this case fails against an entity-only guard while
+/// `guard_does_not_collapse_distinct_entities` pins the entity half.
 #[test]
 fn new_clusters_still_promote_after_prior_runs() {
     let tmp = TempDir::new().unwrap();
@@ -158,10 +164,9 @@ fn new_clusters_still_promote_after_prior_runs() {
     assert_eq!(run_once(&storage, &embedder, ns.id), 1);
     assert_eq!(run_once(&storage, &embedder, ns.id), 0);
 
-    // New entity arrives after the namespace already holds a promotion.
-    let entity_b = Uuid::new_v4();
+    // A different fact arrives for an entity that already holds a promotion.
     for i in 0..2 {
-        let mut mem = EpisodicMemory::new(ns.id, episode.id, source_id, entity_b, "uses fish");
+        let mut mem = EpisodicMemory::new(ns.id, episode.id, source_id, entity_a, "uses fish");
         mem.embedding = embedder.embed(&mem.content).unwrap();
         mem.timestamp = Utc::now() - chrono::Duration::seconds(i);
         storage.save_episodic(&mem).unwrap();

--- a/pensyve-core/tests/test_consolidation_idempotency.rs
+++ b/pensyve-core/tests/test_consolidation_idempotency.rs
@@ -1,0 +1,176 @@
+//! Promotion idempotency — `promote_episodic_to_semantic` must not re-mint a
+//! semantic row for a cluster it has already promoted.
+//!
+//! The promotion pass re-derives clusters from scratch on every run, and the
+//! `(about_entity, content)` pair it writes is fully determined by the winning
+//! cluster. Before the guard, a namespace whose episodic set was stable still
+//! gained one duplicate semantic row per cluster per run. `pensyve_episode_end`
+//! spawns a full-namespace consolidation, so a per-session `episode_end` hook
+//! turned that into unbounded growth: an observed local store held 652
+//! `mentioned` rows covering only 23 distinct objects, every one a verbatim
+//! copy of an episodic row that was still present.
+
+use chrono::Utc;
+use pensyve_core::config::{ConsolidationConfig, PensyveConfig};
+use pensyve_core::consolidation::ConsolidationEngine;
+use pensyve_core::embedding::OnnxEmbedder;
+use pensyve_core::network_policy::NetworkPolicy;
+use pensyve_core::storage::StorageTrait;
+use pensyve_core::storage::sqlite::SqliteBackend;
+use pensyve_core::types::{Episode, EpisodicMemory, Memory, Namespace};
+use tempfile::TempDir;
+use tokio_util::sync::CancellationToken;
+use uuid::Uuid;
+
+fn make_config() -> ConsolidationConfig {
+    PensyveConfig::default().consolidation
+}
+
+fn semantic_rows(storage: &SqliteBackend, ns: Uuid) -> Vec<(Uuid, String)> {
+    storage
+        .get_all_memories_by_namespace(ns)
+        .expect("get_all_memories_by_namespace")
+        .into_iter()
+        .filter_map(|m| match m {
+            Memory::Semantic(sm) if sm.predicate == "mentioned" => Some((sm.subject, sm.object)),
+            _ => None,
+        })
+        .collect()
+}
+
+fn run_once(storage: &SqliteBackend, embedder: &OnnxEmbedder, ns: Uuid) -> usize {
+    ConsolidationEngine::run(
+        storage,
+        embedder,
+        &make_config(),
+        ns,
+        &NetworkPolicy::Disabled,
+        &CancellationToken::new(),
+    )
+    .expect("consolidation run")
+    .promoted
+}
+
+/// Re-running the engine over an unchanged episodic set promotes on the first
+/// pass and is a no-op on every pass after it.
+#[test]
+fn repeated_runs_do_not_duplicate_promotions() {
+    let tmp = TempDir::new().unwrap();
+    let storage = SqliteBackend::open(tmp.path()).expect("open storage");
+    let embedder = OnnxEmbedder::new_mock(64);
+
+    let ns = Namespace::new("idempotent_promotion");
+    storage.save_namespace(&ns).unwrap();
+    let entity_id = Uuid::new_v4();
+    let source_id = Uuid::new_v4();
+    let episode = Episode::new(ns.id, vec![source_id, entity_id]);
+    storage.save_episode(&episode).unwrap();
+
+    // Two near-identical memories under one entity — the mock embedder gives
+    // identical vectors, so they cluster (cosine > 0.8) and promote once.
+    for i in 0..2 {
+        let mut mem =
+            EpisodicMemory::new(ns.id, episode.id, source_id, entity_id, "prefers dark mode");
+        mem.embedding = embedder.embed(&mem.content).unwrap();
+        mem.timestamp = Utc::now() - chrono::Duration::seconds(i);
+        storage.save_episodic(&mem).unwrap();
+    }
+
+    let first = run_once(&storage, &embedder, ns.id);
+    assert_eq!(first, 1, "first run must promote the cluster exactly once");
+    assert_eq!(semantic_rows(&storage, ns.id).len(), 1);
+
+    // The episodic set has not changed, so nothing new is derivable.
+    for pass in 2..=5 {
+        let promoted = run_once(&storage, &embedder, ns.id);
+        assert_eq!(
+            promoted, 0,
+            "run {pass} re-promoted an already-promoted cluster"
+        );
+    }
+
+    let rows = semantic_rows(&storage, ns.id);
+    assert_eq!(
+        rows.len(),
+        1,
+        "5 runs over an unchanged episodic set must leave exactly one \
+         semantic row, found {}: {rows:?}",
+        rows.len()
+    );
+}
+
+/// The guard is keyed on `(about_entity, content)`, not on content alone —
+/// the same sentence about two different entities stays two distinct facts.
+#[test]
+fn guard_does_not_collapse_distinct_entities() {
+    let tmp = TempDir::new().unwrap();
+    let storage = SqliteBackend::open(tmp.path()).expect("open storage");
+    let embedder = OnnxEmbedder::new_mock(64);
+
+    let ns = Namespace::new("idempotent_distinct_entities");
+    storage.save_namespace(&ns).unwrap();
+    let source_id = Uuid::new_v4();
+    let episode = Episode::new(ns.id, vec![source_id]);
+    storage.save_episode(&episode).unwrap();
+
+    let entity_a = Uuid::new_v4();
+    let entity_b = Uuid::new_v4();
+    for entity_id in [entity_a, entity_b] {
+        for i in 0..2 {
+            let mut mem =
+                EpisodicMemory::new(ns.id, episode.id, source_id, entity_id, "ships on Fridays");
+            mem.embedding = embedder.embed(&mem.content).unwrap();
+            mem.timestamp = Utc::now() - chrono::Duration::seconds(i);
+            storage.save_episodic(&mem).unwrap();
+        }
+    }
+
+    assert_eq!(run_once(&storage, &embedder, ns.id), 2);
+    assert_eq!(run_once(&storage, &embedder, ns.id), 0);
+
+    let rows = semantic_rows(&storage, ns.id);
+    assert_eq!(rows.len(), 2, "one fact per entity must survive: {rows:?}");
+    let subjects: Vec<Uuid> = rows.iter().map(|(s, _)| *s).collect();
+    assert!(subjects.contains(&entity_a) && subjects.contains(&entity_b));
+}
+
+/// A genuinely new cluster still promotes after earlier runs have populated
+/// the namespace — the guard suppresses duplicates, not new knowledge.
+#[test]
+fn new_clusters_still_promote_after_prior_runs() {
+    let tmp = TempDir::new().unwrap();
+    let storage = SqliteBackend::open(tmp.path()).expect("open storage");
+    let embedder = OnnxEmbedder::new_mock(64);
+
+    let ns = Namespace::new("idempotent_new_cluster");
+    storage.save_namespace(&ns).unwrap();
+    let source_id = Uuid::new_v4();
+    let episode = Episode::new(ns.id, vec![source_id]);
+    storage.save_episode(&episode).unwrap();
+
+    let entity_a = Uuid::new_v4();
+    for i in 0..2 {
+        let mut mem = EpisodicMemory::new(ns.id, episode.id, source_id, entity_a, "uses zsh");
+        mem.embedding = embedder.embed(&mem.content).unwrap();
+        mem.timestamp = Utc::now() - chrono::Duration::seconds(i);
+        storage.save_episodic(&mem).unwrap();
+    }
+    assert_eq!(run_once(&storage, &embedder, ns.id), 1);
+    assert_eq!(run_once(&storage, &embedder, ns.id), 0);
+
+    // New entity arrives after the namespace already holds a promotion.
+    let entity_b = Uuid::new_v4();
+    for i in 0..2 {
+        let mut mem = EpisodicMemory::new(ns.id, episode.id, source_id, entity_b, "uses fish");
+        mem.embedding = embedder.embed(&mem.content).unwrap();
+        mem.timestamp = Utc::now() - chrono::Duration::seconds(i);
+        storage.save_episodic(&mem).unwrap();
+    }
+
+    assert_eq!(
+        run_once(&storage, &embedder, ns.id),
+        1,
+        "a cluster never promoted before must still promote"
+    );
+    assert_eq!(semantic_rows(&storage, ns.id).len(), 2);
+}


### PR DESCRIPTION
## Problem

`promote_episodic_to_semantic` re-derives clusters from scratch on every run and writes a `SemanticMemory` for each one unconditionally. The `(about_entity, content)` pair it writes is fully determined by the winning cluster, so **a namespace whose episodic set has not changed gains one duplicate semantic row per cluster, per run**.

`pensyve_episode_end` spawns a full-namespace consolidation, so any harness that ends an episode per session compounds this on a fixed schedule.

## Observed impact

A local store driven by a per-session `episode_end` hook accumulated:

| | |
|---|---|
| `mentioned` semantic rows | **652** |
| distinct objects among them | **23** |
| share of all semantic memory | **66%** |
| rows that were verbatim copies of a still-present episodic row | **652 / 652** |
| worst single fact | stored **88 times** |

Each carries its own 3 KB embedding, so the store was mostly duplicate vectors — which also crowds the recall ranking, since near-identical rows compete for the same top-k slots as the user's curated facts.

The clustering makes this self-reinforcing for agent harnesses: session summaries that share a boilerplate prefix sit above the 0.8 cosine threshold with each other regardless of their actual content, so they form one large stable cluster that is re-promoted forever.

## FSRS does not offset it

Across 100 consolidation runs on that store, the decay pass applied **55,445 decay updates and archived 0 rows** — every duplicate is created at retrievability 1.0, well above the 0.1 archival threshold, and new ones arrive faster than old ones decay.

This defeats the guarantee in `docs/RECIPES.md` ("No manual cleanup needed") and `README.md` ("Memory store grows unbounded → FSRS forgetting curve... memories you use get stronger, unused ones fade naturally").

## Fix

Record every promotion the namespace already holds while partitioning episodic memories — reusing the `get_all_memories_by_namespace` call the function already makes, so there is **no new `StorageTrait` method and no additional query**.

`HashSet::insert` returning `false` both detects the duplicate and records the new pair, so it also collapses duplicate clusters *within* a single run.

The guard is keyed on `(about_entity, content)` rather than content alone, so the same sentence about two different entities remains two distinct facts.

## Tests

`pensyve-core/tests/test_consolidation_idempotency.rs` — 3 cases:

- `repeated_runs_do_not_duplicate_promotions` — 5 runs over an unchanged episodic set leave exactly one semantic row (first run promotes, rest are no-ops)
- `guard_does_not_collapse_distinct_entities` — same content under two entities stays two facts
- `new_clusters_still_promote_after_prior_runs` — the guard suppresses duplicates, not new knowledge

All three **fail on `main` without the guard** and pass with it.

`cargo fmt` and `cargo clippy --all-targets` are clean, and the rest of the `pensyve-core` suite is unaffected.

> Note: `test_consolidation_policy_and_cancel::i5_long_running_consolidation_cancels_within_budget` fails on this machine both with and without this change — it is timing-sensitive and its own panic message reports the engine finishing before cancel could interpose. Pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TyTGTKWVUgn7mZLJTcz7wz