### PR TITLE
fix(storage): require namespace scoping on episode and observation access

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2850,6 +2850,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tokio-util",
  "tracing",

--- a/pensyve-core/src/observation.rs
+++ b/pensyve-core/src/observation.rs
@@ -4129,7 +4129,9 @@ mod tests {
         assert_eq!(persisted, 2);
 
         // Verify the observations landed with embeddings attached.
-        let stored = db.list_observations_by_episode_ids(&[ep], 100).unwrap();
+        let stored = db
+            .list_observations_by_episode_ids(ns.id, &[ep], 100)
+            .unwrap();
         assert_eq!(stored.len(), 2);
         for obs in &stored {
             assert_eq!(obs.namespace_id, ns.id);
@@ -4181,7 +4183,9 @@ mod tests {
         .await;
         assert_eq!(persisted, 0);
 
-        let stored = db.list_observations_by_episode_ids(&[ep], 100).unwrap();
+        let stored = db
+            .list_observations_by_episode_ids(ns.id, &[ep], 100)
+            .unwrap();
         assert!(stored.is_empty());
     }
 
@@ -4464,11 +4468,15 @@ mod tests {
         assert_eq!(persisted, 2);
 
         // Episode A got the AC Odyssey observation; B got sourdough.
-        let stored_a = db.list_observations_by_episode_ids(&[ep_a], 100).unwrap();
+        let stored_a = db
+            .list_observations_by_episode_ids(ns.id, &[ep_a], 100)
+            .unwrap();
         assert_eq!(stored_a.len(), 1);
         assert_eq!(stored_a[0].instance, "AC Odyssey");
 
-        let stored_b = db.list_observations_by_episode_ids(&[ep_b], 100).unwrap();
+        let stored_b = db
+            .list_observations_by_episode_ids(ns.id, &[ep_b], 100)
+            .unwrap();
         assert_eq!(stored_b.len(), 1);
         assert_eq!(stored_b[0].instance, "sourdough");
     }
@@ -4509,7 +4517,7 @@ mod tests {
         assert_eq!(persisted, 2);
         assert_eq!(extractor.calls.load(std::sync::atomic::Ordering::SeqCst), 2);
         assert_eq!(
-            db.list_observations_by_episode_ids(&[ep_a, ep_b], 100)
+            db.list_observations_by_episode_ids(ns.id, &[ep_a, ep_b], 100)
                 .unwrap()
                 .len(),
             2
@@ -4535,7 +4543,7 @@ mod tests {
         assert_eq!(*extractor.batch_sizes.lock().unwrap(), [2, 2, 2, 1, 1]);
         for episode_id in [ep_a, ep_b] {
             let stored = db
-                .list_observations_by_episode_ids(&[episode_id], 100)
+                .list_observations_by_episode_ids(ns.id, &[episode_id], 100)
                 .unwrap();
             assert_eq!(stored.len(), 1);
             assert_eq!(stored[0].episode_id, episode_id);
@@ -4568,11 +4576,15 @@ mod tests {
             3
         );
 
-        let stored_a = db.list_observations_by_episode_ids(&[ep_a], 100).unwrap();
+        let stored_a = db
+            .list_observations_by_episode_ids(ns.id, &[ep_a], 100)
+            .unwrap();
         assert_eq!(stored_a.len(), 1);
         assert_eq!(stored_a[0].episode_id, ep_a);
 
-        let stored_b = db.list_observations_by_episode_ids(&[ep_b], 100).unwrap();
+        let stored_b = db
+            .list_observations_by_episode_ids(ns.id, &[ep_b], 100)
+            .unwrap();
         assert!(stored_b.is_empty());
     }
 
@@ -4630,7 +4642,7 @@ mod tests {
         assert_eq!(persisted, 0);
         assert_eq!(extractor.calls.load(std::sync::atomic::Ordering::SeqCst), 3);
         assert!(
-            db.list_observations_by_episode_ids(&[ep_a, ep_b], 100)
+            db.list_observations_by_episode_ids(ns.id, &[ep_a, ep_b], 100)
                 .unwrap()
                 .is_empty()
         );
@@ -4667,8 +4679,12 @@ mod tests {
         assert_eq!(persisted, 0);
 
         // No observations landed for either episode.
-        let stored_a = db.list_observations_by_episode_ids(&[ep_a], 100).unwrap();
-        let stored_b = db.list_observations_by_episode_ids(&[ep_b], 100).unwrap();
+        let stored_a = db
+            .list_observations_by_episode_ids(ns.id, &[ep_a], 100)
+            .unwrap();
+        let stored_b = db
+            .list_observations_by_episode_ids(ns.id, &[ep_b], 100)
+            .unwrap();
         assert!(stored_a.is_empty());
         assert!(stored_b.is_empty());
     }
@@ -4697,7 +4713,9 @@ mod tests {
         .await;
         assert_eq!(persisted, 1);
 
-        let stored = db.list_observations_by_episode_ids(&[ep_a], 100).unwrap();
+        let stored = db
+            .list_observations_by_episode_ids(ns.id, &[ep_a], 100)
+            .unwrap();
         assert_eq!(stored.len(), 1);
     }
 }

--- a/pensyve-core/src/recall_grouped.rs
+++ b/pensyve-core/src/recall_grouped.rs
@@ -303,8 +303,14 @@ pub fn group_by_session(
 ///
 /// Returns the groups unchanged on storage error (observations are optional
 /// enrichment; a failed lookup should never break recall).
+///
+/// `namespace_id` is the caller's namespace and is mandatory: a group's
+/// `session_id` comes from an episodic memory's `episode_id`, which is a
+/// caller-supplied value rather than a tenant boundary, so the observation
+/// lookup must be constrained to the namespace doing the recall.
 pub fn attach_observations_to_groups(
     storage: &dyn crate::storage::StorageTrait,
+    namespace_id: Uuid,
     groups: Vec<SessionGroup>,
 ) -> Vec<SessionGroup> {
     // Collect unique episode IDs across all groups that carry one.
@@ -316,17 +322,18 @@ pub fn attach_observations_to_groups(
     // `limit` is set generously; at our expected 50-top-k workload the
     // per-group observation count is typically 2-5, so a few hundred is
     // well above ceiling. Future phase: configurable cap.
-    let observations = match storage.list_observations_by_episode_ids(&episode_ids, 1024) {
-        Ok(obs) => obs,
-        Err(e) => {
-            tracing::warn!(
-                target: "pensyve::observation",
-                error = %e,
-                "failed to load observations for session groups — returning groups unchanged"
-            );
-            return groups;
-        }
-    };
+    let observations =
+        match storage.list_observations_by_episode_ids(namespace_id, &episode_ids, 1024) {
+            Ok(obs) => obs,
+            Err(e) => {
+                tracing::warn!(
+                    target: "pensyve::observation",
+                    error = %e,
+                    "failed to load observations for session groups — returning groups unchanged"
+                );
+                return groups;
+            }
+        };
 
     if observations.is_empty() {
         return groups;
@@ -740,7 +747,7 @@ mod tests {
             scored(ep_at(ep, t(2026, 1, 2), "turn 2"), 0.8),
         ];
         let groups = group_by_session(candidates, OrderBy::Chronological, None);
-        let attached = attach_observations_to_groups(&db, groups);
+        let attached = attach_observations_to_groups(&db, ns.id, groups);
 
         assert_eq!(attached.len(), 1);
         let g = &attached[0];
@@ -778,7 +785,7 @@ mod tests {
             scored(ep_at(ep_b, t(2026, 1, 2), "b1"), 0.5),
         ];
         let groups = group_by_session(candidates, OrderBy::Chronological, None);
-        let attached = attach_observations_to_groups(&db, groups);
+        let attached = attach_observations_to_groups(&db, ns.id, groups);
 
         assert_eq!(attached.len(), 2);
         for g in &attached {
@@ -813,7 +820,7 @@ mod tests {
 
         let candidates = vec![scored(ep_at(topk_ep, t(2026, 1, 1), "x"), 0.5)];
         let groups = group_by_session(candidates, OrderBy::Chronological, None);
-        let attached = attach_observations_to_groups(&db, groups);
+        let attached = attach_observations_to_groups(&db, ns.id, groups);
 
         assert_eq!(attached.len(), 1);
         let leaked = attached[0].memories.iter().any(|m| match &m.memory {
@@ -834,7 +841,7 @@ mod tests {
 
         let candidates = vec![scored(ep_at(ep, t(2026, 1, 1), "x"), 0.5)];
         let groups = group_by_session(candidates, OrderBy::Chronological, None);
-        let attached = attach_observations_to_groups(&db, groups);
+        let attached = attach_observations_to_groups(&db, ns.id, groups);
 
         assert_eq!(attached.len(), 1);
         assert_eq!(attached[0].memories.len(), 1);
@@ -850,7 +857,7 @@ mod tests {
         let groups = group_by_session(candidates, OrderBy::Chronological, None);
         // Semantic memories don't have a session_id so the attach lookup
         // never runs for them.
-        let attached = attach_observations_to_groups(&db, groups);
+        let attached = attach_observations_to_groups(&db, ns.id, groups);
         assert_eq!(attached.len(), 1);
         assert_eq!(attached[0].session_id, None);
         assert_eq!(attached[0].memories.len(), 1);

--- a/pensyve-core/src/retrieval/engine.rs
+++ b/pensyve-core/src/retrieval/engine.rs
@@ -533,6 +533,7 @@ impl<'a> RecallEngine<'a> {
         // candidate selection, only enrich the sessions that already won.
         Ok(crate::recall_grouped::attach_observations_to_groups(
             self.storage,
+            namespace_id,
             groups,
         ))
     }

--- a/pensyve-core/src/storage/mod.rs
+++ b/pensyve-core/src/storage/mod.rs
@@ -74,7 +74,25 @@ pub trait StorageTrait: Send + Sync {
 
     // Episodes
     fn save_episode(&self, episode: &Episode) -> StorageResult<()>;
-    fn get_episode(&self, id: Uuid) -> StorageResult<Option<Episode>>;
+
+    /// Fetch an episode only when it belongs to `namespace_id`.
+    ///
+    /// There is deliberately no unscoped `get_episode`. One backend instance is
+    /// shared by every tenant of the gateway, so a lookup keyed on `id` alone
+    /// resolves across namespaces — and `Episode::namespace_id` then flows into
+    /// `update_episode`/`save_episode`, letting one tenant's write land on
+    /// another tenant's row. Requiring the namespace here makes that class of
+    /// mistake unrepresentable rather than relying on each caller to compare.
+    ///
+    /// Backends must implement this as a single `id AND namespace_id` query.
+    /// Callers should treat `Ok(None)` as "not found" without distinguishing
+    /// "owned by someone else", so the result is not an existence oracle.
+    fn get_episode_in_namespace(
+        &self,
+        id: Uuid,
+        namespace_id: Uuid,
+    ) -> StorageResult<Option<Episode>>;
+
     fn update_episode(&self, episode: &Episode) -> StorageResult<()>;
 
     // Episodic Memory
@@ -166,20 +184,32 @@ pub trait StorageTrait: Send + Sync {
         Ok(Vec::new())
     }
 
-    /// Fetch all observations attached to any of the given episode IDs,
-    /// bounded by `limit` (applied after fetch). Used by `recall_grouped` to
-    /// attach observations to top-k session groups.
+    /// Fetch all observations attached to any of the given episode IDs *within
+    /// `namespace_id`*, bounded by `limit` (applied after fetch). Used by
+    /// `recall_grouped` to attach observations to top-k session groups.
+    ///
+    /// `episode_id` is not a tenant boundary: an episodic memory in one
+    /// namespace may carry any UUID at all, so joining on `episode_id` alone
+    /// would surface another tenant's observation content. The namespace
+    /// predicate is therefore mandatory, not conditional on backend
+    /// configuration.
     fn list_observations_by_episode_ids(
         &self,
+        _namespace_id: Uuid,
         _episode_ids: &[Uuid],
         _limit: usize,
     ) -> StorageResult<Vec<ObservationMemory>> {
         Ok(Vec::new())
     }
 
-    /// Delete every observation tied to the given episode. Returns the row count.
-    /// Called as part of episode cascade-delete paths.
-    fn delete_observations_by_episode(&self, _episode_id: Uuid) -> StorageResult<usize> {
+    /// Delete every observation tied to the given episode *within
+    /// `namespace_id`*. Returns the row count. Called as part of episode
+    /// cascade-delete paths, whose `episode_id` is caller-supplied.
+    fn delete_observations_by_episode(
+        &self,
+        _namespace_id: Uuid,
+        _episode_id: Uuid,
+    ) -> StorageResult<usize> {
         Ok(0)
     }
 

--- a/pensyve-core/src/storage/postgres.rs
+++ b/pensyve-core/src/storage/postgres.rs
@@ -691,9 +691,13 @@ impl StorageTrait for PostgresBackend {
         })
     }
 
-    fn get_episode(&self, id: Uuid) -> StorageResult<Option<Episode>> {
-        self.block_on(async {
-            let mut conn = self.maybe_scoped_conn().await?;
+    fn get_episode_in_namespace(
+        &self,
+        id: Uuid,
+        namespace_id: Uuid,
+    ) -> StorageResult<Option<Episode>> {
+        self.block_on(async move {
+            let mut conn = self.scoped_conn(namespace_id).await?;
             #[allow(clippy::type_complexity)]
             let row: Option<(
                 Uuid,
@@ -704,28 +708,32 @@ impl StorageTrait for PostgresBackend {
                 Option<String>,
                 serde_json::Value,
             )> = query_as::<Postgres, _>(
-                "SELECT id, namespace_id, participants, started_at, ended_at, outcome, metadata FROM episodes WHERE id = $1",
+                "SELECT id, namespace_id, participants, started_at, ended_at, outcome, metadata \
+                 FROM episodes WHERE id = $1 AND namespace_id = $2",
             )
             .bind(id)
+            .bind(namespace_id)
             .fetch_optional(&mut *conn)
             .await
             .map_err(sqlx_to_io)?;
 
-            Ok(row.map(|(id, namespace_id, participants, started_at, ended_at, outcome, metadata)| {
-                let participants: Vec<Uuid> =
-                    serde_json::from_value(participants).unwrap_or_default();
-                let metadata: HashMap<String, serde_json::Value> =
-                    serde_json::from_value(metadata).unwrap_or_default();
-                Episode {
-                    id,
-                    namespace_id,
-                    participants,
-                    started_at,
-                    ended_at,
-                    outcome: outcome.as_deref().map(str_to_outcome),
-                    metadata,
-                }
-            }))
+            Ok(row.map(
+                |(id, namespace_id, participants, started_at, ended_at, outcome, metadata)| {
+                    let participants: Vec<Uuid> =
+                        serde_json::from_value(participants).unwrap_or_default();
+                    let metadata: HashMap<String, serde_json::Value> =
+                        serde_json::from_value(metadata).unwrap_or_default();
+                    Episode {
+                        id,
+                        namespace_id,
+                        participants,
+                        started_at,
+                        ended_at,
+                        outcome: outcome.as_deref().map(str_to_outcome),
+                        metadata,
+                    }
+                },
+            ))
         })
     }
 
@@ -1150,6 +1158,7 @@ impl StorageTrait for PostgresBackend {
 
     fn list_observations_by_episode_ids(
         &self,
+        namespace_id: Uuid,
         episode_ids: &[Uuid],
         limit: usize,
     ) -> StorageResult<Vec<ObservationMemory>> {
@@ -1157,53 +1166,47 @@ impl StorageTrait for PostgresBackend {
             return Ok(Vec::new());
         }
         let ids = episode_ids.to_vec();
-        // Defensive: if the backend has a `default_namespace` configured,
-        // add an explicit `namespace_id` filter to the query as a second
-        // line of defence beyond RLS. Callers without a default namespace
-        // (test fixtures, one-off scripts) still work via RLS alone —
-        // production deployments should always set the namespace either
-        // via `with_default_namespace` or by using `scoped_conn` upstream.
-        let namespace_filter = self.default_namespace;
+        // The `namespace_id` predicate is unconditional. RLS is a second line
+        // of defence, not the first: `episode_id` is caller-supplied and is
+        // not a tenant boundary, so joining on it alone reaches other
+        // namespaces whenever the session GUC is not in force.
         self.block_on(async move {
-            let mut conn = self.maybe_scoped_conn().await?;
-            let sql = if namespace_filter.is_some() {
+            let mut conn = self.scoped_conn(namespace_id).await?;
+            let rows: Vec<ObservationRow> = query_as::<Postgres, ObservationRow>(
                 r"SELECT id, namespace_id, episode_id, entity_type, instance, action, quantity,
                           unit, content, embedding::text AS embedding, confidence, event_time, created_at,
                           stability, retrievability, superseded_by, invalid_at
                    FROM observation_memories
-                   WHERE episode_id = ANY($1) AND namespace_id = $3
+                   WHERE episode_id = ANY($1) AND namespace_id = $2
                      AND superseded_by IS NULL
                    ORDER BY created_at ASC
-                   LIMIT $2"
-            } else {
-                r"SELECT id, namespace_id, episode_id, entity_type, instance, action, quantity,
-                          unit, content, embedding::text AS embedding, confidence, event_time, created_at,
-                          stability, retrievability, superseded_by, invalid_at
-                   FROM observation_memories
-                   WHERE episode_id = ANY($1) AND superseded_by IS NULL
-                   ORDER BY created_at ASC
-                   LIMIT $2"
-            };
-            let mut q = query_as::<Postgres, ObservationRow>(sql)
-                .bind(&ids)
-                .bind(i64::try_from(limit).unwrap_or(i64::MAX));
-            if let Some(ns) = namespace_filter {
-                q = q.bind(ns);
-            }
-            let rows: Vec<ObservationRow> = q.fetch_all(&mut *conn).await.map_err(sqlx_to_io)?;
+                   LIMIT $3",
+            )
+            .bind(&ids)
+            .bind(namespace_id)
+            .bind(i64::try_from(limit).unwrap_or(i64::MAX))
+            .fetch_all(&mut *conn)
+            .await
+            .map_err(sqlx_to_io)?;
             Ok(rows.into_iter().map(row_to_observation).collect())
         })
     }
 
-    fn delete_observations_by_episode(&self, episode_id: Uuid) -> StorageResult<usize> {
-        self.block_on(async {
-            let mut conn = self.maybe_scoped_conn().await?;
-            let result =
-                query::<Postgres>("DELETE FROM observation_memories WHERE episode_id = $1")
-                    .bind(episode_id)
-                    .execute(&mut *conn)
-                    .await
-                    .map_err(sqlx_to_io)?;
+    fn delete_observations_by_episode(
+        &self,
+        namespace_id: Uuid,
+        episode_id: Uuid,
+    ) -> StorageResult<usize> {
+        self.block_on(async move {
+            let mut conn = self.scoped_conn(namespace_id).await?;
+            let result = query::<Postgres>(
+                "DELETE FROM observation_memories WHERE episode_id = $1 AND namespace_id = $2",
+            )
+            .bind(episode_id)
+            .bind(namespace_id)
+            .execute(&mut *conn)
+            .await
+            .map_err(sqlx_to_io)?;
             Ok(usize::try_from(result.rows_affected()).unwrap_or(0))
         })
     }

--- a/pensyve-core/src/storage/sqlite.rs
+++ b/pensyve-core/src/storage/sqlite.rs
@@ -993,12 +993,17 @@ impl StorageTrait for SqliteBackend {
         Ok(())
     }
 
-    fn get_episode(&self, id: Uuid) -> StorageResult<Option<Episode>> {
+    fn get_episode_in_namespace(
+        &self,
+        id: Uuid,
+        namespace_id: Uuid,
+    ) -> StorageResult<Option<Episode>> {
         let conn = lock_conn!(self);
         let result = conn
             .query_row(
-                "SELECT id, namespace_id, participants, started_at, ended_at, outcome, metadata FROM episodes WHERE id = ?1",
-                params![id.to_string()],
+                "SELECT id, namespace_id, participants, started_at, ended_at, outcome, metadata \
+                 FROM episodes WHERE id = ?1 AND namespace_id = ?2",
+                params![id.to_string(), namespace_id.to_string()],
                 |row| {
                     Ok((
                         row.get::<_, String>(0)?,
@@ -1531,6 +1536,7 @@ impl StorageTrait for SqliteBackend {
 
     fn list_observations_by_episode_ids(
         &self,
+        namespace_id: Uuid,
         episode_ids: &[Uuid],
         limit: usize,
     ) -> StorageResult<Vec<ObservationMemory>> {
@@ -1544,7 +1550,8 @@ impl StorageTrait for SqliteBackend {
               unit, content, embedding, confidence, event_time, created_at, \
               stability, retrievability, agent_id, user_id, superseded_by, invalid_at \
              FROM observation_memories \
-             WHERE episode_id IN ({placeholders}) AND superseded_by IS NULL \
+             WHERE episode_id IN ({placeholders}) AND namespace_id = ? \
+               AND superseded_by IS NULL \
              ORDER BY created_at ASC \
              LIMIT ?"
         );
@@ -1554,6 +1561,7 @@ impl StorageTrait for SqliteBackend {
             .iter()
             .map(|u| Box::new(u.to_string()) as Box<dyn rusqlite::ToSql>)
             .collect();
+        params_vec.push(Box::new(namespace_id.to_string()));
         params_vec.push(Box::new(i64::try_from(limit).unwrap_or(i64::MAX)));
         let param_refs: Vec<&dyn rusqlite::ToSql> =
             params_vec.iter().map(std::convert::AsRef::as_ref).collect();
@@ -1638,9 +1646,14 @@ impl StorageTrait for SqliteBackend {
         }
     }
 
-    fn delete_observations_by_episode(&self, episode_id: Uuid) -> StorageResult<usize> {
+    fn delete_observations_by_episode(
+        &self,
+        namespace_id: Uuid,
+        episode_id: Uuid,
+    ) -> StorageResult<usize> {
         let conn = lock_conn!(self);
         let ep_str = episode_id.to_string();
+        let ns_str = namespace_id.to_string();
         conn.execute_batch("BEGIN")?;
         let result = (|| -> StorageResult<usize> {
             // Phase 2B cascade (CodeRabbit PR #115 round 2): drop
@@ -1648,25 +1661,31 @@ impl StorageTrait for SqliteBackend {
             // departing observation IDs before the owning rows are
             // gone. `kg_entities` are namespace-scoped and may still
             // be referenced by surviving observations; leave them.
+            //
+            // Every sub-select repeats the `namespace_id` predicate: the
+            // caller-supplied `episode_id` alone selects rows across tenants.
             conn.execute(
                 "DELETE FROM kg_triples \
-                 WHERE passage_id IN (SELECT id FROM observation_memories WHERE episode_id = ?1)",
-                params![&ep_str],
+                 WHERE passage_id IN (SELECT id FROM observation_memories \
+                                       WHERE episode_id = ?1 AND namespace_id = ?2)",
+                params![&ep_str, &ns_str],
             )?;
             conn.execute(
                 "DELETE FROM kg_passage_entities \
-                 WHERE passage_id IN (SELECT id FROM observation_memories WHERE episode_id = ?1)",
-                params![&ep_str],
+                 WHERE passage_id IN (SELECT id FROM observation_memories \
+                                       WHERE episode_id = ?1 AND namespace_id = ?2)",
+                params![&ep_str, &ns_str],
             )?;
             conn.execute(
                 "DELETE FROM memory_fts \
                  WHERE memory_type = 'observation' \
-                   AND memory_id IN (SELECT id FROM observation_memories WHERE episode_id = ?1)",
-                params![&ep_str],
+                   AND memory_id IN (SELECT id FROM observation_memories \
+                                      WHERE episode_id = ?1 AND namespace_id = ?2)",
+                params![&ep_str, &ns_str],
             )?;
             let deleted = conn.execute(
-                "DELETE FROM observation_memories WHERE episode_id = ?1",
-                params![&ep_str],
+                "DELETE FROM observation_memories WHERE episode_id = ?1 AND namespace_id = ?2",
+                params![&ep_str, &ns_str],
             )?;
             Ok(deleted)
         })();
@@ -3804,7 +3823,7 @@ mod tests {
 
         // Fetch ep_a + ep_b only
         let fetched = db
-            .list_observations_by_episode_ids(&[ep_a, ep_b], 100)
+            .list_observations_by_episode_ids(ns.id, &[ep_a, ep_b], 100)
             .unwrap();
         assert_eq!(fetched.len(), 3);
         let instances: std::collections::HashSet<_> =
@@ -3885,20 +3904,23 @@ mod tests {
             db.save_observation(&obs).unwrap();
         }
 
-        let fetched = db.list_observations_by_episode_ids(&[ep], 3).unwrap();
+        let fetched = db
+            .list_observations_by_episode_ids(ns.id, &[ep], 3)
+            .unwrap();
         assert_eq!(fetched.len(), 3);
     }
 
     #[test]
     fn test_observations_list_empty_inputs() {
         let (_dir, db) = setup();
+        let ns = make_namespace(&db);
         assert!(
-            db.list_observations_by_episode_ids(&[], 10)
+            db.list_observations_by_episode_ids(ns.id, &[], 10)
                 .unwrap()
                 .is_empty()
         );
         assert!(
-            db.list_observations_by_episode_ids(&[Uuid::new_v4()], 0)
+            db.list_observations_by_episode_ids(ns.id, &[Uuid::new_v4()], 0)
                 .unwrap()
                 .is_empty()
         );
@@ -3916,11 +3938,11 @@ mod tests {
             db.save_observation(&obs).unwrap();
         }
 
-        let deleted = db.delete_observations_by_episode(ep_a).unwrap();
+        let deleted = db.delete_observations_by_episode(ns.id, ep_a).unwrap();
         assert_eq!(deleted, 2);
 
         let remaining = db
-            .list_observations_by_episode_ids(&[ep_a, ep_b], 100)
+            .list_observations_by_episode_ids(ns.id, &[ep_a, ep_b], 100)
             .unwrap();
         assert_eq!(remaining.len(), 1);
         assert_eq!(remaining[0].instance, "b1");
@@ -4327,7 +4349,7 @@ mod tests {
         assert_eq!(kg_triples_count_for_passage(&db, obs.id), 1);
         assert_eq!(kg_passage_entities_count_for_passage(&db, obs.id), 2);
 
-        db.delete_observations_by_episode(ep).unwrap();
+        db.delete_observations_by_episode(ns.id, ep).unwrap();
 
         assert_eq!(
             kg_triples_count_for_passage(&db, obs.id),

--- a/pensyve-core/tests/test_namespace_scoping.rs
+++ b/pensyve-core/tests/test_namespace_scoping.rs
@@ -1,0 +1,218 @@
+//! Namespace scoping guarantees for the storage layer.
+//!
+//! A single `StorageTrait` instance is shared by every tenant of the gateway;
+//! the only thing separating them is the `namespace_id` each call passes down.
+//! Any accessor that resolves rows by a caller-supplied `id` / `episode_id`
+//! alone therefore crosses tenants, regardless of what the callers above it do.
+//!
+//! These tests pin the storage-level half of that contract: given two
+//! namespaces sharing one backend, a lookup scoped to namespace A must never
+//! observe or mutate a row owned by namespace B — even when A supplies B's
+//! primary key verbatim.
+
+use pensyve_core::storage::StorageTrait;
+use pensyve_core::storage::sqlite::SqliteBackend;
+use pensyve_core::types::{Episode, Namespace, ObservationMemory};
+use uuid::Uuid;
+
+/// Two namespaces on one shared backend, mirroring the gateway's
+/// one-storage-many-tenants deployment shape.
+struct TwoTenants {
+    db: SqliteBackend,
+    ns_a: Uuid,
+    ns_b: Uuid,
+}
+
+fn two_tenants(dir: &tempfile::TempDir) -> TwoTenants {
+    let db = SqliteBackend::open(dir.path()).expect("open storage");
+    let a = Namespace::new("tenant-a");
+    let b = Namespace::new("tenant-b");
+    db.save_namespace(&a).expect("save ns a");
+    db.save_namespace(&b).expect("save ns b");
+    TwoTenants {
+        db,
+        ns_a: a.id,
+        ns_b: b.id,
+    }
+}
+
+fn seed_episode(db: &SqliteBackend, namespace_id: Uuid) -> Uuid {
+    let episode = Episode::new(namespace_id, vec![Uuid::new_v4()]);
+    db.save_episode(&episode).expect("save episode");
+    episode.id
+}
+
+fn seed_observation(
+    db: &SqliteBackend,
+    namespace_id: Uuid,
+    episode_id: Uuid,
+    content: &str,
+) -> Uuid {
+    let obs = ObservationMemory::new(
+        namespace_id,
+        episode_id,
+        "secret_document",
+        "quarterly-forecast",
+        "reviewed",
+        content,
+    );
+    db.save_observation(&obs).expect("save observation");
+    obs.id
+}
+
+// ---------------------------------------------------------------------------
+// Episode lookup
+// ---------------------------------------------------------------------------
+
+#[test]
+fn get_episode_in_namespace_does_not_resolve_a_foreign_episode() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let t = two_tenants(&dir);
+    let victim_episode = seed_episode(&t.db, t.ns_b);
+
+    let seen =
+        t.db.get_episode_in_namespace(victim_episode, t.ns_a)
+            .expect("episode lookup");
+
+    assert!(
+        seen.is_none(),
+        "namespace A resolved episode {victim_episode}, which belongs to namespace B"
+    );
+}
+
+#[test]
+fn get_episode_in_namespace_resolves_an_owned_episode() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let t = two_tenants(&dir);
+    let episode = seed_episode(&t.db, t.ns_b);
+
+    let seen =
+        t.db.get_episode_in_namespace(episode, t.ns_b)
+            .expect("episode lookup")
+            .expect("owned episode resolves");
+
+    assert_eq!(seen.id, episode);
+    assert_eq!(seen.namespace_id, t.ns_b);
+}
+
+// ---------------------------------------------------------------------------
+// Observation reads
+//
+// `recall_grouped` joins observations onto the top-k session groups by
+// `episode_id`. A caller who plants an episodic row carrying a foreign
+// `episode_id` would otherwise pull the owning tenant's observation content
+// into their own recall response.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn list_observations_by_episode_ids_does_not_return_foreign_rows() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let t = two_tenants(&dir);
+    let victim_episode = seed_episode(&t.db, t.ns_b);
+    seed_observation(
+        &t.db,
+        t.ns_b,
+        victim_episode,
+        "victim reviewed the quarterly forecast",
+    );
+
+    let seen =
+        t.db.list_observations_by_episode_ids(t.ns_a, &[victim_episode], 1024)
+            .expect("observation lookup");
+
+    assert!(
+        seen.is_empty(),
+        "namespace A read {} observation(s) owned by namespace B: {:?}",
+        seen.len(),
+        seen.iter().map(|o| o.content.as_str()).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn list_observations_by_episode_ids_returns_owned_rows() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let t = two_tenants(&dir);
+    let episode = seed_episode(&t.db, t.ns_b);
+    let obs = seed_observation(&t.db, t.ns_b, episode, "owned observation");
+
+    let seen =
+        t.db.list_observations_by_episode_ids(t.ns_b, &[episode], 1024)
+            .expect("observation lookup");
+
+    assert_eq!(seen.len(), 1);
+    assert_eq!(seen[0].id, obs);
+}
+
+/// The same `episode_id` value existing in both namespaces must not blur them
+/// together: each side sees only its own row.
+#[test]
+fn list_observations_by_episode_ids_partitions_a_shared_episode_id() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let t = two_tenants(&dir);
+
+    // One episode UUID, deliberately reused across both namespaces.
+    let shared_id = Uuid::new_v4();
+    for ns in [t.ns_a, t.ns_b] {
+        let mut episode = Episode::new(ns, vec![Uuid::new_v4()]);
+        episode.id = shared_id;
+        t.db.save_episode(&episode).expect("save episode");
+    }
+    seed_observation(&t.db, t.ns_a, shared_id, "belongs to A");
+    seed_observation(&t.db, t.ns_b, shared_id, "belongs to B");
+
+    let seen_by_a =
+        t.db.list_observations_by_episode_ids(t.ns_a, &[shared_id], 1024)
+            .expect("observation lookup");
+
+    assert_eq!(seen_by_a.len(), 1, "A saw {seen_by_a:?}");
+    assert_eq!(seen_by_a[0].content, "belongs to A");
+    assert_eq!(seen_by_a[0].namespace_id, t.ns_a);
+}
+
+// ---------------------------------------------------------------------------
+// Observation deletes
+//
+// No production caller passes an attacker-controlled `episode_id` here today,
+// but three routes accept one, so the scoping is pinned before it can become
+// a cross-tenant mass delete.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn delete_observations_by_episode_does_not_delete_foreign_rows() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let t = two_tenants(&dir);
+    let victim_episode = seed_episode(&t.db, t.ns_b);
+    seed_observation(&t.db, t.ns_b, victim_episode, "victim observation");
+
+    let deleted =
+        t.db.delete_observations_by_episode(t.ns_a, victim_episode)
+            .expect("delete observations");
+
+    assert_eq!(
+        deleted, 0,
+        "namespace A deleted {deleted} observation(s) owned by namespace B"
+    );
+    let survivors =
+        t.db.list_observations_by_episode_ids(t.ns_b, &[victim_episode], 1024)
+            .expect("observation lookup");
+    assert_eq!(survivors.len(), 1, "victim observation was destroyed");
+}
+
+#[test]
+fn delete_observations_by_episode_deletes_owned_rows() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let t = two_tenants(&dir);
+    let episode = seed_episode(&t.db, t.ns_b);
+    seed_observation(&t.db, t.ns_b, episode, "owned observation");
+
+    let deleted =
+        t.db.delete_observations_by_episode(t.ns_b, episode)
+            .expect("delete observations");
+
+    assert_eq!(deleted, 1);
+    assert!(
+        t.db.list_observations_by_episode_ids(t.ns_b, &[episode], 1024)
+            .expect("observation lookup")
+            .is_empty()
+    );
+}

--- a/pensyve-mcp-gateway/src/rest.rs
+++ b/pensyve-mcp-gateway/src/rest.rs
@@ -980,7 +980,11 @@ async fn recall_grouped(
         // REST, MCP, and SDK callers all see the same response shape — the
         // 89.2% benchmark number is reproducible only when observations are
         // surfaced here.
-        pensyve_core::recall_grouped::attach_observations_to_groups(ps.storage.as_ref(), groups)
+        pensyve_core::recall_grouped::attach_observations_to_groups(
+            ps.storage.as_ref(),
+            ps.namespace.id,
+            groups,
+        )
     };
 
     let _ = ps.storage.log_activity(
@@ -1190,12 +1194,19 @@ async fn delete_memory(
     let memory_id = Uuid::parse_str(&id)
         .map_err(|_| RestError(StatusCode::BAD_REQUEST, "Invalid memory ID".to_string()))?;
 
-    let deleted = ps.storage.delete_memory_by_id(memory_id).map_err(|err| {
-        RestError(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Error deleting memory: {err}"),
-        )
-    })?;
+    // Scoped to the caller's namespace: `memory_id` comes straight off the
+    // request path, and one storage backend is shared by every tenant, so an
+    // unscoped delete would reach another tenant's row. A miss and a foreign
+    // row are both reported as 404 so the response is not an existence oracle.
+    let deleted = ps
+        .storage
+        .delete_memory_by_id_in_namespace(memory_id, ps.namespace.id)
+        .map_err(|err| {
+            RestError(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Error deleting memory: {err}"),
+            )
+        })?;
 
     if !deleted {
         return Err(RestError(
@@ -1514,8 +1525,14 @@ async fn observe(
         )
     })?;
 
-    // Verify the episode exists.
-    match ps.storage.get_episode(episode_id) {
+    // Verify the episode exists *in the caller's namespace*. An episode owned
+    // by another tenant reports the same not-found as a missing one: attaching
+    // to a foreign episode would let this namespace's recall groups join
+    // against the owner's per-episode rows.
+    match ps
+        .storage
+        .get_episode_in_namespace(episode_id, ps.namespace.id)
+    {
         Ok(Some(_)) => {}
         Ok(None) => {
             return Err(RestError(
@@ -1799,8 +1816,11 @@ async fn episode_message(
         )
     })?;
 
-    // Verify the episode exists.
-    match ps.storage.get_episode(episode_id) {
+    // Verify the episode exists *in the caller's namespace* — see `observe`.
+    match ps
+        .storage
+        .get_episode_in_namespace(episode_id, ps.namespace.id)
+    {
         Ok(Some(_)) => {}
         Ok(None) => {
             return Err(RestError(
@@ -1896,7 +1916,13 @@ async fn episode_end(
         }
     };
 
-    let mut episode = match ps.storage.get_episode(episode_id) {
+    // Scoped load: `update_episode` writes back on `episode.namespace_id`, so
+    // an unscoped read here would let this caller stamp `ended_at`/`outcome`
+    // onto another tenant's episode.
+    let mut episode = match ps
+        .storage
+        .get_episode_in_namespace(episode_id, ps.namespace.id)
+    {
         Ok(Some(ep)) => ep,
         Ok(None) => {
             return Err(RestError(

--- a/pensyve-mcp-gateway/tests/test_cross_tenant_isolation.rs
+++ b/pensyve-mcp-gateway/tests/test_cross_tenant_isolation.rs
@@ -22,6 +22,7 @@ use axum::middleware::Next;
 use axum::response::Response;
 use pensyve_core::config::RetrievalConfig;
 use pensyve_core::embedding::OnnxEmbedder;
+use pensyve_core::reranker::Reranker;
 use pensyve_core::storage::StorageTrait;
 use pensyve_core::storage::sqlite::SqliteBackend;
 use pensyve_core::types::Namespace;
@@ -74,22 +75,7 @@ fn gateway_config(dir: &TempDir) -> GatewayConfig {
     }
 }
 
-/// Prevents the lazily-resolved reranker from attempting a real network
-/// model download when a recall assertion runs.
-#[allow(
-    unsafe_code,
-    reason = "test-only env-var guard; std::env::set_var is unsafe in Rust 2024 edition by language design but is safe here because it runs exactly once via std::sync::Once before any reader"
-)]
-fn disable_reranker_for_tests() {
-    static INIT: std::sync::Once = std::sync::Once::new();
-    INIT.call_once(|| {
-        // SAFETY: runs exactly once via `Once`, before any concurrent reader.
-        unsafe { std::env::set_var("PENSYVE_RERANKER", "0") };
-    });
-}
-
 fn app_state(dir: &TempDir) -> Arc<AppState> {
-    disable_reranker_for_tests();
     let storage =
         Arc::new(SqliteBackend::open(dir.path()).expect("open storage")) as Arc<dyn StorageTrait>;
     let namespace = Namespace::new("default");
@@ -104,6 +90,24 @@ fn app_state(dir: &TempDir) -> Arc<AppState> {
         namespace,
         VectorIndex::new(768, 1024),
     );
+
+    // Resolve the shared reranker cell up front with a mock, so nothing in
+    // this binary can trigger the real ~280MB model download. Every tenant
+    // state built by this manager clones the same `OnceLock`, so seeding it
+    // through the default state covers tenants created later too.
+    //
+    // This replaces a `PENSYVE_RERANKER=0` env mutation: `set_var` is process
+    // global, and serialising the write behind a `Once` does nothing about
+    // concurrent readers on other test threads.
+    assert!(
+        tenant_mgr
+            .default_state()
+            .reranker_cell
+            .set(Some(Arc::new(Reranker::new_mock())))
+            .is_ok(),
+        "reranker cell was already resolved before the test could seed it"
+    );
+
     let config = gateway_config(dir);
 
     Arc::new(AppState {
@@ -226,6 +230,32 @@ fn stored_episode(
         .get_episode_in_namespace(episode_id, ps.namespace.id)
         .expect("episode lookup")
         .expect("episode exists")
+}
+
+// ---------------------------------------------------------------------------
+// Harness invariant
+// ---------------------------------------------------------------------------
+
+/// The seeding in `app_state` only works because `TenantStateManager` clones
+/// one `OnceLock` into the default state and every tenant it later builds. If
+/// that ever stops holding, seeding silently covers nothing and the first test
+/// to reach a recall path attempts a real model download instead. `get()` does
+/// not initialise, so this observes the cell without resolving it.
+#[tokio::test]
+async fn tenant_states_share_the_seeded_reranker_cell() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let state = app_state(&dir);
+
+    for tenant in [TENANT_A, TENANT_B] {
+        let ps = state
+            .tenant_mgr
+            .get_tenant_state(tenant)
+            .expect("tenant state");
+        assert!(
+            ps.reranker_cell.get().is_some(),
+            "tenant {tenant} did not inherit the seeded reranker cell"
+        );
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/pensyve-mcp-gateway/tests/test_cross_tenant_isolation.rs
+++ b/pensyve-mcp-gateway/tests/test_cross_tenant_isolation.rs
@@ -1,0 +1,498 @@
+//! Cross-tenant isolation regression tests for the REST surface.
+//!
+//! The gateway shares a single `Arc<dyn StorageTrait>` across every tenant;
+//! isolation comes entirely from the `namespace_id` each handler passes down.
+//! Any handler that resolves a row by a caller-supplied `id` / `episode_id`
+//! *without* also constraining on the caller's namespace therefore reaches
+//! across tenants.
+//!
+//! These tests stand guard over that bug class. Each one drives two tenants
+//! (A and B) against one shared gateway and asserts that tenant A cannot
+//! read, modify, or delete a row owned by tenant B — exercising the real
+//! axum handlers over HTTP rather than the storage methods directly.
+//!
+//! Not-found is the required response for a foreign row: the handlers must
+//! not distinguish "belongs to someone else" from "does not exist", or the
+//! 404/200 split becomes a cross-tenant existence oracle.
+
+use std::sync::Arc;
+
+use axum::extract::Request;
+use axum::middleware::Next;
+use axum::response::Response;
+use pensyve_core::config::RetrievalConfig;
+use pensyve_core::embedding::OnnxEmbedder;
+use pensyve_core::storage::StorageTrait;
+use pensyve_core::storage::sqlite::SqliteBackend;
+use pensyve_core::types::Namespace;
+use pensyve_core::vector::VectorIndex;
+use pensyve_mcp_gateway::AppState;
+use pensyve_mcp_gateway::auth::{AuthContext, AuthValidator};
+use pensyve_mcp_gateway::config::GatewayConfig;
+use pensyve_mcp_gateway::rate_limit::RateLimiter;
+use pensyve_mcp_gateway::rest;
+use pensyve_mcp_gateway::tenant::TenantStateManager;
+use pensyve_mcp_gateway::usage::UsageReporter;
+use pensyve_mcp_gateway::usage_counter::UsageCounter;
+use serde_json::{Value, json};
+use tempfile::TempDir;
+use tokio_util::sync::CancellationToken;
+use uuid::Uuid;
+
+/// Header the test middleware reads to decide which tenant a request is
+/// authenticated as. Stands in for the real auth layer, which derives the
+/// same value from the API key / OAuth subject.
+const TENANT_HEADER: &str = "x-test-tenant";
+const TENANT_A: &str = "tenant-attacker";
+const TENANT_B: &str = "tenant-victim";
+
+fn retrieval_config() -> RetrievalConfig {
+    RetrievalConfig {
+        default_limit: 5,
+        max_candidates: 100,
+        weights: [0.30, 0.15, 0.20, 0.10, 0.10, 0.05, 0.05, 0.05],
+        recall_timeout_secs: 5,
+        rrf_k: 60,
+        rrf_weights: [1.0, 0.8, 1.0, 0.8, 0.5, 0.5, 1.2, 1.0],
+        beam_width: 10,
+        max_depth: 4,
+    }
+}
+
+fn gateway_config(dir: &TempDir) -> GatewayConfig {
+    GatewayConfig {
+        host: "127.0.0.1".to_string(),
+        port: 0,
+        storage_path: dir.path().to_path_buf(),
+        namespace: "default".to_string(),
+        api_keys: vec![],
+        rate_limit_per_minute: 10_000,
+        stripe_api_key: None,
+        admin_key: None,
+        key_user_map: vec![],
+        allowed_hosts: vec![],
+    }
+}
+
+/// Prevents the lazily-resolved reranker from attempting a real network
+/// model download when a recall assertion runs.
+#[allow(
+    unsafe_code,
+    reason = "test-only env-var guard; std::env::set_var is unsafe in Rust 2024 edition by language design but is safe here because it runs exactly once via std::sync::Once before any reader"
+)]
+fn disable_reranker_for_tests() {
+    static INIT: std::sync::Once = std::sync::Once::new();
+    INIT.call_once(|| {
+        // SAFETY: runs exactly once via `Once`, before any concurrent reader.
+        unsafe { std::env::set_var("PENSYVE_RERANKER", "0") };
+    });
+}
+
+fn app_state(dir: &TempDir) -> Arc<AppState> {
+    disable_reranker_for_tests();
+    let storage =
+        Arc::new(SqliteBackend::open(dir.path()).expect("open storage")) as Arc<dyn StorageTrait>;
+    let namespace = Namespace::new("default");
+    storage
+        .save_namespace(&namespace)
+        .expect("save default namespace");
+
+    let tenant_mgr = TenantStateManager::new(
+        storage,
+        Arc::new(OnnxEmbedder::new_mock(768)),
+        retrieval_config(),
+        namespace,
+        VectorIndex::new(768, 1024),
+    );
+    let config = gateway_config(dir);
+
+    Arc::new(AppState {
+        auth: AuthValidator::new(&config),
+        rate_limiter: RateLimiter::new(None),
+        usage_reporter: UsageReporter::new(None),
+        usage_counter: UsageCounter::new(),
+        tenant_mgr,
+        auth_required: false,
+        admin_key: None,
+        ct: CancellationToken::new(),
+        redis: None,
+        extractor: None,
+    })
+}
+
+/// Stand-in for the real auth layer: turns the `x-test-tenant` header into
+/// the `AuthContext` extension the handlers extract, so one server can serve
+/// two distinct tenants.
+async fn tenant_from_header(mut req: Request, next: Next) -> Response {
+    let key_id = req
+        .headers()
+        .get(TENANT_HEADER)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or(TENANT_A)
+        .to_string();
+    req.extensions_mut().insert(AuthContext {
+        key_id,
+        tenant_id: None,
+        user_id: None,
+        scope: "mcp".to_string(),
+        stripe_customer_id: None,
+        plan: "free".to_string(),
+    });
+    next.run(req).await
+}
+
+async fn start_test_server(dir: &TempDir) -> (String, Arc<AppState>, CancellationToken) {
+    let state = app_state(dir);
+    let app = rest::router()
+        .layer(axum::middleware::from_fn(tenant_from_header))
+        .with_state(state.clone());
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test server");
+    let addr = listener.local_addr().expect("test server address");
+    let cancellation = CancellationToken::new();
+    let shutdown = cancellation.clone();
+
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app)
+            .with_graceful_shutdown(shutdown.cancelled_owned())
+            .await;
+    });
+
+    (format!("http://{addr}"), state, cancellation)
+}
+
+// ---------------------------------------------------------------------------
+// Request helpers — every call carries an explicit tenant.
+// ---------------------------------------------------------------------------
+
+async fn remember(
+    client: &reqwest::Client,
+    url: &str,
+    tenant: &str,
+    entity: &str,
+    fact: &str,
+) -> Uuid {
+    let response = client
+        .post(format!("{url}/v1/remember"))
+        .header(TENANT_HEADER, tenant)
+        .json(&json!({ "entity": entity, "fact": fact, "confidence": 0.9 }))
+        .send()
+        .await
+        .expect("remember request");
+    assert_eq!(response.status(), reqwest::StatusCode::CREATED);
+    let body: Value = response.json().await.expect("remember response JSON");
+    Uuid::parse_str(body["id"].as_str().expect("remembered memory id")).expect("valid memory id")
+}
+
+async fn inspect(client: &reqwest::Client, url: &str, tenant: &str, entity: &str) -> Value {
+    let response = client
+        .post(format!("{url}/v1/inspect"))
+        .header(TENANT_HEADER, tenant)
+        .json(&json!({ "entity": entity }))
+        .send()
+        .await
+        .expect("inspect request");
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    response.json().await.expect("inspect response JSON")
+}
+
+async fn episode_start(client: &reqwest::Client, url: &str, tenant: &str) -> Uuid {
+    let response = client
+        .post(format!("{url}/v1/episodes/start"))
+        .header(TENANT_HEADER, tenant)
+        .json(&json!({ "participants": ["assistant", "user"] }))
+        .send()
+        .await
+        .expect("episode start request");
+    assert_eq!(response.status(), reqwest::StatusCode::CREATED);
+    let body: Value = response.json().await.expect("episode start JSON");
+    Uuid::parse_str(body["episode_id"].as_str().expect("episode id")).expect("valid episode id")
+}
+
+/// Read an episode straight out of shared storage, bypassing the handlers,
+/// so assertions can observe writes the API is supposed to have refused.
+fn stored_episode(
+    state: &AppState,
+    tenant: &str,
+    episode_id: Uuid,
+) -> pensyve_core::types::Episode {
+    let ps = state
+        .tenant_mgr
+        .get_tenant_state(tenant)
+        .expect("tenant state");
+    ps.storage
+        .get_episode_in_namespace(episode_id, ps.namespace.id)
+        .expect("episode lookup")
+        .expect("episode exists")
+}
+
+// ---------------------------------------------------------------------------
+// A1 — cross-tenant DELETE of a memory
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn delete_memory_cannot_reach_across_namespaces() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let (url, _state, cancellation) = start_test_server(&dir).await;
+    let client = reqwest::Client::new();
+
+    // Victim stores a memory in their own namespace.
+    let victim_memory = remember(&client, &url, TENANT_B, "bob", "rotates the signing key").await;
+
+    // Attacker, holding only the UUID, asks the gateway to delete it.
+    let response = client
+        .delete(format!("{url}/v1/memories/{victim_memory}"))
+        .header(TENANT_HEADER, TENANT_A)
+        .send()
+        .await
+        .expect("delete request");
+
+    assert_eq!(
+        response.status(),
+        reqwest::StatusCode::NOT_FOUND,
+        "a memory owned by another namespace must be indistinguishable from a missing one"
+    );
+
+    // The victim's memory must survive.
+    let body = inspect(&client, &url, TENANT_B, "bob").await;
+    let semantic = body["semantic"].as_array().expect("semantic array");
+    assert!(
+        semantic
+            .iter()
+            .any(|m| m["id"].as_str() == Some(victim_memory.to_string().as_str())),
+        "victim memory {victim_memory} was deleted by another tenant; inspect returned {body}"
+    );
+
+    cancellation.cancel();
+}
+
+#[tokio::test]
+async fn delete_memory_still_works_within_the_owning_namespace() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let (url, _state, cancellation) = start_test_server(&dir).await;
+    let client = reqwest::Client::new();
+
+    let memory = remember(&client, &url, TENANT_B, "bob", "rotates the signing key").await;
+
+    let response = client
+        .delete(format!("{url}/v1/memories/{memory}"))
+        .header(TENANT_HEADER, TENANT_B)
+        .send()
+        .await
+        .expect("delete request");
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+
+    let body = inspect(&client, &url, TENANT_B, "bob").await;
+    assert_eq!(body["semantic"], json!([]));
+
+    cancellation.cancel();
+}
+
+// ---------------------------------------------------------------------------
+// A2 — cross-namespace attachment to a foreign episode
+//
+// Writing an episodic memory that carries another tenant's `episode_id` is
+// what lets a caller's own recall groups join against the victim's
+// per-episode rows. `/v1/observe` must refuse the foreign episode outright.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn observe_cannot_attach_to_an_episode_in_another_namespace() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let (url, state, cancellation) = start_test_server(&dir).await;
+    let client = reqwest::Client::new();
+
+    let victim_episode = episode_start(&client, &url, TENANT_B).await;
+
+    let response = client
+        .post(format!("{url}/v1/observe"))
+        .header(TENANT_HEADER, TENANT_A)
+        .json(&json!({
+            "episode_id": victim_episode.to_string(),
+            "content": "attacker-supplied turn bound to a foreign episode",
+            "source_entity": "mallory",
+            "about_entity": "mallory",
+        }))
+        .send()
+        .await
+        .expect("observe request");
+
+    assert_eq!(
+        response.status(),
+        reqwest::StatusCode::NOT_FOUND,
+        "an episode owned by another namespace must be indistinguishable from a missing one"
+    );
+
+    // No episodic row may have landed in the attacker's namespace bound to
+    // the victim's episode.
+    let attacker = state
+        .tenant_mgr
+        .get_tenant_state(TENANT_A)
+        .expect("attacker state");
+    let leaked = attacker
+        .storage
+        .list_episodic_by_episode(attacker.namespace.id, victim_episode)
+        .expect("episodic lookup");
+    assert!(
+        leaked.is_empty(),
+        "attacker wrote {} episodic row(s) bound to the victim's episode",
+        leaked.len()
+    );
+
+    cancellation.cancel();
+}
+
+#[tokio::test]
+async fn observe_still_works_within_the_owning_namespace() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let (url, _state, cancellation) = start_test_server(&dir).await;
+    let client = reqwest::Client::new();
+
+    let episode = episode_start(&client, &url, TENANT_B).await;
+
+    let response = client
+        .post(format!("{url}/v1/observe"))
+        .header(TENANT_HEADER, TENANT_B)
+        .json(&json!({
+            "episode_id": episode.to_string(),
+            "content": "a turn in my own episode",
+            "source_entity": "bob",
+            "about_entity": "bob",
+        }))
+        .send()
+        .await
+        .expect("observe request");
+    assert_eq!(response.status(), reqwest::StatusCode::CREATED);
+
+    cancellation.cancel();
+}
+
+// ---------------------------------------------------------------------------
+// A3 — cross-namespace WRITE through episode handlers
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn episode_end_cannot_close_an_episode_in_another_namespace() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let (url, state, cancellation) = start_test_server(&dir).await;
+    let client = reqwest::Client::new();
+
+    let victim_episode = episode_start(&client, &url, TENANT_B).await;
+    assert!(
+        stored_episode(&state, TENANT_B, victim_episode)
+            .ended_at
+            .is_none(),
+        "precondition: the victim's episode starts open"
+    );
+
+    let response = client
+        .post(format!("{url}/v1/episodes/{victim_episode}/end"))
+        .header(TENANT_HEADER, TENANT_A)
+        .json(&json!({ "outcome": "failure" }))
+        .send()
+        .await
+        .expect("episode end request");
+
+    assert_eq!(
+        response.status(),
+        reqwest::StatusCode::NOT_FOUND,
+        "an episode owned by another namespace must be indistinguishable from a missing one"
+    );
+
+    let after = stored_episode(&state, TENANT_B, victim_episode);
+    assert!(
+        after.ended_at.is_none(),
+        "attacker stamped ended_at={:?} on the victim's episode",
+        after.ended_at
+    );
+    assert!(
+        after.outcome.is_none(),
+        "attacker stamped outcome={:?} on the victim's episode",
+        after.outcome
+    );
+
+    cancellation.cancel();
+}
+
+#[tokio::test]
+async fn episode_end_still_works_within_the_owning_namespace() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let (url, state, cancellation) = start_test_server(&dir).await;
+    let client = reqwest::Client::new();
+
+    let episode = episode_start(&client, &url, TENANT_B).await;
+
+    let response = client
+        .post(format!("{url}/v1/episodes/{episode}/end"))
+        .header(TENANT_HEADER, TENANT_B)
+        .json(&json!({ "outcome": "success" }))
+        .send()
+        .await
+        .expect("episode end request");
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+
+    assert!(stored_episode(&state, TENANT_B, episode).ended_at.is_some());
+
+    cancellation.cancel();
+}
+
+#[tokio::test]
+async fn episode_message_cannot_append_to_an_episode_in_another_namespace() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let (url, state, cancellation) = start_test_server(&dir).await;
+    let client = reqwest::Client::new();
+
+    let victim_episode = episode_start(&client, &url, TENANT_B).await;
+
+    let response = client
+        .post(format!("{url}/v1/episodes/{victim_episode}/message"))
+        .header(TENANT_HEADER, TENANT_A)
+        .json(&json!({ "role": "user", "content": "injected turn" }))
+        .send()
+        .await
+        .expect("episode message request");
+
+    assert_eq!(
+        response.status(),
+        reqwest::StatusCode::NOT_FOUND,
+        "an episode owned by another namespace must be indistinguishable from a missing one"
+    );
+
+    let attacker = state
+        .tenant_mgr
+        .get_tenant_state(TENANT_A)
+        .expect("attacker state");
+    let leaked = attacker
+        .storage
+        .list_episodic_by_episode(attacker.namespace.id, victim_episode)
+        .expect("episodic lookup");
+    assert!(
+        leaked.is_empty(),
+        "attacker wrote {} episodic row(s) bound to the victim's episode",
+        leaked.len()
+    );
+
+    cancellation.cancel();
+}
+
+#[tokio::test]
+async fn episode_message_still_works_within_the_owning_namespace() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let (url, _state, cancellation) = start_test_server(&dir).await;
+    let client = reqwest::Client::new();
+
+    let episode = episode_start(&client, &url, TENANT_B).await;
+
+    let response = client
+        .post(format!("{url}/v1/episodes/{episode}/message"))
+        .header(TENANT_HEADER, TENANT_B)
+        .json(&json!({ "role": "user", "content": "a turn in my own episode" }))
+        .send()
+        .await
+        .expect("episode message request");
+    assert_eq!(response.status(), reqwest::StatusCode::CREATED);
+
+    cancellation.cancel();
+}

--- a/pensyve-mcp-tools/Cargo.toml
+++ b/pensyve-mcp-tools/Cargo.toml
@@ -25,5 +25,8 @@ schemars = "1"
 uuid = { version = "1", features = ["v4"] }
 tracing = "0.1"
 
+[dev-dependencies]
+tempfile = "3"
+
 [lints]
 workspace = true

--- a/pensyve-mcp-tools/src/server.rs
+++ b/pensyve-mcp-tools/src/server.rs
@@ -949,6 +949,7 @@ mod tests {
 
     use pensyve_core::config::RetrievalConfig;
     use pensyve_core::embedding::OnnxEmbedder;
+    use pensyve_core::reranker::Reranker;
     use pensyve_core::storage::sqlite::SqliteBackend;
     use pensyve_core::types::{Episode, Namespace};
     use pensyve_core::vector::VectorIndex;
@@ -975,7 +976,18 @@ mod tests {
         let storage = Arc::new(SqliteBackend::open(dir.path()).expect("open storage"))
             as Arc<dyn StorageTrait>;
         let embedder = Arc::new(OnnxEmbedder::new_mock(768));
+
+        // Seed the shared reranker cell with a mock so no test in this binary
+        // can fall through to the real model download. Seeding the cell is the
+        // thread-safe alternative to setting `PENSYVE_RERANKER=0`, which is a
+        // process-global mutation racing every concurrent reader.
         let reranker_cell = Arc::new(OnceLock::new());
+        assert!(
+            reranker_cell
+                .set(Some(Arc::new(Reranker::new_mock())))
+                .is_ok(),
+            "freshly constructed reranker cell must be unset"
+        );
 
         let mut servers = Vec::new();
         for name in ["tenant-attacker", "tenant-victim"] {

--- a/pensyve-mcp-tools/src/server.rs
+++ b/pensyve-mcp-tools/src/server.rs
@@ -364,7 +364,14 @@ impl PensyveMcpServer {
             }
         };
 
-        let mut episode = match state.storage.get_episode(episode_id) {
+        // Scoped load: `update_episode` writes back on `episode.namespace_id`,
+        // so an unscoped read would let this caller stamp `ended_at`/`outcome`
+        // onto another tenant's episode. A foreign episode reports the same
+        // not-found as a missing one.
+        let mut episode = match state
+            .storage
+            .get_episode_in_namespace(episode_id, state.namespace.id)
+        {
             Ok(Some(ep)) => ep,
             Ok(None) => return Err(format!("Episode not found: {episode_id}")),
             Err(e) => return Err(format!("Error loading episode: {e}")),
@@ -469,8 +476,13 @@ impl PensyveMcpServer {
             .parse::<Uuid>()
             .map_err(|_| format!("Invalid episode_id: '{}'", params.episode_id))?;
 
-        // Verify the episode exists.
-        match state.storage.get_episode(episode_id) {
+        // Verify the episode exists *in the caller's namespace*. Attaching to a
+        // foreign episode would let this namespace's recall groups join against
+        // the owning tenant's per-episode rows.
+        match state
+            .storage
+            .get_episode_in_namespace(episode_id, state.namespace.id)
+        {
             Ok(Some(_)) => {}
             Ok(None) => return Err(format!("Episode not found: {episode_id}")),
             Err(e) => return Err(format!("Error loading episode: {e}")),
@@ -925,5 +937,117 @@ mod tests {
     fn test_check_scope_write_denies_read_tools() {
         assert!(check_scope("mcp:write", "pensyve_recall").is_err());
         assert!(check_scope("mcp:write", "pensyve_inspect").is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // Cross-tenant isolation
+    //
+    // The gateway hands every tenant a `PensyveState` over one shared storage
+    // backend; only `state.namespace` differs. A tool that resolves a row from
+    // a caller-supplied UUID alone therefore reaches across tenants.
+    // -----------------------------------------------------------------------
+
+    use pensyve_core::config::RetrievalConfig;
+    use pensyve_core::embedding::OnnxEmbedder;
+    use pensyve_core::storage::sqlite::SqliteBackend;
+    use pensyve_core::types::{Episode, Namespace};
+    use pensyve_core::vector::VectorIndex;
+    use std::sync::OnceLock;
+    use tokio::sync::RwLock;
+
+    fn test_retrieval_config() -> RetrievalConfig {
+        RetrievalConfig {
+            default_limit: 5,
+            max_candidates: 100,
+            weights: [0.30, 0.15, 0.20, 0.10, 0.10, 0.05, 0.05, 0.05],
+            recall_timeout_secs: 5,
+            rrf_k: 60,
+            rrf_weights: [1.0, 0.8, 1.0, 0.8, 0.5, 0.5, 1.2, 1.0],
+            beam_width: 10,
+            max_depth: 4,
+        }
+    }
+
+    /// Two tenant states over one shared backend, as the gateway builds them.
+    fn two_tenant_servers(
+        dir: &tempfile::TempDir,
+    ) -> (PensyveMcpServer, PensyveMcpServer, Arc<dyn StorageTrait>) {
+        let storage = Arc::new(SqliteBackend::open(dir.path()).expect("open storage"))
+            as Arc<dyn StorageTrait>;
+        let embedder = Arc::new(OnnxEmbedder::new_mock(768));
+        let reranker_cell = Arc::new(OnceLock::new());
+
+        let mut servers = Vec::new();
+        for name in ["tenant-attacker", "tenant-victim"] {
+            let namespace = Namespace::new(name);
+            storage.save_namespace(&namespace).expect("save namespace");
+            servers.push(PensyveMcpServer::new(Arc::new(PensyveState {
+                storage: storage.clone(),
+                embedder: embedder.clone(),
+                vector_index: RwLock::new(VectorIndex::new(768, 1024)),
+                namespace,
+                retrieval_config: test_retrieval_config(),
+                is_remote: true,
+                reranker_cell: reranker_cell.clone(),
+            })));
+        }
+        let victim = servers.pop().expect("victim server");
+        let attacker = servers.pop().expect("attacker server");
+        (attacker, victim, storage)
+    }
+
+    #[tokio::test]
+    async fn episode_end_cannot_close_an_episode_in_another_namespace() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (attacker, victim, storage) = two_tenant_servers(&dir);
+
+        let episode = Episode::new(victim.state.namespace.id, vec![Uuid::new_v4()]);
+        storage.save_episode(&episode).expect("save episode");
+
+        let result = attacker
+            .episode_end(Parameters(EpisodeEndParams {
+                episode_id: episode.id.to_string(),
+                outcome: Some("failure".to_string()),
+            }))
+            .await;
+
+        assert!(
+            result.is_err(),
+            "attacker closed the victim's episode: {result:?}"
+        );
+
+        let after = storage
+            .get_episode_in_namespace(episode.id, victim.state.namespace.id)
+            .expect("episode lookup")
+            .expect("victim episode still exists");
+        assert!(
+            after.ended_at.is_none(),
+            "attacker stamped ended_at={:?} on the victim's episode",
+            after.ended_at
+        );
+        assert!(after.outcome.is_none());
+    }
+
+    #[tokio::test]
+    async fn episode_end_still_works_within_the_owning_namespace() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (_attacker, victim, storage) = two_tenant_servers(&dir);
+
+        let episode = Episode::new(victim.state.namespace.id, vec![Uuid::new_v4()]);
+        storage.save_episode(&episode).expect("save episode");
+
+        victim
+            .episode_end(Parameters(EpisodeEndParams {
+                episode_id: episode.id.to_string(),
+                outcome: Some("success".to_string()),
+            }))
+            .await
+            .expect("owner may close their own episode");
+
+        let after = storage
+            .get_episode_in_namespace(episode.id, victim.state.namespace.id)
+            .expect("episode lookup")
+            .expect("episode exists");
+        assert!(after.ended_at.is_some());
     }
 }


### PR DESCRIPTION
## Summary

The gateway builds one `PensyveState` per tenant but shares a single `Arc<dyn StorageTrait>` across all of them (`pensyve-mcp-gateway/src/tenant.rs`). Tenants are separated only by the `namespace_id` each call passes down. Several storage accessors resolved rows from a caller-supplied `id` or `episode_id` alone, with no namespace predicate, so they were not constrained to the calling tenant.

Postgres row-level security does not cover this. `maybe_scoped_conn` applies a scope only when `PostgresBackend::default_namespace` is `Some`, and the only way to set it — `with_default_namespace` — is never called; the gateway constructs the backend with `PostgresBackend::new`. RLS is treated here as a second line of defence, not the first.

## Changes

### Storage layer (`pensyve-core/src/storage/`)

- **`get_episode(id)` is replaced by `get_episode_in_namespace(id, namespace_id)`.** The unscoped variant is removed rather than kept alongside the scoped one. An `Episode` loaded without a namespace check carries the owner's `namespace_id`, and `update_episode` writes back on that field — so an unscoped read is enough to make a later write land on someone else's row. Requiring the namespace at the accessor makes that unrepresentable instead of relying on each caller to compare after the fact. There were no remaining callers that needed the unscoped form.
- **`list_observations_by_episode_ids` takes `namespace_id` and always applies it.** The Postgres implementation previously applied the predicate only on the `default_namespace.is_some()` branch, which no production path took; the other branch filtered on `episode_id` alone. The predicate is now unconditional in both backends.
- **`delete_observations_by_episode` takes `namespace_id`.** It has no production caller today, but three routes accept an `episode_id` straight from the request, so the scoping is pinned before it can acquire one. In SQLite every cascade sub-select (`kg_triples`, `kg_passage_entities`, `memory_fts`) repeats the namespace predicate.

### Callers

- `DELETE /v1/memories/{id}` routes through the existing `delete_memory_by_id_in_namespace` rather than the unscoped delete.
- `POST /v1/observe`, `POST /v1/episodes/{id}/message`, `POST /v1/episodes/{id}/end`, and the `pensyve_observe` / `pensyve_episode_end` MCP tools resolve episodes through the scoped accessor.
- `recall_grouped::attach_observations_to_groups` takes the recalling namespace and passes it to the observation lookup. A group's `session_id` comes from an episodic memory's `episode_id`, which is a caller-supplied value and not a tenant boundary.

A row owned by another namespace returns the same not-found response as a missing one, so the status code does not become a cross-tenant existence oracle.

## Tests

New regression tests, all of which fail without the corresponding fix:

| File | Coverage |
| --- | --- |
| `pensyve-mcp-gateway/tests/test_cross_tenant_isolation.rs` | Two tenants against one gateway over real HTTP. Delete, observe, episode-message and episode-end each get a cross-tenant case (must be refused, and the target row must be unchanged) paired with a same-namespace control (must still succeed). 8 tests. |
| `pensyve-core/tests/test_namespace_scoping.rs` | Storage primitives: scoped episode lookup, observation reads, observation deletes. Includes a case where the same `episode_id` value exists in both namespaces and each side must see only its own row. 7 tests. |
| `pensyve-mcp-tools/src/server.rs` | MCP `pensyve_episode_end` against two tenant states over one backend. 2 tests. |

The paired same-namespace controls are there so a future change cannot make these pass by breaking the feature outright.

## Verification

```
cargo test -p pensyve-core -p pensyve-mcp-tools -p pensyve-mcp-gateway
  34 suites, 867 passed, 0 failed, 9 ignored

cargo test -p pensyve-core --features postgres
  24 suites, 656 passed, 0 failed

cargo fmt --all --check                                          clean
cargo clippy --workspace --all-targets                           clean
cargo clippy -p pensyve-core --features postgres --all-targets   clean
```

The cross-tenant file was also run 20 times across `--test-threads` 1/2/4/8/16 (all green) to confirm the harness is deterministic after the reranker change below.

## Out of scope

- **The `edges` table has no `namespace_id` column at all**, so `get_edges_for_entity` and friends cannot be scoped without a schema migration. Left alone here; it needs its own PR.
- **RLS defects** — `set_config(..., true)` is transaction-local but is issued outside a transaction, and the tables are missing `FORCE ROW LEVEL SECURITY`. Separate PR. The explicit predicates added here mean correctness no longer depends on RLS either way.
- `PostgresBackend::with_default_namespace` is still defined and still never called. The three methods changed here now use `scoped_conn` directly, so none of them depend on it any more. Removing it is left for the RLS PR.
- The paths that already compared namespaces correctly (supersede/PATCH, `get_entity`) were not touched.

## Compatibility

`StorageTrait` is public and three of its methods change signature, so this breaks any out-of-tree backend implementation. All in-tree implementations and callers are updated.

This was raised as conflicting with the `AGENTS.md` rule against breaking the public API without a deprecation cycle. **Maintainer ruling: keep the break** — no deprecation cycle and no fail-closed shim, with `pensyve-core` taking a major bump at release prep. The reasoning is that a deprecation cycle works when the old API is merely superseded, whereas here the old API *is* the defect: `get_episode(id)` hands back an `Episode` carrying the owner's `namespace_id`, and `update_episode` writes back on that field, so keeping a `#[deprecated]` variant would keep the defect reachable for the length of the cycle. No version numbers or CHANGELOG entries are touched in this PR; that is release-prep work.

Two of the three methods (`list_observations_by_episode_ids`, `delete_observations_by_episode`) have default implementations, so an external backend that never overrode them is unaffected.

## Test harness

The regression tests originally disabled the reranker by setting `PENSYVE_RERANKER=0` through `std::env::set_var` behind a `Once`. That serialises the write but not concurrent reads from other tests in the same process, which is both racy and the reason `set_var` is `unsafe` in edition 2024 — a poor foundation for tests meant to stand guard over this bug class.

Replaced with direct seeding of the reranker cell. `TenantStateManager` clones one `Arc<OnceLock<..>>` into its default state and every tenant state it builds, so a single `set(Some(Arc::new(Reranker::new_mock())))` covers the manager. No `unsafe`, no process-global state, and no production API change was required. `tenant_states_share_the_seeded_reranker_cell` asserts the sharing that makes this work, so the arrangement fails loudly rather than silently degrading to a real model download.

https://claude.ai/code/session_01AsVz67dYuk3dufxA683hJA
