### PR TITLE
chore(deps): bump rmcp from 2.2 to 3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -402,6 +402,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -919,12 +925,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+checksum = "88490bf1b990d87eaaa7ac8aa887f629a08e7359765b4911faf63c3763347d23"
 dependencies = [
- "darling_core 0.23.0",
- "darling_macro 0.23.0",
+ "darling_core 0.24.0",
+ "darling_macro 0.24.0",
 ]
 
 [[package]]
@@ -943,15 +949,15 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+checksum = "084e274f91c482280130e1e34e0b8d6e66776a060d7b6de7b84289ca778868c4"
 dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -967,13 +973,13 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+checksum = "68f5792fa0d41cd2325ce0ffa64f0a340eaebd4971a3a0c5e1ffd2cc488a355e"
 dependencies = [
- "darling_core 0.23.0",
+ "darling_core 0.24.0",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3573,12 +3579,12 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "2.2.0"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14db48ee17a9ba61810ab1a9c1beb7d06d8136ae39ac25a1137f10d357af01af"
+checksum = "c8dddc5b1924b9a59fba420166160ca2c4663a4e01803e52eda33070f56d63c8"
 dependencies = [
  "async-trait",
- "base64 0.22.1",
+ "base64 0.23.1",
  "bytes",
  "chrono",
  "futures",
@@ -3604,15 +3610,15 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "2.2.0"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "783d787bf21813b285f13019adc49e11af501c658890c1e519f31f937c68b7e3"
+checksum = "6898e24cd16342b59bfa8a53c2c04b9cf62fc8a2cfea57b9c038b09984bfc521"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.24.0",
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4132,9 +4138,9 @@ dependencies = [
 
 [[package]]
 name = "sse-stream"
-version = "0.2.2"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c5e6deb40826033bd7b11c7ef25ef71193fabd71f680f40dd16538a2704d2f4"
+checksum = "c123f296ade4ec4b8b0f6162116e6629f5146922ca5ab40ca9d3c2e73ab4761e"
 dependencies = [
  "bytes",
  "futures-util",

--- a/pensyve-mcp-gateway/Cargo.toml
+++ b/pensyve-mcp-gateway/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/main.rs"
 [dependencies]
 pensyve-core = { path = "../pensyve-core", version = "2.6.1", features = ["postgres", "observation-extraction"] }
 pensyve-mcp-tools = { path = "../pensyve-mcp-tools", version = "2.6.1" }
-rmcp = { version = "2.2", features = ["server", "transport-streamable-http-server", "macros"] }
+rmcp = { version = "3.1", features = ["server", "transport-streamable-http-server", "macros"] }
 axum = "0.8"
 tower-http = { version = "0.7", features = ["compression-gzip", "compression-br"] }
 tokio = { version = "1", features = ["full"] }

--- a/pensyve-mcp-gateway/src/main.rs
+++ b/pensyve-mcp-gateway/src/main.rs
@@ -331,7 +331,7 @@ async fn async_main(config: GatewayConfig, res: InitResources) -> Result<()> {
             Arc::default(),
             {
                 let mut cfg = StreamableHttpServerConfig::default();
-                cfg.stateful_mode = false;
+                cfg.legacy_session_mode = false;
                 cfg.json_response = true;
                 cfg.sse_keep_alive = None;
                 cfg.cancellation_token = ct.child_token();

--- a/pensyve-mcp-gateway/tests/integration_test.rs
+++ b/pensyve-mcp-gateway/tests/integration_test.rs
@@ -85,7 +85,7 @@ async fn start_test_server(state: Arc<PensyveState>) -> (String, CancellationTok
             Arc::default(),
             {
                 let mut cfg = StreamableHttpServerConfig::default();
-                cfg.stateful_mode = false;
+                cfg.legacy_session_mode = false;
                 cfg.json_response = true;
                 cfg.sse_keep_alive = None;
                 cfg.cancellation_token = ct.child_token();

--- a/pensyve-mcp-gateway/tests/test_multi_tenant_propagation.rs
+++ b/pensyve-mcp-gateway/tests/test_multi_tenant_propagation.rs
@@ -122,7 +122,7 @@ async fn start_test_server(mgr: Arc<TenantStateManager>) -> (String, Cancellatio
             Arc::default(),
             {
                 let mut cfg = StreamableHttpServerConfig::default();
-                cfg.stateful_mode = false;
+                cfg.legacy_session_mode = false;
                 cfg.json_response = true;
                 cfg.sse_keep_alive = None;
                 cfg.cancellation_token = ct.child_token();

--- a/pensyve-mcp-tools/Cargo.toml
+++ b/pensyve-mcp-tools/Cargo.toml
@@ -14,7 +14,7 @@ name = "pensyve_mcp_tools"
 
 [dependencies]
 pensyve-core = { path = "../pensyve-core", version = "2.6.1" }
-rmcp = { version = "2.2", features = ["server", "macros"] }
+rmcp = { version = "3.1", features = ["server", "macros"] }
 tokio = { version = "1", features = ["full"] }
 # G1/P3a: needed for `CancellationToken::new()` passed to
 # `ConsolidationEngine::run` from the post-`episode_end` background spawn.

--- a/pensyve-mcp/Cargo.toml
+++ b/pensyve-mcp/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 [dependencies]
 pensyve-core = { path = "../pensyve-core", version = "2.6.1" }
 pensyve-mcp-tools = { path = "../pensyve-mcp-tools", version = "2.6.1" }
-rmcp = { version = "2.2", features = ["server", "transport-io", "macros"] }
+rmcp = { version = "3.1", features = ["server", "transport-io", "macros"] }
 tokio = { version = "1", features = ["full"] }
 uuid = { version = "1", features = ["v4"] }
 dirs = "6"


### PR DESCRIPTION
Completes the dependency-upgrade round by landing the one dependabot bump that couldn't merge as-is.

Dependabot's #231 only bumped `Cargo.lock` while all three MCP crates pin `rmcp = "2.2"`, which made the lockfile inconsistent with the manifests and failed CI. This does the real migration:

- Bump `rmcp = "2.2"` → `"3.1"` in `pensyve-mcp`, `pensyve-mcp-tools`, and `pensyve-mcp-gateway`
- The only API change affecting us: `StreamableHttpServerConfig.stateful_mode` was renamed to `legacy_session_mode` (sessions were removed from the newest MCP protocol version per SEP-2567; the flag now only governs legacy clients, and our stateless-serving behavior is unchanged). Updated in `main.rs` and the two gateway test harnesses.

Closes #231.

## Verification

Local, on top of current main (i.e. including #218's new `pensyve_forget_memory` tool and #242's dep bumps — a combination no prior CI run covered):

- `cargo test -p pensyve-mcp -p pensyve-mcp-tools -p pensyve-mcp-gateway`: all pass, including the gateway integration suite asserting the 10-tool list
- `cargo fmt --check` and `cargo clippy --workspace` clean

https://claude.ai/code/session_01AsVz67dYuk3dufxA683hJA