### PR TITLE
fix(consolidation): superseded facts no longer re-promoted from unchanged episodic sources

### DIFF
--- a/pensyve-core/src/consolidation/mod.rs
+++ b/pensyve-core/src/consolidation/mod.rs
@@ -222,8 +222,12 @@ impl ConsolidationEngine {
         _policy: &NetworkPolicy,
         cancel: &CancellationToken,
     ) -> Result<usize, ConsolidationError> {
-        // Fetch all memories for this namespace to identify episodic ones.
-        let all_memories = storage.get_all_memories_by_namespace(namespace_id)?;
+        // Fetch all memories for this namespace, superseded history included.
+        // The guard below needs the history: a superseded promotion is a fact
+        // the operator corrected, and re-deriving it from unchanged episodic
+        // evidence would silently undo that correction.
+        let all_memories =
+            storage.get_all_memories_by_namespace_including_superseded(namespace_id)?;
 
         // Partition episodic memories, grouped by about_entity. In the same
         // sweep, record every promotion this namespace already holds so a
@@ -232,12 +236,15 @@ impl ConsolidationEngine {
         let mut already_promoted: HashSet<(Uuid, String)> = HashSet::new();
         for mem in all_memories {
             match mem {
-                Memory::Episodic(em) => {
+                // Superseded episodes are retired evidence and must not seed
+                // new clusters; only live rows feed the clustering pass.
+                Memory::Episodic(em) if em.superseded_by.is_none() => {
                     episodic_by_entity
                         .entry(em.about_entity)
                         .or_default()
                         .push(em);
                 }
+                // Both live and superseded promotions seed the guard.
                 Memory::Semantic(sm) if sm.predicate == "mentioned" => {
                     already_promoted.insert((sm.subject, sm.object));
                 }

--- a/pensyve-core/src/consolidation/mod.rs
+++ b/pensyve-core/src/consolidation/mod.rs
@@ -48,10 +48,10 @@
 pub mod dmem;
 pub mod typed_slots;
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
@@ -124,6 +124,52 @@ pub struct ConsolidationStats {
 pub struct ConsolidationEngine;
 
 const SIMILARITY_THRESHOLD: f32 = 0.8;
+
+/// Live episodic evidence eligible for clustering, grouped by `about_entity`.
+type EpisodicByEntity = HashMap<Uuid, Vec<EpisodicMemory>>;
+
+/// Guards keyed on the `(about_entity, content)` pair a promotion would write.
+type PromotionGuards = HashMap<(Uuid, String), PromotionGuard>;
+
+/// What an `(about_entity, content)` key the namespace already holds implies
+/// for a cluster that would re-derive it.
+///
+/// The promotion pass is a pure function of the episodic set, so a stable
+/// cluster yields the same key on every run. Whether re-deriving it is a
+/// duplicate or a legitimate re-assertion depends on the fate of the rows
+/// already holding that key.
+#[derive(Clone, Copy)]
+enum PromotionGuard {
+    /// A live row holds this key. Re-deriving it would duplicate a fact that
+    /// is already current, so the key is closed regardless of the evidence.
+    Active,
+    /// Every row holding this key is superseded; the moment carried here is
+    /// the most recent supersession. A correction speaks to the evidence that
+    /// existed when it was made: re-deriving the key from episodes that all
+    /// predate it would undo the correction, but episodes recorded after it
+    /// are new testimony and may re-assert the fact (issue #227).
+    SupersededAt(DateTime<Utc>),
+}
+
+impl PromotionGuard {
+    /// Fold another row's verdict for the same key into this one. A live row
+    /// closes the key outright; between two supersessions the later one wins,
+    /// since it is the correction still standing.
+    fn merge(self, other: Self) -> Self {
+        match (self, other) {
+            (Self::Active, _) | (_, Self::Active) => Self::Active,
+            (Self::SupersededAt(a), Self::SupersededAt(b)) => Self::SupersededAt(a.max(b)),
+        }
+    }
+
+    /// Whether a cluster with these episode timestamps may still promote.
+    fn admits(self, episode_times: impl IntoIterator<Item = DateTime<Utc>>) -> bool {
+        match self {
+            Self::Active => false,
+            Self::SupersededAt(at) => episode_times.into_iter().any(|t| t > at),
+        }
+    }
+}
 
 impl ConsolidationEngine {
     /// Run all consolidation jobs for a namespace.
@@ -201,6 +247,47 @@ impl ConsolidationEngine {
     // Job 1: Episodic → Semantic promotion
     // -----------------------------------------------------------------------
 
+    /// Split a namespace's memories into the live episodic evidence the
+    /// promotion pass may cluster, grouped by `about_entity`, and the guards
+    /// its existing `mentioned` rows impose on re-derivation.
+    ///
+    /// Superseded episodes are retired evidence and must not seed new
+    /// clusters, so only live rows feed the clustering pass. Both live and
+    /// superseded promotions seed the guard map, but they bind differently —
+    /// see [`PromotionGuard`].
+    fn partition_for_promotion(all_memories: Vec<Memory>) -> (EpisodicByEntity, PromotionGuards) {
+        let mut episodic_by_entity = EpisodicByEntity::new();
+        let mut already_promoted = PromotionGuards::new();
+
+        for mem in all_memories {
+            match mem {
+                Memory::Episodic(em) if em.superseded_by.is_none() => {
+                    episodic_by_entity
+                        .entry(em.about_entity)
+                        .or_default()
+                        .push(em);
+                }
+                Memory::Semantic(sm) if sm.predicate == "mentioned" => {
+                    let guard = match (sm.superseded_by, sm.invalid_at) {
+                        // Superseded with a stamped moment: the key reopens
+                        // for evidence recorded after it. Everything else —
+                        // a live row, or a supersession with no moment to
+                        // date evidence against — closes the key outright.
+                        (Some(_), Some(at)) => PromotionGuard::SupersededAt(at),
+                        _ => PromotionGuard::Active,
+                    };
+                    already_promoted
+                        .entry((sm.subject, sm.object))
+                        .and_modify(|existing| *existing = existing.merge(guard))
+                        .or_insert(guard);
+                }
+                _ => {}
+            }
+        }
+
+        (episodic_by_entity, already_promoted)
+    }
+
     /// Scan episodic memories for repeated facts about the same entity.
     /// When 2+ episodic memories for the same `about_entity` have cosine similarity
     /// > 0.8, promote them to a single `SemanticMemory`.
@@ -224,33 +311,13 @@ impl ConsolidationEngine {
     ) -> Result<usize, ConsolidationError> {
         // Fetch all memories for this namespace, superseded history included.
         // The guard below needs the history: a superseded promotion is a fact
-        // the operator corrected, and re-deriving it from unchanged episodic
-        // evidence would silently undo that correction.
+        // the operator corrected, and re-deriving it from the evidence that
+        // correction overrode would silently undo it.
         let all_memories =
             storage.get_all_memories_by_namespace_including_superseded(namespace_id)?;
 
-        // Partition episodic memories, grouped by about_entity. In the same
-        // sweep, record every promotion this namespace already holds so a
-        // re-run cannot mint a second copy of it.
-        let mut episodic_by_entity: HashMap<Uuid, Vec<EpisodicMemory>> = HashMap::new();
-        let mut already_promoted: HashSet<(Uuid, String)> = HashSet::new();
-        for mem in all_memories {
-            match mem {
-                // Superseded episodes are retired evidence and must not seed
-                // new clusters; only live rows feed the clustering pass.
-                Memory::Episodic(em) if em.superseded_by.is_none() => {
-                    episodic_by_entity
-                        .entry(em.about_entity)
-                        .or_default()
-                        .push(em);
-                }
-                // Both live and superseded promotions seed the guard.
-                Memory::Semantic(sm) if sm.predicate == "mentioned" => {
-                    already_promoted.insert((sm.subject, sm.object));
-                }
-                _ => {}
-            }
-        }
+        let (episodic_by_entity, mut already_promoted) =
+            Self::partition_for_promotion(all_memories);
 
         let mut promoted = 0usize;
 
@@ -333,9 +400,13 @@ impl ConsolidationEngine {
                 // stable cluster is re-promoted once per run — an episode_end
                 // hook firing per session turns that into unbounded duplicate
                 // growth in semantic memory.
-                if !already_promoted.insert((about_entity, most_recent.content.clone())) {
+                let key = (about_entity, most_recent.content.clone());
+                if let Some(guard) = already_promoted.get(&key)
+                    && !guard.admits(cluster.iter().map(|&idx| memories[idx].timestamp))
+                {
                     continue;
                 }
+                already_promoted.insert(key, PromotionGuard::Active);
 
                 let confidence = (cluster_size as f32 * 0.3).min(1.0);
                 let source_episodes: Vec<Uuid> = cluster

--- a/pensyve-core/tests/test_consolidation_supersession_guard.rs
+++ b/pensyve-core/tests/test_consolidation_supersession_guard.rs
@@ -357,11 +357,13 @@ fn new_evidence_reasserting_same_content_promotes_after_supersession() {
         0,
         "the re-asserted fact must not duplicate on the next run"
     );
+    let live = active_mentioned(&storage, ns.id);
     assert_eq!(
         live.iter()
             .filter(|(_, object)| object == "prefers dark mode")
             .count(),
-        1
+        1,
+        "exactly one live row may carry the re-asserted content, found: {live:?}"
     );
 }
 

--- a/pensyve-core/tests/test_consolidation_supersession_guard.rs
+++ b/pensyve-core/tests/test_consolidation_supersession_guard.rs
@@ -71,17 +71,25 @@ fn run_once(storage: &SqliteBackend, embedder: &OnnxEmbedder, ns: Uuid) -> usize
     .promoted
 }
 
-/// The single `mentioned` row currently live for `entity`.
+/// The single `mentioned` row currently live in `ns`. Panics unless the
+/// namespace holds exactly one, so an unexpected extra row fails loudly here
+/// rather than silently steering a supersession onto the wrong row.
 fn active_mentioned_id(storage: &SqliteBackend, ns: Uuid) -> Uuid {
-    storage
+    let ids: Vec<Uuid> = storage
         .get_all_memories_by_namespace(ns)
         .unwrap()
         .into_iter()
-        .find_map(|m| match m {
+        .filter_map(|m| match m {
             Memory::Semantic(sm) if sm.predicate == "mentioned" => Some(sm.id),
             _ => None,
         })
-        .expect("promoted semantic row")
+        .collect();
+    assert_eq!(
+        ids.len(),
+        1,
+        "expected exactly one live `mentioned` row, found {ids:?}"
+    );
+    ids[0]
 }
 
 /// Save one episodic memory stamped at `at`. Returns its id.

--- a/pensyve-core/tests/test_consolidation_supersession_guard.rs
+++ b/pensyve-core/tests/test_consolidation_supersession_guard.rs
@@ -1,0 +1,224 @@
+//! Promotion must not resurrect superseded facts.
+//!
+//! The promotion pass seeds its idempotency guard from the semantic rows the
+//! namespace already holds. Superseded rows are excluded from the live bulk
+//! read by design (they are history, not current truth), so a corrected fact
+//! dropped out of the guard set while its source episodic memories stayed
+//! intact. The next run re-derived the identical `(about_entity, content)`
+//! pair from that unchanged evidence and wrote a fresh ACTIVE semantic row,
+//! undoing the correction.
+//!
+//! The re-assertion pathway must survive the fix: genuinely new episodic
+//! evidence carrying different content still promotes after a supersession.
+
+use chrono::Utc;
+use pensyve_core::config::{ConsolidationConfig, PensyveConfig};
+use pensyve_core::consolidation::ConsolidationEngine;
+use pensyve_core::embedding::OnnxEmbedder;
+use pensyve_core::network_policy::NetworkPolicy;
+use pensyve_core::storage::StorageTrait;
+use pensyve_core::storage::sqlite::SqliteBackend;
+use pensyve_core::types::{Episode, EpisodicMemory, Memory, Namespace, SemanticMemory};
+use tempfile::TempDir;
+use tokio_util::sync::CancellationToken;
+use uuid::Uuid;
+
+fn make_config() -> ConsolidationConfig {
+    PensyveConfig::default().consolidation
+}
+
+/// Live (non-superseded) `mentioned` rows as `(subject, object)` pairs.
+fn active_mentioned(storage: &SqliteBackend, ns: Uuid) -> Vec<(Uuid, String)> {
+    storage
+        .get_all_memories_by_namespace(ns)
+        .expect("get_all_memories_by_namespace")
+        .into_iter()
+        .filter_map(|m| match m {
+            Memory::Semantic(sm) if sm.predicate == "mentioned" => Some((sm.subject, sm.object)),
+            _ => None,
+        })
+        .collect()
+}
+
+/// Look a semantic row up by id across the full history, superseded included.
+fn find_semantic(storage: &SqliteBackend, ns: Uuid, id: Uuid) -> SemanticMemory {
+    storage
+        .get_all_memories_by_namespace_including_superseded(ns)
+        .expect("get_all_memories_by_namespace_including_superseded")
+        .into_iter()
+        .find_map(|m| match m {
+            Memory::Semantic(sm) if sm.id == id => Some(sm),
+            _ => None,
+        })
+        .expect("semantic row present in history")
+}
+
+fn run_once(storage: &SqliteBackend, embedder: &OnnxEmbedder, ns: Uuid) -> usize {
+    ConsolidationEngine::run(
+        storage,
+        embedder,
+        &make_config(),
+        ns,
+        &NetworkPolicy::Disabled,
+        &CancellationToken::new(),
+    )
+    .expect("consolidation run")
+    .promoted
+}
+
+fn seed_cluster(
+    storage: &SqliteBackend,
+    embedder: &OnnxEmbedder,
+    ns: Uuid,
+    episode_id: Uuid,
+    source_id: Uuid,
+    entity_id: Uuid,
+    content: &str,
+) {
+    for i in 0..2 {
+        let mut mem = EpisodicMemory::new(ns, episode_id, source_id, entity_id, content);
+        mem.embedding = embedder.embed(&mem.content).unwrap();
+        mem.timestamp = Utc::now() - chrono::Duration::seconds(i);
+        storage.save_episodic(&mem).unwrap();
+    }
+}
+
+/// A superseded promotion must not be re-minted from unchanged episodic
+/// evidence — the correction has to hold across later consolidation runs.
+#[test]
+fn superseded_promotion_is_not_reminted_from_unchanged_evidence() {
+    let tmp = TempDir::new().unwrap();
+    let storage = SqliteBackend::open(tmp.path()).expect("open storage");
+    let embedder = OnnxEmbedder::new_mock(64);
+
+    let ns = Namespace::new("supersession_guard");
+    storage.save_namespace(&ns).unwrap();
+    let entity_id = Uuid::new_v4();
+    let source_id = Uuid::new_v4();
+    let episode = Episode::new(ns.id, vec![source_id, entity_id]);
+    storage.save_episode(&episode).unwrap();
+
+    seed_cluster(
+        &storage,
+        &embedder,
+        ns.id,
+        episode.id,
+        source_id,
+        entity_id,
+        "prefers dark mode",
+    );
+
+    assert_eq!(
+        run_once(&storage, &embedder, ns.id),
+        1,
+        "first run must promote the cluster exactly once"
+    );
+    let promoted_rows = active_mentioned(&storage, ns.id);
+    assert_eq!(promoted_rows.len(), 1);
+
+    // Correct the fact: a new semantic row supersedes the promoted one.
+    let promoted_id = storage
+        .get_all_memories_by_namespace(ns.id)
+        .unwrap()
+        .into_iter()
+        .find_map(|m| match m {
+            Memory::Semantic(sm) if sm.predicate == "mentioned" => Some(sm.id),
+            _ => None,
+        })
+        .expect("promoted semantic row");
+    let correction = SemanticMemory::new(ns.id, entity_id, "mentioned", "prefers light mode", 0.9);
+    storage.save_semantic(&correction).unwrap();
+    assert!(
+        storage
+            .supersede_memory(promoted_id, correction.id, Utc::now())
+            .unwrap(),
+        "supersession must mark the promoted row"
+    );
+
+    // The episodic evidence is untouched, so nothing new is derivable.
+    for pass in 2..=3 {
+        assert_eq!(
+            run_once(&storage, &embedder, ns.id),
+            0,
+            "run {pass} resurrected a superseded fact"
+        );
+    }
+
+    let live = active_mentioned(&storage, ns.id);
+    assert_eq!(
+        live,
+        vec![(entity_id, "prefers light mode".to_string())],
+        "only the correction may remain active, found: {live:?}"
+    );
+    assert!(
+        find_semantic(&storage, ns.id, promoted_id)
+            .superseded_by
+            .is_some(),
+        "the original promotion must stay superseded"
+    );
+}
+
+/// The re-assertion pathway stays open: after a supersession, genuinely new
+/// episodic evidence with different content still promotes.
+#[test]
+fn new_evidence_still_promotes_after_supersession() {
+    let tmp = TempDir::new().unwrap();
+    let storage = SqliteBackend::open(tmp.path()).expect("open storage");
+    let embedder = OnnxEmbedder::new_mock(64);
+
+    let ns = Namespace::new("supersession_reassertion");
+    storage.save_namespace(&ns).unwrap();
+    let entity_id = Uuid::new_v4();
+    let source_id = Uuid::new_v4();
+    let episode = Episode::new(ns.id, vec![source_id, entity_id]);
+    storage.save_episode(&episode).unwrap();
+
+    seed_cluster(
+        &storage, &embedder, ns.id, episode.id, source_id, entity_id, "uses zsh",
+    );
+    assert_eq!(run_once(&storage, &embedder, ns.id), 1);
+
+    let promoted_id = storage
+        .get_all_memories_by_namespace(ns.id)
+        .unwrap()
+        .into_iter()
+        .find_map(|m| match m {
+            Memory::Semantic(sm) if sm.predicate == "mentioned" => Some(sm.id),
+            _ => None,
+        })
+        .expect("promoted semantic row");
+    let correction = SemanticMemory::new(ns.id, entity_id, "mentioned", "uses bash", 0.9);
+    storage.save_semantic(&correction).unwrap();
+    assert!(
+        storage
+            .supersede_memory(promoted_id, correction.id, Utc::now())
+            .unwrap()
+    );
+
+    // New observations arrive for the same entity carrying different content.
+    seed_cluster(
+        &storage,
+        &embedder,
+        ns.id,
+        episode.id,
+        source_id,
+        entity_id,
+        "uses fish",
+    );
+
+    assert_eq!(
+        run_once(&storage, &embedder, ns.id),
+        1,
+        "new episodic evidence must still promote after a supersession"
+    );
+
+    let live = active_mentioned(&storage, ns.id);
+    assert!(
+        live.contains(&(entity_id, "uses fish".to_string())),
+        "the newly derived fact must be active, found: {live:?}"
+    );
+    assert!(
+        !live.contains(&(entity_id, "uses zsh".to_string())),
+        "the superseded fact must not come back, found: {live:?}"
+    );
+}

--- a/pensyve-core/tests/test_consolidation_supersession_guard.rs
+++ b/pensyve-core/tests/test_consolidation_supersession_guard.rs
@@ -8,10 +8,15 @@
 //! pair from that unchanged evidence and wrote a fresh ACTIVE semantic row,
 //! undoing the correction.
 //!
-//! The re-assertion pathway must survive the fix: genuinely new episodic
-//! evidence carrying different content still promotes after a supersession.
+//! The re-assertion pathway must survive the fix. Suppression is scoped to the
+//! evidence the correction overrode: a cluster whose episodes all predate the
+//! supersession is the old derivation and stays suppressed, while a cluster
+//! carrying at least one episode recorded after it is new testimony and
+//! promotes — including when it re-asserts the very content that was
+//! corrected. Superseded episodes are retired evidence and cannot cluster at
+//! all.
 
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use pensyve_core::config::{ConsolidationConfig, PensyveConfig};
 use pensyve_core::consolidation::ConsolidationEngine;
 use pensyve_core::embedding::OnnxEmbedder;
@@ -66,6 +71,39 @@ fn run_once(storage: &SqliteBackend, embedder: &OnnxEmbedder, ns: Uuid) -> usize
     .promoted
 }
 
+/// The single `mentioned` row currently live for `entity`.
+fn active_mentioned_id(storage: &SqliteBackend, ns: Uuid) -> Uuid {
+    storage
+        .get_all_memories_by_namespace(ns)
+        .unwrap()
+        .into_iter()
+        .find_map(|m| match m {
+            Memory::Semantic(sm) if sm.predicate == "mentioned" => Some(sm.id),
+            _ => None,
+        })
+        .expect("promoted semantic row")
+}
+
+/// Save one episodic memory stamped at `at`. Returns its id.
+fn save_episode_at(
+    storage: &SqliteBackend,
+    embedder: &OnnxEmbedder,
+    ns: Uuid,
+    episode_id: Uuid,
+    source_id: Uuid,
+    entity_id: Uuid,
+    content: &str,
+    at: DateTime<Utc>,
+) -> Uuid {
+    let mut mem = EpisodicMemory::new(ns, episode_id, source_id, entity_id, content);
+    mem.embedding = embedder.embed(&mem.content).unwrap();
+    mem.timestamp = at;
+    storage.save_episodic(&mem).unwrap();
+    mem.id
+}
+
+/// Two identical episodes around `at` — enough to clear the 2-member minimum
+/// and cluster under the mock embedder.
 fn seed_cluster(
     storage: &SqliteBackend,
     embedder: &OnnxEmbedder,
@@ -74,17 +112,24 @@ fn seed_cluster(
     source_id: Uuid,
     entity_id: Uuid,
     content: &str,
+    at: DateTime<Utc>,
 ) {
     for i in 0..2 {
-        let mut mem = EpisodicMemory::new(ns, episode_id, source_id, entity_id, content);
-        mem.embedding = embedder.embed(&mem.content).unwrap();
-        mem.timestamp = Utc::now() - chrono::Duration::seconds(i);
-        storage.save_episodic(&mem).unwrap();
+        save_episode_at(
+            storage,
+            embedder,
+            ns,
+            episode_id,
+            source_id,
+            entity_id,
+            content,
+            at - chrono::Duration::seconds(i),
+        );
     }
 }
 
-/// A superseded promotion must not be re-minted from unchanged episodic
-/// evidence — the correction has to hold across later consolidation runs.
+/// A superseded promotion must not be re-minted from the evidence the
+/// correction overrode — the correction has to hold across later runs.
 #[test]
 fn superseded_promotion_is_not_reminted_from_unchanged_evidence() {
     let tmp = TempDir::new().unwrap();
@@ -98,6 +143,9 @@ fn superseded_promotion_is_not_reminted_from_unchanged_evidence() {
     let episode = Episode::new(ns.id, vec![source_id, entity_id]);
     storage.save_episode(&episode).unwrap();
 
+    let observed_at = Utc::now() - chrono::Duration::hours(2);
+    let corrected_at = Utc::now() - chrono::Duration::hours(1);
+
     seed_cluster(
         &storage,
         &embedder,
@@ -106,6 +154,7 @@ fn superseded_promotion_is_not_reminted_from_unchanged_evidence() {
         source_id,
         entity_id,
         "prefers dark mode",
+        observed_at,
     );
 
     assert_eq!(
@@ -117,25 +166,18 @@ fn superseded_promotion_is_not_reminted_from_unchanged_evidence() {
     assert_eq!(promoted_rows.len(), 1);
 
     // Correct the fact: a new semantic row supersedes the promoted one.
-    let promoted_id = storage
-        .get_all_memories_by_namespace(ns.id)
-        .unwrap()
-        .into_iter()
-        .find_map(|m| match m {
-            Memory::Semantic(sm) if sm.predicate == "mentioned" => Some(sm.id),
-            _ => None,
-        })
-        .expect("promoted semantic row");
+    let promoted_id = active_mentioned_id(&storage, ns.id);
     let correction = SemanticMemory::new(ns.id, entity_id, "mentioned", "prefers light mode", 0.9);
     storage.save_semantic(&correction).unwrap();
     assert!(
         storage
-            .supersede_memory(promoted_id, correction.id, Utc::now())
+            .supersede_memory(promoted_id, correction.id, corrected_at)
             .unwrap(),
         "supersession must mark the promoted row"
     );
 
-    // The episodic evidence is untouched, so nothing new is derivable.
+    // The episodic evidence is untouched and every episode predates the
+    // correction, so nothing new is derivable.
     for pass in 2..=3 {
         assert_eq!(
             run_once(&storage, &embedder, ns.id),
@@ -173,25 +215,27 @@ fn new_evidence_still_promotes_after_supersession() {
     let episode = Episode::new(ns.id, vec![source_id, entity_id]);
     storage.save_episode(&episode).unwrap();
 
+    let observed_at = Utc::now() - chrono::Duration::hours(2);
+    let corrected_at = Utc::now() - chrono::Duration::hours(1);
+
     seed_cluster(
-        &storage, &embedder, ns.id, episode.id, source_id, entity_id, "uses zsh",
+        &storage,
+        &embedder,
+        ns.id,
+        episode.id,
+        source_id,
+        entity_id,
+        "uses zsh",
+        observed_at,
     );
     assert_eq!(run_once(&storage, &embedder, ns.id), 1);
 
-    let promoted_id = storage
-        .get_all_memories_by_namespace(ns.id)
-        .unwrap()
-        .into_iter()
-        .find_map(|m| match m {
-            Memory::Semantic(sm) if sm.predicate == "mentioned" => Some(sm.id),
-            _ => None,
-        })
-        .expect("promoted semantic row");
+    let promoted_id = active_mentioned_id(&storage, ns.id);
     let correction = SemanticMemory::new(ns.id, entity_id, "mentioned", "uses bash", 0.9);
     storage.save_semantic(&correction).unwrap();
     assert!(
         storage
-            .supersede_memory(promoted_id, correction.id, Utc::now())
+            .supersede_memory(promoted_id, correction.id, corrected_at)
             .unwrap()
     );
 
@@ -204,6 +248,7 @@ fn new_evidence_still_promotes_after_supersession() {
         source_id,
         entity_id,
         "uses fish",
+        Utc::now(),
     );
 
     assert_eq!(
@@ -220,5 +265,179 @@ fn new_evidence_still_promotes_after_supersession() {
     assert!(
         !live.contains(&(entity_id, "uses zsh".to_string())),
         "the superseded fact must not come back, found: {live:?}"
+    );
+}
+
+/// Suppression is scoped to the overridden evidence, not to the content.
+///
+/// A correction says what was true *then*; it cannot bind testimony recorded
+/// afterwards. When fresh episodes re-assert the corrected content — the fact
+/// changed back — that is the re-assertion pathway #227 keeps open, and it
+/// must fire even though the `(entity, content)` key matches a superseded row
+/// exactly. A guard that tombstones the key forever would silence the entity
+/// on that subject permanently.
+#[test]
+fn new_evidence_reasserting_same_content_promotes_after_supersession() {
+    let tmp = TempDir::new().unwrap();
+    let storage = SqliteBackend::open(tmp.path()).expect("open storage");
+    let embedder = OnnxEmbedder::new_mock(64);
+
+    let ns = Namespace::new("supersession_reassert_same_content");
+    storage.save_namespace(&ns).unwrap();
+    let entity_id = Uuid::new_v4();
+    let source_id = Uuid::new_v4();
+    let episode = Episode::new(ns.id, vec![source_id, entity_id]);
+    storage.save_episode(&episode).unwrap();
+
+    let observed_at = Utc::now() - chrono::Duration::days(90);
+    let corrected_at = Utc::now() - chrono::Duration::days(60);
+
+    seed_cluster(
+        &storage,
+        &embedder,
+        ns.id,
+        episode.id,
+        source_id,
+        entity_id,
+        "prefers dark mode",
+        observed_at,
+    );
+    assert_eq!(run_once(&storage, &embedder, ns.id), 1);
+
+    let promoted_id = active_mentioned_id(&storage, ns.id);
+    let correction = SemanticMemory::new(ns.id, entity_id, "mentioned", "prefers light mode", 0.9);
+    storage.save_semantic(&correction).unwrap();
+    assert!(
+        storage
+            .supersede_memory(promoted_id, correction.id, corrected_at)
+            .unwrap()
+    );
+    assert_eq!(
+        run_once(&storage, &embedder, ns.id),
+        0,
+        "the pre-correction evidence alone must stay suppressed"
+    );
+
+    // Months later the entity says it again. This is new testimony, not the
+    // evidence the correction overrode.
+    seed_cluster(
+        &storage,
+        &embedder,
+        ns.id,
+        episode.id,
+        source_id,
+        entity_id,
+        "prefers dark mode",
+        Utc::now(),
+    );
+
+    assert_eq!(
+        run_once(&storage, &embedder, ns.id),
+        1,
+        "episodes recorded after the correction must re-assert the fact"
+    );
+    let live = active_mentioned(&storage, ns.id);
+    assert!(
+        live.contains(&(entity_id, "prefers dark mode".to_string())),
+        "the re-asserted fact must be active again, found: {live:?}"
+    );
+
+    // Re-assertion is a promotion, not a licence to keep promoting: the
+    // freshly written row is active, so the key is guarded unconditionally.
+    assert_eq!(
+        run_once(&storage, &embedder, ns.id),
+        0,
+        "the re-asserted fact must not duplicate on the next run"
+    );
+    assert_eq!(
+        live.iter()
+            .filter(|(_, object)| object == "prefers dark mode")
+            .count(),
+        1
+    );
+}
+
+/// Superseded episodes are retired evidence: they cannot make up the numbers
+/// for a cluster, while the live episodes beside them stay eligible.
+#[test]
+fn superseded_episodic_evidence_cannot_support_a_cluster() {
+    let tmp = TempDir::new().unwrap();
+    let storage = SqliteBackend::open(tmp.path()).expect("open storage");
+    let embedder = OnnxEmbedder::new_mock(64);
+
+    let ns = Namespace::new("supersession_retired_episodes");
+    storage.save_namespace(&ns).unwrap();
+    let entity_id = Uuid::new_v4();
+    let source_id = Uuid::new_v4();
+    let episode = Episode::new(ns.id, vec![source_id, entity_id]);
+    storage.save_episode(&episode).unwrap();
+
+    // Two identical episodes — a would-be cluster.
+    let first = save_episode_at(
+        &storage,
+        &embedder,
+        ns.id,
+        episode.id,
+        source_id,
+        entity_id,
+        "deploys on Fridays",
+        Utc::now() - chrono::Duration::hours(2),
+    );
+    save_episode_at(
+        &storage,
+        &embedder,
+        ns.id,
+        episode.id,
+        source_id,
+        entity_id,
+        "deploys on Fridays",
+        Utc::now() - chrono::Duration::hours(1),
+    );
+
+    // Retire one of them behind an unrelated replacement, leaving a single
+    // live episode on that content.
+    let replacement = save_episode_at(
+        &storage,
+        &embedder,
+        ns.id,
+        episode.id,
+        source_id,
+        entity_id,
+        "deploys behind a feature flag",
+        Utc::now(),
+    );
+    assert!(
+        storage
+            .supersede_memory(first, replacement, Utc::now())
+            .unwrap()
+    );
+
+    assert_eq!(
+        run_once(&storage, &embedder, ns.id),
+        0,
+        "a retired episode must not make up the second member of a cluster"
+    );
+    assert!(active_mentioned(&storage, ns.id).is_empty());
+
+    // A live episode restores the pair, and the pass promotes as usual.
+    save_episode_at(
+        &storage,
+        &embedder,
+        ns.id,
+        episode.id,
+        source_id,
+        entity_id,
+        "deploys on Fridays",
+        Utc::now(),
+    );
+
+    assert_eq!(
+        run_once(&storage, &embedder, ns.id),
+        1,
+        "live evidence beside a retired episode must stay eligible"
+    );
+    assert_eq!(
+        active_mentioned(&storage, ns.id),
+        vec![(entity_id, "deploys on Fridays".to_string())]
     );
 }


### PR DESCRIPTION
## The bug

`promote_episodic_to_semantic` seeds its idempotency guard, keyed on `(about_entity, content)`, from `get_all_memories_by_namespace` — which excludes superseded rows by design (supersession primitive, #200).

So when a consolidation-produced semantic `mentioned` fact was superseded — i.e. someone corrected it — its key dropped out of the guard set, while the episodic memories it was derived from stayed intact and active. The next consolidation run re-derived the identical `(entity, content)` pair from that unchanged evidence and wrote a fresh **ACTIVE** semantic row. The correction was silently undone, and because `pensyve_episode_end` spawns a namespace consolidation, this recurred every session.

## The fix

Read the namespace with `get_all_memories_by_namespace_including_superseded` so superseded promotions are visible to the guard, and record *why* each key is closed rather than just that it is:

- **`Active`** — a live row holds the key. Closed unconditionally; this is the pre-existing duplicate suppression.
- **`SupersededAt(t)`** — every row holding the key is superseded, `t` being the supersession moment stamped on the row by the supersession primitive (`invalid_at`, the third argument to `supersede_memory`). Closed only against clusters whose episodes *all* predate `t`.

That scoping is what keeps #227's two cases apart. A correction speaks to the evidence that existed when it was made, so re-deriving the key from episodes older than it would undo the correction; a cluster carrying at least one episode recorded *after* it is new testimony and promotes — **including when it re-asserts the very content that was corrected**. Keying superseded rows forever would have tombstoned the entity on that subject permanently.

Where several rows share a key, a live row wins and otherwise the latest supersession does, since that is the correction still standing. A supersession with no stamped moment leaves nothing to date evidence against, so it keeps closing the key outright.

Because the history read also returns superseded *episodic* rows, the partition sweep skips those: retired evidence must not seed clusters, which keeps clustering behaving exactly as before. The sweep moved into `partition_for_promotion` to keep the promotion pass within its line budget.

No new storage method was needed; the trait already declared `get_all_memories_by_namespace_including_superseded`.

## Tests

New file `pensyve-core/tests/test_consolidation_supersession_guard.rs`:

1. `superseded_promotion_is_not_reminted_from_unchanged_evidence` — the regression test. Promote, supersede with a correction, consolidate twice more. Asserts no new promotions, that the only active `mentioned` row is the correction, and that the original row is still superseded.
2. `new_evidence_reasserting_same_content_promotes_after_supersession` — the re-assertion pathway with **identical** content: "dark mode" promoted → corrected to "light mode" → fresh episodes say "dark mode" again 60 days later → promotes, and does not duplicate on the run after that.
3. `new_evidence_still_promotes_after_supersession` — re-assertion with different content.
4. `superseded_episodic_evidence_cannot_support_a_cluster` — a retired episode cannot make up the second member of a cluster, while live evidence beside it stays eligible.

Tests 1 and 3 were written first and failed against the unfixed code:

```
---- superseded_promotion_is_not_reminted_from_unchanged_evidence stdout ----
assertion `left == right` failed: run 2 resurrected a superseded fact
  left: 1
 right: 0

---- new_evidence_still_promotes_after_supersession stdout ----
assertion `left == right` failed: new episodic evidence must still promote after a supersession
  left: 2
 right: 1
```

(The second is the same bug from the other side: the run promoted the new fact *plus* the resurrected superseded one.)

Test 2 was then written against the first commit's tombstone guard and failed there:

```
---- new_evidence_reasserting_same_content_promotes_after_supersession stdout ----
assertion `left == right` failed: episodes recorded after the correction must re-assert the fact
  left: 0
 right: 1
```

Supersession tests pin explicit timestamps, so the ordering they depend on is deterministic rather than wall-clock luck.

## Verification

- `cargo test -p pensyve-core` — 640 passed, 0 failed, 9 ignored
- `cargo test -p pensyve-core --features postgres` — 644 passed, 0 failed, 9 ignored
- `cargo fmt --check -p pensyve-core` — clean
- `cargo clippy -p pensyve-core --all-targets` — clean
- The three pre-existing tests in `test_consolidation_idempotency.rs` remain green.

Closes #227

https://claude.ai/code/session_01AsVz67dYuk3dufxA683hJA
