### PR TITLE
fix(recall): paraphrase recall — eval harness, determinism, retrieval fixes (#186)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,19 +96,28 @@ jobs:
       - name: Paraphrase recall gate
         # Fails if top3_hit_rate drops more than --gate-margin below the
         # committed pensyve-benchmarks/results/paraphrase_baseline.json
-        # (#186). The default margin (0.02, engine.rs's
-        # DEFAULT_GATE_MARGIN) is tighter than the harness's residual
-        # run-to-run jitter: apply_reinforcement writes wall-clock
-        # last_accessed during eval, so score ties occasionally resolve
-        # differently between runs even with deterministic tiebreaks
-        # (Task 3.5). 15 local `--release` runs against the committed
-        # baseline (0.581) observed top3_hit_rate in {0.548, 0.565,
-        # 0.581, 0.597} — a 0.049 max spread, and one run failed the
-        # default 0.02 margin outright (0.581 -> 0.548, drop 0.032). 0.07
-        # comfortably clears that observed spread with headroom for
-        # tail risk beyond the sample, while remaining far below the
-        # scale of improvement Task 5+ fixes are expected to deliver.
-        run: cargo run -p pensyve-benchmarks --bin paraphrase_eval --release -- --gate pensyve-benchmarks/results/paraphrase_baseline.json --gate-margin 0.07
+        # (#186). Task 8 rebaselined this gate on the RERANKED pipeline
+        # (`--rerank`) rather than the raw RRF pipeline the gate used
+        # through Task 7: the gateway/CLI attach the BGE reranker by
+        # default (`reranker=Some("BGERerankerBase")` in
+        # pensyve-python/src/lib.rs), so gating on unreranked output was
+        # comparing against a path production doesn't actually take. It
+        # also happens to be far less noisy — the unreranked pipeline's
+        # apply_reinforcement writes wall-clock last_accessed during
+        # eval, so score ties occasionally resolve differently between
+        # runs even with deterministic tiebreaks (Task 3.5), which is
+        # why the original unreranked gate needed a 0.07 margin (15
+        # local runs against the pre-fix 0.581 baseline spread
+        # top3_hit_rate over {0.548, 0.565, 0.581, 0.597}, a 0.049
+        # range). The reranked pipeline doesn't have that failure mode:
+        # 10 local `--release --rerank` runs against the new baseline
+        # (0.903) all landed on exactly 0.903 — zero observed spread.
+        # 0.03 keeps meaningful headroom over that for CI-hardware
+        # variance and reranker-load fallback risk (a model-load
+        # failure degrades gracefully to unreranked per
+        # `resolve_reranker`, which would read as a real drop here) while
+        # being more than 2x tighter than the old margin.
+        run: cargo run -p pensyve-benchmarks --bin paraphrase_eval --release -- --rerank --gate pensyve-benchmarks/results/paraphrase_baseline.json --gate-margin 0.03
 
   test-rust-no-network-invariants:
     name: Rust No-Network Invariants

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,22 @@ jobs:
         # in a process; serializing avoids any residual races on the
         # WAL/index files fastembed maintains alongside `model.onnx`.
         run: cargo test --workspace -- --ignored --test-threads=1
+      - name: Paraphrase recall gate
+        # Fails if top3_hit_rate drops more than --gate-margin below the
+        # committed pensyve-benchmarks/results/paraphrase_baseline.json
+        # (#186). The default margin (0.02, engine.rs's
+        # DEFAULT_GATE_MARGIN) is tighter than the harness's residual
+        # run-to-run jitter: apply_reinforcement writes wall-clock
+        # last_accessed during eval, so score ties occasionally resolve
+        # differently between runs even with deterministic tiebreaks
+        # (Task 3.5). 15 local `--release` runs against the committed
+        # baseline (0.581) observed top3_hit_rate in {0.548, 0.565,
+        # 0.581, 0.597} — a 0.049 max spread, and one run failed the
+        # default 0.02 margin outright (0.581 -> 0.548, drop 0.032). 0.07
+        # comfortably clears that observed spread with headroom for
+        # tail risk beyond the sample, while remaining far below the
+        # scale of improvement Task 5+ fixes are expected to deliver.
+        run: cargo run -p pensyve-benchmarks --bin paraphrase_eval --release -- --gate pensyve-benchmarks/results/paraphrase_baseline.json --gate-margin 0.07
 
   test-rust-no-network-invariants:
     name: Rust No-Network Invariants

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,11 +112,20 @@ jobs:
         # range). The reranked pipeline doesn't have that failure mode:
         # 10 local `--release --rerank` runs against the new baseline
         # (0.903) all landed on exactly 0.903 — zero observed spread.
-        # 0.03 keeps meaningful headroom over that for CI-hardware
-        # variance and reranker-load fallback risk (a model-load
-        # failure degrades gracefully to unreranked per
-        # `resolve_reranker`, which would read as a real drop here) while
-        # being more than 2x tighter than the old margin.
+        # Mechanistically: this fixture's gold docs already sit within
+        # the top-20 pre-rerank pool, so the last_accessed jitter that
+        # reshuffles ties at the pool boundary never changes which
+        # candidates the cross-encoder sees, only their pre-rerank
+        # order, which reranking discards anyway. 0.03 keeps meaningful
+        # headroom over that for CI-hardware variance and reranker-load
+        # fallback risk (a model-load failure degrades gracefully to
+        # unreranked per `resolve_reranker`, which would read as a real
+        # drop here) while being more than 2x tighter than the old
+        # margin. paraphrase_eval also hard-errors if the committed
+        # baseline's recorded mode (reranked/unreranked) doesn't match
+        # --rerank below, so a future baseline write in the wrong mode
+        # can't silently widen this margin (see BaselineOutput::reranked
+        # in paraphrase_eval.rs).
         run: cargo run -p pensyve-benchmarks --bin paraphrase_eval --release -- --rerank --gate pensyve-benchmarks/results/paraphrase_baseline.json --gate-margin 0.03
 
   test-rust-no-network-invariants:

--- a/docs/superpowers/plans/2026-08-04-forget-safety-completion.md
+++ b/docs/superpowers/plans/2026-08-04-forget-safety-completion.md
@@ -1,0 +1,249 @@
+# Forget Safety Completion Implementation Plan (#217, plus the #189 comment)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close issue #217 by hardening the last unscoped delete path, removing stale `hard_delete` references, and making destructive forgets recoverable through an archive and restore layer.
+
+**Architecture:** Every destructive forget writes the deleted rows (with embeddings) into a new `forget_archives` table inside the same transaction as the delete. A new `pensyve_restore` MCP tool and REST endpoint reinsert archived rows. The consolidation maintenance pass prunes expired archives. No read path changes.
+
+**Tech Stack:** Rust (rusqlite, sqlx/postgres, rmcp, axum), serde_json for archive payloads.
+
+## Global Constraints
+
+- **Precondition: PR #218 must be merged first.** Tasks 2 onward use `delete_memory_by_id_in_namespace`, which #218 introduces. Task 1 and Task 3 have no dependency on #218.
+- MCP and REST surfaces stay in parity (repo precedent from PR #197).
+- All new storage methods are namespace scoped. A tenant must never read, restore, or delete another tenant's archives.
+- Archive serialization failure aborts the forget (transaction rolls back). A delete that cannot be archived must not happen.
+- Default archive retention is 30 days; `PENSYVE_ARCHIVE_RETENTION_DAYS` overrides it.
+- Match existing code style: rusqlite `params![]`, `StorageResult<T>`, `lock_conn!` macro in sqlite.rs, `scoped_conn(namespace_id)` for every Postgres method that takes a namespace.
+- Run `cargo fmt` and `cargo clippy --workspace -- -D warnings` before every commit.
+
+---
+
+### Task 1: Post the #189 decision comment
+
+**Files:** none (GitHub only)
+
+- [ ] **Step 1: Post the comment**
+
+```bash
+gh issue comment 189 --body "Decision (2026-08-04): we wait for the ecosystem rather than build tooling. typescript-eslint 8.65.0 still declares peer typescript >=4.8.4 <6.1.0, so nothing in this repo can unblock the bump. Dependabot opens a fresh PR on each new TypeScript 7.x release; merge criteria are bun run lint, build, and test all green on that PR, which requires a typescript-eslint release that admits TS 7. major7apps/pensyve-cloud#58 follows the same trigger. Keeping this issue open as the tracker."
+```
+
+- [ ] **Step 2: Verify** — `gh issue view 189 --comments | tail -20` shows the comment.
+
+### Task 2: Scope the REST delete endpoint
+
+**Files:**
+- Modify: `pensyve-mcp-gateway/src/rest.rs:1156` (the `delete_memory` handler)
+- Test: `pensyve-mcp-gateway/tests/integration_test.rs`
+
+**Interfaces:**
+- Consumes: `StorageTrait::delete_memory_by_id_in_namespace(&self, memory_id: Uuid, namespace_id: Uuid) -> StorageResult<bool>` (from PR #218).
+- Produces: no new interfaces; behavior change only (foreign-namespace REST delete now 404s).
+
+- [ ] **Step 1: Write the failing test.** In `pensyve-mcp-gateway/tests/integration_test.rs`, next to the existing `test_mcp_forget_memory_rejects_foreign_namespace` (added by #218), add a REST variant. Follow that test's setup pattern (`create_test_state`, two namespaces, memory saved in namespace A):
+
+```rust
+#[tokio::test]
+async fn test_rest_delete_memory_rejects_foreign_namespace() {
+    // Arrange: state with namespace A holding one memory; request authenticated as namespace B.
+    // Mirror the setup of test_mcp_forget_memory_rejects_foreign_namespace, but issue
+    // DELETE /v1/memories/{id} through the axum router with namespace B's auth context.
+    // Assert: response status is 404 and the memory still exists in namespace A
+    // (storage.get_memory_by_id or an FTS lookup returns it).
+}
+```
+
+Write the body by copying the arrange/act plumbing from the sibling test in the same file; only the route and assertion differ.
+
+- [ ] **Step 2: Run it, expect failure** — `cargo test -p pensyve-mcp-gateway test_rest_delete_memory_rejects_foreign_namespace`. Expected: FAIL (the unscoped delete succeeds, so the handler returns 200).
+
+- [ ] **Step 3: Fix the handler.** In `rest.rs:1156` change:
+
+```rust
+let deleted = ps.storage.delete_memory_by_id(memory_id).map_err(|err| {
+```
+
+to
+
+```rust
+let deleted = ps
+    .storage
+    .delete_memory_by_id_in_namespace(memory_id, ps.namespace.id)
+    .map_err(|err| {
+```
+
+The existing `!deleted → 404` branch below already produces the right result for foreign-namespace IDs.
+
+- [ ] **Step 4: Run the test, expect pass**, then run the full gateway suite: `cargo test -p pensyve-mcp-gateway`.
+
+- [ ] **Step 5: Commit** — `git commit -m "fix(rest): scope DELETE /v1/memories/{id} to the caller's namespace (#217)"`
+
+### Task 3: Remove stale hard_delete references
+
+**Files:**
+- Modify: `integrations/hermes/__init__.py:261` (schema) and `:646` (request construction)
+- Modify: `pensyve-mcp/README.md:254`, `integrations/claude-code/README.md:244`, `integrations/gemini-extension/README.md:143`
+
+**Interfaces:** none.
+
+- [ ] **Step 1: Fix hermes.** Delete line 261 (the `"hard_delete"` property in the tool schema) and line 646 (`"hard_delete": args.get("hard_delete"),` in the arguments dict). Check surrounding dict syntax stays valid (trailing commas).
+
+- [ ] **Step 2: Fix the three READMEs.** Remove the `hard_delete` row from `pensyve-mcp/README.md:254`, and drop `hard_delete?` from the `pensyve_forget` parameter lists in the two integration READMEs. While in each table, confirm `pensyve_forget_memory` (added by #218) is listed; add a row if missing: parameters `memory_id`, returns `deleted`, `archive_id` (after Task 5 lands; if writing before Task 5, returns `deleted`).
+
+- [ ] **Step 3: Verify** — `grep -rn hard_delete --include='*.py' --include='*.md' .` returns only CHANGELOG/historical mentions, and hermes tests pass: run the hermes test suite per `integrations/hermes/` README (pytest with a clean env, no `PENSYVE_API_KEY` set).
+
+- [ ] **Step 4: Commit** — `git commit -m "docs: remove retired hard_delete parameter from callers and docs (#217)"`
+
+### Task 4: forget_archives storage layer (SQLite)
+
+**Files:**
+- Modify: `pensyve-core/src/storage/mod.rs` (trait + `ForgetArchive` type), `pensyve-core/src/storage/sqlite.rs` (schema + impl)
+- Test: unit tests at the bottom of `sqlite.rs`, following the file's existing test module pattern
+
+**Interfaces (Produces — later tasks rely on these exact signatures):**
+
+```rust
+pub struct ForgetArchive {
+    pub id: Uuid,
+    pub namespace_id: Uuid,
+    pub created_at: DateTime<Utc>,
+    pub expires_at: DateTime<Utc>,
+    pub description: String,
+    pub payload: String, // JSON, see ArchivePayload
+}
+
+/// Serialized content of one archive.
+#[derive(Serialize, Deserialize)]
+pub struct ArchivePayload {
+    pub memories: Vec<Memory>,            // existing enum, already serde-capable
+    pub embeddings: Vec<(Uuid, Vec<f32>)>, // memory id → vector
+    pub kg_edges: Vec<KgEdgeRecord>,       // define alongside; SQLite KG rows
+}
+
+// StorageTrait additions (default impls return Err(StorageError::Unsupported(...)),
+// mirroring the fail-closed pattern from delete_memory_by_id_in_namespace in #218):
+fn save_forget_archive(&self, archive: &ForgetArchive) -> StorageResult<()>;
+fn get_forget_archive(&self, archive_id: Uuid, namespace_id: Uuid) -> StorageResult<Option<ForgetArchive>>;
+fn delete_forget_archive(&self, archive_id: Uuid, namespace_id: Uuid) -> StorageResult<bool>;
+fn delete_expired_archives(&self, now: DateTime<Utc>) -> StorageResult<usize>;
+```
+
+- [ ] **Step 1: Add the table to the SQLite schema** (in `sqlite.rs` where the other `CREATE TABLE IF NOT EXISTS` statements live):
+
+```sql
+CREATE TABLE IF NOT EXISTS forget_archives (
+    id TEXT PRIMARY KEY,
+    namespace_id TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    expires_at TEXT NOT NULL,
+    description TEXT NOT NULL,
+    payload TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_forget_archives_ns ON forget_archives(namespace_id);
+CREATE INDEX IF NOT EXISTS idx_forget_archives_exp ON forget_archives(expires_at);
+```
+
+- [ ] **Step 2: Write failing unit tests** in the `sqlite.rs` test module: save then get round-trips all fields; get with the wrong namespace returns `None`; `delete_expired_archives` removes only rows with `expires_at < now`.
+
+- [ ] **Step 3: Run tests, expect failure** — `cargo test -p pensyve-core forget_archive`.
+
+- [ ] **Step 4: Implement the four methods** in `SqliteBackend` with plain parameterized SQL (`INSERT`, `SELECT ... WHERE id = ?1 AND namespace_id = ?2`, `DELETE ... WHERE id = ?1 AND namespace_id = ?2`, `DELETE ... WHERE expires_at < ?1`). Timestamps stored RFC 3339, matching the file's existing convention.
+
+- [ ] **Step 5: Run tests, expect pass.** Then `cargo clippy -p pensyve-core -- -D warnings`.
+
+- [ ] **Step 6: Commit** — `git commit -m "feat(storage): forget_archives table and trait methods, sqlite (#217)"`
+
+### Task 5: forget_archives storage layer (Postgres)
+
+**Files:**
+- Modify: `pensyve-core/src/storage/postgres.rs`, `pensyve-core/src/storage/postgres_schema.sql`
+- Test: the Postgres test module in `postgres.rs` (uses the existing dockerized/`DATABASE_URL` test harness in that file)
+
+**Interfaces:** Consumes and implements the exact trait signatures from Task 4.
+
+- [ ] **Step 1: Add the table to `postgres_schema.sql`** with the same columns (`id UUID PRIMARY KEY`, `namespace_id UUID NOT NULL`, `created_at TIMESTAMPTZ`, `expires_at TIMESTAMPTZ`, `description TEXT`, `payload JSONB`), plus an RLS policy identical in shape to the existing `namespace_isolation_*` policies so archives are invisible cross-tenant.
+
+- [ ] **Step 2: Write failing tests** mirroring Task 4's three tests, in the Postgres test module.
+
+- [ ] **Step 3: Implement the four methods.** Every method that takes `namespace_id` MUST acquire its connection with `self.scoped_conn(namespace_id)` (the invariant documented at `postgres.rs:265-288`; the #218 review bug was exactly a violation of it). `delete_expired_archives` takes no namespace and uses `maybe_scoped_conn()`.
+
+- [ ] **Step 4: Run tests, expect pass** — `cargo test -p pensyve-core --features postgres` (or the repo's existing Postgres test invocation; check `.github/workflows/ci.yml` for the exact command).
+
+- [ ] **Step 5: Commit** — `git commit -m "feat(storage): forget_archives for postgres with RLS (#217)"`
+
+### Task 6: Archive on forget (both tools)
+
+**Files:**
+- Modify: `pensyve-mcp-tools/src/server.rs` (the `forget` handler at ~536 and `forget_memory` at ~611)
+- Modify: `pensyve-core/src/storage/mod.rs`, `sqlite.rs`, `postgres.rs` (archiving delete variants)
+- Test: `pensyve-mcp-gateway/tests/integration_test.rs`
+
+**Interfaces (Produces):**
+
+```rust
+// Trait additions; each performs archive + delete in ONE transaction and
+// returns the created archive id with the deleted count:
+fn delete_memories_by_entity_archived(
+    &self, entity_id: Uuid, namespace_id: Uuid, expires_at: DateTime<Utc>, description: &str,
+) -> StorageResult<(usize, Uuid)>;
+fn delete_memory_by_id_in_namespace_archived(
+    &self, memory_id: Uuid, namespace_id: Uuid, expires_at: DateTime<Utc>, description: &str,
+) -> StorageResult<(bool, Option<Uuid>)>;
+```
+
+Tool responses gain fields: `pensyve_forget` → `{ forgotten_count, archive_id, recoverable_until }`; `pensyve_forget_memory` → `{ deleted, archive_id, recoverable_until }` (`archive_id` null when nothing was deleted).
+
+- [ ] **Step 1: Write the failing integration test**: forget an entity via the MCP tool, assert the response contains `archive_id`, then read the archive with `get_forget_archive` and assert its payload lists the same number of memories.
+
+- [ ] **Step 2: Implement the archived delete variants.** In SQLite, inside the existing delete transaction (the helper #218 refactored, `delete_memory_by_id_with_namespace`, and the entity-wide path behind `delete_memories_by_entity`): first `SELECT` the affected rows from each memory table plus KG edges, build `ArchivePayload` (embeddings read from the rows' stored vectors), `serde_json::to_string` it, `INSERT` the archive row, then run the existing deletes, then commit. Any serialization or insert error rolls back the whole transaction. Postgres mirrors the shape with `scoped_conn`.
+
+- [ ] **Step 3: Update the two handlers in `server.rs`** to call the archived variants, compute `expires_at = now + retention_days`, and include the new response fields. Retention days: read `PENSYVE_ARCHIVE_RETENTION_DAYS` (default 30) once, following the env-var pattern used elsewhere in the crate.
+
+- [ ] **Step 4: Run the failing test, expect pass**; then the full workspace test suite `cargo test --workspace`.
+
+- [ ] **Step 5: Commit** — `git commit -m "feat(forget): archive deleted rows transactionally, return archive_id (#217)"`
+
+### Task 7: Restore (MCP tool + REST endpoint)
+
+**Files:**
+- Modify: `pensyve-mcp-tools/src/params.rs` (new `RestoreParams { archive_id: String }`, with `deny_unknown_fields`), `pensyve-mcp-tools/src/server.rs` (new `pensyve_restore` tool), `pensyve-mcp-gateway/src/rest.rs` (new route `POST /v1/archives/{id}/restore`)
+- Modify: `pensyve-core/src/storage/mod.rs` + backends: `restore_forget_archive(&self, archive_id: Uuid, namespace_id: Uuid) -> StorageResult<RestoreOutcome>` where `RestoreOutcome { restored: usize, skipped: Vec<Uuid> }`
+- Test: `pensyve-mcp-gateway/tests/integration_test.rs`
+
+**Interfaces:**
+- Consumes: `get_forget_archive`, `ArchivePayload` (Task 4), storage `save_*` methods for each memory type.
+- Produces: `pensyve_restore(archive_id)` MCP tool returning `{ restored, skipped, archive_id }`; REST returns the same JSON.
+
+- [ ] **Step 1: Write failing integration tests** (three):
+  1. Round trip: seed memories, `pensyve_forget` the entity, `pensyve_restore(archive_id)`, then recall/FTS returns the memories again and the vector index contains their ids.
+  2. Foreign namespace: restoring an archive created in namespace A while authenticated as namespace B returns an error and restores nothing.
+  3. Skip conflicts: restore twice; second call reports all rows in `skipped`, none duplicated.
+
+- [ ] **Step 2: Implement `restore_forget_archive`** in both backends: load the archive (namespace scoped), deserialize `ArchivePayload`, and inside one transaction reinsert each memory row (skip when a row with the same UUID exists — `INSERT OR IGNORE` in SQLite, `ON CONFLICT DO NOTHING` in Postgres, collecting skipped ids via a pre-check `SELECT`), reinsert KG edges and FTS rows the same way the normal save path does. Do not delete the archive on restore (it stays until expiry, so a bad restore can be repeated).
+
+- [ ] **Step 3: Implement the MCP tool** in `server.rs` (write scope, like `forget`), re-adding vector index entries from `payload.embeddings` after the storage call, mirroring how `forget_memory` removes them. Update the gateway tool-count assertion (10 → 11) and name list in `integration_test.rs`.
+
+- [ ] **Step 4: Implement the REST route** calling the same storage method with `ps.namespace.id`, 404 when the archive is missing or foreign.
+
+- [ ] **Step 5: Run all tests, expect pass** — `cargo test --workspace`.
+
+- [ ] **Step 6: Commit** — `git commit -m "feat(restore): pensyve_restore tool and REST endpoint (#217)"`
+
+### Task 8: Retention pruning + docs
+
+**Files:**
+- Modify: `pensyve-core/src/consolidation/mod.rs` (maintenance: after `decay_pass` at ~194, call `storage.delete_expired_archives(Utc::now())`)
+- Modify: `pensyve-mcp/README.md` (document `pensyve_restore`, `archive_id`, `recoverable_until`, `PENSYVE_ARCHIVE_RETENTION_DAYS`), `docs/SECURITY.md` (archives are namespace scoped; retention window)
+- Test: consolidation test module in `mod.rs`
+
+- [ ] **Step 1: Write the failing test**: create one expired and one live archive, run the consolidation maintenance path, assert only the expired one is gone.
+
+- [ ] **Step 2: Implement** the one-line pruning call with a logged count, matching the surrounding decay_pass error-handling style (failures logged, never abort consolidation).
+
+- [ ] **Step 3: Run tests, expect pass**; update the two docs.
+
+- [ ] **Step 4: Commit** — `git commit -m "feat(consolidation): prune expired forget archives; document restore (#217)"`
+
+- [ ] **Step 5: Open the two PRs.** PR-1 = Tasks 2-3 (branch `fix/217-prevention-followups`), PR-2 = Tasks 4-8 (branch `feat/217-forget-archive-restore`). Reference "Closes #217" in PR-2.

--- a/docs/superpowers/plans/2026-08-04-paraphrase-recall.md
+++ b/docs/superpowers/plans/2026-08-04-paraphrase-recall.md
@@ -94,6 +94,23 @@ pub fn load_corpus() -> FixtureCorpus; // include_str! + serde_json, panics on m
 
 - [ ] **Step 3: Commit the baseline** — save output as `pensyve-benchmarks/results/paraphrase_baseline.json`; `git commit -m "feat(benchmarks): paraphrase_eval binary and pre-fix baseline (#186)"`
 
+### Task 3.5: Deterministic ranking (inserted 2026-08-04 after Task 3's discovery)
+
+**Why inserted:** Task 3 found `RecallEngine` returns different rankings for identical inputs run to run (top-3 hit rate swings 0.435 to 0.645). Root cause: the per-leg and final fusion sorts compare only f32 scores, over candidate lists collected from `HashMap` iteration whose order reseeds each call, so ties land in arbitrary order. The CI gate (Task 4) and the ablations (Task 8) cannot measure anything until rankings are reproducible, and nondeterministic recall is itself a #186-class defect (known items flicker in and out of top-3).
+
+**Files:**
+- Modify: `pensyve-core/src/retrieval/engine.rs` (the `sort_by` calls at ~724, 729, 751, 782, 798, 817 and the final fused-score sort)
+- Test: `pensyve-core/tests/` or the engine's test module
+- Modify: `pensyve-benchmarks/results/paraphrase_baseline.json` (regenerate once deterministic)
+
+**Interfaces:** no signature changes; ranking becomes a pure function of inputs.
+
+- [ ] **Step 1: Write the failing test**: build a small in-memory corpus (mock embedder fine), call the recall path twice with the same inputs in one process, assert the two ranked ID lists are identical. Run: FAILS (or flakes) today.
+- [ ] **Step 2: Add stable tiebreaks**: every ranking sort orders by score descending, then by memory UUID ascending as the tiebreak. Where candidate maps are iterated to build lists whose order feeds ranks, collect and sort deterministically first.
+- [ ] **Step 3: Test passes; run it 10 times** (`cargo test ... -- --test-threads=1` in a loop) to confirm stability; full core suite green.
+- [ ] **Step 4: Verify at the harness level**: run `paraphrase_eval` 3 times; assert identical JSON output (diff the files). Regenerate and commit the baseline with `--write-baseline`.
+- [ ] **Step 5: Commit** — `git commit -m "fix(recall): deterministic ranking via stable sort tiebreaks (#186)"`
+
 ### Task 4: CI regression gate
 
 **Files:**

--- a/docs/superpowers/plans/2026-08-04-paraphrase-recall.md
+++ b/docs/superpowers/plans/2026-08-04-paraphrase-recall.md
@@ -1,0 +1,197 @@
+# Paraphrase Recall Fix Implementation Plan (#186)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a committed paraphrase-recall evaluation harness, then fix the retrieval defects that make paraphrased queries miss top-3, proving each fix against the harness.
+
+**Architecture:** A fixture corpus (JSON, ~250 memories) and paraphrase query set live in `pensyve-benchmarks/fixtures/`. A new `paraphrase_eval` binary loads them into a temp SQLite backend, embeds with the real ONNX embedder, runs `RecallEngine`, and reports top-3 hit rate and MRR. Fixes land one commit each, re-running the eval after each: FTS bm25 ordering, OR semantics for multi-token FTS queries, reranker wiring in gateway/CLI, then measured ablations of adaptive-k and the activation leg.
+
+**Tech Stack:** Rust, `pensyve-benchmarks` crate (template: `src/bin/real_content_eval.rs`), fastembed ONNX models (`Alibaba-NLP/gte-base-en-v1.5` embedder, `BGERerankerBase` reranker), FTS5.
+
+## Global Constraints
+
+- No network at recall time; models come from the local fastembed cache (CI uses the seeded cache from PR #201's "Rust Tests (with models)" job).
+- Model swaps are out of scope. Query expansion is out of scope.
+- Success bar: the two audit failures ("arrow parquet reader benchmark speed" → bob's parquet fact; "rollback when p99 exceeds threshold" → deploy-pipeline fact) hit top-3; corpus-wide top-3 hit rate ≥ 0.90 (confirm after baseline); no regression on `real_content_eval`.
+- Ablations (Task 7) are adopted only if the harness improves; otherwise revert and record the numbers in the task's commit message.
+- Run `cargo fmt` and `cargo clippy --workspace -- -D warnings` before every commit.
+
+---
+
+### Task 1: Corpus fixture + loader
+
+**Files:**
+- Create: `pensyve-benchmarks/fixtures/paraphrase_corpus.json`
+- Create: `pensyve-benchmarks/src/fixture.rs` (loader) and register `pub mod fixture;` in `pensyve-benchmarks/src/lib.rs`
+- Test: `#[cfg(test)]` module inside `fixture.rs`
+
+**Interfaces (Produces):**
+
+```rust
+#[derive(Deserialize)]
+pub struct FixtureCorpus {
+    pub memories: Vec<FixtureMemory>,
+    pub queries: Vec<FixtureQuery>,
+}
+#[derive(Deserialize)]
+pub struct FixtureMemory {
+    pub key: String,          // stable handle referenced by queries, e.g. "bob-parquet-bench"
+    pub entity: String,       // one of 5 entity names
+    pub kind: String,         // "semantic" | "episodic"
+    pub content: String,
+    pub confidence: f32,      // 0.35 to 1.0
+}
+#[derive(Deserialize)]
+pub struct FixtureQuery {
+    pub query: String,
+    pub gold_keys: Vec<String>, // keys of memories that count as hits
+    pub kind: String,           // "paraphrase" | "lexical" (control)
+}
+pub fn load_corpus() -> FixtureCorpus; // include_str! + serde_json, panics on malformed fixture
+```
+
+- [ ] **Step 1: Write the corpus JSON.** Shape per the audit (`pensyve-docs/research/2026-07-12-pensyve-memory-explorer-p0-audit.md` lines 13-19): 250 memories (220 semantic, 30 episodic) across 5 entities (`bob`, `alice`, `deploy-pipeline`, `acme-corp`, `research-notes`), confidence spread 0.35 to 1.0, 10 contradiction pairs, and 5 planted known-item facts. The two audit-relevant facts MUST be present verbatim in spirit:
+  - key `bob-parquet-bench`, entity `bob`: "Bob benchmarked the Arrow-based Parquet reader at 2.1 GB/s on the m7i instance"
+  - key `deploy-p99-rollback`, entity `deploy-pipeline`: "The deploy pipeline automatically rolls back a release when p99 latency exceeds the alert threshold for five minutes"
+  Write the remaining 248 as realistic varied facts (model them on `real_content_eval.rs`'s `build_memories()` domains). Bulk generation hint for the implementer: write 40 to 50 distinct facts per entity by hand or scripted, but the file itself is committed data; no runtime generation.
+
+- [ ] **Step 2: Write the loader + test.** Test asserts: 250 memories, 220 semantic, every `gold_keys` entry resolves to an existing memory `key`, and the two audit keys exist. Run `cargo test -p pensyve-benchmarks fixture` (FAIL first if written test-first, then PASS).
+
+- [ ] **Step 3: Commit** — `git commit -m "feat(benchmarks): committed paraphrase corpus fixture and loader (#186)"`
+
+### Task 2: Paraphrase query set
+
+**Files:**
+- Modify: `pensyve-benchmarks/fixtures/paraphrase_corpus.json` (fill `queries`)
+- Test: extend the `fixture.rs` test
+
+**Interfaces:** Consumes `FixtureQuery` from Task 1.
+
+- [ ] **Step 1: Write 60 queries**: 50 paraphrase (no content-word overlap with their gold memory where possible — reword verbs and nouns, e.g. gold "benchmarked ... 2.1 GB/s" → query "how fast is bob's parquet reader"), 10 lexical controls (near-verbatim wording, these should stay at hit rate 1.0 and catch over-correction). Include the two audit failures verbatim: `"arrow parquet reader benchmark speed"` → `["bob-parquet-bench"]` and `"rollback when p99 exceeds threshold"` → `["deploy-p99-rollback"]`.
+
+- [ ] **Step 2: Extend the fixture test**: ≥ 60 queries, ≥ 50 with kind `paraphrase`, both audit queries present. Run to green.
+
+- [ ] **Step 3: Commit** — `git commit -m "feat(benchmarks): paraphrase query set with audit failure cases (#186)"`
+
+### Task 3: paraphrase_eval binary + baseline
+
+**Files:**
+- Create: `pensyve-benchmarks/src/bin/paraphrase_eval.rs`
+- Create: `pensyve-benchmarks/results/paraphrase_baseline.json` (generated, committed)
+
+**Interfaces:**
+- Consumes: `fixture::load_corpus()`; `OnnxEmbedder`, `SqliteBackend`, `VectorIndex`, `RecallEngine` exactly as `real_content_eval.rs` uses them (copy its setup: temp dir SQLite, namespace, entities, save memories, embed contents, populate the vector index).
+- Produces: binary printing and writing JSON `{ top3_hit_rate, mrr, per_query: [{query, kind, gold_rank}] }`; exits nonzero when `--gate <path>` is passed and top3_hit_rate drops more than 0.02 below the gate file's value.
+
+- [ ] **Step 1: Write the binary.** Structure, modeled line-for-line on `real_content_eval.rs`:
+  1. Load fixture; create temp SQLite backend + namespace; create the 5 entities; save each memory as its kind (semantic via `SemanticMemory::new(entity_id, "mentioned", content, ...)`, episodic via `EpisodicMemory` — copy constructor usage from `real_content_eval.rs`).
+  2. Embed every content with `OnnxEmbedder` and insert into `VectorIndex` keyed by memory id. Keep a map key → memory id.
+  3. For each query: embed, call `engine.recall_with_embedding(...)` with `limit=10` (match the audit's usage; check the exact recall entry point signature in `engine.rs:490` and mirror how `real_content_eval.rs` invokes it), record the best rank of any gold id.
+  4. Metrics: `top3_hit_rate` = fraction of queries with gold rank ≤ 3 (use `metrics::recall_at_k` if it fits, else compute inline); `mrr` via `metrics::mrr`.
+  5. Print a per-kind breakdown (paraphrase vs lexical) and write the JSON.
+
+- [ ] **Step 2: Run it** — `cargo run -p pensyve-benchmarks --bin paraphrase_eval --release`. Expected: runs clean, paraphrase hit rate well below 1.0 (the audit predicts misses), both audit queries likely missing top-3. If the audit queries PASS here, stop and investigate the fixture (contents may be too lexically close to the queries) before proceeding — the harness must reproduce the bug to validate the fixes.
+
+- [ ] **Step 3: Commit the baseline** — save output as `pensyve-benchmarks/results/paraphrase_baseline.json`; `git commit -m "feat(benchmarks): paraphrase_eval binary and pre-fix baseline (#186)"`
+
+### Task 4: CI regression gate
+
+**Files:**
+- Modify: `.github/workflows/ci.yml` (the "Rust Tests (with models)" job)
+
+- [ ] **Step 1: Add a step** after the existing model-cached test step:
+
+```yaml
+      - name: Paraphrase recall gate
+        run: cargo run -p pensyve-benchmarks --bin paraphrase_eval --release -- --gate pensyve-benchmarks/results/paraphrase_baseline.json
+```
+
+The `--gate` flag (built in Task 3) fails the job if top3_hit_rate drops > 0.02 below the committed reference. After the fixes land (Task 6+), the committed reference file is updated so the gate protects the improved level.
+
+- [ ] **Step 2: Verify on a branch** — push and confirm the job runs the step and passes.
+
+- [ ] **Step 3: Commit** — `git commit -m "ci: paraphrase recall regression gate (#186)"`
+
+### Task 5: Order FTS results by bm25
+
+**Files:**
+- Modify: `pensyve-core/src/storage/sqlite.rs:1614` (`search_fts`)
+- Check: the Postgres FTS equivalent in `postgres.rs` (find the `search_fts` impl; if it lacks `ORDER BY ts_rank(...)`, apply the same fix)
+- Test: unit test in `sqlite.rs`
+
+- [ ] **Step 1: Write the failing test**: insert three memories where exactly one contains the query token several times (higher bm25 relevance) and the others mention it once, inserted in reverse-relevance order; assert `search_fts` returns the most relevant first. Today it returns insertion order, so the test FAILS.
+
+- [ ] **Step 2: Fix the query.** In the SQL at `sqlite.rs:1638`, add before `LIMIT ?3`:
+
+```sql
+ORDER BY bm25(memory_fts)
+```
+
+(bm25() in FTS5 is ascending = best first. If `memory_fts` was created without column weights, the bare call is correct.)
+
+- [ ] **Step 3: Test passes; run the full core suite** — `cargo test -p pensyve-core`. Then re-run `paraphrase_eval`; record numbers in the commit message.
+
+- [ ] **Step 4: Commit** — `git commit -m "fix(fts): order search_fts results by bm25 relevance (#186)"`
+
+### Task 6: Stop dropping the lexical leg on long paraphrases
+
+**Files:**
+- Modify: `pensyve-core/src/storage/sqlite.rs:1620-1626` (query construction in `search_fts`)
+- Test: unit test in `sqlite.rs`
+
+- [ ] **Step 1: Write the failing test**: a memory containing "deploy pipeline rolls back on latency alerts"; query "rollback when p99 exceeds threshold" (shares only one content word after tokenization, so implicit AND returns nothing). Assert `search_fts` returns the memory. FAILS today.
+
+- [ ] **Step 2: Change token joining** from `" "` (implicit AND) to `" OR "`:
+
+```rust
+let escaped_query: String = query
+    .split_whitespace()
+    .map(|token| format!("\"{}\"", token.replace('"', "\"\"")))
+    .collect::<Vec<_>>()
+    .join(" OR ");
+```
+
+With Task 5's bm25 ordering in place, OR is safe: multi-term matches rank above single-term matches, so precision is preserved while recall stops collapsing to zero.
+
+- [ ] **Step 3: Tests pass; full core suite; re-run `paraphrase_eval`** (expect the "rollback when p99 exceeds threshold" audit query to improve — this defect is its likely direct cause). Record numbers in the commit message.
+
+- [ ] **Step 4: Commit** — `git commit -m "fix(fts): OR semantics for multi-token queries so paraphrases keep a lexical leg (#186)"`
+
+### Task 7: Wire the reranker into gateway and CLI
+
+**Files:**
+- Modify: `pensyve-mcp-gateway/src/rest.rs` (engine construction at :833, :919, :2161), gateway state (`AppState`/`PensyveState` — wherever `vector_index` lives, add the reranker slot), `pensyve-mcp-gateway/src/main.rs`
+- Modify: `pensyve-cli/src/main.rs:296`
+- Test: gateway integration test
+
+**Interfaces:**
+- Consumes: `Reranker::new_cached(model_name: &str) -> Result<Arc<Reranker>, RerankerError>` (`pensyve-core/src/reranker.rs:104`); `RecallEngine::with_reranker(self, reranker: &Reranker) -> Self` (`engine.rs:428`); wiring pattern reference: `pensyve-python/src/lib.rs:915-925`.
+- Produces: gateway/CLI recalls now rerank top-20 candidates with `BGERerankerBase`; env `PENSYVE_RERANKER=0` disables; model load failure logs a warning once and recall proceeds unreranked (lazy pattern precedent: PR #162's lazy embedder).
+
+- [ ] **Step 1: Write the failing test**: gateway recall path with a mock/absent reranker still returns results (graceful fallback), and with `PENSYVE_RERANKER=0` the state holds no reranker. (Asserting ranking improvement is the harness's job, not this test's.)
+
+- [ ] **Step 2: Gateway wiring.** In the shared state, add `reranker: OnceLock<Option<Arc<Reranker>>>`. A helper resolves it lazily on first recall: unless `PENSYVE_RERANKER=0`, try `Reranker::new_cached("BGERerankerBase")`, log warn + store `None` on error. At each of the three construction sites: `let engine = RecallEngine::new(...); let engine = match state.reranker() { Some(r) => engine.with_reranker(r), None => engine };`
+
+- [ ] **Step 3: CLI wiring.** Same lazy resolve before `RecallEngine::new` at `pensyve-cli/src/main.rs:296`.
+
+- [ ] **Step 4: Tests pass; full workspace suite; confirm the no-network invariant job still passes locally** (`cargo test -p pensyve-core --test network_policy` or the repo's equivalent — reranker load must not fetch when the model is absent; `new_cached` reads the local cache only... verify by running the gateway once with an empty `FASTEMBED_CACHE_PATH` and asserting startup + recall succeed with the warning logged).
+
+- [ ] **Step 5: Re-run `paraphrase_eval`** — but note the harness exercises `RecallEngine` directly, so to measure the reranker add `--rerank` flag support to the binary in this task (attach the reranker the same lazy way). Record both numbers (with and without) in the commit message.
+
+- [ ] **Step 6: Commit** — `git commit -m "feat(recall): wire BGE reranker into gateway and CLI with lazy fallback (#186)"`
+
+### Task 8: Ablations, final numbers, close-out
+
+**Files:**
+- Modify (conditionally): `pensyve-core/src/retrieval/rrf.rs:32` (`adaptive_k`), `pensyve-core/src/retrieval/engine.rs:732-749` (activation leg)
+- Modify: `pensyve-benchmarks/results/paraphrase_baseline.json` (update to post-fix reference), `.github` gate unchanged
+
+- [ ] **Step 1: Ablation A — adaptive_k.** Change `adaptive_k` to return the configured `rrf_k` (60) unconditionally; run `paraphrase_eval` and `real_content_eval`. Keep the change only if paraphrase top-3 improves and `real_content_eval` does not regress; otherwise revert. Either way record both runs' numbers in the commit message.
+
+- [ ] **Step 2: Ablation B — activation leg.** In the engine, skip the activation ranking (treat as non-discriminative) when episodic memories are < 25% of candidates. Same keep/revert rule, same measurement.
+
+- [ ] **Step 3: Verify success criteria** from the spec: both audit queries rank ≤ 3; paraphrase top-3 hit rate ≥ 0.90; `real_content_eval` unregressed. If the bar is missed, STOP and report the numbers — model swaps (spec's out-of-scope 2B) need a new decision, not silent scope creep.
+
+- [ ] **Step 4: Update the committed reference** with the post-fix eval output so the CI gate holds the new level. Commit — `git commit -m "feat(recall): adopt measured ablations; update paraphrase gate reference (#186)"`
+
+- [ ] **Step 5: Open the PR** (branch `fix/186-paraphrase-recall`, "Closes #186"), PR body includes the before/after table from the eval runs.

--- a/docs/superpowers/specs/2026-08-04-open-issues-remediation-design.md
+++ b/docs/superpowers/specs/2026-08-04-open-issues-remediation-design.md
@@ -1,0 +1,89 @@
+# Design: closing out the three open issues
+
+Date: 2026-08-04
+Status: approved in session, pending spec review
+Issues: #217 (forget data loss), #189 (TypeScript 7 bump), #186 (paraphrase recall)
+
+The three issues are independent. Each gets its own workstream and its own implementation plan. Workstream 1 and workstream 3 involve code. Workstream 2 is a documented decision to wait.
+
+## Workstream 1: finish #217 with prevention and recovery
+
+Issue #217 reports that a bad `pensyve_forget` call deleted 1,528 memories for one entity, and that the deletion could not be undone. PR #218 (in flight from palworth) fixes the prevention half. The remaining work is one small follow-up PR for the gaps found in review, and one PR that makes destructive deletes recoverable.
+
+### Sequencing
+
+1. PR #218 lands first. It is waiting on one fix in `postgres.rs` (use `scoped_conn(namespace_id)` instead of `maybe_scoped_conn()` in `delete_memory_by_id_in_namespace`). If palworth has not pushed the fix within a few days, we ask the maintainer to authorize pushing the fix to his branch so he keeps authorship of the PR.
+2. PR-1 (prevention follow-ups) can start right away and merge after #218.
+3. PR-2 (recovery) builds on the schema and merges last.
+
+### PR-1: prevention follow-ups
+
+- Change the REST handler for `DELETE /v1/memories/{id}` (`pensyve-mcp-gateway/src/rest.rs:1156`) to call `delete_memory_by_id_in_namespace` instead of the unscoped `delete_memory_by_id`. Today only accidental row-level security behavior protects the unscoped path, and only on Postgres.
+- Update the four places that still use the removed `hard_delete` parameter. `integrations/hermes/__init__.py` sends it, and `pensyve-mcp/README.md`, `integrations/claude-code/README.md`, and `integrations/gemini-extension/README.md` document it. After #218, a request with `hard_delete` fails to parse, so these must change together.
+- Tests: a gateway integration test that a foreign-namespace REST delete is rejected.
+
+### PR-2: recovery layer (archive on delete)
+
+The design goal is that any destructive forget can be undone for a limited time, without changing any read path.
+
+Schema. Add a `forget_archives` table to both backends (SQLite and Postgres):
+
+- `id` (UUID), `namespace_id`, `created_at`, `expires_at`
+- `payload`: the deleted rows serialized as JSON, including all memory types, knowledge graph edges, and embedding vectors
+- `description`: a short human summary, e.g. "entity acme-corp, 1528 memories"
+
+Write path. `pensyve_forget` and `pensyve_forget_memory` serialize the affected rows into `forget_archives` inside the same transaction that deletes them. Their responses gain two fields, `archive_id` and `recoverable_until`. Embeddings go into the payload so a restore is exact and does not depend on the embedder version at restore time.
+
+Restore. A new `pensyve_restore(archive_id)` MCP tool and a matching REST endpoint `POST /v1/archives/{id}/restore`. The MCP and REST surfaces stay in parity, following the repo precedent from PR #197. Restore is namespace scoped, so a tenant can only restore archives from its own namespace. If a row with the same UUID already exists, restore skips it and reports the skip. Restore re-adds the vector index entries from the archived embeddings.
+
+Retention. The consolidation maintenance pass deletes archives past `expires_at`. The default window is 30 days. The `PENSYVE_ARCHIVE_RETENTION_DAYS` environment variable overrides it.
+
+Tests, on both backends:
+
+- Round trip: forget an entity, restore the archive, and confirm recall returns the memories again.
+- A restore from a foreign namespace is rejected.
+- Expired archives are pruned and can no longer be restored.
+- Knowledge graph edges and full-text search rows are restored correctly.
+
+Error handling. Archive serialization failure aborts the forget (the transaction rolls back), because a delete that cannot be archived would be unrecoverable. Restore failure leaves the archive untouched so the restore can be retried.
+
+## Workstream 2: wait out #189
+
+Issue #189 tracks re-attempting the TypeScript 7 bump in `pensyve-ts`. The blocker is upstream. typescript-eslint 8.65.0 still declares a peer range of `typescript >=4.8.4 <6.1.0`, so no action in this repo can unblock it.
+
+The decision is to rely on Dependabot. Dependabot opens a fresh PR whenever a new TypeScript 7.x release appears, and CI shows whether lint passes. The merge criteria are that `bun run lint`, `bun run build`, and `bun run test` are all green on the bump PR, which requires a typescript-eslint release that admits TypeScript 7. The sibling repo issue major7apps/pensyve-cloud#58 follows the same trigger.
+
+The only action is a comment on #189 documenting the decision and the merge criteria, so the next person who reads the issue knows the plan. The issue stays open as the tracker.
+
+## Workstream 3: fix paraphrase recall (#186)
+
+Issue #186 reports that paraphrased queries missed the top 3 results for 2 of 5 known items in the July audit. The plan is to build a permanent evaluation harness first, then fix the defects that a code walkthrough already found, and measure each fix against the harness.
+
+### Why harness first
+
+The audit sample was 5 items, and its seed script was session scratchpad that no longer exists. Without a committed harness, any fix would be validated against anecdote, and future changes could silently regress recall quality.
+
+### Deliverable 1: evaluation harness in pensyve-benchmarks
+
+- A committed corpus fixture that rebuilds the audit shape: about 250 memories (220 semantic, 30 episodic), 5 entities, planted known-item facts, and contradiction pairs. The fixture is data in the repo, not a script that generates it fresh each run, so results are reproducible.
+- A committed query set of 50 to 100 known-item paraphrase queries with expected memory IDs, including the two audit failures ("arrow parquet reader benchmark speed" and "rollback when p99 exceeds threshold").
+- A new `paraphrase_eval` binary in `pensyve-benchmarks` that loads the fixture, runs the real `RecallEngine` with the real embedder, and reports the top-3 hit rate and mean reciprocal rank.
+- A baseline run recorded before any fix, committed alongside the fixture.
+- The eval runs in the existing "Rust Tests (with models)" CI job as a regression gate, using the seeded model cache from PR #201.
+
+### Deliverable 2: fixes, one commit each, measured on the harness
+
+1. Order full-text search results by relevance. `search_fts` in `pensyve-core/src/storage/sqlite.rs` has no `ORDER BY bm25()`, so rows come back in insertion order. That ordering feeds the second-highest-weighted slot in the rank fusion, so every query currently fuses noise. Check the Postgres text search path for the same defect.
+2. Stop dropping the lexical leg on long queries. The FTS query joins tokens with implicit AND, so a paraphrase whose words do not all co-occur in one memory returns zero rows and the lexical leg silently vanishes. Switch multi-token queries to OR semantics and measure the effect.
+3. Wire the cross-encoder reranker into the gateway and CLI. Today only the Python SDK attaches `BGERerankerBase`, so the audited path never reranks. The reranker loads lazily and recall proceeds without it if the model is unavailable, following the pattern from the lazy embedder fix in PR #162. A cross-encoder scores the query against each candidate text directly, which is the stage best suited to rescue paraphrases that lexical matching misses.
+4. Ablate two suspects and adopt only what measures better: the adaptive RRF constant (it collapses to about 10 at this corpus size, which amplifies noisy legs) and the activation leg (it scores every non-episodic memory 0.0, which is near-degenerate on a corpus that is 88 percent semantic).
+
+### Success criteria
+
+- Both audit failures return their known item in the top 3.
+- The corpus-wide top-3 hit rate meets a bar set after the baseline run, with a target of at least 90 percent.
+- No regression on the existing `real_content_eval` results.
+
+### Out of scope
+
+Model swaps (a different embedder or reranker) are deferred. They come back only if the harness still shows a gap after the fixes above. Query expansion and any network-dependent path are out entirely, to preserve the no-network invariant.

--- a/pensyve-benchmarks/fixtures/paraphrase_corpus.json
+++ b/pensyve-benchmarks/fixtures/paraphrase_corpus.json
@@ -2005,12 +2005,12 @@
     {
       "query": "arrow parquet reader benchmark speed",
       "gold_keys": ["bob-parquet-bench"],
-      "kind": "lexical"
+      "kind": "paraphrase"
     },
     {
       "query": "rollback when p99 exceeds threshold",
       "gold_keys": ["deploy-p99-rollback"],
-      "kind": "lexical"
+      "kind": "paraphrase"
     },
     {
       "query": "switching from JSON to rkyv cut p50 latency by 60%",
@@ -2050,6 +2050,16 @@
     {
       "query": "Alice's cat Pixel only eats wet food, ignores dry kibble",
       "gold_keys": ["alice-s-cat-pixel-only-07"],
+      "kind": "lexical"
+    },
+    {
+      "query": "Alice's favorite museum in the city is the small photography gallery near the river",
+      "gold_keys": ["alice-s-favorite-museum-city-14"],
+      "kind": "lexical"
+    },
+    {
+      "query": "deploy pipeline tags every production release with git commit SHA and build timestamp",
+      "gold_keys": ["deploy-pipeline-tags-every-production-release-05"],
       "kind": "lexical"
     }
   ]

--- a/pensyve-benchmarks/fixtures/paraphrase_corpus.json
+++ b/pensyve-benchmarks/fixtures/paraphrase_corpus.json
@@ -1751,5 +1751,306 @@
       "confidence": 1.0
     }
   ],
-  "queries": []
+  "queries": [
+    {
+      "query": "how fast is bob's parquet reader",
+      "gold_keys": ["bob-parquet-bench"],
+      "kind": "paraphrase"
+    },
+    {
+      "query": "which async runtime setup does bob suggest for the data intake pipeline",
+      "gold_keys": ["bob-recommends-tokio-s-multi-03"],
+      "kind": "paraphrase"
+    },
+    {
+      "query": "what did bob identify as the biggest slowdown once simultaneous writes climbed past two dozen",
+      "gold_keys": ["bob-measured-mutex-contention-becoming-04"],
+      "kind": "paraphrase"
+    },
+    {
+      "query": "which embedded database does bob favor when queries mostly scan large tables",
+      "gold_keys": ["bob-prefers-duckdb-over-sqlite-05"],
+      "kind": "paraphrase"
+    },
+    {
+      "query": "what search parameter, when set too low, hurts bob's vector index accuracy",
+      "gold_keys": ["bob-discovered-hnsw-recall-drops-06"],
+      "kind": "paraphrase"
+    },
+    {
+      "query": "roughly how much traffic can the gateway handle before it maxes out, per bob's testing",
+      "gold_keys": ["bob-s-load-test-showed-12"],
+      "kind": "paraphrase"
+    },
+    {
+      "query": "why did bob move the caching system to a different tool that has built-in messaging",
+      "gold_keys": ["bob-switched-cache-layer-from-13"],
+      "kind": "paraphrase"
+    },
+    {
+      "query": "how did bob get rid of garbage-collector pauses in the critical code path",
+      "gold_keys": ["bob-found-avoiding-heap-allocations-15"],
+      "kind": "paraphrase"
+    },
+    {
+      "query": "which data format does bob favor when schemas need to change across services over time",
+      "gold_keys": ["bob-recommends-protobuf-over-avro-20"],
+      "kind": "paraphrase"
+    },
+    {
+      "query": "where did bob trace an unexpected memory-usage bug back to",
+      "gold_keys": ["bob-discovered-memory-leak-traced-27"],
+      "kind": "paraphrase"
+    },
+    {
+      "query": "which trek does alice enjoy most near the reservoir and how long does it take",
+      "gold_keys": ["alice-s-favorite-hiking-trail-02"],
+      "kind": "paraphrase"
+    },
+    {
+      "query": "why did alice change her morning coffee brewing method to something less of a hassle to wash",
+      "gold_keys": ["alice-switched-from-french-press-03"],
+      "kind": "paraphrase"
+    },
+    {
+      "query": "how long has alice been growing her own bread starter",
+      "gold_keys": ["alice-keeps-sourdough-starter-she-04"],
+      "kind": "paraphrase"
+    },
+    {
+      "query": "how often does alice go jogging and which day does she take off",
+      "gold_keys": ["alice-runs-three-mornings-week-06"],
+      "kind": "paraphrase"
+    },
+    {
+      "query": "which plants thrive for alice outdoors and which one won't survive",
+      "gold_keys": ["alice-grows-basil-rosemary-her-09"],
+      "kind": "paraphrase"
+    },
+    {
+      "query": "why does alice pick a specific airplane seat for napping",
+      "gold_keys": ["alice-prefers-window-seats-flights-11"],
+      "kind": "paraphrase"
+    },
+    {
+      "query": "what skill did alice pick up so she could repair her own keyboard",
+      "gold_keys": ["alice-learned-solder-so-she-13"],
+      "kind": "paraphrase"
+    },
+    {
+      "query": "what display trick does alice use to curb compulsive phone checking",
+      "gold_keys": ["alice-keeps-her-phone-grayscale-15"],
+      "kind": "paraphrase"
+    },
+    {
+      "query": "what equipment change did alice make at her desk after hurting her wrist",
+      "gold_keys": ["alice-s-desk-setup-uses-18"],
+      "kind": "paraphrase"
+    },
+    {
+      "query": "how often and where does alice spend time volunteering with plants",
+      "gold_keys": ["alice-volunteers-community-garden-first-19"],
+      "kind": "paraphrase"
+    },
+    {
+      "query": "how many sign-offs are needed before a payments-related change can ship",
+      "gold_keys": ["deploy-pipeline-requires-two-approvals-any-03"],
+      "kind": "paraphrase"
+    },
+    {
+      "query": "what test coverage threshold prevents code from merging into the main branch",
+      "gold_keys": ["deploy-pipeline-blocks-merges-main-if-04"],
+      "kind": "paraphrase"
+    },
+    {
+      "query": "what zero-downtime release strategy is used for the gateway service",
+      "gold_keys": ["deploy-pipeline-uses-blue-green-deployment-06"],
+      "kind": "paraphrase"
+    },
+    {
+      "query": "under what failure-rate condition does the system alert whoever is on duty",
+      "gold_keys": ["deploy-pipeline-pages-call-engineer-if-07"],
+      "kind": "paraphrase"
+    },
+    {
+      "query": "when during the week does the release process pause shipping changes",
+      "gold_keys": ["deploy-pipeline-freezes-deployments-during-last-09"],
+      "kind": "paraphrase"
+    },
+    {
+      "query": "how was container build duration shortened",
+      "gold_keys": ["deploy-pipeline-caches-docker-layers-cut-12"],
+      "kind": "paraphrase"
+    },
+    {
+      "query": "how does the team get notified whenever something ships to production",
+      "gold_keys": ["deploy-pipeline-sends-slack-notification-team-14"],
+      "kind": "paraphrase"
+    },
+    {
+      "query": "how many prior working builds are kept on hand for quick reverting",
+      "gold_keys": ["deploy-pipeline-stores-last-five-successful-18"],
+      "kind": "paraphrase"
+    },
+    {
+      "query": "how often is failure-injection testing done to confirm automatic recovery works",
+      "gold_keys": ["deploy-pipeline-runs-chaos-experiments-quarterly-26"],
+      "kind": "paraphrase"
+    },
+    {
+      "query": "where must credentials be sourced from instead of config files",
+      "gold_keys": ["deploy-pipeline-requires-all-secrets-be-30"],
+      "kind": "paraphrase"
+    },
+    {
+      "query": "how long is acme's deal with its main cloud provider and when was it signed",
+      "gold_keys": ["acme-corp-signed-three-year-enterprise-01"],
+      "kind": "paraphrase"
+    },
+    {
+      "query": "by how much did the size of acme's engineering team increase last year",
+      "gold_keys": ["acme-corp-s-engineering-headcount-grew-02"],
+      "kind": "paraphrase"
+    },
+    {
+      "query": "why did acme downsize its main office space",
+      "gold_keys": ["acme-corp-moved-its-headquarters-smaller-03"],
+      "kind": "paraphrase"
+    },
+    {
+      "query": "what company did acme buy to build its own reporting features",
+      "gold_keys": ["acme-corp-acquired-small-analytics-startup-05"],
+      "kind": "paraphrase"
+    },
+    {
+      "query": "what was acme's yearly subscription income milestone recently",
+      "gold_keys": ["acme-corp-s-annual-recurring-revenue-07"],
+      "kind": "paraphrase"
+    },
+    {
+      "query": "how did revamping the new-user setup affect customer cancellations at acme",
+      "gold_keys": ["acme-corp-s-churn-rate-dropped-10"],
+      "kind": "paraphrase"
+    },
+    {
+      "query": "which older self-hosted product is acme planning to retire",
+      "gold_keys": ["acme-corp-s-leadership-decided-sunset-11"],
+      "kind": "paraphrase"
+    },
+    {
+      "query": "how quickly must customer records be deleted once an account closes",
+      "gold_keys": ["acme-corp-s-data-retention-policy-13"],
+      "kind": "paraphrase"
+    },
+    {
+      "query": "how many bids does acme need before approving a large purchase",
+      "gold_keys": ["acme-corp-s-procurement-process-now-15"],
+      "kind": "paraphrase"
+    },
+    {
+      "query": "what happened to acme's Texas office once its lease ran out",
+      "gold_keys": ["acme-corp-s-office-austin-closed-23"],
+      "kind": "paraphrase"
+    },
+    {
+      "query": "which retrieval approach wins for uncommon proper-noun lookups according to the study",
+      "gold_keys": ["research-notes-show-hybrid-search-outperforms-02"],
+      "kind": "paraphrase"
+    },
+    {
+      "query": "what limitation undermines the credibility of the component-removal experiment",
+      "gold_keys": ["research-notes-flag-ablation-study-used-03"],
+      "kind": "paraphrase"
+    },
+    {
+      "query": "what training technique is cited as boosting low-data classification performance",
+      "gold_keys": ["research-notes-cite-paper-showing-contrastive-05"],
+      "kind": "paraphrase"
+    },
+    {
+      "query": "what statistical check should happen before claiming a performance gain",
+      "gold_keys": ["research-notes-recommend-running-significance-tests-07"],
+      "kind": "paraphrase"
+    },
+    {
+      "query": "what measurement artifact appeared from grouping requests together while testing",
+      "gold_keys": ["research-notes-highlight-batching-queries-during-09"],
+      "kind": "paraphrase"
+    },
+    {
+      "query": "how did adjusting the proportion of negative examples affect training stability",
+      "gold_keys": ["research-notes-track-increasing-negative-sampling-11"],
+      "kind": "paraphrase"
+    },
+    {
+      "query": "what gain resulted from including difficult counterexamples during training",
+      "gold_keys": ["research-notes-document-adding-hard-negatives-21"],
+      "kind": "paraphrase"
+    },
+    {
+      "query": "what unwanted tendency does the evaluator model have regarding answer length",
+      "gold_keys": ["research-notes-note-current-judge-model-22"],
+      "kind": "paraphrase"
+    },
+    {
+      "query": "what contamination problem was found between evaluation and training sets",
+      "gold_keys": ["research-notes-flag-data-leakage-issue-29"],
+      "kind": "paraphrase"
+    },
+    {
+      "query": "what tradeoff appears when limiting search to one entity versus searching across entities",
+      "gold_keys": ["research-notes-note-entity-scoped-search-33"],
+      "kind": "paraphrase"
+    },
+    {
+      "query": "arrow parquet reader benchmark speed",
+      "gold_keys": ["bob-parquet-bench"],
+      "kind": "lexical"
+    },
+    {
+      "query": "rollback when p99 exceeds threshold",
+      "gold_keys": ["deploy-p99-rollback"],
+      "kind": "lexical"
+    },
+    {
+      "query": "switching from JSON to rkyv cut p50 latency by 60%",
+      "gold_keys": ["bob-found-switching-from-json-02"],
+      "kind": "lexical"
+    },
+    {
+      "query": "Bob set up CI pipeline to run clippy with pedantic lint group enabled",
+      "gold_keys": ["bob-set-up-ci-pipeline-07"],
+      "kind": "lexical"
+    },
+    {
+      "query": "Alice's titanium card wallet survives being dropped without denting",
+      "gold_keys": ["alice-titanium-wallet"],
+      "kind": "lexical"
+    },
+    {
+      "query": "Acme Corp SOC 2 Type II certification after six-month audit",
+      "gold_keys": ["acme-soc2-cert"],
+      "kind": "lexical"
+    },
+    {
+      "query": "reranker model improves nDCG@10 by 8 points over base retriever",
+      "gold_keys": ["research-rrf-vs-linear"],
+      "kind": "lexical"
+    },
+    {
+      "query": "deploy pipeline runs integration tests against staging replica before production",
+      "gold_keys": ["deploy-pipeline-runs-integration-tests-against-02"],
+      "kind": "lexical"
+    },
+    {
+      "query": "Bob's flamegraph profiling showed 30% CPU time in serde_json parsing",
+      "gold_keys": ["bob-s-flamegraph-profiling-showed-08"],
+      "kind": "lexical"
+    },
+    {
+      "query": "Alice's cat Pixel only eats wet food, ignores dry kibble",
+      "gold_keys": ["alice-s-cat-pixel-only-07"],
+      "kind": "lexical"
+    }
+  ]
 }

--- a/pensyve-benchmarks/fixtures/paraphrase_corpus.json
+++ b/pensyve-benchmarks/fixtures/paraphrase_corpus.json
@@ -1,0 +1,1755 @@
+{
+  "memories": [
+    {
+      "key": "bob-parquet-bench",
+      "entity": "bob",
+      "kind": "semantic",
+      "content": "Bob benchmarked the Arrow-based Parquet reader at 2.1 GB/s on the m7i instance",
+      "confidence": 0.35
+    },
+    {
+      "key": "bob-found-switching-from-json-02",
+      "entity": "bob",
+      "kind": "semantic",
+      "content": "Bob found that switching from JSON to rkyv zero-copy deserialization cut p50 latency by 60%",
+      "confidence": 0.35
+    },
+    {
+      "key": "bob-recommends-tokio-s-multi-03",
+      "entity": "bob",
+      "kind": "semantic",
+      "content": "Bob recommends tokio's multi-threaded runtime over the current-thread runtime for the ingestion service",
+      "confidence": 0.36
+    },
+    {
+      "key": "bob-measured-mutex-contention-becoming-04",
+      "entity": "bob",
+      "kind": "semantic",
+      "content": "Bob measured mutex contention becoming the dominant bottleneck above 24 concurrent writers",
+      "confidence": 0.36
+    },
+    {
+      "key": "bob-prefers-duckdb-over-sqlite-05",
+      "entity": "bob",
+      "kind": "semantic",
+      "content": "Bob prefers DuckDB over SQLite for analytical scan-heavy workloads",
+      "confidence": 0.36
+    },
+    {
+      "key": "bob-discovered-hnsw-recall-drops-06",
+      "entity": "bob",
+      "kind": "semantic",
+      "content": "Bob discovered that HNSW recall drops below 0.9 once ef_search is set under 40",
+      "confidence": 0.36
+    },
+    {
+      "key": "bob-set-up-ci-pipeline-07",
+      "entity": "bob",
+      "kind": "semantic",
+      "content": "Bob set up the CI pipeline to run clippy with the pedantic lint group enabled",
+      "confidence": 0.37
+    },
+    {
+      "key": "bob-s-flamegraph-profiling-showed-08",
+      "entity": "bob",
+      "kind": "semantic",
+      "content": "Bob's flamegraph profiling showed 30% of CPU time was spent in serde_json parsing",
+      "confidence": 0.37
+    },
+    {
+      "key": "bob-configured-criterion-run-each-09",
+      "entity": "bob",
+      "kind": "semantic",
+      "content": "Bob configured criterion to run each benchmark for a minimum of 10 seconds for statistical stability",
+      "confidence": 0.37
+    },
+    {
+      "key": "bob-chose-grpc-over-rest-10",
+      "entity": "bob",
+      "kind": "semantic",
+      "content": "Bob chose gRPC over REST for the internal service mesh because of lower serialization overhead",
+      "confidence": 0.37
+    },
+    {
+      "key": "bob-observed-connection-pooling-reduced-11",
+      "entity": "bob",
+      "kind": "semantic",
+      "content": "Bob observed that connection pooling reduced Postgres connection setup latency from 40ms to 2ms",
+      "confidence": 0.38
+    },
+    {
+      "key": "bob-s-load-test-showed-12",
+      "entity": "bob",
+      "kind": "semantic",
+      "content": "Bob's load test showed the API gateway saturates at roughly 8,000 requests per second",
+      "confidence": 0.38
+    },
+    {
+      "key": "bob-switched-cache-layer-from-13",
+      "entity": "bob",
+      "kind": "semantic",
+      "content": "Bob switched the cache layer from Memcached to Redis to get built-in pub/sub support",
+      "confidence": 0.38
+    },
+    {
+      "key": "bob-reported-clickhouse-ingestion-job-14",
+      "entity": "bob",
+      "kind": "semantic",
+      "content": "Bob reported that the ClickHouse ingestion job processes 1.2 million rows per minute",
+      "confidence": 0.38
+    },
+    {
+      "key": "bob-found-avoiding-heap-allocations-15",
+      "entity": "bob",
+      "kind": "semantic",
+      "content": "Bob found that avoiding heap allocations in the hot loop cut GC pause time to near zero",
+      "confidence": 0.39
+    },
+    {
+      "key": "bob-s-analysis-showed-quic-16",
+      "entity": "bob",
+      "kind": "semantic",
+      "content": "Bob's analysis showed QUIC reduces tail latency versus HTTP/2 on lossy mobile networks",
+      "confidence": 0.39
+    },
+    {
+      "key": "bob-set-connection-timeout-payments-17",
+      "entity": "bob",
+      "kind": "semantic",
+      "content": "Bob set the connection timeout for the payments service to 3 seconds after a production incident",
+      "confidence": 0.39
+    },
+    {
+      "key": "bob-prefers-channels-over-shared-18",
+      "entity": "bob",
+      "kind": "semantic",
+      "content": "Bob prefers channels over shared-state locking for the worker pool coordination logic",
+      "confidence": 0.39
+    },
+    {
+      "key": "bob-s-profiling-revealed-vector-19",
+      "entity": "bob",
+      "kind": "semantic",
+      "content": "Bob's profiling revealed the vector index rebuild takes 45 seconds for 500k embeddings",
+      "confidence": 0.4
+    },
+    {
+      "key": "bob-recommends-protobuf-over-avro-20",
+      "entity": "bob",
+      "kind": "semantic",
+      "content": "Bob recommends Protobuf over Avro for schema evolution across service boundaries",
+      "confidence": 0.4
+    },
+    {
+      "key": "bob-measured-batching-writes-groups-21",
+      "entity": "bob",
+      "kind": "semantic",
+      "content": "Bob measured that batching writes in groups of 500 improved throughput by 3x over single-row inserts",
+      "confidence": 0.4
+    },
+    {
+      "key": "bob-s-team-adopted-trunk-22",
+      "entity": "bob",
+      "kind": "semantic",
+      "content": "Bob's team adopted trunk-based development to reduce merge conflict overhead",
+      "confidence": 0.4
+    },
+    {
+      "key": "bob-configured-load-balancer-use-23",
+      "entity": "bob",
+      "kind": "semantic",
+      "content": "Bob configured the load balancer to use least-connections routing instead of round-robin",
+      "confidence": 0.41
+    },
+    {
+      "key": "bob-found-enabling-tcp-nodelay-24",
+      "entity": "bob",
+      "kind": "semantic",
+      "content": "Bob found that enabling TCP_NODELAY shaved 8ms off average request latency",
+      "confidence": 0.41
+    },
+    {
+      "key": "bob-s-benchmark-showed-columnar-25",
+      "entity": "bob",
+      "kind": "semantic",
+      "content": "Bob's benchmark showed columnar storage outperforms row storage 4x for aggregate queries",
+      "confidence": 0.41
+    },
+    {
+      "key": "bob-recommends-pinning-worker-threads-26",
+      "entity": "bob",
+      "kind": "semantic",
+      "content": "Bob recommends pinning worker threads to CPU cores for the low-latency matching engine",
+      "confidence": 0.42
+    },
+    {
+      "key": "bob-discovered-memory-leak-traced-27",
+      "entity": "bob",
+      "kind": "semantic",
+      "content": "Bob discovered a memory leak traced to an unbounded channel buffer in the retry logic",
+      "confidence": 0.42
+    },
+    {
+      "key": "bob-s-team-standardized-opentelemetry-28",
+      "entity": "bob",
+      "kind": "semantic",
+      "content": "Bob's team standardized on OpenTelemetry for distributed tracing across all services",
+      "confidence": 0.42
+    },
+    {
+      "key": "bob-prefers-explicit-error-types-29",
+      "entity": "bob",
+      "kind": "semantic",
+      "content": "Bob prefers explicit error types over anyhow for library code, reserving anyhow for binaries",
+      "confidence": 0.42
+    },
+    {
+      "key": "bob-measured-cold-start-latency-30",
+      "entity": "bob",
+      "kind": "semantic",
+      "content": "Bob measured the cold-start latency of the Lambda function at 340ms with the current bundle size",
+      "confidence": 0.43
+    },
+    {
+      "key": "bob-s-audit-found-retry-31",
+      "entity": "bob",
+      "kind": "semantic",
+      "content": "Bob's audit found the retry policy was missing exponential backoff, causing thundering herd",
+      "confidence": 0.43
+    },
+    {
+      "key": "bob-configured-vector-index-use-32",
+      "entity": "bob",
+      "kind": "semantic",
+      "content": "Bob configured the vector index to use product quantization to cut memory usage by 75%",
+      "confidence": 0.43
+    },
+    {
+      "key": "bob-recommends-wal-mode-sqlite-33",
+      "entity": "bob",
+      "kind": "semantic",
+      "content": "Bob recommends WAL mode for SQLite when multiple readers need to coexist with a writer",
+      "confidence": 0.43
+    },
+    {
+      "key": "bob-s-team-migrated-build-34",
+      "entity": "bob",
+      "kind": "semantic",
+      "content": "Bob's team migrated the build pipeline from Make to a Rust workspace with cargo xtask",
+      "confidence": 0.44
+    },
+    {
+      "key": "bob-found-increasing-shard-count-35",
+      "entity": "bob",
+      "kind": "semantic",
+      "content": "Bob found that increasing the shard count from 4 to 16 improved write throughput linearly",
+      "confidence": 0.44
+    },
+    {
+      "key": "bob-prefers-structured-logging-tracing-36",
+      "entity": "bob",
+      "kind": "semantic",
+      "content": "Bob prefers structured logging with tracing over println-style debugging in production code",
+      "confidence": 0.44
+    },
+    {
+      "key": "bob-s-benchmark-embedding-model-37",
+      "entity": "bob",
+      "kind": "semantic",
+      "content": "Bob's benchmark of the embedding model showed 384 dimensions gives the best latency/quality tradeoff",
+      "confidence": 0.44
+    },
+    {
+      "key": "bob-discovered-deploy-script-missing-38",
+      "entity": "bob",
+      "kind": "semantic",
+      "content": "Bob discovered the deploy script was missing a health check, causing traffic to hit unready pods",
+      "confidence": 0.45
+    },
+    {
+      "key": "bob-recommends-feature-flags-over-39",
+      "entity": "bob",
+      "kind": "semantic",
+      "content": "Bob recommends feature flags over long-lived branches for gradual rollout of risky changes",
+      "confidence": 0.45
+    },
+    {
+      "key": "bob-s-team-adopted-shared-40",
+      "entity": "bob",
+      "kind": "semantic",
+      "content": "Bob's team adopted a shared style guide after code review comments repeatedly flagged the same issues",
+      "confidence": 0.45
+    },
+    {
+      "key": "bob-m7i-instance-type-gives-41",
+      "entity": "bob",
+      "kind": "semantic",
+      "content": "Bob said the m7i instance type gives the best price-performance for Parquet read benchmarks",
+      "confidence": 0.45
+    },
+    {
+      "key": "bob-c7g-instance-type-gives-42",
+      "entity": "bob",
+      "kind": "semantic",
+      "content": "Bob later said the c7g instance type gives the best price-performance for Parquet read benchmarks",
+      "confidence": 0.46
+    },
+    {
+      "key": "bob-recommended-15-minute-canary-43",
+      "entity": "bob",
+      "kind": "semantic",
+      "content": "Bob recommended a 15-minute canary window before promoting a build to full production",
+      "confidence": 0.46
+    },
+    {
+      "key": "bob-recommended-45-minute-canary-44",
+      "entity": "bob",
+      "kind": "semantic",
+      "content": "Bob later recommended a 45-minute canary window before promoting a build to full production",
+      "confidence": 0.46
+    },
+    {
+      "key": "bob-ep-during-retro-ingestion-project-01",
+      "entity": "bob",
+      "kind": "episodic",
+      "content": "During the retro on the ingestion project, Bob demoed the new batching logic and reported a 40% throughput improvement",
+      "confidence": 0.46
+    },
+    {
+      "key": "bob-ep-architecture-review-walked-team-02",
+      "entity": "bob",
+      "kind": "episodic",
+      "content": "In the architecture review, Bob walked the team through the tradeoffs between HNSW and IVF-PQ for the vector index",
+      "confidence": 0.47
+    },
+    {
+      "key": "bob-ep-postmortem-outage-explained-root-03",
+      "entity": "bob",
+      "kind": "episodic",
+      "content": "At the postmortem for the outage, Bob explained the root cause was an unbounded retry loop exhausting connections",
+      "confidence": 0.47
+    },
+    {
+      "key": "bob-ep-during-onboarding-showed-new-04",
+      "entity": "bob",
+      "kind": "episodic",
+      "content": "During onboarding, Bob showed the new hire how to profile a Rust binary with perf and flamegraph",
+      "confidence": 0.47
+    },
+    {
+      "key": "bob-ep-planning-meeting-proposed-migrating-05",
+      "entity": "bob",
+      "kind": "episodic",
+      "content": "In the planning meeting, Bob proposed migrating the cache layer to Redis Cluster for horizontal scaling",
+      "confidence": 0.48
+    },
+    {
+      "key": "bob-ep-benchmark-review-session-presented-06",
+      "entity": "bob",
+      "kind": "episodic",
+      "content": "At the benchmark review session, Bob presented results showing rkyv beats serde_json by 3x on deserialization",
+      "confidence": 0.48
+    },
+    {
+      "key": "alice-titanium-wallet",
+      "entity": "alice",
+      "kind": "semantic",
+      "content": "Alice bought a titanium card wallet last month and says it survives being dropped without denting",
+      "confidence": 0.48
+    },
+    {
+      "key": "alice-s-favorite-hiking-trail-02",
+      "entity": "alice",
+      "kind": "semantic",
+      "content": "Alice's favorite hiking trail is the ridge loop above the reservoir, about 8 miles round trip",
+      "confidence": 0.48
+    },
+    {
+      "key": "alice-switched-from-french-press-03",
+      "entity": "alice",
+      "kind": "semantic",
+      "content": "Alice switched from a French press to a pour-over setup because it's easier to clean",
+      "confidence": 0.49
+    },
+    {
+      "key": "alice-keeps-sourdough-starter-she-04",
+      "entity": "alice",
+      "kind": "semantic",
+      "content": "Alice keeps a sourdough starter that she's maintained for over two years",
+      "confidence": 0.49
+    },
+    {
+      "key": "alice-s-apartment-gets-best-05",
+      "entity": "alice",
+      "kind": "semantic",
+      "content": "Alice's apartment gets the best afternoon light in the west-facing bedroom",
+      "confidence": 0.49
+    },
+    {
+      "key": "alice-runs-three-mornings-week-06",
+      "entity": "alice",
+      "kind": "semantic",
+      "content": "Alice runs three mornings a week and treats Sunday as a rest day",
+      "confidence": 0.49
+    },
+    {
+      "key": "alice-s-cat-pixel-only-07",
+      "entity": "alice",
+      "kind": "semantic",
+      "content": "Alice's cat, Pixel, only eats wet food and ignores dry kibble entirely",
+      "confidence": 0.5
+    },
+    {
+      "key": "alice-reads-mostly-science-fiction-08",
+      "entity": "alice",
+      "kind": "semantic",
+      "content": "Alice reads mostly science fiction but makes an exception for biographies",
+      "confidence": 0.5
+    },
+    {
+      "key": "alice-grows-basil-rosemary-her-09",
+      "entity": "alice",
+      "kind": "semantic",
+      "content": "Alice grows basil and rosemary on her balcony but the mint keeps dying",
+      "confidence": 0.5
+    },
+    {
+      "key": "alice-s-commute-takes-25-10",
+      "entity": "alice",
+      "kind": "semantic",
+      "content": "Alice's commute takes 25 minutes by bike versus 40 minutes on the bus",
+      "confidence": 0.5
+    },
+    {
+      "key": "alice-prefers-window-seats-flights-11",
+      "entity": "alice",
+      "kind": "semantic",
+      "content": "Alice prefers window seats on flights so she can lean against the wall to sleep",
+      "confidence": 0.51
+    },
+    {
+      "key": "alice-s-go-weeknight-dinner-12",
+      "entity": "alice",
+      "kind": "semantic",
+      "content": "Alice's go-to weeknight dinner is a stir-fry with whatever vegetables are about to go bad",
+      "confidence": 0.51
+    },
+    {
+      "key": "alice-learned-solder-so-she-13",
+      "entity": "alice",
+      "kind": "semantic",
+      "content": "Alice learned to solder so she could fix her own mechanical keyboard",
+      "confidence": 0.51
+    },
+    {
+      "key": "alice-s-favorite-museum-city-14",
+      "entity": "alice",
+      "kind": "semantic",
+      "content": "Alice's favorite museum in the city is the small photography gallery near the river",
+      "confidence": 0.51
+    },
+    {
+      "key": "alice-keeps-her-phone-grayscale-15",
+      "entity": "alice",
+      "kind": "semantic",
+      "content": "Alice keeps her phone on grayscale to reduce how often she checks it",
+      "confidence": 0.52
+    },
+    {
+      "key": "alice-s-family-recipe-chili-16",
+      "entity": "alice",
+      "kind": "semantic",
+      "content": "Alice's family recipe for chili always includes a square of dark chocolate",
+      "confidence": 0.52
+    },
+    {
+      "key": "alice-takes-stairs-instead-elevator-17",
+      "entity": "alice",
+      "kind": "semantic",
+      "content": "Alice takes the stairs instead of the elevator whenever it's fewer than six flights",
+      "confidence": 0.52
+    },
+    {
+      "key": "alice-s-desk-setup-uses-18",
+      "entity": "alice",
+      "kind": "semantic",
+      "content": "Alice's desk setup uses a split ergonomic keyboard after wrist strain last year",
+      "confidence": 0.52
+    },
+    {
+      "key": "alice-volunteers-community-garden-first-19",
+      "entity": "alice",
+      "kind": "semantic",
+      "content": "Alice volunteers at the community garden on the first Saturday of each month",
+      "confidence": 0.53
+    },
+    {
+      "key": "alice-s-favorite-season-autumn-20",
+      "entity": "alice",
+      "kind": "semantic",
+      "content": "Alice's favorite season is autumn because of the light and the cooler running weather",
+      "confidence": 0.53
+    },
+    {
+      "key": "alice-keeps-paper-notebook-ideas-21",
+      "entity": "alice",
+      "kind": "semantic",
+      "content": "Alice keeps a paper notebook for ideas because typing feels too permanent for rough drafts",
+      "confidence": 0.53
+    },
+    {
+      "key": "alice-s-playlist-deep-work-22",
+      "entity": "alice",
+      "kind": "semantic",
+      "content": "Alice's playlist for deep work is almost entirely instrumental post-rock",
+      "confidence": 0.54
+    },
+    {
+      "key": "alice-learned-pottery-last-year-23",
+      "entity": "alice",
+      "kind": "semantic",
+      "content": "Alice learned pottery last year and now makes most of her own mugs",
+      "confidence": 0.54
+    },
+    {
+      "key": "alice-s-rule-buying-gadgets-24",
+      "entity": "alice",
+      "kind": "semantic",
+      "content": "Alice's rule for buying gadgets is to wait 30 days before purchasing anything over $100",
+      "confidence": 0.54
+    },
+    {
+      "key": "alice-s-favorite-way-unwind-25",
+      "entity": "alice",
+      "kind": "semantic",
+      "content": "Alice's favorite way to unwind after a hard day is a long bath with a physical book",
+      "confidence": 0.54
+    },
+    {
+      "key": "alice-keeps-houseplants-every-room-26",
+      "entity": "alice",
+      "kind": "semantic",
+      "content": "Alice keeps houseplants in every room except the kitchen, where the light is too low",
+      "confidence": 0.55
+    },
+    {
+      "key": "alice-s-ideal-vacation-involves-27",
+      "entity": "alice",
+      "kind": "semantic",
+      "content": "Alice's ideal vacation involves one big city and one quiet coastal town",
+      "confidence": 0.55
+    },
+    {
+      "key": "alice-bikes-farmers-market-every-28",
+      "entity": "alice",
+      "kind": "semantic",
+      "content": "Alice bikes to the farmers market every Saturday morning regardless of weather",
+      "confidence": 0.55
+    },
+    {
+      "key": "alice-s-favorite-pen-fine-29",
+      "entity": "alice",
+      "kind": "semantic",
+      "content": "Alice's favorite pen is a fine-point rollerball that she buys in bulk",
+      "confidence": 0.55
+    },
+    {
+      "key": "alice-s-parents-taught-her-30",
+      "entity": "alice",
+      "kind": "semantic",
+      "content": "Alice's parents taught her to always tip generously, a habit she never broke",
+      "confidence": 0.56
+    },
+    {
+      "key": "alice-s-laptop-sticker-collection-31",
+      "entity": "alice",
+      "kind": "semantic",
+      "content": "Alice's laptop sticker collection is themed entirely around old video games",
+      "confidence": 0.56
+    },
+    {
+      "key": "alice-keeps-jar-loose-change-32",
+      "entity": "alice",
+      "kind": "semantic",
+      "content": "Alice keeps a jar of loose change specifically for parking meters",
+      "confidence": 0.56
+    },
+    {
+      "key": "alice-s-favorite-comfort-food-33",
+      "entity": "alice",
+      "kind": "semantic",
+      "content": "Alice's favorite comfort food is her grandmother's version of chicken soup",
+      "confidence": 0.56
+    },
+    {
+      "key": "alice-s-closet-organized-by-34",
+      "entity": "alice",
+      "kind": "semantic",
+      "content": "Alice's closet is organized by color rather than by garment type",
+      "confidence": 0.57
+    },
+    {
+      "key": "alice-s-morning-routine-always-35",
+      "entity": "alice",
+      "kind": "semantic",
+      "content": "Alice's morning routine always starts with stretching before she checks her phone",
+      "confidence": 0.57
+    },
+    {
+      "key": "alice-s-go-conversation-starter-36",
+      "entity": "alice",
+      "kind": "semantic",
+      "content": "Alice's go-to conversation starter at parties is asking what people are reading",
+      "confidence": 0.57
+    },
+    {
+      "key": "alice-s-favorite-type-puzzle-37",
+      "entity": "alice",
+      "kind": "semantic",
+      "content": "Alice's favorite type of puzzle is a 1000-piece with almost no distinguishing pattern",
+      "confidence": 0.57
+    },
+    {
+      "key": "alice-s-spare-key-lives-38",
+      "entity": "alice",
+      "kind": "semantic",
+      "content": "Alice's spare key lives with her downstairs neighbor rather than under a mat",
+      "confidence": 0.58
+    },
+    {
+      "key": "alice-s-favorite-time-write-39",
+      "entity": "alice",
+      "kind": "semantic",
+      "content": "Alice's favorite time to write is early morning before anyone else is awake",
+      "confidence": 0.58
+    },
+    {
+      "key": "alice-keeps-running-list-restaurants-40",
+      "entity": "alice",
+      "kind": "semantic",
+      "content": "Alice keeps a running list of restaurants to try, sorted by how far she has to travel",
+      "confidence": 0.58
+    },
+    {
+      "key": "alice-she-prefers-python-scripting-41",
+      "entity": "alice",
+      "kind": "semantic",
+      "content": "Alice said she prefers Python for scripting because of the ecosystem of libraries",
+      "confidence": 0.58
+    },
+    {
+      "key": "alice-she-prefers-typescript-scripting-42",
+      "entity": "alice",
+      "kind": "semantic",
+      "content": "Alice later said she prefers TypeScript for scripting because of static typing",
+      "confidence": 0.59
+    },
+    {
+      "key": "alice-her-go-morning-drink-43",
+      "entity": "alice",
+      "kind": "semantic",
+      "content": "Alice said her go-to morning drink is black coffee, no sugar",
+      "confidence": 0.59
+    },
+    {
+      "key": "alice-switched-green-tea-as-44",
+      "entity": "alice",
+      "kind": "semantic",
+      "content": "Alice later switched to green tea as her go-to morning drink",
+      "confidence": 0.59
+    },
+    {
+      "key": "alice-ep-last-weekend-hosted-dinner-01",
+      "entity": "alice",
+      "kind": "episodic",
+      "content": "Last weekend Alice hosted a dinner party and made the chili recipe with the dark chocolate twist",
+      "confidence": 0.6
+    },
+    {
+      "key": "alice-ep-hiking-trip-sunday-led-02",
+      "entity": "alice",
+      "kind": "episodic",
+      "content": "On the hiking trip Sunday, Alice led the group up the ridge loop and they saw a family of deer",
+      "confidence": 0.6
+    },
+    {
+      "key": "alice-ep-pottery-class-last-tuesday-03",
+      "entity": "alice",
+      "kind": "episodic",
+      "content": "At the pottery class last Tuesday, Alice finally got a mug to come out without a wobble",
+      "confidence": 0.6
+    },
+    {
+      "key": "alice-ep-during-move-last-month-04",
+      "entity": "alice",
+      "kind": "episodic",
+      "content": "During the move last month, Alice packed her entire book collection by genre instead of by size",
+      "confidence": 0.6
+    },
+    {
+      "key": "alice-ep-farmers-market-this-week-05",
+      "entity": "alice",
+      "kind": "episodic",
+      "content": "At the farmers market this week, Alice picked up a new sourdough starter as a backup",
+      "confidence": 0.61
+    },
+    {
+      "key": "alice-ep-her-flight-home-finished-06",
+      "entity": "alice",
+      "kind": "episodic",
+      "content": "On her flight home, Alice finished the biography she'd been reading for three weeks",
+      "confidence": 0.61
+    },
+    {
+      "key": "deploy-p99-rollback",
+      "entity": "deploy-pipeline",
+      "kind": "semantic",
+      "content": "The deploy pipeline automatically rolls back a release when p99 latency exceeds the alert threshold for five minutes",
+      "confidence": 0.61
+    },
+    {
+      "key": "deploy-pipeline-runs-integration-tests-against-02",
+      "entity": "deploy-pipeline",
+      "kind": "semantic",
+      "content": "The deploy pipeline runs integration tests against a staging replica before promoting to production",
+      "confidence": 0.61
+    },
+    {
+      "key": "deploy-pipeline-requires-two-approvals-any-03",
+      "entity": "deploy-pipeline",
+      "kind": "semantic",
+      "content": "The deploy pipeline requires two approvals for any change touching the payments service",
+      "confidence": 0.62
+    },
+    {
+      "key": "deploy-pipeline-blocks-merges-main-if-04",
+      "entity": "deploy-pipeline",
+      "kind": "semantic",
+      "content": "The deploy pipeline blocks merges to main if code coverage drops below 80 percent",
+      "confidence": 0.62
+    },
+    {
+      "key": "deploy-pipeline-tags-every-production-release-05",
+      "entity": "deploy-pipeline",
+      "kind": "semantic",
+      "content": "The deploy pipeline tags every production release with the git commit SHA and build timestamp",
+      "confidence": 0.62
+    },
+    {
+      "key": "deploy-pipeline-uses-blue-green-deployment-06",
+      "entity": "deploy-pipeline",
+      "kind": "semantic",
+      "content": "The deploy pipeline uses blue-green deployment for the API gateway to avoid downtime",
+      "confidence": 0.62
+    },
+    {
+      "key": "deploy-pipeline-pages-call-engineer-if-07",
+      "entity": "deploy-pipeline",
+      "kind": "semantic",
+      "content": "The deploy pipeline pages the on-call engineer if error rate exceeds 2 percent for three minutes",
+      "confidence": 0.63
+    },
+    {
+      "key": "deploy-pipeline-runs-smoke-test-suite-08",
+      "entity": "deploy-pipeline",
+      "kind": "semantic",
+      "content": "The deploy pipeline runs a smoke test suite immediately after every canary promotion",
+      "confidence": 0.63
+    },
+    {
+      "key": "deploy-pipeline-freezes-deployments-during-last-09",
+      "entity": "deploy-pipeline",
+      "kind": "semantic",
+      "content": "The deploy pipeline freezes deployments during the last two hours of the business day on Fridays",
+      "confidence": 0.63
+    },
+    {
+      "key": "deploy-pipeline-retries-failed-deployments-up-10",
+      "entity": "deploy-pipeline",
+      "kind": "semantic",
+      "content": "The deploy pipeline retries failed deployments up to three times before marking the release as failed",
+      "confidence": 0.63
+    },
+    {
+      "key": "deploy-pipeline-enforces-database-migrations-run-11",
+      "entity": "deploy-pipeline",
+      "kind": "semantic",
+      "content": "The deploy pipeline enforces that database migrations run in a separate step before application code deploys",
+      "confidence": 0.64
+    },
+    {
+      "key": "deploy-pipeline-caches-docker-layers-cut-12",
+      "entity": "deploy-pipeline",
+      "kind": "semantic",
+      "content": "The deploy pipeline caches Docker layers to cut build time from 12 minutes to 4 minutes",
+      "confidence": 0.64
+    },
+    {
+      "key": "deploy-pipeline-requires-passing-security-scan-13",
+      "entity": "deploy-pipeline",
+      "kind": "semantic",
+      "content": "The deploy pipeline requires a passing security scan before any container image can be pushed",
+      "confidence": 0.64
+    },
+    {
+      "key": "deploy-pipeline-sends-slack-notification-team-14",
+      "entity": "deploy-pipeline",
+      "kind": "semantic",
+      "content": "The deploy pipeline sends a Slack notification to the team channel for every production deploy",
+      "confidence": 0.64
+    },
+    {
+      "key": "deploy-pipeline-uses-feature-flags-decouple-15",
+      "entity": "deploy-pipeline",
+      "kind": "semantic",
+      "content": "The deploy pipeline uses feature flags to decouple deployment from feature release",
+      "confidence": 0.65
+    },
+    {
+      "key": "deploy-pipeline-runs-load-tests-nightly-16",
+      "entity": "deploy-pipeline",
+      "kind": "semantic",
+      "content": "The deploy pipeline runs load tests nightly against a scaled-down replica of production",
+      "confidence": 0.65
+    },
+    {
+      "key": "deploy-pipeline-automatically-scales-down-canary-17",
+      "entity": "deploy-pipeline",
+      "kind": "semantic",
+      "content": "The deploy pipeline automatically scales down canary traffic to zero if error budgets are exhausted",
+      "confidence": 0.65
+    },
+    {
+      "key": "deploy-pipeline-stores-last-five-successful-18",
+      "entity": "deploy-pipeline",
+      "kind": "semantic",
+      "content": "The deploy pipeline stores the last five successful release artifacts for fast rollback",
+      "confidence": 0.66
+    },
+    {
+      "key": "deploy-pipeline-requires-changelog-be-updated-19",
+      "entity": "deploy-pipeline",
+      "kind": "semantic",
+      "content": "The deploy pipeline requires the changelog to be updated before a release can be tagged",
+      "confidence": 0.66
+    },
+    {
+      "key": "deploy-pipeline-runs-dependency-vulnerability-scans-20",
+      "entity": "deploy-pipeline",
+      "kind": "semantic",
+      "content": "The deploy pipeline runs dependency vulnerability scans as part of every build",
+      "confidence": 0.66
+    },
+    {
+      "key": "deploy-pipeline-enforces-immutable-infrastructure-by-21",
+      "entity": "deploy-pipeline",
+      "kind": "semantic",
+      "content": "The deploy pipeline enforces immutable infrastructure by rebuilding rather than patching servers",
+      "confidence": 0.66
+    },
+    {
+      "key": "deploy-pipeline-uses-dedicated-queue-hotfix-22",
+      "entity": "deploy-pipeline",
+      "kind": "semantic",
+      "content": "The deploy pipeline uses a dedicated queue for hotfix deployments to bypass the normal review cadence",
+      "confidence": 0.67
+    },
+    {
+      "key": "deploy-pipeline-validates-configuration-files-against-23",
+      "entity": "deploy-pipeline",
+      "kind": "semantic",
+      "content": "The deploy pipeline validates configuration files against a schema before deployment",
+      "confidence": 0.67
+    },
+    {
+      "key": "deploy-pipeline-records-deployment-frequency-lead-24",
+      "entity": "deploy-pipeline",
+      "kind": "semantic",
+      "content": "The deploy pipeline records deployment frequency and lead time as core DORA metrics",
+      "confidence": 0.67
+    },
+    {
+      "key": "deploy-pipeline-requires-rollback-plan-documented-25",
+      "entity": "deploy-pipeline",
+      "kind": "semantic",
+      "content": "The deploy pipeline requires a rollback plan documented in every deployment ticket",
+      "confidence": 0.67
+    },
+    {
+      "key": "deploy-pipeline-runs-chaos-experiments-quarterly-26",
+      "entity": "deploy-pipeline",
+      "kind": "semantic",
+      "content": "The deploy pipeline runs chaos experiments quarterly to validate the rollback automation",
+      "confidence": 0.68
+    },
+    {
+      "key": "deploy-pipeline-uses-separate-credentials-staging-27",
+      "entity": "deploy-pipeline",
+      "kind": "semantic",
+      "content": "The deploy pipeline uses separate credentials for staging and production to limit blast radius",
+      "confidence": 0.68
+    },
+    {
+      "key": "deploy-pipeline-archives-build-logs-90-28",
+      "entity": "deploy-pipeline",
+      "kind": "semantic",
+      "content": "The deploy pipeline archives build logs for 90 days for audit purposes",
+      "confidence": 0.68
+    },
+    {
+      "key": "deploy-pipeline-automatically-closes-associated-ticket-29",
+      "entity": "deploy-pipeline",
+      "kind": "semantic",
+      "content": "The deploy pipeline automatically closes the associated ticket when a deployment succeeds",
+      "confidence": 0.68
+    },
+    {
+      "key": "deploy-pipeline-requires-all-secrets-be-30",
+      "entity": "deploy-pipeline",
+      "kind": "semantic",
+      "content": "The deploy pipeline requires all secrets to be pulled from the vault rather than environment files",
+      "confidence": 0.69
+    },
+    {
+      "key": "deploy-pipeline-supports-one-click-rollback-31",
+      "entity": "deploy-pipeline",
+      "kind": "semantic",
+      "content": "The deploy pipeline supports one-click rollback to any of the last ten releases",
+      "confidence": 0.69
+    },
+    {
+      "key": "deploy-pipeline-runs-database-backup-snapshot-32",
+      "entity": "deploy-pipeline",
+      "kind": "semantic",
+      "content": "The deploy pipeline runs a database backup snapshot immediately before any schema migration",
+      "confidence": 0.69
+    },
+    {
+      "key": "deploy-pipeline-throttles-concurrent-deployments-single-33",
+      "entity": "deploy-pipeline",
+      "kind": "semantic",
+      "content": "The deploy pipeline throttles concurrent deployments to a single service at a time",
+      "confidence": 0.69
+    },
+    {
+      "key": "deploy-pipeline-runs-contract-tests-between-34",
+      "entity": "deploy-pipeline",
+      "kind": "semantic",
+      "content": "The deploy pipeline runs contract tests between services before allowing a deploy to proceed",
+      "confidence": 0.7
+    },
+    {
+      "key": "deploy-pipeline-requires-release-notes-be-35",
+      "entity": "deploy-pipeline",
+      "kind": "semantic",
+      "content": "The deploy pipeline requires the release notes to be reviewed by a second engineer",
+      "confidence": 0.7
+    },
+    {
+      "key": "deploy-pipeline-exposes-status-dashboard-showing-36",
+      "entity": "deploy-pipeline",
+      "kind": "semantic",
+      "content": "The deploy pipeline exposes a status dashboard showing the health of the last ten deployments",
+      "confidence": 0.7
+    },
+    {
+      "key": "deploy-pipeline-uses-weighted-traffic-shift-37",
+      "entity": "deploy-pipeline",
+      "kind": "semantic",
+      "content": "The deploy pipeline uses a weighted traffic shift, starting canary at 5 percent of production traffic",
+      "confidence": 0.71
+    },
+    {
+      "key": "deploy-pipeline-configured-skip-canary-stage-38",
+      "entity": "deploy-pipeline",
+      "kind": "semantic",
+      "content": "The deploy pipeline is configured to skip the canary stage for documentation-only changes",
+      "confidence": 0.71
+    },
+    {
+      "key": "deploy-pipeline-emails-release-manager-summary-39",
+      "entity": "deploy-pipeline",
+      "kind": "semantic",
+      "content": "The deploy pipeline emails the release manager a summary at the end of each deploy window",
+      "confidence": 0.71
+    },
+    {
+      "key": "deploy-pipeline-requires-incident-ticket-be-40",
+      "entity": "deploy-pipeline",
+      "kind": "semantic",
+      "content": "The deploy pipeline requires an incident ticket to be linked before any emergency hotfix can merge",
+      "confidence": 0.71
+    },
+    {
+      "key": "deploy-pipeline-configured-start-canary-rollouts-41",
+      "entity": "deploy-pipeline",
+      "kind": "semantic",
+      "content": "The deploy pipeline was configured to start canary rollouts at 10 percent of production traffic",
+      "confidence": 0.72
+    },
+    {
+      "key": "deploy-pipeline-configuration-changed-start-canary-42",
+      "entity": "deploy-pipeline",
+      "kind": "semantic",
+      "content": "The deploy pipeline configuration was later changed to start canary rollouts at 25 percent of production traffic",
+      "confidence": 0.72
+    },
+    {
+      "key": "deploy-pipeline-enforces-deployment-freeze-24-43",
+      "entity": "deploy-pipeline",
+      "kind": "semantic",
+      "content": "The deploy pipeline enforces a deployment freeze for 24 hours before major holidays",
+      "confidence": 0.72
+    },
+    {
+      "key": "deploy-pipeline-freeze-window-before-major-44",
+      "entity": "deploy-pipeline",
+      "kind": "semantic",
+      "content": "The deploy pipeline freeze window before major holidays was later shortened to 12 hours",
+      "confidence": 0.72
+    },
+    {
+      "key": "deploy-pipeline-ep-during-last-week-s-01",
+      "entity": "deploy-pipeline",
+      "kind": "episodic",
+      "content": "During last week's incident, the deploy pipeline auto-rolled-back the checkout service within four minutes",
+      "confidence": 0.73
+    },
+    {
+      "key": "deploy-pipeline-ep-yesterday-s-release-window-02",
+      "entity": "deploy-pipeline",
+      "kind": "episodic",
+      "content": "In yesterday's release window, the deploy pipeline flagged a failed smoke test and blocked the promotion",
+      "confidence": 0.73
+    },
+    {
+      "key": "deploy-pipeline-ep-during-chaos-drill-s-03",
+      "entity": "deploy-pipeline",
+      "kind": "episodic",
+      "content": "During the chaos drill, the deploy pipeline's rollback automation restored service in under two minutes",
+      "confidence": 0.73
+    },
+    {
+      "key": "deploy-pipeline-ep-postmortem-meeting-team-traced-04",
+      "entity": "deploy-pipeline",
+      "kind": "episodic",
+      "content": "In the postmortem meeting, the team traced a bad deploy to a missing approval gate that was later added",
+      "confidence": 0.73
+    },
+    {
+      "key": "deploy-pipeline-ep-during-migration-cutover-paused-05",
+      "entity": "deploy-pipeline",
+      "kind": "episodic",
+      "content": "During the migration cutover, the deploy pipeline paused canary traffic after the error budget alarm fired",
+      "confidence": 0.74
+    },
+    {
+      "key": "deploy-pipeline-ep-last-month-s-audit-06",
+      "entity": "deploy-pipeline",
+      "kind": "episodic",
+      "content": "In last month's audit, the deploy pipeline logs showed 45 deployments with zero unplanned downtime",
+      "confidence": 0.74
+    },
+    {
+      "key": "acme-corp-signed-three-year-enterprise-01",
+      "entity": "acme-corp",
+      "kind": "semantic",
+      "content": "Acme Corp signed a three-year enterprise contract with its primary cloud vendor in Q1",
+      "confidence": 0.74
+    },
+    {
+      "key": "acme-corp-s-engineering-headcount-grew-02",
+      "entity": "acme-corp",
+      "kind": "semantic",
+      "content": "Acme Corp's engineering headcount grew from 40 to 65 over the past fiscal year",
+      "confidence": 0.74
+    },
+    {
+      "key": "acme-corp-moved-its-headquarters-smaller-03",
+      "entity": "acme-corp",
+      "kind": "semantic",
+      "content": "Acme Corp moved its headquarters to a smaller office after shifting to a hybrid work policy",
+      "confidence": 0.75
+    },
+    {
+      "key": "acme-corp-s-board-approved-budget-04",
+      "entity": "acme-corp",
+      "kind": "semantic",
+      "content": "Acme Corp's board approved a budget of $2.4 million for infrastructure modernization",
+      "confidence": 0.75
+    },
+    {
+      "key": "acme-corp-acquired-small-analytics-startup-05",
+      "entity": "acme-corp",
+      "kind": "semantic",
+      "content": "Acme Corp acquired a small analytics startup to bring dashboarding capability in-house",
+      "confidence": 0.75
+    },
+    {
+      "key": "acme-corp-s-customer-support-team-06",
+      "entity": "acme-corp",
+      "kind": "semantic",
+      "content": "Acme Corp's customer support team switched from email-only to a ticketing system with SLAs",
+      "confidence": 0.75
+    },
+    {
+      "key": "acme-corp-s-annual-recurring-revenue-07",
+      "entity": "acme-corp",
+      "kind": "semantic",
+      "content": "Acme Corp's annual recurring revenue crossed $18 million last quarter",
+      "confidence": 0.76
+    },
+    {
+      "key": "acme-soc2-cert",
+      "entity": "acme-corp",
+      "kind": "semantic",
+      "content": "Acme Corp's security team achieved SOC 2 Type II certification after a six-month audit",
+      "confidence": 0.76
+    },
+    {
+      "key": "acme-corp-s-sales-team-restructured-09",
+      "entity": "acme-corp",
+      "kind": "semantic",
+      "content": "Acme Corp's sales team restructured into pods aligned by industry vertical",
+      "confidence": 0.76
+    },
+    {
+      "key": "acme-corp-s-churn-rate-dropped-10",
+      "entity": "acme-corp",
+      "kind": "semantic",
+      "content": "Acme Corp's churn rate dropped from 8 percent to 5 percent after the onboarding redesign",
+      "confidence": 0.77
+    },
+    {
+      "key": "acme-corp-s-leadership-decided-sunset-11",
+      "entity": "acme-corp",
+      "kind": "semantic",
+      "content": "Acme Corp's leadership decided to sunset the legacy on-premise product line by next year",
+      "confidence": 0.77
+    },
+    {
+      "key": "acme-corp-s-marketing-budget-reallocated-12",
+      "entity": "acme-corp",
+      "kind": "semantic",
+      "content": "Acme Corp's marketing budget was reallocated toward content and away from paid search",
+      "confidence": 0.77
+    },
+    {
+      "key": "acme-corp-s-data-retention-policy-13",
+      "entity": "acme-corp",
+      "kind": "semantic",
+      "content": "Acme Corp's data retention policy requires customer data to be purged 90 days after account closure",
+      "confidence": 0.77
+    },
+    {
+      "key": "acme-corp-s-engineering-team-adopted-14",
+      "entity": "acme-corp",
+      "kind": "semantic",
+      "content": "Acme Corp's engineering team adopted a four-day work week trial for the summer",
+      "confidence": 0.78
+    },
+    {
+      "key": "acme-corp-s-procurement-process-now-15",
+      "entity": "acme-corp",
+      "kind": "semantic",
+      "content": "Acme Corp's procurement process now requires three vendor quotes for purchases over $10,000",
+      "confidence": 0.78
+    },
+    {
+      "key": "acme-corp-s-compliance-team-added-16",
+      "entity": "acme-corp",
+      "kind": "semantic",
+      "content": "Acme Corp's compliance team added GDPR data processing addenda to all new contracts",
+      "confidence": 0.78
+    },
+    {
+      "key": "acme-corp-s-product-team-ships-17",
+      "entity": "acme-corp",
+      "kind": "semantic",
+      "content": "Acme Corp's product team ships a public changelog every two weeks",
+      "confidence": 0.78
+    },
+    {
+      "key": "acme-corp-s-finance-team-moved-18",
+      "entity": "acme-corp",
+      "kind": "semantic",
+      "content": "Acme Corp's finance team moved from quarterly to monthly close to improve forecasting accuracy",
+      "confidence": 0.79
+    },
+    {
+      "key": "acme-corp-s-customer-advisory-board-19",
+      "entity": "acme-corp",
+      "kind": "semantic",
+      "content": "Acme Corp's customer advisory board meets twice a year to prioritize the roadmap",
+      "confidence": 0.79
+    },
+    {
+      "key": "acme-corp-s-largest-customer-by-20",
+      "entity": "acme-corp",
+      "kind": "semantic",
+      "content": "Acme Corp's largest customer by revenue is a logistics company representing 12 percent of ARR",
+      "confidence": 0.79
+    },
+    {
+      "key": "acme-corp-s-hr-team-introduced-21",
+      "entity": "acme-corp",
+      "kind": "semantic",
+      "content": "Acme Corp's HR team introduced a formalized career ladder for engineering roles",
+      "confidence": 0.79
+    },
+    {
+      "key": "acme-corp-s-legal-team-standardized-22",
+      "entity": "acme-corp",
+      "kind": "semantic",
+      "content": "Acme Corp's legal team standardized on a single MSA template to speed up deal cycles",
+      "confidence": 0.8
+    },
+    {
+      "key": "acme-corp-s-office-austin-closed-23",
+      "entity": "acme-corp",
+      "kind": "semantic",
+      "content": "Acme Corp's office in Austin closed after the lease expired and staff went fully remote",
+      "confidence": 0.8
+    },
+    {
+      "key": "acme-corp-s-incident-response-policy-24",
+      "entity": "acme-corp",
+      "kind": "semantic",
+      "content": "Acme Corp's incident response policy requires a postmortem within 48 hours of any P1",
+      "confidence": 0.8
+    },
+    {
+      "key": "acme-corp-s-data-warehouse-migrated-25",
+      "entity": "acme-corp",
+      "kind": "semantic",
+      "content": "Acme Corp's data warehouse migrated from a legacy on-prem cluster to a managed cloud service",
+      "confidence": 0.8
+    },
+    {
+      "key": "acme-corp-s-benefits-package-added-26",
+      "entity": "acme-corp",
+      "kind": "semantic",
+      "content": "Acme Corp's benefits package added a $1,500 annual learning and development stipend",
+      "confidence": 0.81
+    },
+    {
+      "key": "acme-corp-s-founders-retained-majority-27",
+      "entity": "acme-corp",
+      "kind": "semantic",
+      "content": "Acme Corp's founders retained majority board control after the most recent funding round",
+      "confidence": 0.81
+    },
+    {
+      "key": "acme-corp-s-customer-success-team-28",
+      "entity": "acme-corp",
+      "kind": "semantic",
+      "content": "Acme Corp's customer success team owns renewal conversations for accounts under $50,000 ARR",
+      "confidence": 0.81
+    },
+    {
+      "key": "acme-corp-s-internal-tools-team-29",
+      "entity": "acme-corp",
+      "kind": "semantic",
+      "content": "Acme Corp's internal tools team built a self-service reporting dashboard for account managers",
+      "confidence": 0.81
+    },
+    {
+      "key": "acme-corp-s-brand-refresh-included-30",
+      "entity": "acme-corp",
+      "kind": "semantic",
+      "content": "Acme Corp's brand refresh included a new logo and a simplified color palette",
+      "confidence": 0.82
+    },
+    {
+      "key": "acme-corp-s-partnership-systems-integrator-31",
+      "entity": "acme-corp",
+      "kind": "semantic",
+      "content": "Acme Corp's partnership with a systems integrator drove 20 percent of new pipeline last quarter",
+      "confidence": 0.82
+    },
+    {
+      "key": "acme-corp-s-engineering-org-uses-32",
+      "entity": "acme-corp",
+      "kind": "semantic",
+      "content": "Acme Corp's engineering org uses a RFC process for any change affecting more than one team",
+      "confidence": 0.82
+    },
+    {
+      "key": "acme-corp-s-most-recent-employee-33",
+      "entity": "acme-corp",
+      "kind": "semantic",
+      "content": "Acme Corp's most recent employee survey showed a 12-point increase in engagement scores",
+      "confidence": 0.83
+    },
+    {
+      "key": "acme-corp-s-pricing-model-shifted-34",
+      "entity": "acme-corp",
+      "kind": "semantic",
+      "content": "Acme Corp's pricing model shifted from per-seat to usage-based for the enterprise tier",
+      "confidence": 0.83
+    },
+    {
+      "key": "acme-corp-s-data-privacy-officer-35",
+      "entity": "acme-corp",
+      "kind": "semantic",
+      "content": "Acme Corp's data privacy officer reports directly to the general counsel",
+      "confidence": 0.83
+    },
+    {
+      "key": "acme-corp-s-customer-onboarding-time-36",
+      "entity": "acme-corp",
+      "kind": "semantic",
+      "content": "Acme Corp's customer onboarding time dropped from six weeks to ten days after the redesign",
+      "confidence": 0.83
+    },
+    {
+      "key": "acme-corp-s-supply-chain-team-37",
+      "entity": "acme-corp",
+      "kind": "semantic",
+      "content": "Acme Corp's supply chain team diversified vendors after a single-source outage last winter",
+      "confidence": 0.84
+    },
+    {
+      "key": "acme-corp-s-executive-team-holds-38",
+      "entity": "acme-corp",
+      "kind": "semantic",
+      "content": "Acme Corp's executive team holds a public all-hands every first Monday of the month",
+      "confidence": 0.84
+    },
+    {
+      "key": "acme-corp-s-revenue-mix-now-39",
+      "entity": "acme-corp",
+      "kind": "semantic",
+      "content": "Acme Corp's revenue mix is now 70 percent subscription and 30 percent services",
+      "confidence": 0.84
+    },
+    {
+      "key": "acme-corp-s-engineering-team-runs-40",
+      "entity": "acme-corp",
+      "kind": "semantic",
+      "content": "Acme Corp's engineering team runs a quarterly hackathon that has produced two shipped features",
+      "confidence": 0.84
+    },
+    {
+      "key": "acme-corp-announced-it-relocating-its-41",
+      "entity": "acme-corp",
+      "kind": "semantic",
+      "content": "Acme Corp announced it was relocating its headquarters to Denver",
+      "confidence": 0.85
+    },
+    {
+      "key": "acme-corp-announced-it-relocating-its-42",
+      "entity": "acme-corp",
+      "kind": "semantic",
+      "content": "Acme Corp later announced it was relocating its headquarters to Austin instead of Denver",
+      "confidence": 0.85
+    },
+    {
+      "key": "acme-corp-s-enterprise-tier-priced-43",
+      "entity": "acme-corp",
+      "kind": "semantic",
+      "content": "Acme Corp's enterprise tier was priced at a flat annual rate regardless of usage",
+      "confidence": 0.85
+    },
+    {
+      "key": "acme-corp-s-enterprise-tier-pricing-44",
+      "entity": "acme-corp",
+      "kind": "semantic",
+      "content": "Acme Corp's enterprise tier pricing was later changed to scale with monthly active usage",
+      "confidence": 0.85
+    },
+    {
+      "key": "acme-corp-ep-last-quarter-s-all-01",
+      "entity": "acme-corp",
+      "kind": "episodic",
+      "content": "At last quarter's all-hands, Acme Corp's CEO announced the acquisition of the analytics startup",
+      "confidence": 0.86
+    },
+    {
+      "key": "acme-corp-ep-during-board-meeting-march-02",
+      "entity": "acme-corp",
+      "kind": "episodic",
+      "content": "During the board meeting in March, Acme Corp's leadership approved the infrastructure budget increase",
+      "confidence": 0.86
+    },
+    {
+      "key": "acme-corp-ep-customer-advisory-board-session-03",
+      "entity": "acme-corp",
+      "kind": "episodic",
+      "content": "At the customer advisory board session, Acme Corp's product team presented the usage-based pricing proposal",
+      "confidence": 0.86
+    },
+    {
+      "key": "acme-corp-ep-during-soc-2-audit-04",
+      "entity": "acme-corp",
+      "kind": "episodic",
+      "content": "During the SOC 2 audit kickoff, Acme Corp's security team walked auditors through the access control policy",
+      "confidence": 0.86
+    },
+    {
+      "key": "acme-corp-ep-q2-town-hall-s-05",
+      "entity": "acme-corp",
+      "kind": "episodic",
+      "content": "At the Q2 town hall, Acme Corp's finance lead explained the move to monthly financial close",
+      "confidence": 0.87
+    },
+    {
+      "key": "acme-corp-ep-during-office-consolidation-announcement-06",
+      "entity": "acme-corp",
+      "kind": "episodic",
+      "content": "During the office consolidation announcement, Acme Corp confirmed the Austin lease would not be renewed",
+      "confidence": 0.87
+    },
+    {
+      "key": "research-rrf-vs-linear",
+      "entity": "research-notes",
+      "kind": "semantic",
+      "content": "The research notes conclude that the reranker model improves nDCG@10 by 8 points over the base retriever",
+      "confidence": 0.87
+    },
+    {
+      "key": "research-notes-show-hybrid-search-outperforms-02",
+      "entity": "research-notes",
+      "kind": "semantic",
+      "content": "The research notes show that hybrid search outperforms pure vector search on queries with rare entity names",
+      "confidence": 0.87
+    },
+    {
+      "key": "research-notes-flag-ablation-study-used-03",
+      "entity": "research-notes",
+      "kind": "semantic",
+      "content": "The research notes flag that the ablation study used too small a held-out set to be conclusive",
+      "confidence": 0.88
+    },
+    {
+      "key": "research-notes-document-reducing-embedding-dimensionality-04",
+      "entity": "research-notes",
+      "kind": "semantic",
+      "content": "The research notes document that reducing embedding dimensionality from 768 to 384 barely hurt recall",
+      "confidence": 0.88
+    },
+    {
+      "key": "research-notes-cite-paper-showing-contrastive-05",
+      "entity": "research-notes",
+      "kind": "semantic",
+      "content": "The research notes cite a paper showing contrastive pretraining improves few-shot classification accuracy",
+      "confidence": 0.88
+    },
+    {
+      "key": "research-notes-describe-experiment-where-bm25-06",
+      "entity": "research-notes",
+      "kind": "semantic",
+      "content": "The research notes describe an experiment where BM25 alone matched dense retrieval on short queries",
+      "confidence": 0.89
+    },
+    {
+      "key": "research-notes-recommend-running-significance-tests-07",
+      "entity": "research-notes",
+      "kind": "semantic",
+      "content": "The research notes recommend running significance tests before reporting any benchmark improvement",
+      "confidence": 0.89
+    },
+    {
+      "key": "research-notes-summarize-survey-reranking-approaches-08",
+      "entity": "research-notes",
+      "kind": "semantic",
+      "content": "The research notes summarize a survey of reranking approaches used in production search systems",
+      "confidence": 0.89
+    },
+    {
+      "key": "research-notes-highlight-batching-queries-during-09",
+      "entity": "research-notes",
+      "kind": "semantic",
+      "content": "The research notes highlight that batching queries during evaluation introduced a subtle latency bias",
+      "confidence": 0.89
+    },
+    {
+      "key": "research-notes-propose-new-evaluation-metric-10",
+      "entity": "research-notes",
+      "kind": "semantic",
+      "content": "The research notes propose a new evaluation metric that penalizes stale or superseded retrieved facts",
+      "confidence": 0.9
+    },
+    {
+      "key": "research-notes-track-increasing-negative-sampling-11",
+      "entity": "research-notes",
+      "kind": "semantic",
+      "content": "The research notes track that increasing negative sampling ratio improved the contrastive loss convergence",
+      "confidence": 0.9
+    },
+    {
+      "key": "research-notes-report-fine-tuning-domain-12",
+      "entity": "research-notes",
+      "kind": "semantic",
+      "content": "The research notes report that fine-tuning on domain data closed most of the gap to the larger base model",
+      "confidence": 0.9
+    },
+    {
+      "key": "research-notes-note-annotation-guidelines-needed-13",
+      "entity": "research-notes",
+      "kind": "semantic",
+      "content": "The research notes note that the annotation guidelines needed revision after inter-rater agreement was low",
+      "confidence": 0.9
+    },
+    {
+      "key": "research-notes-reference-experiment-comparing-cosine-14",
+      "entity": "research-notes",
+      "kind": "semantic",
+      "content": "The research notes reference an experiment comparing cosine similarity to dot product for ranking stability",
+      "confidence": 0.91
+    },
+    {
+      "key": "research-notes-conclude-query-expansion-helps-15",
+      "entity": "research-notes",
+      "kind": "semantic",
+      "content": "The research notes conclude that query expansion helps recall but hurts precision on ambiguous queries",
+      "confidence": 0.91
+    },
+    {
+      "key": "research-notes-document-failure-mode-where-16",
+      "entity": "research-notes",
+      "kind": "semantic",
+      "content": "The research notes document a failure mode where paraphrased queries scored lower than verbatim queries",
+      "confidence": 0.91
+    },
+    {
+      "key": "research-notes-describe-pilot-where-human-17",
+      "entity": "research-notes",
+      "kind": "semantic",
+      "content": "The research notes describe a pilot where human evaluators preferred the reranked results 68 percent of the time",
+      "confidence": 0.91
+    },
+    {
+      "key": "research-notes-flag-training-data-had-18",
+      "entity": "research-notes",
+      "kind": "semantic",
+      "content": "The research notes flag that the training data had a skew toward short factual queries over conversational ones",
+      "confidence": 0.92
+    },
+    {
+      "key": "research-notes-recommend-held-out-temporal-19",
+      "entity": "research-notes",
+      "kind": "semantic",
+      "content": "The research notes recommend a held-out temporal split rather than a random split for recency-sensitive evaluation",
+      "confidence": 0.92
+    },
+    {
+      "key": "research-notes-summarize-findings-from-replicating-20",
+      "entity": "research-notes",
+      "kind": "semantic",
+      "content": "The research notes summarize findings from replicating a published retrieval benchmark on internal data",
+      "confidence": 0.92
+    },
+    {
+      "key": "research-notes-document-adding-hard-negatives-21",
+      "entity": "research-notes",
+      "kind": "semantic",
+      "content": "The research notes document that adding hard negatives during training improved top-1 accuracy by 5 points",
+      "confidence": 0.92
+    },
+    {
+      "key": "research-notes-note-current-judge-model-22",
+      "entity": "research-notes",
+      "kind": "semantic",
+      "content": "The research notes note that the current judge model shows a length bias favoring longer answers",
+      "confidence": 0.93
+    },
+    {
+      "key": "research-notes-track-experiment-where-multi-23",
+      "entity": "research-notes",
+      "kind": "semantic",
+      "content": "The research notes track an experiment where multi-vector representations improved recall for long documents",
+      "confidence": 0.93
+    },
+    {
+      "key": "research-notes-describe-calibration-study-comparing-24",
+      "entity": "research-notes",
+      "kind": "semantic",
+      "content": "The research notes describe a calibration study comparing predicted confidence to observed accuracy",
+      "confidence": 0.93
+    },
+    {
+      "key": "research-notes-conclude-combining-bm25-dense-25",
+      "entity": "research-notes",
+      "kind": "semantic",
+      "content": "The research notes conclude that combining BM25 and dense scores via reciprocal rank fusion is more robust than linear weighting",
+      "confidence": 0.93
+    },
+    {
+      "key": "research-notes-report-supersession-detection-reduced-26",
+      "entity": "research-notes",
+      "kind": "semantic",
+      "content": "The research notes report that supersession detection reduced contradictory answers by roughly a third",
+      "confidence": 0.94
+    },
+    {
+      "key": "research-notes-reference-follow-up-experiment-27",
+      "entity": "research-notes",
+      "kind": "semantic",
+      "content": "The research notes reference a follow-up experiment planned to test the effect of confidence decay over time",
+      "confidence": 0.94
+    },
+    {
+      "key": "research-notes-document-offline-eval-online-28",
+      "entity": "research-notes",
+      "kind": "semantic",
+      "content": "The research notes document that the offline eval and online A/B test disagreed on the winning variant",
+      "confidence": 0.94
+    },
+    {
+      "key": "research-notes-flag-data-leakage-issue-29",
+      "entity": "research-notes",
+      "kind": "semantic",
+      "content": "The research notes flag a data leakage issue where test queries overlapped with training memories",
+      "confidence": 0.95
+    },
+    {
+      "key": "research-notes-recommend-logging-raw-retrieval-30",
+      "entity": "research-notes",
+      "kind": "semantic",
+      "content": "The research notes recommend logging raw retrieval scores in addition to final ranked results for debugging",
+      "confidence": 0.95
+    },
+    {
+      "key": "research-notes-summarize-literature-review-catastrophic-31",
+      "entity": "research-notes",
+      "kind": "semantic",
+      "content": "The research notes summarize a literature review on catastrophic forgetting in continually updated memory systems",
+      "confidence": 0.95
+    },
+    {
+      "key": "research-notes-describe-experiment-measuring-latency-32",
+      "entity": "research-notes",
+      "kind": "semantic",
+      "content": "The research notes describe an experiment measuring the latency cost of adding a cross-encoder reranking stage",
+      "confidence": 0.95
+    },
+    {
+      "key": "research-notes-note-entity-scoped-search-33",
+      "entity": "research-notes",
+      "kind": "semantic",
+      "content": "The research notes note that entity-scoped search improved precision but reduced recall for cross-entity queries",
+      "confidence": 0.96
+    },
+    {
+      "key": "research-notes-track-increasing-candidate-pool-34",
+      "entity": "research-notes",
+      "kind": "semantic",
+      "content": "The research notes track that increasing the candidate pool size from 50 to 200 improved recall with modest latency cost",
+      "confidence": 0.96
+    },
+    {
+      "key": "research-notes-document-bug-where-duplicate-35",
+      "entity": "research-notes",
+      "kind": "semantic",
+      "content": "The research notes document a bug where duplicate memories inflated recall metrics until deduplication was added",
+      "confidence": 0.96
+    },
+    {
+      "key": "research-notes-conclude-current-judge-prompt-36",
+      "entity": "research-notes",
+      "kind": "semantic",
+      "content": "The research notes conclude the current judge prompt is more reliable for factual than for subjective queries",
+      "confidence": 0.96
+    },
+    {
+      "key": "research-notes-reference-plan-run-paraphrase-37",
+      "entity": "research-notes",
+      "kind": "semantic",
+      "content": "The research notes reference a plan to run the paraphrase robustness study on a held-out corpus",
+      "confidence": 0.97
+    },
+    {
+      "key": "research-notes-describe-how-synthetic-paraphrases-38",
+      "entity": "research-notes",
+      "kind": "semantic",
+      "content": "The research notes describe how synthetic paraphrases were generated using template substitution and back-translation",
+      "confidence": 0.97
+    },
+    {
+      "key": "research-notes-document-removing-stopwords-before-39",
+      "entity": "research-notes",
+      "kind": "semantic",
+      "content": "The research notes document that removing stopwords before BM25 scoring had negligible effect on ranking quality",
+      "confidence": 0.97
+    },
+    {
+      "key": "research-notes-recommend-re-running-paraphrase-40",
+      "entity": "research-notes",
+      "kind": "semantic",
+      "content": "The research notes recommend re-running the paraphrase study whenever the embedding model is upgraded",
+      "confidence": 0.97
+    },
+    {
+      "key": "research-notes-concluded-reciprocal-rank-fusion-41",
+      "entity": "research-notes",
+      "kind": "semantic",
+      "content": "The research notes concluded that reciprocal rank fusion outperforms linear weighted scoring for hybrid retrieval",
+      "confidence": 0.98
+    },
+    {
+      "key": "research-notes-revision-concluded-linear-weighted-42",
+      "entity": "research-notes",
+      "kind": "semantic",
+      "content": "A later revision of the research notes concluded that linear weighted scoring outperforms reciprocal rank fusion for hybrid retrieval",
+      "confidence": 0.98
+    },
+    {
+      "key": "research-notes-reported-384-dimensional-embeddings-43",
+      "entity": "research-notes",
+      "kind": "semantic",
+      "content": "The research notes reported that 384-dimensional embeddings matched 768-dimensional embeddings on the benchmark",
+      "confidence": 0.98
+    },
+    {
+      "key": "research-notes-corrected-report-768-dimensional-44",
+      "entity": "research-notes",
+      "kind": "semantic",
+      "content": "The research notes were later corrected to report that 768-dimensional embeddings outperformed 384-dimensional embeddings by a small margin",
+      "confidence": 0.98
+    },
+    {
+      "key": "research-notes-ep-yesterday-s-sync-team-01",
+      "entity": "research-notes",
+      "kind": "episodic",
+      "content": "In yesterday's research sync, the team reviewed the ablation study and flagged the small held-out set",
+      "confidence": 0.99
+    },
+    {
+      "key": "research-notes-ep-during-paper-reading-group-02",
+      "entity": "research-notes",
+      "kind": "episodic",
+      "content": "During the paper reading group, the team discussed the contrastive pretraining paper cited in the notes",
+      "confidence": 0.99
+    },
+    {
+      "key": "research-notes-ep-eval-review-meeting-team-03",
+      "entity": "research-notes",
+      "kind": "episodic",
+      "content": "At the eval review meeting, the team examined why the offline and online experiments disagreed",
+      "confidence": 0.99
+    },
+    {
+      "key": "research-notes-ep-during-annotation-calibration-session-04",
+      "entity": "research-notes",
+      "kind": "episodic",
+      "content": "During the annotation calibration session, the team revised the guidelines after low inter-rater agreement",
+      "confidence": 0.99
+    },
+    {
+      "key": "research-notes-ep-planning-meeting-paraphrase-study-05",
+      "entity": "research-notes",
+      "kind": "episodic",
+      "content": "In the planning meeting for the paraphrase study, the team decided to use template substitution for synthetic queries",
+      "confidence": 1.0
+    },
+    {
+      "key": "research-notes-ep-quarterly-review-team-presented-06",
+      "entity": "research-notes",
+      "kind": "episodic",
+      "content": "At the quarterly research review, the team presented the reranker's 8-point nDCG@10 improvement",
+      "confidence": 1.0
+    }
+  ],
+  "queries": []
+}

--- a/pensyve-benchmarks/results/paraphrase_baseline.json
+++ b/pensyve-benchmarks/results/paraphrase_baseline.json
@@ -1,26 +1,26 @@
 {
-  "top3_hit_rate": 0.532258064516129,
-  "mrr": 0.4236303123399897,
+  "top3_hit_rate": 0.5806451612903226,
+  "mrr": 0.49014976958525336,
   "per_query": [
     {
       "query": "how fast is bob's parquet reader",
       "kind": "paraphrase",
-      "gold_rank": 3
+      "gold_rank": 1
     },
     {
       "query": "which async runtime setup does bob suggest for the data intake pipeline",
       "kind": "paraphrase",
-      "gold_rank": 6
+      "gold_rank": 7
     },
     {
       "query": "what did bob identify as the biggest slowdown once simultaneous writes climbed past two dozen",
       "kind": "paraphrase",
-      "gold_rank": 3
+      "gold_rank": 4
     },
     {
       "query": "which embedded database does bob favor when queries mostly scan large tables",
       "kind": "paraphrase",
-      "gold_rank": 9
+      "gold_rank": 6
     },
     {
       "query": "what search parameter, when set too low, hurts bob's vector index accuracy",
@@ -30,7 +30,7 @@
     {
       "query": "roughly how much traffic can the gateway handle before it maxes out, per bob's testing",
       "kind": "paraphrase",
-      "gold_rank": 4
+      "gold_rank": 2
     },
     {
       "query": "why did bob move the caching system to a different tool that has built-in messaging",
@@ -40,22 +40,22 @@
     {
       "query": "how did bob get rid of garbage-collector pauses in the critical code path",
       "kind": "paraphrase",
-      "gold_rank": 5
+      "gold_rank": 3
     },
     {
       "query": "which data format does bob favor when schemas need to change across services over time",
       "kind": "paraphrase",
-      "gold_rank": 5
+      "gold_rank": 3
     },
     {
       "query": "where did bob trace an unexpected memory-usage bug back to",
       "kind": "paraphrase",
-      "gold_rank": 4
+      "gold_rank": 7
     },
     {
       "query": "which trek does alice enjoy most near the reservoir and how long does it take",
       "kind": "paraphrase",
-      "gold_rank": 2
+      "gold_rank": 3
     },
     {
       "query": "why did alice change her morning coffee brewing method to something less of a hassle to wash",
@@ -70,32 +70,32 @@
     {
       "query": "how often does alice go jogging and which day does she take off",
       "kind": "paraphrase",
-      "gold_rank": 1
+      "gold_rank": 7
     },
     {
       "query": "which plants thrive for alice outdoors and which one won't survive",
       "kind": "paraphrase",
-      "gold_rank": 4
+      "gold_rank": 3
     },
     {
       "query": "why does alice pick a specific airplane seat for napping",
       "kind": "paraphrase",
-      "gold_rank": 2
+      "gold_rank": 8
     },
     {
       "query": "what skill did alice pick up so she could repair her own keyboard",
       "kind": "paraphrase",
-      "gold_rank": 4
+      "gold_rank": 8
     },
     {
       "query": "what display trick does alice use to curb compulsive phone checking",
       "kind": "paraphrase",
-      "gold_rank": 3
+      "gold_rank": 4
     },
     {
       "query": "what equipment change did alice make at her desk after hurting her wrist",
       "kind": "paraphrase",
-      "gold_rank": 3
+      "gold_rank": 1
     },
     {
       "query": "how often and where does alice spend time volunteering with plants",
@@ -105,7 +105,7 @@
     {
       "query": "how many sign-offs are needed before a payments-related change can ship",
       "kind": "paraphrase",
-      "gold_rank": 1
+      "gold_rank": 2
     },
     {
       "query": "what test coverage threshold prevents code from merging into the main branch",
@@ -115,17 +115,17 @@
     {
       "query": "what zero-downtime release strategy is used for the gateway service",
       "kind": "paraphrase",
-      "gold_rank": 2
+      "gold_rank": 1
     },
     {
       "query": "under what failure-rate condition does the system alert whoever is on duty",
       "kind": "paraphrase",
-      "gold_rank": 4
+      "gold_rank": 1
     },
     {
       "query": "when during the week does the release process pause shipping changes",
       "kind": "paraphrase",
-      "gold_rank": 1
+      "gold_rank": 2
     },
     {
       "query": "how was container build duration shortened",
@@ -135,22 +135,22 @@
     {
       "query": "how does the team get notified whenever something ships to production",
       "kind": "paraphrase",
-      "gold_rank": 4
+      "gold_rank": 3
     },
     {
       "query": "how many prior working builds are kept on hand for quick reverting",
       "kind": "paraphrase",
-      "gold_rank": 3
+      "gold_rank": 1
     },
     {
       "query": "how often is failure-injection testing done to confirm automatic recovery works",
       "kind": "paraphrase",
-      "gold_rank": 8
+      "gold_rank": 7
     },
     {
       "query": "where must credentials be sourced from instead of config files",
       "kind": "paraphrase",
-      "gold_rank": 3
+      "gold_rank": 5
     },
     {
       "query": "how long is acme's deal with its main cloud provider and when was it signed",
@@ -160,22 +160,22 @@
     {
       "query": "by how much did the size of acme's engineering team increase last year",
       "kind": "paraphrase",
-      "gold_rank": 1
+      "gold_rank": 2
     },
     {
       "query": "why did acme downsize its main office space",
       "kind": "paraphrase",
-      "gold_rank": 5
+      "gold_rank": 1
     },
     {
       "query": "what company did acme buy to build its own reporting features",
       "kind": "paraphrase",
-      "gold_rank": 9
+      "gold_rank": null
     },
     {
       "query": "what was acme's yearly subscription income milestone recently",
       "kind": "paraphrase",
-      "gold_rank": 4
+      "gold_rank": 10
     },
     {
       "query": "how did revamping the new-user setup affect customer cancellations at acme",
@@ -190,32 +190,32 @@
     {
       "query": "how quickly must customer records be deleted once an account closes",
       "kind": "paraphrase",
-      "gold_rank": 4
+      "gold_rank": 2
     },
     {
       "query": "how many bids does acme need before approving a large purchase",
       "kind": "paraphrase",
-      "gold_rank": 3
+      "gold_rank": 1
     },
     {
       "query": "what happened to acme's Texas office once its lease ran out",
       "kind": "paraphrase",
-      "gold_rank": 3
+      "gold_rank": 5
     },
     {
       "query": "which retrieval approach wins for uncommon proper-noun lookups according to the study",
       "kind": "paraphrase",
-      "gold_rank": 4
+      "gold_rank": 8
     },
     {
       "query": "what limitation undermines the credibility of the component-removal experiment",
       "kind": "paraphrase",
-      "gold_rank": 5
+      "gold_rank": 4
     },
     {
       "query": "what training technique is cited as boosting low-data classification performance",
       "kind": "paraphrase",
-      "gold_rank": 8
+      "gold_rank": 4
     },
     {
       "query": "what statistical check should happen before claiming a performance gain",
@@ -230,12 +230,12 @@
     {
       "query": "how did adjusting the proportion of negative examples affect training stability",
       "kind": "paraphrase",
-      "gold_rank": 7
+      "gold_rank": 1
     },
     {
       "query": "what gain resulted from including difficult counterexamples during training",
       "kind": "paraphrase",
-      "gold_rank": 3
+      "gold_rank": 1
     },
     {
       "query": "what unwanted tendency does the evaluator model have regarding answer length",
@@ -250,17 +250,17 @@
     {
       "query": "what tradeoff appears when limiting search to one entity versus searching across entities",
       "kind": "paraphrase",
-      "gold_rank": 4
+      "gold_rank": 2
     },
     {
       "query": "arrow parquet reader benchmark speed",
       "kind": "paraphrase",
-      "gold_rank": 4
+      "gold_rank": 1
     },
     {
       "query": "rollback when p99 exceeds threshold",
       "kind": "paraphrase",
-      "gold_rank": 3
+      "gold_rank": 5
     },
     {
       "query": "switching from JSON to rkyv cut p50 latency by 60%",
@@ -275,7 +275,7 @@
     {
       "query": "Alice's titanium card wallet survives being dropped without denting",
       "kind": "lexical",
-      "gold_rank": 3
+      "gold_rank": 7
     },
     {
       "query": "Acme Corp SOC 2 Type II certification after six-month audit",
@@ -313,21 +313,21 @@
       "gold_rank": 1
     }
   ],
-  "timestamp": "2026-08-04T16:49:20.396473440+00:00",
+  "timestamp": "2026-08-04T17:47:48.822518086+00:00",
   "n_memories": 250,
   "n_queries": 62,
   "per_kind": [
     {
       "kind": "lexical",
       "n": 10,
-      "top3_hit_rate": 1.0,
-      "mrr": 0.9333333333333333
+      "top3_hit_rate": 0.9,
+      "mrr": 0.9142857142857143
     },
     {
       "kind": "paraphrase",
       "n": 52,
-      "top3_hit_rate": 0.4423076923076923,
-      "mrr": 0.32561050061050056
+      "top3_hit_rate": 0.5192307692307693,
+      "mrr": 0.4085851648351647
     }
   ]
 }

--- a/pensyve-benchmarks/results/paraphrase_baseline.json
+++ b/pensyve-benchmarks/results/paraphrase_baseline.json
@@ -1,6 +1,6 @@
 {
-  "top3_hit_rate": 0.5806451612903226,
-  "mrr": 0.49014976958525336,
+  "top3_hit_rate": 0.9032258064516129,
+  "mrr": 0.881989247311828,
   "per_query": [
     {
       "query": "how fast is bob's parquet reader",
@@ -10,87 +10,87 @@
     {
       "query": "which async runtime setup does bob suggest for the data intake pipeline",
       "kind": "paraphrase",
-      "gold_rank": 7
+      "gold_rank": 1
     },
     {
       "query": "what did bob identify as the biggest slowdown once simultaneous writes climbed past two dozen",
       "kind": "paraphrase",
-      "gold_rank": 4
+      "gold_rank": 1
     },
     {
       "query": "which embedded database does bob favor when queries mostly scan large tables",
       "kind": "paraphrase",
-      "gold_rank": 6
+      "gold_rank": 1
     },
     {
       "query": "what search parameter, when set too low, hurts bob's vector index accuracy",
       "kind": "paraphrase",
-      "gold_rank": null
+      "gold_rank": 1
     },
     {
       "query": "roughly how much traffic can the gateway handle before it maxes out, per bob's testing",
       "kind": "paraphrase",
-      "gold_rank": 2
+      "gold_rank": 1
     },
     {
       "query": "why did bob move the caching system to a different tool that has built-in messaging",
       "kind": "paraphrase",
-      "gold_rank": 5
+      "gold_rank": 1
     },
     {
       "query": "how did bob get rid of garbage-collector pauses in the critical code path",
       "kind": "paraphrase",
-      "gold_rank": 3
+      "gold_rank": 1
     },
     {
       "query": "which data format does bob favor when schemas need to change across services over time",
       "kind": "paraphrase",
-      "gold_rank": 3
+      "gold_rank": 1
     },
     {
       "query": "where did bob trace an unexpected memory-usage bug back to",
       "kind": "paraphrase",
-      "gold_rank": 7
+      "gold_rank": 1
     },
     {
       "query": "which trek does alice enjoy most near the reservoir and how long does it take",
       "kind": "paraphrase",
-      "gold_rank": 3
+      "gold_rank": 1
     },
     {
       "query": "why did alice change her morning coffee brewing method to something less of a hassle to wash",
       "kind": "paraphrase",
-      "gold_rank": null
+      "gold_rank": 1
     },
     {
       "query": "how long has alice been growing her own bread starter",
       "kind": "paraphrase",
-      "gold_rank": 2
+      "gold_rank": 1
     },
     {
       "query": "how often does alice go jogging and which day does she take off",
       "kind": "paraphrase",
-      "gold_rank": 7
+      "gold_rank": 1
     },
     {
       "query": "which plants thrive for alice outdoors and which one won't survive",
       "kind": "paraphrase",
-      "gold_rank": 3
+      "gold_rank": 1
     },
     {
       "query": "why does alice pick a specific airplane seat for napping",
       "kind": "paraphrase",
-      "gold_rank": 8
+      "gold_rank": 1
     },
     {
       "query": "what skill did alice pick up so she could repair her own keyboard",
       "kind": "paraphrase",
-      "gold_rank": 8
+      "gold_rank": 1
     },
     {
       "query": "what display trick does alice use to curb compulsive phone checking",
       "kind": "paraphrase",
-      "gold_rank": 4
+      "gold_rank": 1
     },
     {
       "query": "what equipment change did alice make at her desk after hurting her wrist",
@@ -100,17 +100,17 @@
     {
       "query": "how often and where does alice spend time volunteering with plants",
       "kind": "paraphrase",
-      "gold_rank": 2
+      "gold_rank": 1
     },
     {
       "query": "how many sign-offs are needed before a payments-related change can ship",
       "kind": "paraphrase",
-      "gold_rank": 2
+      "gold_rank": 1
     },
     {
       "query": "what test coverage threshold prevents code from merging into the main branch",
       "kind": "paraphrase",
-      "gold_rank": 5
+      "gold_rank": 1
     },
     {
       "query": "what zero-downtime release strategy is used for the gateway service",
@@ -120,22 +120,22 @@
     {
       "query": "under what failure-rate condition does the system alert whoever is on duty",
       "kind": "paraphrase",
-      "gold_rank": 1
+      "gold_rank": 4
     },
     {
       "query": "when during the week does the release process pause shipping changes",
       "kind": "paraphrase",
-      "gold_rank": 2
+      "gold_rank": 5
     },
     {
       "query": "how was container build duration shortened",
       "kind": "paraphrase",
-      "gold_rank": 6
+      "gold_rank": 1
     },
     {
       "query": "how does the team get notified whenever something ships to production",
       "kind": "paraphrase",
-      "gold_rank": 3
+      "gold_rank": 1
     },
     {
       "query": "how many prior working builds are kept on hand for quick reverting",
@@ -145,22 +145,22 @@
     {
       "query": "how often is failure-injection testing done to confirm automatic recovery works",
       "kind": "paraphrase",
-      "gold_rank": 7
+      "gold_rank": 5
     },
     {
       "query": "where must credentials be sourced from instead of config files",
       "kind": "paraphrase",
-      "gold_rank": 5
+      "gold_rank": 1
     },
     {
       "query": "how long is acme's deal with its main cloud provider and when was it signed",
       "kind": "paraphrase",
-      "gold_rank": 3
+      "gold_rank": 1
     },
     {
       "query": "by how much did the size of acme's engineering team increase last year",
       "kind": "paraphrase",
-      "gold_rank": 2
+      "gold_rank": 1
     },
     {
       "query": "why did acme downsize its main office space",
@@ -170,27 +170,27 @@
     {
       "query": "what company did acme buy to build its own reporting features",
       "kind": "paraphrase",
-      "gold_rank": null
+      "gold_rank": 1
     },
     {
       "query": "what was acme's yearly subscription income milestone recently",
       "kind": "paraphrase",
-      "gold_rank": 10
+      "gold_rank": 1
     },
     {
       "query": "how did revamping the new-user setup affect customer cancellations at acme",
       "kind": "paraphrase",
-      "gold_rank": null
+      "gold_rank": 2
     },
     {
       "query": "which older self-hosted product is acme planning to retire",
       "kind": "paraphrase",
-      "gold_rank": 5
+      "gold_rank": 2
     },
     {
       "query": "how quickly must customer records be deleted once an account closes",
       "kind": "paraphrase",
-      "gold_rank": 2
+      "gold_rank": 1
     },
     {
       "query": "how many bids does acme need before approving a large purchase",
@@ -200,22 +200,22 @@
     {
       "query": "what happened to acme's Texas office once its lease ran out",
       "kind": "paraphrase",
-      "gold_rank": 5
+      "gold_rank": 1
     },
     {
       "query": "which retrieval approach wins for uncommon proper-noun lookups according to the study",
       "kind": "paraphrase",
-      "gold_rank": 8
+      "gold_rank": null
     },
     {
       "query": "what limitation undermines the credibility of the component-removal experiment",
       "kind": "paraphrase",
-      "gold_rank": 4
+      "gold_rank": 5
     },
     {
       "query": "what training technique is cited as boosting low-data classification performance",
       "kind": "paraphrase",
-      "gold_rank": 4
+      "gold_rank": 1
     },
     {
       "query": "what statistical check should happen before claiming a performance gain",
@@ -230,7 +230,7 @@
     {
       "query": "how did adjusting the proportion of negative examples affect training stability",
       "kind": "paraphrase",
-      "gold_rank": 1
+      "gold_rank": 2
     },
     {
       "query": "what gain resulted from including difficult counterexamples during training",
@@ -240,7 +240,7 @@
     {
       "query": "what unwanted tendency does the evaluator model have regarding answer length",
       "kind": "paraphrase",
-      "gold_rank": 3
+      "gold_rank": 1
     },
     {
       "query": "what contamination problem was found between evaluation and training sets",
@@ -250,7 +250,7 @@
     {
       "query": "what tradeoff appears when limiting search to one entity versus searching across entities",
       "kind": "paraphrase",
-      "gold_rank": 2
+      "gold_rank": 1
     },
     {
       "query": "arrow parquet reader benchmark speed",
@@ -260,7 +260,7 @@
     {
       "query": "rollback when p99 exceeds threshold",
       "kind": "paraphrase",
-      "gold_rank": 5
+      "gold_rank": 1
     },
     {
       "query": "switching from JSON to rkyv cut p50 latency by 60%",
@@ -275,7 +275,7 @@
     {
       "query": "Alice's titanium card wallet survives being dropped without denting",
       "kind": "lexical",
-      "gold_rank": 7
+      "gold_rank": 1
     },
     {
       "query": "Acme Corp SOC 2 Type II certification after six-month audit",
@@ -313,21 +313,21 @@
       "gold_rank": 1
     }
   ],
-  "timestamp": "2026-08-04T17:47:48.822518086+00:00",
+  "timestamp": "2026-08-04T20:17:11.452512002+00:00",
   "n_memories": 250,
   "n_queries": 62,
   "per_kind": [
     {
       "kind": "lexical",
       "n": 10,
-      "top3_hit_rate": 0.9,
-      "mrr": 0.9142857142857143
+      "top3_hit_rate": 1.0,
+      "mrr": 1.0
     },
     {
       "kind": "paraphrase",
       "n": 52,
-      "top3_hit_rate": 0.5192307692307693,
-      "mrr": 0.4085851648351647
+      "top3_hit_rate": 0.8846153846153846,
+      "mrr": 0.8592948717948719
     }
   ]
 }

--- a/pensyve-benchmarks/results/paraphrase_baseline.json
+++ b/pensyve-benchmarks/results/paraphrase_baseline.json
@@ -1,0 +1,333 @@
+{
+  "top3_hit_rate": 0.532258064516129,
+  "mrr": 0.4236303123399897,
+  "per_query": [
+    {
+      "query": "how fast is bob's parquet reader",
+      "kind": "paraphrase",
+      "gold_rank": 3
+    },
+    {
+      "query": "which async runtime setup does bob suggest for the data intake pipeline",
+      "kind": "paraphrase",
+      "gold_rank": 6
+    },
+    {
+      "query": "what did bob identify as the biggest slowdown once simultaneous writes climbed past two dozen",
+      "kind": "paraphrase",
+      "gold_rank": 3
+    },
+    {
+      "query": "which embedded database does bob favor when queries mostly scan large tables",
+      "kind": "paraphrase",
+      "gold_rank": 9
+    },
+    {
+      "query": "what search parameter, when set too low, hurts bob's vector index accuracy",
+      "kind": "paraphrase",
+      "gold_rank": null
+    },
+    {
+      "query": "roughly how much traffic can the gateway handle before it maxes out, per bob's testing",
+      "kind": "paraphrase",
+      "gold_rank": 4
+    },
+    {
+      "query": "why did bob move the caching system to a different tool that has built-in messaging",
+      "kind": "paraphrase",
+      "gold_rank": 5
+    },
+    {
+      "query": "how did bob get rid of garbage-collector pauses in the critical code path",
+      "kind": "paraphrase",
+      "gold_rank": 5
+    },
+    {
+      "query": "which data format does bob favor when schemas need to change across services over time",
+      "kind": "paraphrase",
+      "gold_rank": 5
+    },
+    {
+      "query": "where did bob trace an unexpected memory-usage bug back to",
+      "kind": "paraphrase",
+      "gold_rank": 4
+    },
+    {
+      "query": "which trek does alice enjoy most near the reservoir and how long does it take",
+      "kind": "paraphrase",
+      "gold_rank": 2
+    },
+    {
+      "query": "why did alice change her morning coffee brewing method to something less of a hassle to wash",
+      "kind": "paraphrase",
+      "gold_rank": null
+    },
+    {
+      "query": "how long has alice been growing her own bread starter",
+      "kind": "paraphrase",
+      "gold_rank": 2
+    },
+    {
+      "query": "how often does alice go jogging and which day does she take off",
+      "kind": "paraphrase",
+      "gold_rank": 1
+    },
+    {
+      "query": "which plants thrive for alice outdoors and which one won't survive",
+      "kind": "paraphrase",
+      "gold_rank": 4
+    },
+    {
+      "query": "why does alice pick a specific airplane seat for napping",
+      "kind": "paraphrase",
+      "gold_rank": 2
+    },
+    {
+      "query": "what skill did alice pick up so she could repair her own keyboard",
+      "kind": "paraphrase",
+      "gold_rank": 4
+    },
+    {
+      "query": "what display trick does alice use to curb compulsive phone checking",
+      "kind": "paraphrase",
+      "gold_rank": 3
+    },
+    {
+      "query": "what equipment change did alice make at her desk after hurting her wrist",
+      "kind": "paraphrase",
+      "gold_rank": 3
+    },
+    {
+      "query": "how often and where does alice spend time volunteering with plants",
+      "kind": "paraphrase",
+      "gold_rank": 2
+    },
+    {
+      "query": "how many sign-offs are needed before a payments-related change can ship",
+      "kind": "paraphrase",
+      "gold_rank": 1
+    },
+    {
+      "query": "what test coverage threshold prevents code from merging into the main branch",
+      "kind": "paraphrase",
+      "gold_rank": 5
+    },
+    {
+      "query": "what zero-downtime release strategy is used for the gateway service",
+      "kind": "paraphrase",
+      "gold_rank": 2
+    },
+    {
+      "query": "under what failure-rate condition does the system alert whoever is on duty",
+      "kind": "paraphrase",
+      "gold_rank": 4
+    },
+    {
+      "query": "when during the week does the release process pause shipping changes",
+      "kind": "paraphrase",
+      "gold_rank": 1
+    },
+    {
+      "query": "how was container build duration shortened",
+      "kind": "paraphrase",
+      "gold_rank": 6
+    },
+    {
+      "query": "how does the team get notified whenever something ships to production",
+      "kind": "paraphrase",
+      "gold_rank": 4
+    },
+    {
+      "query": "how many prior working builds are kept on hand for quick reverting",
+      "kind": "paraphrase",
+      "gold_rank": 3
+    },
+    {
+      "query": "how often is failure-injection testing done to confirm automatic recovery works",
+      "kind": "paraphrase",
+      "gold_rank": 8
+    },
+    {
+      "query": "where must credentials be sourced from instead of config files",
+      "kind": "paraphrase",
+      "gold_rank": 3
+    },
+    {
+      "query": "how long is acme's deal with its main cloud provider and when was it signed",
+      "kind": "paraphrase",
+      "gold_rank": 3
+    },
+    {
+      "query": "by how much did the size of acme's engineering team increase last year",
+      "kind": "paraphrase",
+      "gold_rank": 1
+    },
+    {
+      "query": "why did acme downsize its main office space",
+      "kind": "paraphrase",
+      "gold_rank": 5
+    },
+    {
+      "query": "what company did acme buy to build its own reporting features",
+      "kind": "paraphrase",
+      "gold_rank": 9
+    },
+    {
+      "query": "what was acme's yearly subscription income milestone recently",
+      "kind": "paraphrase",
+      "gold_rank": 4
+    },
+    {
+      "query": "how did revamping the new-user setup affect customer cancellations at acme",
+      "kind": "paraphrase",
+      "gold_rank": null
+    },
+    {
+      "query": "which older self-hosted product is acme planning to retire",
+      "kind": "paraphrase",
+      "gold_rank": 5
+    },
+    {
+      "query": "how quickly must customer records be deleted once an account closes",
+      "kind": "paraphrase",
+      "gold_rank": 4
+    },
+    {
+      "query": "how many bids does acme need before approving a large purchase",
+      "kind": "paraphrase",
+      "gold_rank": 3
+    },
+    {
+      "query": "what happened to acme's Texas office once its lease ran out",
+      "kind": "paraphrase",
+      "gold_rank": 3
+    },
+    {
+      "query": "which retrieval approach wins for uncommon proper-noun lookups according to the study",
+      "kind": "paraphrase",
+      "gold_rank": 4
+    },
+    {
+      "query": "what limitation undermines the credibility of the component-removal experiment",
+      "kind": "paraphrase",
+      "gold_rank": 5
+    },
+    {
+      "query": "what training technique is cited as boosting low-data classification performance",
+      "kind": "paraphrase",
+      "gold_rank": 8
+    },
+    {
+      "query": "what statistical check should happen before claiming a performance gain",
+      "kind": "paraphrase",
+      "gold_rank": 1
+    },
+    {
+      "query": "what measurement artifact appeared from grouping requests together while testing",
+      "kind": "paraphrase",
+      "gold_rank": null
+    },
+    {
+      "query": "how did adjusting the proportion of negative examples affect training stability",
+      "kind": "paraphrase",
+      "gold_rank": 7
+    },
+    {
+      "query": "what gain resulted from including difficult counterexamples during training",
+      "kind": "paraphrase",
+      "gold_rank": 3
+    },
+    {
+      "query": "what unwanted tendency does the evaluator model have regarding answer length",
+      "kind": "paraphrase",
+      "gold_rank": 3
+    },
+    {
+      "query": "what contamination problem was found between evaluation and training sets",
+      "kind": "paraphrase",
+      "gold_rank": 3
+    },
+    {
+      "query": "what tradeoff appears when limiting search to one entity versus searching across entities",
+      "kind": "paraphrase",
+      "gold_rank": 4
+    },
+    {
+      "query": "arrow parquet reader benchmark speed",
+      "kind": "paraphrase",
+      "gold_rank": 4
+    },
+    {
+      "query": "rollback when p99 exceeds threshold",
+      "kind": "paraphrase",
+      "gold_rank": 3
+    },
+    {
+      "query": "switching from JSON to rkyv cut p50 latency by 60%",
+      "kind": "lexical",
+      "gold_rank": 1
+    },
+    {
+      "query": "Bob set up CI pipeline to run clippy with pedantic lint group enabled",
+      "kind": "lexical",
+      "gold_rank": 1
+    },
+    {
+      "query": "Alice's titanium card wallet survives being dropped without denting",
+      "kind": "lexical",
+      "gold_rank": 3
+    },
+    {
+      "query": "Acme Corp SOC 2 Type II certification after six-month audit",
+      "kind": "lexical",
+      "gold_rank": 1
+    },
+    {
+      "query": "reranker model improves nDCG@10 by 8 points over base retriever",
+      "kind": "lexical",
+      "gold_rank": 1
+    },
+    {
+      "query": "deploy pipeline runs integration tests against staging replica before production",
+      "kind": "lexical",
+      "gold_rank": 1
+    },
+    {
+      "query": "Bob's flamegraph profiling showed 30% CPU time in serde_json parsing",
+      "kind": "lexical",
+      "gold_rank": 1
+    },
+    {
+      "query": "Alice's cat Pixel only eats wet food, ignores dry kibble",
+      "kind": "lexical",
+      "gold_rank": 1
+    },
+    {
+      "query": "Alice's favorite museum in the city is the small photography gallery near the river",
+      "kind": "lexical",
+      "gold_rank": 1
+    },
+    {
+      "query": "deploy pipeline tags every production release with git commit SHA and build timestamp",
+      "kind": "lexical",
+      "gold_rank": 1
+    }
+  ],
+  "timestamp": "2026-08-04T16:49:20.396473440+00:00",
+  "n_memories": 250,
+  "n_queries": 62,
+  "per_kind": [
+    {
+      "kind": "lexical",
+      "n": 10,
+      "top3_hit_rate": 1.0,
+      "mrr": 0.9333333333333333
+    },
+    {
+      "kind": "paraphrase",
+      "n": 52,
+      "top3_hit_rate": 0.4423076923076923,
+      "mrr": 0.32561050061050056
+    }
+  ]
+}

--- a/pensyve-benchmarks/results/paraphrase_baseline.json
+++ b/pensyve-benchmarks/results/paraphrase_baseline.json
@@ -1,6 +1,6 @@
 {
   "top3_hit_rate": 0.9032258064516129,
-  "mrr": 0.881989247311828,
+  "mrr": 0.8827956989247313,
   "per_query": [
     {
       "query": "how fast is bob's parquet reader",
@@ -125,7 +125,7 @@
     {
       "query": "when during the week does the release process pause shipping changes",
       "kind": "paraphrase",
-      "gold_rank": 5
+      "gold_rank": 4
     },
     {
       "query": "how was container build duration shortened",
@@ -313,7 +313,7 @@
       "gold_rank": 1
     }
   ],
-  "timestamp": "2026-08-04T20:17:11.452512002+00:00",
+  "timestamp": "2026-08-04T20:33:49.273613516+00:00",
   "n_memories": 250,
   "n_queries": 62,
   "per_kind": [
@@ -327,7 +327,8 @@
       "kind": "paraphrase",
       "n": 52,
       "top3_hit_rate": 0.8846153846153846,
-      "mrr": 0.8592948717948719
+      "mrr": 0.8602564102564104
     }
-  ]
+  ],
+  "reranked": true
 }

--- a/pensyve-benchmarks/src/bin/paraphrase_eval.rs
+++ b/pensyve-benchmarks/src/bin/paraphrase_eval.rs
@@ -7,10 +7,19 @@
 //!
 //! Usage:
 //!   `cargo run -p pensyve-benchmarks --bin paraphrase_eval --release`
+//!     Writes `results/paraphrase_latest.json`. Does NOT touch the committed
+//!     baseline.
 //!   `cargo run -p pensyve-benchmarks --bin paraphrase_eval --release -- --gate results/paraphrase_baseline.json`
-//!
-//! With `--gate <path>`, exits nonzero if `top3_hit_rate` drops more than
-//! 0.02 below the `top3_hit_rate` recorded in the gate file.
+//!     Reads and parses the gate file **before** writing any output, then
+//!     exits nonzero if `top3_hit_rate` drops more than 0.02 below the
+//!     `top3_hit_rate` recorded in the gate file. Still writes
+//!     `results/paraphrase_latest.json` (for post-mortem inspection), never
+//!     the committed baseline.
+//!   `cargo run -p pensyve-benchmarks --bin paraphrase_eval --release -- --write-baseline`
+//!     Explicitly overwrites the committed
+//!     `results/paraphrase_baseline.json` instead of the latest-run path.
+//!     This is the only way this binary touches the committed baseline —
+//!     never as a side effect of a plain or `--gate`-checked run.
 
 use std::collections::HashMap;
 
@@ -121,6 +130,24 @@ fn main() {
         .position(|a| a == "--gate")
         .and_then(|i| args.get(i + 1))
         .cloned();
+    let write_baseline = args.iter().any(|a| a == "--write-baseline");
+
+    // Read and parse the gate file up front, before any recall work runs and
+    // long before any output file is written. This guarantees the gate
+    // check compares against what was on disk when the run *started*, never
+    // against a file this same run just wrote (see #186 review: reading the
+    // gate file after writing output made every `--gate
+    // results/paraphrase_baseline.json` run compare the baseline to itself).
+    let gate: Option<BaselineOutput> = gate_path.as_ref().map(|path| {
+        let raw = std::fs::read_to_string(path).unwrap_or_else(|e| {
+            eprintln!("Failed to read gate file '{path}': {e}");
+            std::process::exit(1);
+        });
+        serde_json::from_str(&raw).unwrap_or_else(|e| {
+            eprintln!("Failed to parse gate file '{path}': {e}");
+            std::process::exit(1);
+        })
+    });
 
     println!("=== Paraphrase Recall Baseline (250 memories, 62 queries) ===");
     println!();
@@ -392,29 +419,35 @@ fn main() {
 
     let json = serde_json::to_string_pretty(&output).expect("Failed to serialize results");
     // Resolve relative to this crate's manifest dir (not the process cwd) so
-    // the file always lands at `pensyve-benchmarks/results/...` regardless
-    // of where `cargo run` is invoked from.
+    // the file always lands under `pensyve-benchmarks/results/...`
+    // regardless of where `cargo run` is invoked from.
     let results_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("results");
     std::fs::create_dir_all(&results_dir).ok();
-    let filepath = results_dir.join("paraphrase_baseline.json");
+    // Only `--write-baseline` touches the committed baseline file. Every
+    // other invocation — plain or `--gate`-checked — writes to a separate
+    // "latest run" path, so a gate-checked run can never silently clobber
+    // the committed baseline it may just have failed against.
+    let filename = if write_baseline {
+        "paraphrase_baseline.json"
+    } else {
+        "paraphrase_latest.json"
+    };
+    let filepath = results_dir.join(filename);
     std::fs::write(&filepath, &json).expect("Failed to write results");
     println!("\nResults written to {}", filepath.display());
+    if write_baseline {
+        println!("(--write-baseline: committed baseline file updated)");
+    }
 
     // Clean up temp dir
     let _ = std::fs::remove_dir_all(&tmp_dir);
 
     // ---------- Gate check ----------
+    // `gate` was read and parsed at the very start of `main`, before any
+    // output was written, so this always compares against the pre-run
+    // on-disk state — never against a file this run itself produced.
 
-    if let Some(gate_path) = gate_path {
-        let gate_raw = std::fs::read_to_string(&gate_path).unwrap_or_else(|e| {
-            eprintln!("Failed to read gate file '{gate_path}': {e}");
-            std::process::exit(1);
-        });
-        let gate: BaselineOutput = serde_json::from_str(&gate_raw).unwrap_or_else(|e| {
-            eprintln!("Failed to parse gate file '{gate_path}': {e}");
-            std::process::exit(1);
-        });
-
+    if let Some(gate) = gate {
         let drop = gate.top3_hit_rate - top3_hit_rate;
         if drop > GATE_TOLERANCE {
             eprintln!(

--- a/pensyve-benchmarks/src/bin/paraphrase_eval.rs
+++ b/pensyve-benchmarks/src/bin/paraphrase_eval.rs
@@ -13,8 +13,12 @@
 //!     Reads and parses the gate file **before** writing any output, then
 //!     exits nonzero if `top3_hit_rate` drops more than `--gate-margin`
 //!     (default 0.02) below the `top3_hit_rate` recorded in the gate file.
-//!     Still writes `results/paraphrase_latest.json` (for post-mortem
-//!     inspection), never the committed baseline.
+//!     Also hard-fails immediately (before any recall work runs) if the gate
+//!     file's `reranked` mode doesn't match this run's `--rerank` flag —
+//!     reranked and unreranked `top3_hit_rate` live on different scales, so
+//!     a cross-mode comparison isn't a meaningful regression check. Still
+//!     writes `results/paraphrase_latest.json` (for post-mortem inspection),
+//!     never the committed baseline.
 //!   `... -- --gate results/paraphrase_baseline.json --gate-margin 0.07`
 //!     Same as above, but with an explicit tolerance instead of the 0.02
 //!     default. Widen this when run-to-run ranking jitter (see
@@ -38,8 +42,13 @@
 //!     passes `--rerank` to match. It's also far less noisy: 10 local
 //!     `--release` runs showed zero run-to-run spread in `top3_hit_rate`
 //!     vs. the unreranked pipeline's ~0.05 spread (see the CI workflow
-//!     comment). Omit `--rerank` to measure the unreranked fallback path
-//!     instead (what runs when the reranker fails to load).
+//!     comment) — mechanically, the gold docs for this fixture already sit
+//!     within the top-20 pre-rerank pool, so the `apply_reinforcement`
+//!     timestamp jitter that reshuffles ties *at* the pool boundary never
+//!     changes which candidates the cross-encoder sees, only their
+//!     pre-rerank order, which the cross-encoder discards. Omit `--rerank`
+//!     to measure the unreranked fallback path instead (what runs when the
+//!     reranker fails to load).
 
 use std::collections::HashMap;
 
@@ -147,6 +156,18 @@ struct BaselineOutput {
     n_queries: Option<usize>,
     #[serde(default)]
     per_kind: Vec<KindBreakdown>,
+    /// Whether this run had `--rerank` attached. `#[serde(default)]` so
+    /// baseline files written before this field existed still parse — they
+    /// deserialize as `false`, i.e. "unreranked", which was true of every
+    /// baseline committed before Task 8 (#186). The `--gate` path hard-errors
+    /// on a mismatch between this and the current run's mode (see `main`):
+    /// reranked and unreranked `top3_hit_rate` live on different scales
+    /// (0.774 vs 0.903 pre-fix-vs-post on this fixture), so comparing across
+    /// modes isn't a meaningful regression check — it would silently widen
+    /// the effective gate margin from the tuned value to the full gap
+    /// between modes.
+    #[serde(default)]
+    reranked: bool,
 }
 
 /// Number of candidates requested per query, matching the audit's usage.
@@ -229,6 +250,40 @@ fn main() {
             std::process::exit(1);
         })
     });
+
+    // Reranked and unreranked `top3_hit_rate` live on different scales (this
+    // fixture: ~0.774 unreranked vs ~0.903 reranked), so comparing a run in
+    // one mode against a gate file recorded in the other isn't a meaningful
+    // regression check — it would silently widen the effective gate margin
+    // from the tuned value to the full gap between modes, with no error or
+    // warning. Hard-fail on mode mismatch before doing any recall work.
+    if let Some(gate) = &gate
+        && gate.reranked != rerank
+    {
+        let gate_mode = if gate.reranked {
+            "--rerank"
+        } else {
+            "unreranked"
+        };
+        let run_mode = if rerank { "--rerank" } else { "unreranked" };
+        let rerun_hint = if gate.reranked {
+            "Re-run this eval with --rerank to match"
+        } else {
+            "Re-run this eval without --rerank to match"
+        };
+        let regen_hint = if rerank {
+            "--write-baseline --rerank"
+        } else {
+            "--write-baseline"
+        };
+        eprintln!(
+            "GATE FAILED: mode mismatch — gate file '{}' was recorded {gate_mode} but this \
+             run is {run_mode}. {rerun_hint}, or regenerate the gate file with \
+             `{regen_hint}` if {run_mode} is now the intended baseline mode.",
+            gate_path.as_deref().unwrap_or("<unknown>"),
+        );
+        std::process::exit(1);
+    }
 
     println!("=== Paraphrase Recall Baseline (250 memories, 62 queries) ===");
     println!();
@@ -511,6 +566,7 @@ fn main() {
         n_memories: Some(corpus.memories.len()),
         n_queries: Some(corpus.queries.len()),
         per_kind,
+        reranked: rerank,
     };
 
     let json = serde_json::to_string_pretty(&output).expect("Failed to serialize results");

--- a/pensyve-benchmarks/src/bin/paraphrase_eval.rs
+++ b/pensyve-benchmarks/src/bin/paraphrase_eval.rs
@@ -11,10 +11,16 @@
 //!     baseline.
 //!   `cargo run -p pensyve-benchmarks --bin paraphrase_eval --release -- --gate results/paraphrase_baseline.json`
 //!     Reads and parses the gate file **before** writing any output, then
-//!     exits nonzero if `top3_hit_rate` drops more than 0.02 below the
-//!     `top3_hit_rate` recorded in the gate file. Still writes
-//!     `results/paraphrase_latest.json` (for post-mortem inspection), never
-//!     the committed baseline.
+//!     exits nonzero if `top3_hit_rate` drops more than `--gate-margin`
+//!     (default 0.02) below the `top3_hit_rate` recorded in the gate file.
+//!     Still writes `results/paraphrase_latest.json` (for post-mortem
+//!     inspection), never the committed baseline.
+//!   `... -- --gate results/paraphrase_baseline.json --gate-margin 0.07`
+//!     Same as above, but with an explicit tolerance instead of the 0.02
+//!     default. Widen this when run-to-run ranking jitter (see
+//!     `deterministic_id` below) makes the default too tight for a given
+//!     harness/fixture combination — see Task 4's 15-run local evidence in
+//!     the CI workflow comment for how the CI value was chosen.
 //!   `cargo run -p pensyve-benchmarks --bin paraphrase_eval --release -- --write-baseline`
 //!     Explicitly overwrites the committed
 //!     `results/paraphrase_baseline.json` instead of the latest-run path.
@@ -36,9 +42,10 @@ use pensyve_core::storage::sqlite::SqliteBackend;
 use pensyve_core::types::{Entity, EntityKind, Episode, EpisodicMemory, Namespace, SemanticMemory};
 use pensyve_core::vector::VectorIndex;
 
-/// Regression gate tolerance: the current run's `top3_hit_rate` must not
-/// drop more than this far below the gate file's recorded value.
-const GATE_TOLERANCE: f64 = 0.02;
+/// Default regression gate tolerance: the current run's `top3_hit_rate`
+/// must not drop more than this far below the gate file's recorded value.
+/// Overridable via `--gate-margin <value>`.
+const DEFAULT_GATE_MARGIN: f64 = 0.02;
 
 /// Namespace UUID for this binary's deterministic `Uuid::new_v5` ids.
 /// Arbitrary but fixed — see `deterministic_id`.
@@ -159,6 +166,16 @@ fn main() {
         .and_then(|i| args.get(i + 1))
         .cloned();
     let write_baseline = args.iter().any(|a| a == "--write-baseline");
+    let gate_margin: f64 = args
+        .iter()
+        .position(|a| a == "--gate-margin")
+        .and_then(|i| args.get(i + 1))
+        .map_or(DEFAULT_GATE_MARGIN, |v| {
+            v.parse().unwrap_or_else(|e| {
+                eprintln!("Invalid --gate-margin value '{v}': {e}");
+                std::process::exit(1);
+            })
+        });
 
     // Read and parse the gate file up front, before any recall work runs and
     // long before any output file is written. This guarantees the gate
@@ -483,15 +500,15 @@ fn main() {
 
     if let Some(gate) = gate {
         let drop = gate.top3_hit_rate - top3_hit_rate;
-        if drop > GATE_TOLERANCE {
+        if drop > gate_margin {
             eprintln!(
-                "GATE FAILED: top3_hit_rate dropped by {drop:.3} (gate={:.3}, current={:.3}, tolerance={GATE_TOLERANCE:.3})",
+                "GATE FAILED: top3_hit_rate dropped by {drop:.3} (gate={:.3}, current={:.3}, tolerance={gate_margin:.3})",
                 gate.top3_hit_rate, top3_hit_rate
             );
             std::process::exit(1);
         }
         println!(
-            "Gate check passed: top3_hit_rate {:.3} vs gate {:.3} (tolerance {GATE_TOLERANCE:.3})",
+            "Gate check passed: top3_hit_rate {:.3} vs gate {:.3} (tolerance {gate_margin:.3})",
             top3_hit_rate, gate.top3_hit_rate
         );
     }

--- a/pensyve-benchmarks/src/bin/paraphrase_eval.rs
+++ b/pensyve-benchmarks/src/bin/paraphrase_eval.rs
@@ -26,6 +26,13 @@
 //!     `results/paraphrase_baseline.json` instead of the latest-run path.
 //!     This is the only way this binary touches the committed baseline —
 //!     never as a side effect of a plain or `--gate`-checked run.
+//!   `cargo run -p pensyve-benchmarks --bin paraphrase_eval --release -- --rerank`
+//!     Attaches the BGE cross-encoder reranker to the engine before running
+//!     (same lazy/infallible resolution as the gateway and CLI: a model-load
+//!     failure logs a warning and the run proceeds unreranked). Combine with
+//!     `--gate`/`--write-baseline` as needed. Omit `--rerank` to measure the
+//!     unreranked pipeline (the harness's default, and what the committed
+//!     baseline reflects).
 
 use std::collections::HashMap;
 
@@ -36,11 +43,32 @@ use pensyve_benchmarks::fixture::{self, FixtureQuery};
 use pensyve_benchmarks::metrics;
 use pensyve_core::config::RetrievalConfig;
 use pensyve_core::embedding::OnnxEmbedder;
+use pensyve_core::reranker::Reranker;
 use pensyve_core::retrieval::RecallEngine;
 use pensyve_core::storage::StorageTrait;
 use pensyve_core::storage::sqlite::SqliteBackend;
 use pensyve_core::types::{Entity, EntityKind, Episode, EpisodicMemory, Namespace, SemanticMemory};
 use pensyve_core::vector::VectorIndex;
+
+/// Lazily resolve the cross-encoder reranker when `--rerank` is passed.
+/// Mirrors the gateway/CLI fallback: `PENSYVE_RERANKER=0` disables it, and a
+/// model-load failure logs one warning and the run proceeds unreranked
+/// rather than aborting.
+fn resolve_reranker() -> Option<std::sync::Arc<Reranker>> {
+    if std::env::var("PENSYVE_RERANKER").as_deref() == Ok("0") {
+        return None;
+    }
+    match Reranker::new_cached("BGERerankerBase") {
+        Ok(r) => Some(r),
+        Err(e) => {
+            eprintln!(
+                "Warning: reranker unavailable ({e}), continuing unreranked. \
+                 Set PENSYVE_RERANKER=0 to silence this warning."
+            );
+            None
+        }
+    }
+}
 
 /// Default regression gate tolerance: the current run's `top3_hit_rate`
 /// must not drop more than this far below the gate file's recorded value.
@@ -166,6 +194,7 @@ fn main() {
         .and_then(|i| args.get(i + 1))
         .cloned();
     let write_baseline = args.iter().any(|a| a == "--write-baseline");
+    let rerank = args.iter().any(|a| a == "--rerank");
     let gate_margin: f64 = args
         .iter()
         .position(|a| a == "--gate-margin")
@@ -335,7 +364,16 @@ fn main() {
         max_depth: 4,
     };
 
-    let engine = RecallEngine::new(&storage, &embedder, &vector_index, &retrieval_config);
+    let mut engine = RecallEngine::new(&storage, &embedder, &vector_index, &retrieval_config);
+    let reranker = if rerank { resolve_reranker() } else { None };
+    if let Some(r) = reranker.as_deref() {
+        println!("Reranker: BGERerankerBase (--rerank)");
+        engine = engine.with_reranker(r);
+    } else if rerank {
+        println!("Reranker: requested via --rerank but unavailable; running unreranked");
+    } else {
+        println!("Reranker: disabled (pass --rerank to enable)");
+    }
 
     // Embed queries and run recall
     println!("Embedding {} queries...", corpus.queries.len());

--- a/pensyve-benchmarks/src/bin/paraphrase_eval.rs
+++ b/pensyve-benchmarks/src/bin/paraphrase_eval.rs
@@ -40,6 +40,34 @@ use pensyve_core::vector::VectorIndex;
 /// drop more than this far below the gate file's recorded value.
 const GATE_TOLERANCE: f64 = 0.02;
 
+/// Namespace UUID for this binary's deterministic `Uuid::new_v5` ids.
+/// Arbitrary but fixed — see `deterministic_id`.
+const ID_NAMESPACE: Uuid = Uuid::from_bytes([
+    0x8c, 0x1e, 0x6b, 0x4a, 0x0a, 0x3f, 0x4b, 0x8e, 0x9c, 0x27, 0x6e, 0x2a, 0x1d, 0x5f, 0x0c, 0x3b,
+]);
+
+/// Derive a stable, content-addressed id for entities/episodes/memories
+/// instead of `Uuid::new_v4()`.
+///
+/// The eval harness recreates its entire corpus from scratch on every
+/// run (a fresh temp `SqliteBackend`, fresh entities, fresh memories).
+/// With random v4 ids, two separate `cargo run` invocations produce a
+/// structurally identical corpus whose records nonetheless carry
+/// different ids. `RecallEngine`'s ranking sorts are a pure function of
+/// (score, id) — deterministic given fixed inputs (verified by
+/// `pensyve-core`'s `test_recall_is_deterministic_across_repeated_calls`)
+/// — but score TIES are common (e.g. all-episodic confidence, or
+/// same-second activation), and the sort's tiebreak is ascending id.
+/// Random ids turn that deterministic tiebreak into an effectively
+/// random pick every run, which shows up as run-to-run drift in this
+/// binary's output even though the ranking algorithm itself is stable.
+/// Deriving every id from the fixture's own stable strings (entity
+/// name, memory `key`) removes that harness-only source of variance so
+/// repeated runs are directly comparable (see `--gate` / Task 3.5).
+fn deterministic_id(kind: &str, key: &str) -> Uuid {
+    Uuid::new_v5(&ID_NAMESPACE, format!("{kind}:{key}").as_bytes())
+}
+
 /// Result of evaluating a single fixture query against the recall engine.
 struct QueryOutcome {
     query: String,
@@ -193,6 +221,7 @@ fn main() {
     let mut entities: HashMap<String, Entity> = HashMap::new();
     for name in &entity_names {
         let mut entity = Entity::new(*name, EntityKind::User);
+        entity.id = deterministic_id("entity", name);
         entity.namespace_id = ns.id;
         storage.save_entity(&entity).expect("Failed to save entity");
         entities.insert((*name).to_string(), entity);
@@ -200,13 +229,15 @@ fn main() {
 
     // Source entity (the "narrator") for episodic memories
     let mut source_entity = Entity::new("narrator", EntityKind::Agent);
+    source_entity.id = deterministic_id("entity", "narrator");
     source_entity.namespace_id = ns.id;
     storage
         .save_entity(&source_entity)
         .expect("Failed to save source entity");
 
     // Episode for episodic memories
-    let episode = Episode::new(ns.id, vec![source_entity.id]);
+    let mut episode = Episode::new(ns.id, vec![source_entity.id]);
+    episode.id = deterministic_id("episode", "main");
     storage
         .save_episode(&episode)
         .expect("Failed to save episode");
@@ -238,7 +269,9 @@ fn main() {
                     about_entity.id,
                     mem.content.clone(),
                 );
+                emem.id = deterministic_id("memory", &mem.key);
                 emem.embedding.clone_from(embedding);
+                emem.timestamp = chrono::DateTime::from_timestamp(1_700_000_000, 0).unwrap();
                 storage
                     .save_episodic(&emem)
                     .expect("Failed to save episodic memory");
@@ -252,6 +285,7 @@ fn main() {
                     mem.content.clone(),
                     mem.confidence,
                 );
+                smem.id = deterministic_id("memory", &mem.key);
                 smem.embedding.clone_from(embedding);
                 storage
                     .save_semantic(&smem)

--- a/pensyve-benchmarks/src/bin/paraphrase_eval.rs
+++ b/pensyve-benchmarks/src/bin/paraphrase_eval.rs
@@ -30,9 +30,16 @@
 //!     Attaches the BGE cross-encoder reranker to the engine before running
 //!     (same lazy/infallible resolution as the gateway and CLI: a model-load
 //!     failure logs a warning and the run proceeds unreranked). Combine with
-//!     `--gate`/`--write-baseline` as needed. Omit `--rerank` to measure the
-//!     unreranked pipeline (the harness's default, and what the committed
-//!     baseline reflects).
+//!     `--gate`/`--write-baseline` as needed. `--rerank` is what the
+//!     committed baseline reflects as of Task 8 (#186) — the gateway/CLI
+//!     attach the reranker by default (`reranker=Some("BGERerankerBase")`
+//!     in `pensyve-python/src/lib.rs`), so a reranked baseline compares
+//!     like against like with production behavior, and the CI gate step
+//!     passes `--rerank` to match. It's also far less noisy: 10 local
+//!     `--release` runs showed zero run-to-run spread in `top3_hit_rate`
+//!     vs. the unreranked pipeline's ~0.05 spread (see the CI workflow
+//!     comment). Omit `--rerank` to measure the unreranked fallback path
+//!     instead (what runs when the reranker fails to load).
 
 use std::collections::HashMap;
 

--- a/pensyve-benchmarks/src/bin/paraphrase_eval.rs
+++ b/pensyve-benchmarks/src/bin/paraphrase_eval.rs
@@ -1,0 +1,431 @@
+//! Paraphrase-recall baseline benchmark for Pensyve cognitive activation engine.
+//!
+//! Loads the committed 250-memory / 62-query paraphrase-recall fixture
+//! (`pensyve_benchmarks::fixture::load_corpus`), runs every query through the
+//! real `RecallEngine` pipeline, and reports top-3 hit rate and MRR overall
+//! and broken down by query kind (paraphrase vs lexical control).
+//!
+//! Usage:
+//!   `cargo run -p pensyve-benchmarks --bin paraphrase_eval --release`
+//!   `cargo run -p pensyve-benchmarks --bin paraphrase_eval --release -- --gate results/paraphrase_baseline.json`
+//!
+//! With `--gate <path>`, exits nonzero if `top3_hit_rate` drops more than
+//! 0.02 below the `top3_hit_rate` recorded in the gate file.
+
+use std::collections::HashMap;
+
+use chrono::Utc;
+use uuid::Uuid;
+
+use pensyve_benchmarks::fixture::{self, FixtureQuery};
+use pensyve_benchmarks::metrics;
+use pensyve_core::config::RetrievalConfig;
+use pensyve_core::embedding::OnnxEmbedder;
+use pensyve_core::retrieval::RecallEngine;
+use pensyve_core::storage::StorageTrait;
+use pensyve_core::storage::sqlite::SqliteBackend;
+use pensyve_core::types::{Entity, EntityKind, Episode, EpisodicMemory, Namespace, SemanticMemory};
+use pensyve_core::vector::VectorIndex;
+
+/// Regression gate tolerance: the current run's `top3_hit_rate` must not
+/// drop more than this far below the gate file's recorded value.
+const GATE_TOLERANCE: f64 = 0.02;
+
+/// Result of evaluating a single fixture query against the recall engine.
+struct QueryOutcome {
+    query: String,
+    kind: String,
+    /// 1-based rank of the best-ranked gold memory in the top-`RECALL_LIMIT`
+    /// results, or `None` if no gold memory appeared.
+    gold_rank: Option<usize>,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct PerQueryResult {
+    query: String,
+    kind: String,
+    gold_rank: Option<usize>,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct KindBreakdown {
+    kind: String,
+    n: usize,
+    top3_hit_rate: f64,
+    mrr: f64,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct BaselineOutput {
+    top3_hit_rate: f64,
+    mrr: f64,
+    per_query: Vec<PerQueryResult>,
+    #[serde(default)]
+    timestamp: Option<String>,
+    #[serde(default)]
+    n_memories: Option<usize>,
+    #[serde(default)]
+    n_queries: Option<usize>,
+    #[serde(default)]
+    per_kind: Vec<KindBreakdown>,
+}
+
+/// Number of candidates requested per query, matching the audit's usage.
+const RECALL_LIMIT: usize = 10;
+/// Rank threshold for a "top-3 hit".
+const TOP_K: usize = 3;
+
+fn mean(v: &[f64]) -> f64 {
+    if v.is_empty() {
+        0.0
+    } else {
+        v.iter().sum::<f64>() / v.len() as f64
+    }
+}
+
+/// Fraction of outcomes whose gold rank is within the top-`k`.
+fn top_k_hit_rate(outcomes: &[&QueryOutcome], k: usize) -> f64 {
+    if outcomes.is_empty() {
+        return 0.0;
+    }
+    let hits = outcomes
+        .iter()
+        .filter(|o| o.gold_rank.is_some_and(|r| r <= k))
+        .count();
+    hits as f64 / outcomes.len() as f64
+}
+
+/// Mean reciprocal rank across outcomes, using `metrics::mrr` per-query.
+fn mean_mrr(outcomes: &[&QueryOutcome]) -> f64 {
+    if outcomes.is_empty() {
+        return 0.0;
+    }
+    let per_query_mrr: Vec<f64> = outcomes
+        .iter()
+        .map(|o| {
+            let relevant_at: Vec<bool> = match o.gold_rank {
+                Some(r) => (1..=r).map(|i| i == r).collect(),
+                None => Vec::new(),
+            };
+            metrics::mrr(&relevant_at)
+        })
+        .collect();
+    mean(&per_query_mrr)
+}
+
+#[allow(clippy::too_many_lines)]
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let gate_path = args
+        .iter()
+        .position(|a| a == "--gate")
+        .and_then(|i| args.get(i + 1))
+        .cloned();
+
+    println!("=== Paraphrase Recall Baseline (250 memories, 62 queries) ===");
+    println!();
+
+    // Load fixture
+    let corpus = fixture::load_corpus();
+    println!(
+        "Loaded fixture: {} memories, {} queries",
+        corpus.memories.len(),
+        corpus.queries.len()
+    );
+
+    // Initialize embedder — real ONNX only; STOP if it cannot load a model.
+    let embedder = match OnnxEmbedder::new("all-MiniLM-L6-v2") {
+        Ok(e) => {
+            println!("Embedder: all-MiniLM-L6-v2 (384d, real ONNX)");
+            e
+        }
+        Err(err) => {
+            eprintln!("BLOCKED: ONNX embedder failed to load: {err}");
+            std::process::exit(2);
+        }
+    };
+    let dims = embedder.dimensions();
+
+    // Create temp storage
+    let tmp_dir = std::env::temp_dir().join(format!("pensyve_paraphrase_eval_{}", Uuid::new_v4()));
+    let storage = SqliteBackend::open(&tmp_dir).expect("Failed to create SQLite backend");
+
+    // Create namespace
+    let ns = Namespace::new("paraphrase-eval");
+    storage
+        .save_namespace(&ns)
+        .expect("Failed to save namespace");
+
+    // Create the 5 entities named in the fixture
+    let entity_names: Vec<&str> = {
+        let mut names: Vec<&str> = corpus.memories.iter().map(|m| m.entity.as_str()).collect();
+        names.sort_unstable();
+        names.dedup();
+        names
+    };
+    let mut entities: HashMap<String, Entity> = HashMap::new();
+    for name in &entity_names {
+        let mut entity = Entity::new(*name, EntityKind::User);
+        entity.namespace_id = ns.id;
+        storage.save_entity(&entity).expect("Failed to save entity");
+        entities.insert((*name).to_string(), entity);
+    }
+
+    // Source entity (the "narrator") for episodic memories
+    let mut source_entity = Entity::new("narrator", EntityKind::Agent);
+    source_entity.namespace_id = ns.id;
+    storage
+        .save_entity(&source_entity)
+        .expect("Failed to save source entity");
+
+    // Episode for episodic memories
+    let episode = Episode::new(ns.id, vec![source_entity.id]);
+    storage
+        .save_episode(&episode)
+        .expect("Failed to save episode");
+
+    // Embed all memory contents
+    println!("Embedding {} memories...", corpus.memories.len());
+    let memory_embeddings: Vec<Vec<f32>> = corpus
+        .memories
+        .iter()
+        .map(|m| embedder.embed(&m.content).expect("Failed to embed memory"))
+        .collect();
+
+    // Save memories by kind, build vector index, and key -> memory id map
+    let mut vector_index = VectorIndex::new(dims, corpus.memories.len());
+    let mut key_to_id: HashMap<String, Uuid> = HashMap::with_capacity(corpus.memories.len());
+
+    for (i, mem) in corpus.memories.iter().enumerate() {
+        let about_entity = entities
+            .get(&mem.entity)
+            .expect("Unknown entity in fixture");
+        let embedding = &memory_embeddings[i];
+
+        let mem_id = match mem.kind.as_str() {
+            "episodic" => {
+                let mut emem = EpisodicMemory::new(
+                    ns.id,
+                    episode.id,
+                    source_entity.id,
+                    about_entity.id,
+                    mem.content.clone(),
+                );
+                emem.embedding.clone_from(embedding);
+                storage
+                    .save_episodic(&emem)
+                    .expect("Failed to save episodic memory");
+                emem.id
+            }
+            "semantic" => {
+                let mut smem = SemanticMemory::new(
+                    ns.id,
+                    about_entity.id,
+                    "mentioned",
+                    mem.content.clone(),
+                    mem.confidence,
+                );
+                smem.embedding.clone_from(embedding);
+                storage
+                    .save_semantic(&smem)
+                    .expect("Failed to save semantic memory");
+                smem.id
+            }
+            other => panic!("Unknown fixture memory kind: {other}"),
+        };
+
+        vector_index
+            .add_with_entity(mem_id, embedding, about_entity.id)
+            .expect("Failed to add to vector index");
+        key_to_id.insert(mem.key.clone(), mem_id);
+    }
+
+    println!(
+        "Stored {} memories, built vector index",
+        corpus.memories.len()
+    );
+
+    // Configure retrieval — mirror real_content_eval.rs defaults
+    let retrieval_config = RetrievalConfig {
+        default_limit: 5,
+        max_candidates: 50,
+        weights: [0.25, 0.10, 0.15, 0.05, 0.20, 0.10, 0.10, 0.05],
+        recall_timeout_secs: 5,
+        rrf_k: 60,
+        rrf_weights: [1.0, 0.8, 1.0, 0.8, 0.5, 0.5, 1.2, 1.0],
+        beam_width: 10,
+        max_depth: 4,
+    };
+
+    let engine = RecallEngine::new(&storage, &embedder, &vector_index, &retrieval_config);
+
+    // Embed queries and run recall
+    println!("Embedding {} queries...", corpus.queries.len());
+    println!("Running recall for {} queries...", corpus.queries.len());
+
+    let mut outcomes: Vec<QueryOutcome> = Vec::with_capacity(corpus.queries.len());
+
+    for query_entry in &corpus.queries {
+        let FixtureQuery {
+            query,
+            gold_keys,
+            kind,
+        } = query_entry;
+
+        let gold_ids: Vec<Uuid> = gold_keys
+            .iter()
+            .map(|k| {
+                *key_to_id
+                    .get(k)
+                    .unwrap_or_else(|| panic!("gold_key '{k}' not found in memory map"))
+            })
+            .collect();
+
+        let query_embedding = embedder.embed(query).expect("Failed to embed query");
+
+        let gold_rank = match engine.recall_with_embedding(
+            query,
+            Some(&query_embedding),
+            ns.id,
+            RECALL_LIMIT,
+            None,
+        ) {
+            Ok(result) => result
+                .memories
+                .iter()
+                .position(|sc| gold_ids.contains(&sc.memory_id))
+                .map(|idx| idx + 1),
+            Err(e) => {
+                eprintln!("  Query '{query}': recall error: {e}");
+                None
+            }
+        };
+
+        outcomes.push(QueryOutcome {
+            query: query.clone(),
+            kind: kind.clone(),
+            gold_rank,
+        });
+    }
+
+    // ---------- Metrics ----------
+
+    let all_refs: Vec<&QueryOutcome> = outcomes.iter().collect();
+    let top3_hit_rate = top_k_hit_rate(&all_refs, TOP_K);
+    let overall_mrr = mean_mrr(&all_refs);
+
+    println!("\n{}", "=".repeat(60));
+    println!("=== Paraphrase Recall Baseline Results ===");
+    println!("{}", "=".repeat(60));
+    println!("\nOverall (n={}):", outcomes.len());
+    println!("  top3_hit_rate: {top3_hit_rate:.3}");
+    println!("  MRR:           {overall_mrr:.3}");
+
+    let mut kind_names: Vec<String> = outcomes.iter().map(|o| o.kind.clone()).collect();
+    kind_names.sort_unstable();
+    kind_names.dedup();
+
+    let mut per_kind: Vec<KindBreakdown> = Vec::new();
+    println!("\nPer-kind breakdown:");
+    for kind in &kind_names {
+        let refs: Vec<&QueryOutcome> = outcomes.iter().filter(|o| &o.kind == kind).collect();
+        let hit_rate = top_k_hit_rate(&refs, TOP_K);
+        let kind_mrr = mean_mrr(&refs);
+        println!(
+            "  {:10} (n={:2}): top3_hit_rate = {:.3}, MRR = {:.3}",
+            kind,
+            refs.len(),
+            hit_rate,
+            kind_mrr
+        );
+        per_kind.push(KindBreakdown {
+            kind: kind.clone(),
+            n: refs.len(),
+            top3_hit_rate: hit_rate,
+            mrr: kind_mrr,
+        });
+    }
+
+    // Audit queries — explicit call-out since these are the known bug cases.
+    println!("\nAudit queries:");
+    for (query_text, label) in [
+        ("arrow parquet reader benchmark speed", "bob-parquet-bench"),
+        ("rollback when p99 exceeds threshold", "deploy-p99-rollback"),
+    ] {
+        if let Some(o) = outcomes.iter().find(|o| o.query == query_text) {
+            let rank_str = o.gold_rank.map_or_else(
+                || "not found in top-10".to_string(),
+                |r| format!("rank {r}"),
+            );
+            let verdict = if o.gold_rank.is_some_and(|r| r <= TOP_K) {
+                "PASS top-3"
+            } else {
+                "MISS top-3"
+            };
+            println!("  \"{query_text}\" -> {label}: {rank_str} ({verdict})");
+        } else {
+            eprintln!("  WARNING: audit query '{query_text}' not found in fixture queries");
+        }
+    }
+    println!("{}", "=".repeat(60));
+
+    // ---------- Write JSON ----------
+
+    let per_query: Vec<PerQueryResult> = outcomes
+        .iter()
+        .map(|o| PerQueryResult {
+            query: o.query.clone(),
+            kind: o.kind.clone(),
+            gold_rank: o.gold_rank,
+        })
+        .collect();
+
+    let output = BaselineOutput {
+        top3_hit_rate,
+        mrr: overall_mrr,
+        per_query,
+        timestamp: Some(Utc::now().to_rfc3339()),
+        n_memories: Some(corpus.memories.len()),
+        n_queries: Some(corpus.queries.len()),
+        per_kind,
+    };
+
+    let json = serde_json::to_string_pretty(&output).expect("Failed to serialize results");
+    // Resolve relative to this crate's manifest dir (not the process cwd) so
+    // the file always lands at `pensyve-benchmarks/results/...` regardless
+    // of where `cargo run` is invoked from.
+    let results_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("results");
+    std::fs::create_dir_all(&results_dir).ok();
+    let filepath = results_dir.join("paraphrase_baseline.json");
+    std::fs::write(&filepath, &json).expect("Failed to write results");
+    println!("\nResults written to {}", filepath.display());
+
+    // Clean up temp dir
+    let _ = std::fs::remove_dir_all(&tmp_dir);
+
+    // ---------- Gate check ----------
+
+    if let Some(gate_path) = gate_path {
+        let gate_raw = std::fs::read_to_string(&gate_path).unwrap_or_else(|e| {
+            eprintln!("Failed to read gate file '{gate_path}': {e}");
+            std::process::exit(1);
+        });
+        let gate: BaselineOutput = serde_json::from_str(&gate_raw).unwrap_or_else(|e| {
+            eprintln!("Failed to parse gate file '{gate_path}': {e}");
+            std::process::exit(1);
+        });
+
+        let drop = gate.top3_hit_rate - top3_hit_rate;
+        if drop > GATE_TOLERANCE {
+            eprintln!(
+                "GATE FAILED: top3_hit_rate dropped by {drop:.3} (gate={:.3}, current={:.3}, tolerance={GATE_TOLERANCE:.3})",
+                gate.top3_hit_rate, top3_hit_rate
+            );
+            std::process::exit(1);
+        }
+        println!(
+            "Gate check passed: top3_hit_rate {:.3} vs gate {:.3} (tolerance {GATE_TOLERANCE:.3})",
+            top3_hit_rate, gate.top3_hit_rate
+        );
+    }
+}

--- a/pensyve-benchmarks/src/fixture.rs
+++ b/pensyve-benchmarks/src/fixture.rs
@@ -1,0 +1,132 @@
+//! Committed corpus fixture loader for paraphrase-recall benchmarks.
+//!
+//! Loads a static, hand-authored corpus of memories and queries embedded at
+//! compile time (`include_str!`) so benchmarks and tests never depend on
+//! network access or runtime generation.
+
+use serde::Deserialize;
+
+/// The full fixture corpus: memories plus the queries evaluated against them.
+#[derive(Debug, Clone, Deserialize)]
+pub struct FixtureCorpus {
+    pub memories: Vec<FixtureMemory>,
+    pub queries: Vec<FixtureQuery>,
+}
+
+/// A single memory in the fixture corpus.
+#[derive(Debug, Clone, Deserialize)]
+pub struct FixtureMemory {
+    /// Stable handle referenced by queries' `gold_keys`, e.g. "bob-parquet-bench".
+    pub key: String,
+    /// One of 5 entity names.
+    pub entity: String,
+    /// "semantic" | "episodic"
+    pub kind: String,
+    pub content: String,
+    /// Confidence in the range 0.35 to 1.0.
+    pub confidence: f32,
+}
+
+/// A single evaluation query with ground-truth answers.
+#[derive(Debug, Clone, Deserialize)]
+pub struct FixtureQuery {
+    pub query: String,
+    /// Keys of memories that count as hits for this query.
+    pub gold_keys: Vec<String>,
+    /// "paraphrase" | "lexical" (control)
+    pub kind: String,
+}
+
+/// Load the committed paraphrase-recall corpus fixture.
+///
+/// The fixture is embedded at compile time via `include_str!`, so this never
+/// touches the filesystem or network at call time. Panics if the fixture is
+/// malformed, since a broken committed fixture is a build-time bug.
+#[must_use]
+pub fn load_corpus() -> FixtureCorpus {
+    let raw = include_str!("../fixtures/paraphrase_corpus.json");
+    serde_json::from_str(raw).expect("malformed paraphrase_corpus.json fixture")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn test_load_corpus_memory_counts() {
+        let corpus = load_corpus();
+        assert_eq!(corpus.memories.len(), 250);
+        let semantic_count = corpus
+            .memories
+            .iter()
+            .filter(|m| m.kind == "semantic")
+            .count();
+        assert_eq!(semantic_count, 220);
+        let episodic_count = corpus
+            .memories
+            .iter()
+            .filter(|m| m.kind == "episodic")
+            .count();
+        assert_eq!(episodic_count, 30);
+    }
+
+    #[test]
+    fn test_gold_keys_resolve_to_existing_memories() {
+        let corpus = load_corpus();
+        let keys: HashSet<&str> = corpus.memories.iter().map(|m| m.key.as_str()).collect();
+        for query in &corpus.queries {
+            for gold_key in &query.gold_keys {
+                assert!(
+                    keys.contains(gold_key.as_str()),
+                    "query '{}' references unknown gold_key '{gold_key}'",
+                    query.query
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_audit_known_item_keys_present() {
+        let corpus = load_corpus();
+        let keys: HashSet<&str> = corpus.memories.iter().map(|m| m.key.as_str()).collect();
+        assert!(
+            keys.contains("bob-parquet-bench"),
+            "missing audit known-item key bob-parquet-bench"
+        );
+        assert!(
+            keys.contains("deploy-p99-rollback"),
+            "missing audit known-item key deploy-p99-rollback"
+        );
+    }
+
+    #[test]
+    fn test_memory_keys_are_unique() {
+        let corpus = load_corpus();
+        let mut keys: Vec<&str> = corpus.memories.iter().map(|m| m.key.as_str()).collect();
+        let n = keys.len();
+        keys.sort_unstable();
+        keys.dedup();
+        assert_eq!(keys.len(), n, "duplicate memory keys in fixture");
+    }
+
+    #[test]
+    fn test_confidence_range() {
+        let corpus = load_corpus();
+        for m in &corpus.memories {
+            assert!(
+                (0.35..=1.0).contains(&m.confidence),
+                "memory '{}' confidence {} out of range 0.35..=1.0",
+                m.key,
+                m.confidence
+            );
+        }
+    }
+
+    #[test]
+    fn test_five_entities() {
+        let corpus = load_corpus();
+        let entities: HashSet<&str> = corpus.memories.iter().map(|m| m.entity.as_str()).collect();
+        assert_eq!(entities.len(), 5);
+    }
+}

--- a/pensyve-benchmarks/src/fixture.rs
+++ b/pensyve-benchmarks/src/fixture.rs
@@ -129,4 +129,39 @@ mod tests {
         let entities: HashSet<&str> = corpus.memories.iter().map(|m| m.entity.as_str()).collect();
         assert_eq!(entities.len(), 5);
     }
+
+    #[test]
+    fn test_query_set_size_and_composition() {
+        let corpus = load_corpus();
+        assert!(
+            corpus.queries.len() >= 60,
+            "expected at least 60 queries, found {}",
+            corpus.queries.len()
+        );
+        let paraphrase_count = corpus
+            .queries
+            .iter()
+            .filter(|q| q.kind == "paraphrase")
+            .count();
+        assert!(
+            paraphrase_count >= 50,
+            "expected at least 50 paraphrase queries, found {paraphrase_count}"
+        );
+        let has_parquet_audit_query = corpus.queries.iter().any(|q| {
+            q.query == "arrow parquet reader benchmark speed"
+                && q.gold_keys == vec!["bob-parquet-bench".to_string()]
+        });
+        assert!(
+            has_parquet_audit_query,
+            "missing audit query 'arrow parquet reader benchmark speed' -> bob-parquet-bench"
+        );
+        let has_rollback_audit_query = corpus.queries.iter().any(|q| {
+            q.query == "rollback when p99 exceeds threshold"
+                && q.gold_keys == vec!["deploy-p99-rollback".to_string()]
+        });
+        assert!(
+            has_rollback_audit_query,
+            "missing audit query 'rollback when p99 exceeds threshold' -> deploy-p99-rollback"
+        );
+    }
 }

--- a/pensyve-benchmarks/src/lib.rs
+++ b/pensyve-benchmarks/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod corpus;
+pub mod fixture;
 pub mod judge;
 pub mod metrics;
 pub mod resilience;

--- a/pensyve-cli/src/main.rs
+++ b/pensyve-cli/src/main.rs
@@ -4,11 +4,33 @@ use clap::{Parser, Subcommand};
 use pensyve_core::{
     config::RetrievalConfig,
     embedding::OnnxEmbedder,
+    reranker::Reranker,
     retrieval::RecallEngine,
     storage::{StorageTrait, sqlite::SqliteBackend},
     types::{Entity, EntityKind, Memory, Namespace, SemanticMemory},
     vector::VectorIndex,
 };
+
+/// Lazily resolve the cross-encoder reranker for `recall`. Only called from
+/// `cmd_recall`, so other subcommands never pay the model-load cost.
+/// `PENSYVE_RERANKER=0` disables it outright; a model-load failure is
+/// logged once (to stderr) and recall proceeds unreranked rather than
+/// failing the command.
+fn resolve_reranker() -> Option<std::sync::Arc<Reranker>> {
+    if std::env::var("PENSYVE_RERANKER").as_deref() == Ok("0") {
+        return None;
+    }
+    match Reranker::new_cached("BGERerankerBase") {
+        Ok(r) => Some(r),
+        Err(e) => {
+            eprintln!(
+                "Warning: reranker unavailable ({e}), continuing unreranked. \
+                 Set PENSYVE_RERANKER=0 to silence this warning."
+            );
+            None
+        }
+    }
+}
 
 // ---------------------------------------------------------------------------
 // CLI definition
@@ -293,7 +315,11 @@ fn cmd_recall(
         max_depth: 4,
     };
 
-    let engine = RecallEngine::new(&storage, &embedder, &vector_index, &config);
+    let mut engine = RecallEngine::new(&storage, &embedder, &vector_index, &config);
+    let reranker = resolve_reranker();
+    if let Some(r) = reranker.as_deref() {
+        engine = engine.with_reranker(r);
+    }
     let result = engine.recall(query, ns.id, limit)?;
 
     // If an entity filter is provided, look up the entity UUID and filter.

--- a/pensyve-core/src/graph.rs
+++ b/pensyve-core/src/graph.rs
@@ -361,12 +361,22 @@ impl MemoryGraph {
             beam = next_beam;
         }
 
-        // Collect results: all visited nodes except start, sorted by score descending.
+        // Collect results: all visited nodes except start, sorted by score
+        // descending, tiebreak ascending by memory/entity UUID. `scores` is
+        // a `HashMap`, whose iteration order reseeds on every fresh
+        // `HashMap::new()` (even within the same process/thread) — without
+        // the tiebreak, score ties land in a different order each call and
+        // that arbitrary order feeds `ranking_spread` directly with no
+        // further sort downstream (see #186 / Task 3.5).
         let mut results: Vec<(Uuid, f32)> = scores
             .iter()
             .map(|(&node_idx, &score)| (self.graph[node_idx], score))
             .collect();
-        results.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        results.sort_by(|a, b| {
+            b.1.partial_cmp(&a.1)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| a.0.cmp(&b.0))
+        });
         results
     }
 

--- a/pensyve-core/src/retrieval/engine.rs
+++ b/pensyve-core/src/retrieval/engine.rs
@@ -721,12 +721,20 @@ impl<'a> RecallEngine<'a> {
         // 1. Vector similarity ranking (already have scores from gather_candidates)
         let mut ranking_vec: Vec<(Uuid, f32)> =
             vector_map.iter().map(|(&id, &score)| (id, score)).collect();
-        ranking_vec.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        ranking_vec.sort_by(|a, b| {
+            b.1.partial_cmp(&a.1)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| a.0.cmp(&b.0))
+        });
 
         // 2. BM25 ranking (from FTS results — already gathered)
         let mut ranking_bm25: Vec<(Uuid, f32)> =
             bm25_map.iter().map(|(&id, &score)| (id, score)).collect();
-        ranking_bm25.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        ranking_bm25.sort_by(|a, b| {
+            b.1.partial_cmp(&a.1)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| a.0.cmp(&b.0))
+        });
 
         // 3. Activation ranking (ACT-R base-level activation)
         let mut ranking_activation: Vec<(Uuid, f32)> = candidates
@@ -747,8 +755,11 @@ impl<'a> RecallEngine<'a> {
                 (id, b)
             })
             .collect();
-        ranking_activation
-            .sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        ranking_activation.sort_by(|a, b| {
+            b.1.partial_cmp(&a.1)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| a.0.cmp(&b.0))
+        });
 
         // 4. Spreading activation / graph ranking
         let ranking_spread: Vec<(Uuid, f32)> = match (self.graph, target_entity) {
@@ -779,7 +790,11 @@ impl<'a> RecallEngine<'a> {
                 (id, score)
             })
             .collect();
-        ranking_intent.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        ranking_intent.sort_by(|a, b| {
+            b.1.partial_cmp(&a.1)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| a.0.cmp(&b.0))
+        });
 
         // 6. Confidence/reliability ranking
         let mut ranking_confidence: Vec<(Uuid, f32)> = candidates
@@ -794,8 +809,11 @@ impl<'a> RecallEngine<'a> {
                 (id, conf)
             })
             .collect();
-        ranking_confidence
-            .sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        ranking_confidence.sort_by(|a, b| {
+            b.1.partial_cmp(&a.1)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| a.0.cmp(&b.0))
+        });
 
         // 7. Entity-affinity ranking
         let mut ranking_entity: Vec<(Uuid, f32)> = if let Some(entity_id) = target_entity {
@@ -814,7 +832,11 @@ impl<'a> RecallEngine<'a> {
         } else {
             Vec::new()
         };
-        ranking_entity.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        ranking_entity.sort_by(|a, b| {
+            b.1.partial_cmp(&a.1)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| a.0.cmp(&b.0))
+        });
 
         // Phase 2A/2C SelRoute mask: when the env-gate fired and the
         // classification confidence cleared the 0.5 threshold,
@@ -1742,6 +1764,116 @@ mod tests {
             assert_ne!(
                 top_id, mem_b.id,
                 "Cooking memory should not be top result for quantum physics query"
+            );
+        }
+    }
+
+    /// Insert an episodic memory with an explicit (fixed) id, so repeated
+    /// fresh-corpus builds in a loop produce directly comparable id lists.
+    fn setup_episodic_with_id(
+        storage: &SqliteBackend,
+        embedder: &OnnxEmbedder,
+        ns: &Namespace,
+        id: Uuid,
+        content: &str,
+    ) -> EpisodicMemory {
+        let mut entity = Entity::new("agent", EntityKind::Agent);
+        entity.namespace_id = ns.id;
+        storage.save_entity(&entity).unwrap();
+
+        let episode = Episode::new(ns.id, vec![entity.id]);
+        storage.save_episode(&episode).unwrap();
+
+        let mut mem = EpisodicMemory::new(ns.id, episode.id, entity.id, entity.id, content);
+        mem.id = id;
+        // Pin `timestamp` to a fixed instant shared by every memory in the
+        // corpus (rather than each's real wall-clock creation time). The
+        // activation-ranking signal (`base_level_activation`) is built
+        // from `.timestamp()`, which truncates to whole seconds — six
+        // back-to-back real SQLite writes can, rarely, straddle a
+        // wall-clock second boundary, which would make that signal
+        // non-uniform (discriminative) for reasons unrelated to the
+        // tie-break bug under test and reintroduce flakiness here.
+        mem.timestamp = chrono::DateTime::from_timestamp(1_700_000_000, 0).unwrap();
+        mem.embedding = embedder.embed(content).unwrap();
+        storage.save_episodic(&mem).unwrap();
+        mem
+    }
+
+    /// Build a fresh corpus with 4 identical-content memories (an exact
+    /// vector-score tie, and an exact FTS/bm25-score tie once matched) plus
+    /// 2 unrelated filler memories (keeping the vector ranking from being
+    /// entirely flat, which would make `has_discriminative_signal` drop it
+    /// from RRF and hide the bug), then run one `recall()` call and return
+    /// the ranked id list.
+    ///
+    /// Memory ids are fixed constants (not `Uuid::new_v4()`) so results
+    /// from independently-built corpora are directly comparable. Each
+    /// build uses a brand-new `SqliteBackend`/`VectorIndex`/`RecallEngine`
+    /// and issues exactly one `recall()` call, so retrieval-induced
+    /// reinforcement (which mutates `access_count`/`last_accessed` as a
+    /// side effect of a call) never carries over between iterations —
+    /// isolating the tie-break bug from that unrelated temporal effect.
+    fn run_tied_recall_once() -> Vec<Uuid> {
+        const TIED_CONTENT: &str = "the quick brown fox jumps over the lazy dog";
+        const TIED_IDS: [Uuid; 4] = [
+            Uuid::from_bytes([1; 16]),
+            Uuid::from_bytes([2; 16]),
+            Uuid::from_bytes([3; 16]),
+            Uuid::from_bytes([4; 16]),
+        ];
+        const FILLER_IDS: [Uuid; 2] = [Uuid::from_bytes([5; 16]), Uuid::from_bytes([6; 16])];
+
+        let dir = tempfile::tempdir().unwrap();
+        let storage = SqliteBackend::open(dir.path()).unwrap();
+        let embedder = OnnxEmbedder::new_mock(64);
+        let mut vector_index = VectorIndex::new(64, 16);
+        let config = test_config();
+
+        let ns = Namespace::new("determinism-ns");
+        storage.save_namespace(&ns).unwrap();
+
+        for id in TIED_IDS {
+            let mem = setup_episodic_with_id(&storage, &embedder, &ns, id, TIED_CONTENT);
+            vector_index.add(mem.id, &mem.embedding).unwrap();
+        }
+        for (id, content) in FILLER_IDS.into_iter().zip([
+            "completely unrelated filler alpha",
+            "completely unrelated filler beta",
+        ]) {
+            let mem = setup_episodic_with_id(&storage, &embedder, &ns, id, content);
+            vector_index.add(mem.id, &mem.embedding).unwrap();
+        }
+
+        let engine = RecallEngine::new(&storage, &embedder, &vector_index, &config);
+        let result = engine.recall(TIED_CONTENT, ns.id, 10).unwrap();
+        let ids: Vec<Uuid> = result.memories.iter().map(|c| c.memory_id).collect();
+
+        assert!(
+            TIED_IDS.iter().all(|id| ids.contains(id)),
+            "expected all 4 tied-content memories to be recalled"
+        );
+        ids
+    }
+
+    #[test]
+    fn test_recall_is_deterministic_across_repeated_calls() {
+        // Regression test for #186 / Task 3.5: `recall()` on identical
+        // inputs must return byte-for-byte identical rankings. Several
+        // per-signal rankings (`ranking_vec`, `ranking_bm25`, etc.) were
+        // built by collecting a `HashMap` into a `Vec` and sorting by
+        // score with no tiebreaker. `HashMap`'s default hasher reseeds
+        // its keys on every fresh `HashMap::new()` call — even within
+        // the same process/thread — so identical scores (ties) land in
+        // a different iteration order each call, and the unbroken sort
+        // let that arbitrary order leak into the final ranking.
+        let first = run_tied_recall_once();
+        for i in 0..20 {
+            let repeat = run_tied_recall_once();
+            assert_eq!(
+                first, repeat,
+                "recall() run #{i} returned a different ranking than run #0 for identical \
+                 inputs (nondeterministic tie-break in engine ranking sorts)"
             );
         }
     }

--- a/pensyve-core/src/storage/sqlite.rs
+++ b/pensyve-core/src/storage/sqlite.rs
@@ -1651,6 +1651,7 @@ impl StorageTrait for SqliteBackend {
                          WHERE p.id = memory_id AND p.superseded_by IS NULL
                      ))
                  )
+               ORDER BY bm25(memory_fts)
                LIMIT ?3",
         )?;
         let rows: Vec<(String, String)> = stmt
@@ -3462,6 +3463,51 @@ mod tests {
         let r3 = db.search_fts("kiwi", ns.id, 10).unwrap();
         assert_eq!(r3.len(), 1);
         assert!(matches!(&r3[0], Memory::Procedural(_)));
+    }
+
+    #[test]
+    fn test_search_fts_orders_by_bm25_relevance() {
+        let (_dir, db) = setup();
+        let ns = make_namespace(&db);
+
+        // Two low-relevance memories (single mention of "zephyr") are saved
+        // before the high-relevance one (multiple mentions), so relying on
+        // insertion order (today's behavior, no ORDER BY) would return a
+        // low-relevance memory first.
+        let low1 = EpisodicMemory::new(
+            ns.id,
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            "the zephyr blew across the plains",
+        );
+        db.save_episodic(&low1).unwrap();
+
+        let low2 = EpisodicMemory::new(
+            ns.id,
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            "a light zephyr passed through the valley",
+        );
+        db.save_episodic(&low2).unwrap();
+
+        let high = EpisodicMemory::new(
+            ns.id,
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            "zephyr zephyr zephyr: the zephyr project is a real-time OS",
+        );
+        db.save_episodic(&high).unwrap();
+
+        let results = db.search_fts("zephyr", ns.id, 10).unwrap();
+        assert_eq!(results.len(), 3);
+        assert_eq!(
+            results[0].id(),
+            high.id,
+            "most relevant (highest term frequency) memory should rank first"
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/pensyve-core/src/storage/sqlite.rs
+++ b/pensyve-core/src/storage/sqlite.rs
@@ -1619,11 +1619,16 @@ impl StorageTrait for SqliteBackend {
     ) -> StorageResult<Vec<Memory>> {
         // Escape the query for FTS5: wrap each token in double quotes to prevent
         // special characters (?, [, ], *, etc.) from being interpreted as operators.
+        // Tokens are joined with OR (not implicit AND): with `ORDER BY
+        // bm25(memory_fts)` in place below, a match on more query terms still
+        // ranks above a match on fewer, so OR preserves precision while
+        // keeping paraphrase-style queries (which rarely share every token
+        // with a memory) from collapsing to zero recall.
         let escaped_query: String = query
             .split_whitespace()
             .map(|token| format!("\"{}\"", token.replace('"', "\"\"")))
             .collect::<Vec<_>>()
-            .join(" ");
+            .join(" OR ");
 
         if escaped_query.is_empty() {
             return Ok(Vec::new());
@@ -3508,6 +3513,45 @@ mod tests {
             high.id,
             "most relevant (highest term frequency) memory should rank first"
         );
+    }
+
+    #[test]
+    fn test_search_fts_paraphrase_query_uses_or_semantics() {
+        // Reproduces the paraphrase_eval "deploy-p99-rollback" audit query
+        // against its gold memory content (pensyve-benchmarks/fixtures/
+        // paraphrase_corpus.json). The query's "rollback" never matches the
+        // content's "rolls"/"back" tokens (FTS5 porter stemming doesn't
+        // decompose compounds), so implicit AND (requiring every query
+        // token to match) fails on that one token and returns nothing, even
+        // though "when", "p99", "exceeds"/"exceed", and "threshold" all
+        // match directly. With Task 5's `ORDER BY bm25(...)` in place,
+        // switching the token join to `OR` is safe: a match on more shared
+        // terms still ranks above a match on fewer, so recall stops
+        // collapsing to zero without sacrificing precision.
+        let (_dir, db) = setup();
+        let ns = make_namespace(&db);
+
+        let ep = EpisodicMemory::new(
+            ns.id,
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            "The deploy pipeline automatically rolls back a release when p99 \
+             latency exceeds the alert threshold for five minutes",
+        );
+        db.save_episodic(&ep).unwrap();
+
+        let results = db
+            .search_fts("rollback when p99 exceeds threshold", ns.id, 10)
+            .unwrap();
+        assert_eq!(
+            results.len(),
+            1,
+            "OR-joined query should still find the memory via its shared terms \
+             (when/p99/exceeds/threshold), even though \"rollback\" itself never \
+             matches \"rolls\"/\"back\""
+        );
+        assert_eq!(results[0].id(), ep.id);
     }
 
     // -----------------------------------------------------------------------

--- a/pensyve-core/src/vector.rs
+++ b/pensyve-core/src/vector.rs
@@ -146,8 +146,17 @@ impl VectorIndex {
             .map(|(id, emb)| (*id, dot(&q, emb)))
             .collect();
 
-        // Sort descending by similarity score.
-        scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        // Sort descending by similarity score, tiebreak ascending by id.
+        // Without the tiebreak, a tie straddling the `truncate(limit)`
+        // boundary makes the candidate SET returned (not just its order)
+        // nondeterministic across calls, since the pre-sort order comes
+        // from `HashMap` iteration whose hasher keys reseed on every
+        // fresh `HashMap::new()` (see #186 / Task 3.5).
+        scored.sort_by(|a, b| {
+            b.1.partial_cmp(&a.1)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| a.0.cmp(&b.0))
+        });
         scored.truncate(limit);
 
         Ok(scored)
@@ -185,8 +194,13 @@ impl VectorIndex {
             .map(|(id, emb)| (*id, dot(&q, emb)))
             .collect();
 
-        // Sort descending by similarity score.
-        scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        // Sort descending by similarity score, tiebreak ascending by id
+        // (see the comment on the identical pattern in `search`, above).
+        scored.sort_by(|a, b| {
+            b.1.partial_cmp(&a.1)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| a.0.cmp(&b.0))
+        });
         scored.truncate(limit);
 
         Ok(scored)
@@ -317,6 +331,101 @@ mod tests {
         }
         let results = index.search(&[1.0, 0.0], 3).unwrap();
         assert_eq!(results.len(), 3);
+    }
+
+    /// Regression test for #186 / Task 3.5 (reviewer follow-up): a score
+    /// tie straddling `search`'s `truncate(limit)` boundary must not make
+    /// the returned candidate *set* nondeterministic. `entries` is a
+    /// `HashMap`, whose iteration order reseeds on every fresh
+    /// `HashMap::new()` — even within the same process/thread — so
+    /// without a tiebreak on the pre-truncate sort, which items survive
+    /// the cut (not just their order) could change from call to call.
+    ///
+    /// Builds a brand-new index each iteration (fresh `HashMap`, fresh
+    /// hasher keys) with 8 entries sharing an identical embedding (an
+    /// exact score tie against the query for all 8), searches with
+    /// `limit = 3` — well inside the tied group — and asserts every
+    /// rebuild returns the exact same 3 ids in the exact same order.
+    #[test]
+    fn test_search_truncation_boundary_tie_is_deterministic() {
+        const TIED_IDS: [Uuid; 8] = [
+            Uuid::from_bytes([1; 16]),
+            Uuid::from_bytes([2; 16]),
+            Uuid::from_bytes([3; 16]),
+            Uuid::from_bytes([4; 16]),
+            Uuid::from_bytes([5; 16]),
+            Uuid::from_bytes([6; 16]),
+            Uuid::from_bytes([7; 16]),
+            Uuid::from_bytes([8; 16]),
+        ];
+        const QUERY: [f32; 4] = [1.0, 0.0, 0.0, 0.0];
+        const LIMIT: usize = 3;
+
+        fn run_once() -> Vec<(Uuid, f32)> {
+            let mut index = VectorIndex::new(4, 16);
+            for id in TIED_IDS {
+                index.add(id, &QUERY).unwrap(); // identical embedding -> exact tie
+            }
+            index.search(&QUERY, LIMIT).unwrap()
+        }
+
+        let first = run_once();
+        assert_eq!(first.len(), LIMIT);
+        // Deterministic tiebreak is score desc then id asc, so the exact
+        // winners are predictable, not just "some 3 of the 8".
+        assert_eq!(
+            first.iter().map(|(id, _)| *id).collect::<Vec<_>>(),
+            TIED_IDS[..LIMIT]
+        );
+
+        for i in 0..20 {
+            let repeat = run_once();
+            assert_eq!(
+                first, repeat,
+                "search() rebuild #{i} returned a different candidate set/order than \
+                 rebuild #0 for an identical tied index (nondeterministic truncation boundary)"
+            );
+        }
+    }
+
+    /// Sibling of the above for `filtered_search`, which has the same
+    /// sort-then-truncate shape.
+    #[test]
+    fn test_filtered_search_truncation_boundary_tie_is_deterministic() {
+        const TIED_IDS: [Uuid; 8] = [
+            Uuid::from_bytes([1; 16]),
+            Uuid::from_bytes([2; 16]),
+            Uuid::from_bytes([3; 16]),
+            Uuid::from_bytes([4; 16]),
+            Uuid::from_bytes([5; 16]),
+            Uuid::from_bytes([6; 16]),
+            Uuid::from_bytes([7; 16]),
+            Uuid::from_bytes([8; 16]),
+        ];
+        const QUERY: [f32; 4] = [1.0, 0.0, 0.0, 0.0];
+        const LIMIT: usize = 3;
+
+        fn run_once() -> Vec<(Uuid, f32)> {
+            let mut index = VectorIndex::new(4, 16);
+            for id in TIED_IDS {
+                index.add(id, &QUERY).unwrap();
+            }
+            index.filtered_search(&QUERY, LIMIT, |_| true).unwrap()
+        }
+
+        let first = run_once();
+        assert_eq!(
+            first.iter().map(|(id, _)| *id).collect::<Vec<_>>(),
+            TIED_IDS[..LIMIT]
+        );
+        for i in 0..20 {
+            let repeat = run_once();
+            assert_eq!(
+                first, repeat,
+                "filtered_search() rebuild #{i} returned a different candidate set/order than \
+                 rebuild #0 for an identical tied index"
+            );
+        }
     }
 
     #[test]

--- a/pensyve-mcp-gateway/src/rest.rs
+++ b/pensyve-mcp-gateway/src/rest.rs
@@ -830,12 +830,16 @@ async fn recall(
     // Hold read lock only for retrieval — allows concurrent recalls.
     let result = {
         let vector_index = ps.vector_index.read().await;
-        let engine = RecallEngine::new(
+        let mut engine = RecallEngine::new(
             ps.storage.as_ref(),
             &ps.embedder,
             &vector_index,
             &ps.retrieval_config,
         );
+        let reranker = ps.reranker();
+        if let Some(r) = reranker.as_deref() {
+            engine = engine.with_reranker(r);
+        }
         engine
             .recall_with_embedding(
                 &body.query,
@@ -916,12 +920,16 @@ async fn recall_grouped(
     // Hold the read lock only for the actual retrieval call.
     let result = {
         let vector_index = ps.vector_index.read().await;
-        let engine = RecallEngine::new(
+        let mut engine = RecallEngine::new(
             ps.storage.as_ref(),
             &ps.embedder,
             &vector_index,
             &ps.retrieval_config,
         );
+        let reranker = ps.reranker();
+        if let Some(r) = reranker.as_deref() {
+            engine = engine.with_reranker(r);
+        }
         let flat = engine
             .recall_with_embedding(
                 &body.query,
@@ -2158,12 +2166,16 @@ async fn a2a_recall(
         .and_then(Result::ok);
 
     let vector_index = ps.vector_index.read().await;
-    let engine = RecallEngine::new(
+    let mut engine = RecallEngine::new(
         ps.storage.as_ref(),
         &ps.embedder,
         &vector_index,
         &ps.retrieval_config,
     );
+    let reranker = ps.reranker();
+    if let Some(r) = reranker.as_deref() {
+        engine = engine.with_reranker(r);
+    }
 
     match engine.recall_with_embedding(
         &query,

--- a/pensyve-mcp-gateway/src/rest.rs
+++ b/pensyve-mcp-gateway/src/rest.rs
@@ -827,6 +827,24 @@ async fn recall(
         .ok()
         .and_then(Result::ok);
 
+    // Resolve the reranker off the runtime too, and before the read lock:
+    // first resolution synchronously loads a ~280MB ONNX model (or blocks on
+    // a failed network attempt), and `OnceLock::get_or_init` blocks every
+    // concurrent caller until it completes — see `PensyveState::reranker`'s
+    // docs. Running it on a tokio worker thread would stall the runtime;
+    // running it under the vector index lock would stall every other recall
+    // on this tenant.
+    let reranker_cell = ps.reranker_cell.clone();
+    let reranker =
+        tokio::task::spawn_blocking(move || PensyveState::resolve_reranker_cell(&reranker_cell))
+            .await
+            .unwrap_or_else(|e| {
+                tracing::warn!(
+                    "Reranker resolution task panicked ({e}); recall proceeding unreranked"
+                );
+                None
+            });
+
     // Hold read lock only for retrieval — allows concurrent recalls.
     let result = {
         let vector_index = ps.vector_index.read().await;
@@ -836,7 +854,6 @@ async fn recall(
             &vector_index,
             &ps.retrieval_config,
         );
-        let reranker = ps.reranker();
         if let Some(r) = reranker.as_deref() {
             engine = engine.with_reranker(r);
         }
@@ -917,6 +934,19 @@ async fn recall_grouped(
         .ok()
         .and_then(Result::ok);
 
+    // Resolve the reranker off the runtime too, and before the read lock —
+    // see the identical rationale in `recall` above.
+    let reranker_cell = ps.reranker_cell.clone();
+    let reranker =
+        tokio::task::spawn_blocking(move || PensyveState::resolve_reranker_cell(&reranker_cell))
+            .await
+            .unwrap_or_else(|e| {
+                tracing::warn!(
+                    "Reranker resolution task panicked ({e}); recall proceeding unreranked"
+                );
+                None
+            });
+
     // Hold the read lock only for the actual retrieval call.
     let result = {
         let vector_index = ps.vector_index.read().await;
@@ -926,7 +956,6 @@ async fn recall_grouped(
             &vector_index,
             &ps.retrieval_config,
         );
-        let reranker = ps.reranker();
         if let Some(r) = reranker.as_deref() {
             engine = engine.with_reranker(r);
         }
@@ -2165,6 +2194,19 @@ async fn a2a_recall(
         .ok()
         .and_then(Result::ok);
 
+    // Resolve the reranker off the runtime too, and before the read lock —
+    // see the identical rationale in `recall` above.
+    let reranker_cell = ps.reranker_cell.clone();
+    let reranker =
+        tokio::task::spawn_blocking(move || PensyveState::resolve_reranker_cell(&reranker_cell))
+            .await
+            .unwrap_or_else(|e| {
+                tracing::warn!(
+                    "Reranker resolution task panicked ({e}); recall proceeding unreranked"
+                );
+                None
+            });
+
     let vector_index = ps.vector_index.read().await;
     let mut engine = RecallEngine::new(
         ps.storage.as_ref(),
@@ -2172,7 +2214,6 @@ async fn a2a_recall(
         &vector_index,
         &ps.retrieval_config,
     );
-    let reranker = ps.reranker();
     if let Some(r) = reranker.as_deref() {
         engine = engine.with_reranker(r);
     }

--- a/pensyve-mcp-gateway/src/tenant.rs
+++ b/pensyve-mcp-gateway/src/tenant.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use dashmap::DashMap;
 use dashmap::mapref::entry::Entry;
@@ -7,6 +7,7 @@ use uuid::Uuid;
 
 use pensyve_core::config::RetrievalConfig;
 use pensyve_core::embedding::OnnxEmbedder;
+use pensyve_core::reranker::Reranker;
 use pensyve_core::storage::StorageTrait;
 use pensyve_core::types::Namespace;
 use pensyve_core::vector::VectorIndex;
@@ -26,6 +27,10 @@ pub struct TenantStateManager {
     default_state: Arc<PensyveState>,
     dimensions: usize,
     tenants: DashMap<String, Arc<PensyveState>>,
+    /// Shared across every tenant's `PensyveState` so the reranker model
+    /// resolves (or fails, with a single warning) at most once per gateway
+    /// process rather than once per tenant.
+    reranker_cell: Arc<OnceLock<Option<Arc<Reranker>>>>,
 }
 
 impl TenantStateManager {
@@ -37,6 +42,7 @@ impl TenantStateManager {
         default_vector_index: VectorIndex,
     ) -> Self {
         let dimensions = default_vector_index.dimensions();
+        let reranker_cell = Arc::new(OnceLock::new());
 
         let default_state = Arc::new(PensyveState {
             storage: storage.clone(),
@@ -45,6 +51,7 @@ impl TenantStateManager {
             namespace: default_namespace,
             retrieval_config: retrieval_config.clone(),
             is_remote: true,
+            reranker_cell: reranker_cell.clone(),
         });
 
         Self {
@@ -54,6 +61,7 @@ impl TenantStateManager {
             default_state,
             dimensions,
             tenants: DashMap::new(),
+            reranker_cell,
         }
     }
 
@@ -158,6 +166,7 @@ impl TenantStateManager {
             namespace,
             retrieval_config: self.retrieval_config.clone(),
             is_remote: true,
+            reranker_cell: self.reranker_cell.clone(),
         }))
     }
 }

--- a/pensyve-mcp-gateway/tests/integration_test.rs
+++ b/pensyve-mcp-gateway/tests/integration_test.rs
@@ -1,8 +1,9 @@
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use axum::Router;
 use pensyve_core::config::RetrievalConfig;
 use pensyve_core::embedding::OnnxEmbedder;
+use pensyve_core::reranker::Reranker;
 use pensyve_core::storage::StorageTrait;
 use pensyve_core::storage::sqlite::SqliteBackend;
 use pensyve_core::types::{Namespace, ObservationMemory, Outcome, ProceduralMemory};
@@ -14,8 +15,33 @@ use rmcp::transport::streamable_http_server::{
 use tokio::sync::RwLock;
 use tokio_util::sync::CancellationToken;
 
-/// Create a test server with a temporary database.
-fn create_test_state(dir: &tempfile::TempDir) -> Arc<PensyveState> {
+/// Prevents the lazily-resolved reranker (`PensyveState::reranker`) from
+/// attempting a real network model download when a test builds a state via
+/// [`create_test_state`] without pre-seeding `reranker_cell`. Tests that
+/// specifically exercise reranker behavior instead pre-seed the cell with
+/// `Reranker::new_mock()` (see [`create_test_state_with_reranker`]), which
+/// bypasses this env check entirely. Uses `Once` so the (unsafe, per Rust
+/// 2024 edition) env mutation happens exactly once, before any reader.
+#[allow(
+    unsafe_code,
+    reason = "test-only env-var guard; std::env::set_var is unsafe in Rust 2024 edition by language design but is safe here because it runs exactly once via std::sync::Once before any reader observes the environment"
+)]
+fn disable_reranker_for_tests() {
+    static INIT: std::sync::Once = std::sync::Once::new();
+    INIT.call_once(|| {
+        // SAFETY: runs exactly once via `Once`, before any concurrent
+        // reader — no data race.
+        unsafe { std::env::set_var("PENSYVE_RERANKER", "0") };
+    });
+}
+
+/// Create a test server state, optionally with a reranker pre-attached
+/// (bypassing lazy resolution entirely — no network call either way).
+fn create_test_state_with_reranker(
+    dir: &tempfile::TempDir,
+    reranker: Option<Arc<Reranker>>,
+) -> Arc<PensyveState> {
+    disable_reranker_for_tests();
     let storage = SqliteBackend::open(dir.path()).expect("open test storage");
     let namespace = Namespace::new("test");
     storage.save_namespace(&namespace).expect("save namespace");
@@ -39,7 +65,13 @@ fn create_test_state(dir: &tempfile::TempDir) -> Arc<PensyveState> {
             max_depth: 4,
         },
         is_remote: false,
+        reranker_cell: Arc::new(OnceLock::from(reranker)),
     })
+}
+
+/// Create a test server with a temporary database and no reranker attached.
+fn create_test_state(dir: &tempfile::TempDir) -> Arc<PensyveState> {
+    create_test_state_with_reranker(dir, None)
 }
 
 /// Start a test server and return its address.
@@ -700,4 +732,124 @@ async fn test_mcp_get_method_not_allowed_in_stateless() {
     assert_eq!(resp.status(), 405);
 
     ct.cancel();
+}
+
+// ---------------------------------------------------------------------------
+// Reranker wiring (#186 Task 7)
+// ---------------------------------------------------------------------------
+
+async fn remember_and_recall(url: &str, query: &str) -> Vec<serde_json::Value> {
+    let client = reqwest::Client::new();
+
+    client
+        .post(format!("{url}/mcp"))
+        .header("content-type", "application/json")
+        .header("accept", "application/json, text/event-stream")
+        .body(json_rpc(
+            "initialize",
+            serde_json::json!({
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": { "name": "test", "version": "0.1.0" }
+            }),
+            1,
+        ))
+        .send()
+        .await
+        .expect("init");
+
+    client
+        .post(format!("{url}/mcp"))
+        .header("content-type", "application/json")
+        .header("accept", "application/json, text/event-stream")
+        .body(json_rpc(
+            "tools/call",
+            serde_json::json!({
+                "name": "pensyve_remember",
+                "arguments": { "entity": "alice", "fact": query }
+            }),
+            2,
+        ))
+        .send()
+        .await
+        .expect("remember");
+
+    let resp = client
+        .post(format!("{url}/mcp"))
+        .header("content-type", "application/json")
+        .header("accept", "application/json, text/event-stream")
+        .body(json_rpc(
+            "tools/call",
+            serde_json::json!({
+                "name": "pensyve_recall",
+                "arguments": { "query": query, "limit": 5 }
+            }),
+            3,
+        ))
+        .send()
+        .await
+        .expect("recall");
+
+    assert_eq!(resp.status(), 200);
+    let text = resp.text().await.unwrap();
+    let json: serde_json::Value = serde_json::from_str(&text).expect("parse json");
+    let content_text = json["result"]["content"][0]["text"]
+        .as_str()
+        .expect("content text");
+    serde_json::from_str(content_text).expect("parse recalled memories array")
+}
+
+/// Step 1 (part A): a mock reranker attached via `with_reranker` must not
+/// break the recall path — results still come back. Uses `Reranker::new_mock`
+/// (pre-seeded into `reranker_cell`, never touching the network) to exercise
+/// the same `RecallEngine::with_reranker` wiring `pensyve-mcp-tools::server`
+/// uses in production.
+#[tokio::test]
+async fn test_recall_with_mock_reranker_attached_returns_results() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let reranker = Some(Arc::new(Reranker::new_mock()));
+    let state = create_test_state_with_reranker(&dir, reranker);
+    let (url, ct) = start_test_server(state).await;
+
+    let memories = remember_and_recall(&url, "reranker attach test fact").await;
+    assert!(
+        !memories.is_empty(),
+        "expected at least one recalled memory with a mock reranker attached"
+    );
+
+    ct.cancel();
+}
+
+/// Step 1 (part B): an absent reranker (the default in this test binary —
+/// see `disable_reranker_for_tests`) must not break the recall path either.
+/// This is the graceful-fallback path a production gateway takes when
+/// `PENSYVE_RERANKER=0` is set, or when model resolution fails.
+#[tokio::test]
+async fn test_recall_without_reranker_falls_back_gracefully() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let state = create_test_state(&dir);
+    let (url, ct) = start_test_server(state).await;
+
+    let memories = remember_and_recall(&url, "no reranker fallback test fact").await;
+    assert!(
+        !memories.is_empty(),
+        "expected at least one recalled memory with no reranker attached"
+    );
+
+    ct.cancel();
+}
+
+/// Step 1 (part C): with `PENSYVE_RERANKER=0`, `PensyveState::reranker()`
+/// must resolve to `None` — i.e. the state holds no reranker. This binary
+/// sets the env var once via `disable_reranker_for_tests` (shared by every
+/// test above), so by the time this test runs the variable is already "0";
+/// asserting on `state.reranker()` here pins down the state-level contract
+/// the brief calls out explicitly, on top of the unit-level coverage in
+/// `pensyve_mcp_tools::state::tests`.
+#[tokio::test]
+async fn test_state_holds_no_reranker_when_disabled_via_env() {
+    disable_reranker_for_tests();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let state = create_test_state(&dir);
+    assert!(state.reranker().is_none());
 }

--- a/pensyve-mcp-gateway/tests/test_multi_tenant_propagation.rs
+++ b/pensyve-mcp-gateway/tests/test_multi_tenant_propagation.rs
@@ -61,7 +61,25 @@ async fn tenant_middleware(
     CURRENT_TENANT.scope(tenant_id, next.run(req)).await
 }
 
+/// Prevents the lazily-resolved reranker (`PensyveState::reranker`) from
+/// attempting a real network model download the first time this suite's
+/// recall assertions run. Uses `Once` so the (unsafe, per Rust 2024
+/// edition) env mutation happens exactly once, before any reader.
+#[allow(
+    unsafe_code,
+    reason = "test-only env-var guard; std::env::set_var is unsafe in Rust 2024 edition by language design but is safe here because it runs exactly once via std::sync::Once before any reader observes the environment"
+)]
+fn disable_reranker_for_tests() {
+    static INIT: std::sync::Once = std::sync::Once::new();
+    INIT.call_once(|| {
+        // SAFETY: runs exactly once via `Once`, before any concurrent
+        // reader — no data race.
+        unsafe { std::env::set_var("PENSYVE_RERANKER", "0") };
+    });
+}
+
 fn make_mgr(dir: &tempfile::TempDir) -> Arc<TenantStateManager> {
+    disable_reranker_for_tests();
     let storage =
         Arc::new(SqliteBackend::open(dir.path()).expect("open storage")) as Arc<dyn StorageTrait>;
     let ns = Namespace::new("default");

--- a/pensyve-mcp-gateway/tests/test_rest_recall_contradictions.rs
+++ b/pensyve-mcp-gateway/tests/test_rest_recall_contradictions.rs
@@ -50,7 +50,25 @@ fn gateway_config(dir: &TempDir) -> GatewayConfig {
     }
 }
 
+/// Prevents the lazily-resolved reranker (`PensyveState::reranker`) from
+/// attempting a real network model download the first time this suite's
+/// `/v1/recall` assertions run. Uses `Once` so the (unsafe, per Rust 2024
+/// edition) env mutation happens exactly once, before any reader.
+#[allow(
+    unsafe_code,
+    reason = "test-only env-var guard; std::env::set_var is unsafe in Rust 2024 edition by language design but is safe here because it runs exactly once via std::sync::Once before any reader observes the environment"
+)]
+fn disable_reranker_for_tests() {
+    static INIT: std::sync::Once = std::sync::Once::new();
+    INIT.call_once(|| {
+        // SAFETY: runs exactly once via `Once`, before any concurrent
+        // reader — no data race.
+        unsafe { std::env::set_var("PENSYVE_RERANKER", "0") };
+    });
+}
+
 fn app_state(dir: &TempDir) -> Arc<AppState> {
+    disable_reranker_for_tests();
     let storage =
         Arc::new(SqliteBackend::open(dir.path()).expect("open storage")) as Arc<dyn StorageTrait>;
     let namespace = Namespace::new("default");

--- a/pensyve-mcp-tools/src/server.rs
+++ b/pensyve-mcp-tools/src/server.rs
@@ -147,6 +147,23 @@ impl PensyveMcpServer {
             .ok()
             .and_then(Result::ok);
 
+        // Resolve the reranker off the runtime too, and before the read
+        // lock: first resolution synchronously loads a ~280MB ONNX model
+        // (or blocks on a failed network attempt), and
+        // `OnceLock::get_or_init` blocks every concurrent caller until it
+        // completes — see `PensyveState::reranker`'s docs. Running it on a
+        // tokio worker thread would stall the runtime; running it under the
+        // vector index lock would stall every other recall on this tenant.
+        let reranker_cell = state.reranker_cell.clone();
+        let reranker = tokio::task::spawn_blocking(move || {
+            PensyveState::resolve_reranker_cell(&reranker_cell)
+        })
+        .await
+        .unwrap_or_else(|e| {
+            tracing::warn!("Reranker resolution task panicked ({e}); recall proceeding unreranked");
+            None
+        });
+
         // Hold the read lock only for the retrieval phase, not embedding or serialization.
         let result = {
             let vector_index = state.vector_index.read().await;
@@ -156,7 +173,6 @@ impl PensyveMcpServer {
                 &vector_index,
                 &state.retrieval_config,
             );
-            let reranker = state.reranker();
             if let Some(r) = reranker.as_deref() {
                 engine = engine.with_reranker(r);
             }

--- a/pensyve-mcp-tools/src/server.rs
+++ b/pensyve-mcp-tools/src/server.rs
@@ -150,12 +150,16 @@ impl PensyveMcpServer {
         // Hold the read lock only for the retrieval phase, not embedding or serialization.
         let result = {
             let vector_index = state.vector_index.read().await;
-            let engine = RecallEngine::new(
+            let mut engine = RecallEngine::new(
                 state.storage.as_ref(),
                 &state.embedder,
                 &vector_index,
                 &state.retrieval_config,
             );
+            let reranker = state.reranker();
+            if let Some(r) = reranker.as_deref() {
+                engine = engine.with_reranker(r);
+            }
             engine
                 .recall_with_embedding(
                     &params.query,

--- a/pensyve-mcp-tools/src/state.rs
+++ b/pensyve-mcp-tools/src/state.rs
@@ -1,12 +1,17 @@
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use tokio::sync::RwLock;
 
 use pensyve_core::config::RetrievalConfig;
 use pensyve_core::embedding::OnnxEmbedder;
+use pensyve_core::reranker::Reranker;
 use pensyve_core::storage::StorageTrait;
 use pensyve_core::types::Namespace;
 use pensyve_core::vector::VectorIndex;
+
+/// Model name used for the lazily-resolved cross-encoder reranker. Matches
+/// the default in `pensyve-python`'s `Pensyve(reranker="BGERerankerBase")`.
+const RERANKER_MODEL: &str = "BGERerankerBase";
 
 /// Shared state for the Pensyve MCP server.
 ///
@@ -20,4 +25,82 @@ pub struct PensyveState {
     pub retrieval_config: RetrievalConfig,
     /// True when running as a remote gateway (Streamable HTTP), false for local (stdio).
     pub is_remote: bool,
+    /// Lazily resolved cross-encoder reranker. Callers that construct
+    /// multiple `PensyveState`s from the same process (e.g. the gateway's
+    /// per-tenant states) should clone the same `Arc<OnceLock<..>>` into
+    /// each one so the model loads — or fails — at most once per process
+    /// rather than once per tenant. Resolution happens on first call to
+    /// [`Self::reranker`], never at construction: `PENSYVE_RERANKER=0`
+    /// disables it outright, and a model-load failure is logged once and
+    /// leaves recall unreranked rather than failing startup or the request.
+    pub reranker_cell: Arc<OnceLock<Option<Arc<Reranker>>>>,
+}
+
+impl PensyveState {
+    /// Resolve the reranker lazily (first call wins) and return a clone of
+    /// the cached result on every subsequent call. `None` means either
+    /// `PENSYVE_RERANKER=0` was set or the model failed to load; either way
+    /// callers should proceed with an unreranked `RecallEngine`.
+    pub fn reranker(&self) -> Option<Arc<Reranker>> {
+        self.reranker_cell.get_or_init(resolve_reranker).clone()
+    }
+}
+
+fn resolve_reranker() -> Option<Arc<Reranker>> {
+    if std::env::var("PENSYVE_RERANKER").as_deref() == Ok("0") {
+        tracing::info!("Reranker disabled via PENSYVE_RERANKER=0");
+        return None;
+    }
+    match Reranker::new_cached(RERANKER_MODEL) {
+        Ok(r) => Some(r),
+        Err(e) => {
+            tracing::warn!(
+                "Reranker unavailable ({e}); recall proceeding unreranked. \
+                 Set PENSYVE_RERANKER=0 to silence this warning."
+            );
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    unsafe_code,
+    reason = "test-only env-var guard; std::env::set_var is unsafe in Rust 2024 edition by language design but is safe here because it runs exactly once via std::sync::Once before any reader observes the environment"
+)]
+mod tests {
+    use super::*;
+
+    /// Sets `PENSYVE_RERANKER=0` exactly once for this test binary. Uses
+    /// `Once` (rather than a bare `set_var` per test) so the mutation is
+    /// guaranteed to happen-before any reader, even if more tests are added
+    /// later and `cargo test`'s default thread-per-test runner interleaves
+    /// them.
+    fn disable_reranker_via_env() {
+        static INIT: std::sync::Once = std::sync::Once::new();
+        INIT.call_once(|| {
+            // SAFETY: runs exactly once via `Once`, before any concurrent
+            // reader observes the environment — no data race.
+            unsafe { std::env::set_var("PENSYVE_RERANKER", "0") };
+        });
+    }
+
+    #[test]
+    fn resolve_reranker_disabled_via_env_returns_none() {
+        disable_reranker_via_env();
+        // Short-circuits before `Reranker::new_cached` — no network/model
+        // load is attempted, so this is safe to run offline.
+        assert!(resolve_reranker().is_none());
+    }
+
+    #[test]
+    fn state_reranker_delegates_to_resolve_reranker_via_get_or_init() {
+        disable_reranker_via_env();
+        // `PensyveState::reranker()` is a thin `get_or_init` wrapper around
+        // `resolve_reranker`; exercise it directly (no full `PensyveState`
+        // construction needed — that's covered end-to-end by the gateway's
+        // `pensyve-mcp-gateway/tests/integration_test.rs`).
+        let cell: OnceLock<Option<Arc<Reranker>>> = OnceLock::new();
+        assert!(cell.get_or_init(resolve_reranker).clone().is_none());
+    }
 }

--- a/pensyve-mcp-tools/src/state.rs
+++ b/pensyve-mcp-tools/src/state.rs
@@ -41,8 +41,31 @@ impl PensyveState {
     /// the cached result on every subsequent call. `None` means either
     /// `PENSYVE_RERANKER=0` was set or the model failed to load; either way
     /// callers should proceed with an unreranked `RecallEngine`.
+    ///
+    /// # Blocking
+    ///
+    /// First resolution synchronously loads a ~280MB ONNX model (or blocks
+    /// on a failed network attempt before giving up), and
+    /// `OnceLock::get_or_init` blocks every concurrent caller until it
+    /// completes. **Never call this directly from an async fn running on a
+    /// tokio worker thread** — use [`Self::resolve_reranker_cell`] inside
+    /// `tokio::task::spawn_blocking` instead (see
+    /// `pensyve-mcp-gateway/src/rest.rs`'s recall handlers and
+    /// `pensyve-mcp-tools/src/server.rs`'s `recall` tool for the pattern).
+    /// This method is fine to call from sync contexts (the CLI,
+    /// `paraphrase_eval`) where there is no runtime to stall.
     pub fn reranker(&self) -> Option<Arc<Reranker>> {
-        self.reranker_cell.get_or_init(resolve_reranker).clone()
+        Self::resolve_reranker_cell(&self.reranker_cell)
+    }
+
+    /// Same resolution as [`Self::reranker`], but takes the cell directly
+    /// rather than `&self` — for async callers that only have a
+    /// `&PensyveState` (not an owned `Arc<PensyveState>`) but still need to
+    /// move the (slow, blocking) resolution onto a blocking thread. Clone
+    /// `state.reranker_cell` (an `Arc`, cheap) and move the clone into a
+    /// `tokio::task::spawn_blocking` closure that calls this.
+    pub fn resolve_reranker_cell(cell: &OnceLock<Option<Arc<Reranker>>>) -> Option<Arc<Reranker>> {
+        cell.get_or_init(resolve_reranker).clone()
     }
 }
 

--- a/pensyve-mcp/src/main.rs
+++ b/pensyve-mcp/src/main.rs
@@ -1,5 +1,5 @@
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use anyhow::Result;
 use rmcp::ServiceExt;
@@ -314,6 +314,10 @@ async fn main() -> Result<()> {
         namespace,
         retrieval_config,
         is_remote: false,
+        // Same lazy/infallible resolution as the gateway (PENSYVE_RERANKER=0
+        // to disable; a model-load failure logs once and recall proceeds
+        // unreranked) — see `pensyve_mcp_tools::state::PensyveState::reranker`.
+        reranker_cell: Arc::new(OnceLock::new()),
     });
 
     let server = PensyveMcpServer::new(state);


### PR DESCRIPTION
Fixes paraphrase recall missing top-3 on known items (P0 audit F11). Closes #186.

Implements docs/superpowers/specs/2026-08-04-open-issues-remediation-design.md (workstream 3) via docs/superpowers/plans/2026-08-04-paraphrase-recall.md.

## Results (committed eval harness, 250-memory corpus, 62 queries)

| Metric | Before | After |
|---|---|---|
| Top-3 hit rate (corpus-wide) | 0.581 (nondeterministic 0.435-0.645) | 0.903, deterministic |
| MRR | 0.490 | 0.882 |
| Audit query "arrow parquet reader benchmark speed" | rank 4 (jittering) | rank 1 |
| Audit query "rollback when p99 exceeds threshold" | rank 5 | rank 1 |

## What changed

- Committed paraphrase eval harness (fixture corpus + 62-query set + paraphrase_eval binary) with a CI regression gate (reranked baseline 0.903/0.882, margin 0.03, rerank-mode mismatch hard-fails)
- Deterministic ranking: stable sort tiebreaks in engine.rs, vector.rs (incl. truncation boundary), graph.rs — identical inputs now produce identical rankings
- FTS: ORDER BY bm25() (the lexical RRF leg previously fused rowid-order noise) and OR semantics for multi-token queries (long paraphrases no longer drop the lexical leg; +0.19 top-3)
- Cross-encoder reranker (BGERerankerBase) wired into gateway REST + MCP + CLI with lazy spawn_blocking load, graceful fallback, PENSYVE_RERANKER=0 opt-out
- Ablations (fixed rrf_k=60; activation-leg skip) measured and reverted with evidence in empty audit-trail commits

## Known follow-ups (issues being filed)

- Paraphrase-kind top-3 is 0.885 vs the 0.90 target (corpus-wide meets it); next lever is a local model swap
- Postgres FTS keeps AND semantics (plainto_tsquery, 5 call sites) pending live-PG test coverage
- The paraphrase gate currently sits in a continue-on-error job; a blocking-job split lands as a follow-up PR

https://claude.ai/code/session_01AVSNawDtP4xFVJCHbrTEGq