### PR TITLE
fix(storage): bind the namespace setting so Postgres RLS policies apply (#225)

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -51,27 +51,28 @@ per namespaced table. Each policy matches `namespace_id` against the
 `pensyve.namespace_id` setting, on both the read half (`USING`) and the write
 half (`WITH CHECK`), so a connection scoped to one namespace can neither read
 nor write another's rows. The backend binds that setting on every connection it
-takes from the pool; a connection that is not scoped to a namespace is bound to
+takes from the pool. A connection that is not scoped to a namespace is bound to
 a value no row can match, so it fails closed rather than inheriting the
 previous caller's namespace.
 
-**Layer 2 is not active by default.** Postgres exempts a table's owner from its
-own policies, and the application connects as the role that owns the schema, so
-the policies do not apply to it. Removing that exemption requires
-`FORCE ROW LEVEL SECURITY`, which ships as a separate, operator-applied file
-(`postgres_rls_enforce.sql`, also reachable as `PostgresBackend::enforce_rls`)
-rather than as part of the schema that runs on every startup.
+Layer 2 is not active by default. Postgres exempts a table's owner from its own
+policies, and the application connects as the role that owns the schema, so the
+policies do not apply to it. Removing that exemption requires
+`FORCE ROW LEVEL SECURITY`, which ships as a separate file that an operator
+applies (`postgres_rls_enforce.sql`, also reachable as
+`PostgresBackend::enforce_rls`) rather than as part of the schema that runs on
+every startup.
 
 #### Before enabling enforcement
 
-Enforcement fails closed, and it fails *silently*: a query path that does not
-carry a namespace does not error, it returns no rows. A delete returns "0 rows
-deleted" and reports success. Several `StorageTrait` methods still take no
-`namespace_id` and therefore run unscoped — among them the ones behind recall
-candidate hydration, memory supersession, entity forget, and GDPR erase. The
-test `enforced_rls_fails_closed_for_unscoped_methods` in
-`pensyve-core/src/storage/postgres/live_rls.rs` enumerates them and is the
-checklist that must reach zero before enforcement becomes the default.
+Enforcement fails closed, and it fails without raising an error. A query path
+that does not carry a namespace returns no rows, and a delete on that path
+reports success after deleting nothing. Several `StorageTrait` methods still
+take no `namespace_id` and therefore run unscoped, including the ones behind
+recall candidate hydration, memory supersession, entity forget, and GDPR erase.
+The test `enforced_rls_fails_closed_for_unscoped_methods` in
+`pensyve-core/src/storage/postgres/live_rls.rs` lists them, and the list must
+be empty before enforcement becomes the default.
 
 Do not apply enforcement to a deployment until those paths carry a namespace.
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -50,10 +50,25 @@ layers:
 per namespaced table. Each policy matches `namespace_id` against the
 `pensyve.namespace_id` setting, on both the read half (`USING`) and the write
 half (`WITH CHECK`), so a connection scoped to one namespace can neither read
-nor write another's rows. The backend binds that setting on every connection it
-takes from the pool. A connection that is not scoped to a namespace is bound to
-a value no row can match, so it fails closed rather than inheriting the
-previous caller's namespace.
+nor write another's rows.
+
+The backend binds that setting on every connection its own storage methods take
+from the pool. A storage method that carries no namespace binds the empty
+string instead, which no UUID can match, so those paths fail closed rather than
+inheriting the previous caller's namespace.
+
+The guarantee stops at the backend's own storage methods. A few call sites
+deliberately take a connection with nothing bound, reached through
+`ScopedPool::unbound`, and one of them is the public `PostgresBackend::pool`
+accessor. A connection from there carries whatever namespace the previous
+checkout left set, because the setting is session-scoped and Postgres does not
+clear it. Anything querying a table that carries a `namespace_isolation_*`
+policy through such a connection must bind a namespace first, with
+`PostgresBackend::set_namespace_config`, or bind the empty string to fail
+closed on purpose. Without that, a query reads the previous caller's namespace
+once RLS is enforced, which is a cross-namespace read rather than an empty
+result. The internal uses are limited to DDL, which RLS does not apply to, and
+to `namespaces`, `edges`, and `activity_events`, none of which carry a policy.
 
 Layer 2 is not active by default. Postgres exempts a table's owner from its own
 policies, and the application connects as the role that owns the schema, so the
@@ -78,10 +93,50 @@ Do not apply enforcement to a deployment until those paths carry a namespace.
 
 #### Applying enforcement
 
-Apply `pensyve-core/src/storage/postgres_rls_enforce.sql`, or call
+First check that the application's role is not a superuser. Postgres exempts
+superusers from row-level security unconditionally, and `FORCE` does not change
+that, so enforcement applied to a superuser connection silently does nothing.
+The enforce script will still report success, which makes this easy to get
+wrong. Check with the query below, and expect `f`:
+
+```sql
+SELECT rolsuper FROM pg_roles WHERE rolname = current_user;
+```
+
+If it returns `t`, enforcement cannot work on that connection. Move the
+application to an ordinary role that owns the tables before going further.
+
+Then apply `pensyve-core/src/storage/postgres_rls_enforce.sql`, or call
 `PostgresBackend::enforce_rls`. Both run the same statements. The connecting
 role must own the tables, and the application already connects as the owner, so
 no new role is needed.
+
+Then verify enforcement actually took effect, because a successful run does not
+prove it. Every row below should report `t`:
+
+```sql
+SELECT relname, relrowsecurity, relforcerowsecurity
+  FROM pg_class
+ WHERE relname IN ('entities', 'episodes', 'episodic_memories',
+                   'semantic_memories', 'procedural_memories',
+                   'observation_memories');
+```
+
+All `t` proves the tables are forced. It does not prove the policies apply to
+the role the application connects as, and the difference matters. A superuser
+gets `t` on every row above and still reads every namespace, which is exactly
+how a broken deployment looks like a working one. The only check that settles
+it is behavioural. Run this as the application role against a database that
+holds data, using a namespace id that owns no rows:
+
+```sql
+SELECT set_config('pensyve.namespace_id', '00000000-0000-0000-0000-000000000000', false);
+SELECT count(*) FROM episodic_memories;
+```
+
+A count of 0 means the policies apply to this role. Anything above 0 means they
+do not, whatever the catalog says, and the usual cause is connecting as a
+superuser or as a role holding `BYPASSRLS`.
 
 To roll back, run `ALTER TABLE <table> NO FORCE ROW LEVEL SECURITY;` for each
 table. Rollback takes effect immediately and touches neither the policies nor

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -89,9 +89,11 @@ the data.
 
 #### The dedicated application role, and why it is not available yet
 
-A role that does not own the tables is subject to their policies whether or not
+A role that does not own the tables is subject to their policies whether
 `FORCE` is set, so running the application as a non-owner role would be the
-more durable control. It is not possible today.
+more durable control. It is not possible today. Do not follow the SQL below as
+deployment instructions, because an application pointed at such a role will not
+start. Issue #254 tracks the change that makes it usable.
 
 `PostgresBackend::new` applies the schema on every startup, and the schema
 contains statements only a table's owner may run, including
@@ -103,16 +105,26 @@ the application from starting.
 
 Supporting a non-owner role needs a code change first, so that applying the
 schema is separate from serving traffic. Once that exists, the role should look
-like this, and `NOBYPASSRLS` is required because a role with `BYPASSRLS`, and
-any superuser, ignores every policy:
+like the target state below. `NOBYPASSRLS` is required because a role with
+`BYPASSRLS`, and any superuser, ignores every policy.
 
 ```sql
+-- Target state. Not usable until issue #254 lands.
 CREATE ROLE pensyve_app LOGIN PASSWORD '...' NOSUPERUSER NOBYPASSRLS;
 GRANT USAGE ON SCHEMA public TO pensyve_app;
 GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO pensyve_app;
-ALTER DEFAULT PRIVILEGES IN SCHEMA public
+
+-- Run this as the role that owns the tables, or name that role with FOR ROLE.
+-- ALTER DEFAULT PRIVILEGES only covers tables created later by the role it
+-- names, so running it as anyone else silently grants nothing on the tables
+-- the owner goes on to create.
+ALTER DEFAULT PRIVILEGES FOR ROLE pensyve_owner IN SCHEMA public
   GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO pensyve_app;
 ```
+
+`ALTER DEFAULT PRIVILEGES` never applies to tables that already exist, so the
+`GRANT ... ON ALL TABLES` above is what covers the current schema. Both
+statements are needed.
 
 #### What goes wrong
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -77,37 +77,48 @@ Do not apply enforcement to a deployment until those paths carry a namespace.
 
 #### Applying enforcement
 
-Two changes, in this order. Both are reversible.
-
-1. **Run a dedicated application role that does not own the tables.** A
-   non-owner role is subject to RLS whether or not `FORCE` is set, so this is
-   the durable half of the control:
-
-   ```sql
-   CREATE ROLE pensyve_app LOGIN PASSWORD '...' NOSUPERUSER NOBYPASSRLS;
-   GRANT USAGE ON SCHEMA public TO pensyve_app;
-   GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO pensyve_app;
-   ALTER DEFAULT PRIVILEGES IN SCHEMA public
-     GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO pensyve_app;
-   ```
-
-   `NOBYPASSRLS` matters: a role with `BYPASSRLS`, and any superuser, ignores
-   every policy. Point `DATABASE_URL` at this role. Keep the owning role for
-   migrations only — the schema is applied on startup, so the owner must still
-   be able to run DDL.
-
-2. **Force the policies onto the owner** by applying
-   `pensyve-core/src/storage/postgres_rls_enforce.sql`. This closes the gap for
-   deployments where the application still connects as the owner.
+Apply `pensyve-core/src/storage/postgres_rls_enforce.sql`, or call
+`PostgresBackend::enforce_rls`. Both run the same statements. The connecting
+role must own the tables, and the application already connects as the owner, so
+no new role is needed.
 
 To roll back, run `ALTER TABLE <table> NO FORCE ROW LEVEL SECURITY;` for each
-table. It takes effect immediately and touches neither the policies nor the
-data.
+table. Rollback takes effect immediately and touches neither the policies nor
+the data.
 
-Getting the order wrong locks the application out of its own tables: an
-application role with no `GRANT`s, or enforcement applied while query paths are
-still unscoped, produces empty reads and silent no-op writes rather than a
-visible failure.
+#### The dedicated application role, and why it is not available yet
+
+A role that does not own the tables is subject to their policies whether or not
+`FORCE` is set, so running the application as a non-owner role would be the
+more durable control. It is not possible today.
+
+`PostgresBackend::new` applies the schema on every startup, and the schema
+contains statements only a table's owner may run, including
+`ALTER TABLE ... ADD COLUMN`, `CREATE INDEX`, `ALTER TABLE ... ENABLE ROW LEVEL
+SECURITY`, and `CREATE POLICY`. A non-owner role fails at startup with
+`must be owner of table entities`, even when it holds every table privilege and
+`CREATE` on the schema. Pointing `DATABASE_URL` at a non-owner role today stops
+the application from starting.
+
+Supporting a non-owner role needs a code change first, so that applying the
+schema is separate from serving traffic. Once that exists, the role should look
+like this, and `NOBYPASSRLS` is required because a role with `BYPASSRLS`, and
+any superuser, ignores every policy:
+
+```sql
+CREATE ROLE pensyve_app LOGIN PASSWORD '...' NOSUPERUSER NOBYPASSRLS;
+GRANT USAGE ON SCHEMA public TO pensyve_app;
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO pensyve_app;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO pensyve_app;
+```
+
+#### What goes wrong
+
+Enforcement applied while query paths are still unscoped produces empty reads
+and writes that do nothing, rather than a visible failure. A non-owner role
+without grants stops the application from starting. Check the unscoped-method
+list first, and roll back with `NO FORCE` if reads start coming back empty.
 
 ## Network Policy
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -37,6 +37,78 @@ Cross-tenant queries are rejected at the storage layer. The cloud gateway
 (`pensyve-mcp-gateway`) maintains per-tenant state via `tenant.rs`, ensuring
 one tenant's data is never visible to another.
 
+### Postgres row-level security
+
+On the Postgres backend, namespace isolation is meant to have two independent
+layers:
+
+1. The explicit `namespace_id = $n` predicates in the storage layer's SQL.
+   This is what enforces isolation in every deployment today.
+2. Row-level security, as a backstop for a query that omits the predicate.
+
+`postgres_schema.sql` enables RLS and declares a `namespace_isolation_*` policy
+per namespaced table. Each policy matches `namespace_id` against the
+`pensyve.namespace_id` setting, on both the read half (`USING`) and the write
+half (`WITH CHECK`), so a connection scoped to one namespace can neither read
+nor write another's rows. The backend binds that setting on every connection it
+takes from the pool; a connection that is not scoped to a namespace is bound to
+a value no row can match, so it fails closed rather than inheriting the
+previous caller's namespace.
+
+**Layer 2 is not active by default.** Postgres exempts a table's owner from its
+own policies, and the application connects as the role that owns the schema, so
+the policies do not apply to it. Removing that exemption requires
+`FORCE ROW LEVEL SECURITY`, which ships as a separate, operator-applied file
+(`postgres_rls_enforce.sql`, also reachable as `PostgresBackend::enforce_rls`)
+rather than as part of the schema that runs on every startup.
+
+#### Before enabling enforcement
+
+Enforcement fails closed, and it fails *silently*: a query path that does not
+carry a namespace does not error, it returns no rows. A delete returns "0 rows
+deleted" and reports success. Several `StorageTrait` methods still take no
+`namespace_id` and therefore run unscoped — among them the ones behind recall
+candidate hydration, memory supersession, entity forget, and GDPR erase. The
+test `enforced_rls_fails_closed_for_unscoped_methods` in
+`pensyve-core/src/storage/postgres/live_rls.rs` enumerates them and is the
+checklist that must reach zero before enforcement becomes the default.
+
+Do not apply enforcement to a deployment until those paths carry a namespace.
+
+#### Applying enforcement
+
+Two changes, in this order. Both are reversible.
+
+1. **Run a dedicated application role that does not own the tables.** A
+   non-owner role is subject to RLS whether or not `FORCE` is set, so this is
+   the durable half of the control:
+
+   ```sql
+   CREATE ROLE pensyve_app LOGIN PASSWORD '...' NOSUPERUSER NOBYPASSRLS;
+   GRANT USAGE ON SCHEMA public TO pensyve_app;
+   GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO pensyve_app;
+   ALTER DEFAULT PRIVILEGES IN SCHEMA public
+     GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO pensyve_app;
+   ```
+
+   `NOBYPASSRLS` matters: a role with `BYPASSRLS`, and any superuser, ignores
+   every policy. Point `DATABASE_URL` at this role. Keep the owning role for
+   migrations only — the schema is applied on startup, so the owner must still
+   be able to run DDL.
+
+2. **Force the policies onto the owner** by applying
+   `pensyve-core/src/storage/postgres_rls_enforce.sql`. This closes the gap for
+   deployments where the application still connects as the owner.
+
+To roll back, run `ALTER TABLE <table> NO FORCE ROW LEVEL SECURITY;` for each
+table. It takes effect immediately and touches neither the policies nor the
+data.
+
+Getting the order wrong locks the application out of its own tables: an
+application role with no `GRANT`s, or enforcement applied while query paths are
+still unscoped, produces empty reads and silent no-op writes rather than a
+visible failure.
+
 ## Network Policy
 
 The `NetworkPolicy` enum controls outbound network access for the core engine:

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -82,9 +82,13 @@ every startup.
 
 Enforcement fails closed, and it fails without raising an error. A query path
 that does not carry a namespace returns no rows, and a delete on that path
-reports success after deleting nothing. Several `StorageTrait` methods still
-take no `namespace_id` and therefore run unscoped, including the ones behind
-recall candidate hydration, memory supersession, entity forget, and GDPR erase.
+deletes nothing while still returning `Ok`. It does not claim a deletion:
+`delete_memory_by_id` returns `Ok(false)` and `delete_memories_by_entity`
+returns `Ok(0)`. The hazard is that the call succeeds at all, so a caller that
+only checks for an error treats a no-op as a completed erase. Several
+`StorageTrait` methods still take no `namespace_id` and run unscoped, including
+the ones behind recall candidate hydration, memory supersession, entity forget,
+and GDPR erase.
 The test `enforced_rls_fails_closed_for_unscoped_methods` in
 `pensyve-core/src/storage/postgres/live_rls.rs` lists them, and the list must
 be empty before enforcement becomes the default.
@@ -144,11 +148,11 @@ the data.
 
 #### The dedicated application role, and why it is not available yet
 
-A role that does not own the tables is subject to their policies whether
-`FORCE` is set, so running the application as a non-owner role would be the
-more durable control. It is not possible today. Do not follow the SQL below as
-deployment instructions, because an application pointed at such a role will not
-start. Issue #254 tracks the change that makes it usable.
+A role that does not own the tables is subject to their policies regardless of
+whether `FORCE` is set, so running the application as a non-owner role would be
+the more durable control. It is not possible today. Do not follow the SQL below
+as deployment instructions, because an application pointed at such a role will
+not start. Issue #254 tracks the change that makes it usable.
 
 `PostgresBackend::new` applies the schema on every startup, and the schema
 contains statements only a table's owner may run, including
@@ -184,9 +188,17 @@ statements are needed.
 #### What goes wrong
 
 Enforcement applied while query paths are still unscoped produces empty reads
-and writes that do nothing, rather than a visible failure. A non-owner role
-without grants stops the application from starting. Check the unscoped-method
-list first, and roll back with `NO FORCE` if reads start coming back empty.
+and writes that do nothing, rather than a visible failure. Check the
+unscoped-method list first, and roll back with `NO FORCE` if reads start coming
+back empty.
+
+Pointing `DATABASE_URL` at a role that does not own the tables stops the
+application from starting, and adding privileges does not fix it. The blocker
+is ownership, not grants: the schema runs owner-restricted statements on every
+startup, and a non-owner role fails with `must be owner of table entities` even
+holding every table privilege and `CREATE` on the schema. The fix is to connect
+as the owning role until issue #254 separates schema application from serving
+traffic.
 
 ## Network Policy
 

--- a/pensyve-core/src/storage/postgres.rs
+++ b/pensyve-core/src/storage/postgres.rs
@@ -1557,7 +1557,13 @@ impl StorageTrait for PostgresBackend {
         persist: &mut dyn FnMut(&[Memory]) -> StorageResult<()>,
     ) -> StorageResult<Vec<Memory>> {
         self.block_on(async {
-            let mut conn = self.maybe_scoped_conn().await?;
+            // Bound to the namespace being forgotten, not left unscoped: this
+            // method knows its namespace, and an unscoped connection would
+            // match nothing once RLS is enforced. The explicit
+            // `AND namespace_id = $2` predicates below stay regardless — they
+            // are what confines the delete while RLS is inert, which is every
+            // deployment today.
+            let mut conn = self.scoped_conn(namespace_id).await?;
             let mut tx = (&mut *conn).begin().await.map_err(sqlx_to_io)?;
             let mut memories = Vec::new();
 

--- a/pensyve-core/src/storage/postgres.rs
+++ b/pensyve-core/src/storage/postgres.rs
@@ -165,13 +165,9 @@ type EdgeRow = (
 // PostgresBackend
 // ---------------------------------------------------------------------------
 
-/// Binds the namespace GUC that every `namespace_isolation_*` policy in
-/// `postgres_schema.sql` reads.
-///
-/// `false` makes the setting session-scoped rather than transaction-local.
-/// Transaction-local would be discarded before the scoped query ever ran — see
-/// [`PostgresBackend::conn_with_namespace`] for the full reasoning.
-const SET_NAMESPACE_GUC_SQL: &str = "SELECT set_config('pensyve.namespace_id', $1, false)";
+mod scoped_pool;
+
+use scoped_pool::ScopedPool;
 
 /// The namespace GUC value used for connections that are not scoped to any
 /// namespace.
@@ -182,7 +178,13 @@ const SET_NAMESPACE_GUC_SQL: &str = "SELECT set_config('pensyve.namespace_id', $
 const UNSCOPED_NAMESPACE: &str = "";
 
 pub struct PostgresBackend {
-    pool: PgPool,
+    /// Wrapped so that the only ways to obtain a connection are
+    /// [`ScopedPool::acquire_bound`], which binds the namespace the RLS
+    /// policies read, and [`ScopedPool::unbound`], which is named to be
+    /// conspicuous. `sqlx` implements `Executor` and `Acquire` for `&PgPool`,
+    /// so holding a bare `PgPool` here would let any `fetch(&self.pool)` or
+    /// `self.pool.begin()` check out an unbound connection.
+    pool: ScopedPool,
     rt: Runtime,
     /// Optional default namespace for RLS scoping on get-by-id methods
     /// where the trait signature does not provide a `namespace_id`.
@@ -227,7 +229,7 @@ impl PostgresBackend {
         };
 
         let backend = Self {
-            pool,
+            pool: ScopedPool::new(pool),
             rt,
             default_namespace: None,
         };
@@ -239,7 +241,7 @@ impl PostgresBackend {
     pub fn from_pool(pool: PgPool) -> StorageResult<Self> {
         let rt = Runtime::new().map_err(io_err)?;
         let backend = Self {
-            pool,
+            pool: ScopedPool::new(pool),
             rt,
             default_namespace: None,
         };
@@ -258,6 +260,7 @@ impl PostgresBackend {
     fn run_schema(&self) -> StorageResult<()> {
         self.block_on(async {
             self.pool
+                .unbound()
                 .execute(raw_sql(SCHEMA))
                 .await
                 .map_err(sqlx_to_io)?;
@@ -282,6 +285,7 @@ impl PostgresBackend {
     pub fn enforce_rls(&self) -> StorageResult<()> {
         self.block_on(async {
             self.pool
+                .unbound()
                 .execute(raw_sql(RLS_ENFORCE_SCHEMA))
                 .await
                 .map_err(sqlx_to_io)?;
@@ -357,13 +361,7 @@ impl PostgresBackend {
         &self,
         namespace: &str,
     ) -> StorageResult<sqlx_core::pool::PoolConnection<sqlx_postgres::Postgres>> {
-        let mut conn = self.pool.acquire().await.map_err(sqlx_to_io)?;
-        query(SET_NAMESPACE_GUC_SQL)
-            .bind(namespace)
-            .execute(&mut *conn)
-            .await
-            .map_err(sqlx_to_io)?;
-        Ok(conn)
+        self.pool.acquire_bound(namespace).await.map_err(sqlx_to_io)
     }
 
     /// Set the active namespace on a single Postgres connection so that the
@@ -374,15 +372,28 @@ impl PostgresBackend {
     /// connections.  The `StorageTrait` methods scope their own connections
     /// internally, so you typically do not need to call this directly.
     ///
-    /// The setting is session-scoped: it stays in effect until this connection
-    /// is scoped again or closed.  A caller that returns the connection to a
-    /// shared pool is responsible for re-scoping it before reuse.
+    /// # Behaviour change
+    ///
+    /// This used to set the value with `is_local = true`, which scoped it to
+    /// the current transaction.  Issued outside a transaction, as a standalone
+    /// statement, Postgres discarded it before the next statement ran, so the
+    /// helper reliably did nothing.  It is now session-scoped, which is what
+    /// makes it work.
+    ///
+    /// # Responsibility this places on the caller
+    ///
+    /// The setting now outlives the enclosing transaction and stays in effect
+    /// until the connection is scoped again or closed.  If you return this
+    /// connection to a pool, the next borrower inherits this namespace, and
+    /// under enforced RLS it will read this namespace's rows.  Postgres no
+    /// longer clears the value for you.  A pooling caller must therefore
+    /// re-scope every connection on checkout, exactly as this backend does.
     pub async fn set_namespace_config(
         &self,
         conn: &mut sqlx_postgres::PgConnection,
         namespace_id: uuid::Uuid,
     ) -> StorageResult<()> {
-        query(SET_NAMESPACE_GUC_SQL)
+        query(scoped_pool::SET_NAMESPACE_GUC_SQL)
             .bind(namespace_id.to_string())
             .execute(&mut *conn)
             .await
@@ -391,9 +402,13 @@ impl PostgresBackend {
     }
 
     /// Expose the underlying pool so callers can acquire explicit connections
-    /// for namespace-scoped RLS sessions (see [`set_namespace_config`]).
+    /// for namespace-scoped RLS sessions (see [`Self::set_namespace_config`]).
+    ///
+    /// Connections taken from here carry no namespace, so a caller that
+    /// queries a table with a `namespace_isolation_*` policy must scope them
+    /// itself. See [`Self::set_namespace_config`] for the contract.
     pub fn pool(&self) -> &PgPool {
-        &self.pool
+        self.pool.unbound()
     }
 
     fn load_memories_by_namespace(
@@ -629,15 +644,17 @@ impl StorageTrait for PostgresBackend {
     fn get_namespace_by_name(&self, name: &str) -> StorageResult<Option<Namespace>> {
         let name = name.to_string();
         self.block_on(async {
-            // Namespace-by-name lookup: RLS on namespaces table may not filter
-            // by pensyve.namespace_id (it applies to memory tables). Use pool
-            // directly — namespaces are not tenant-scoped via RLS.
+            // Namespace-by-name lookup. The `namespaces` table carries no
+            // `namespace_isolation_*` policy, and this lookup is how a caller
+            // discovers the namespace id it would scope by, so there is
+            // nothing to bind yet. Safe on an unbound connection for as long
+            // as `namespaces` stays unpolicied.
             let row: Option<(Uuid, String, DateTime<Utc>, serde_json::Value)> =
                 query_as::<Postgres, _>(
                     "SELECT id, name, created_at, metadata FROM namespaces WHERE name = $1",
                 )
                 .bind(&name)
-                .fetch_optional(&self.pool)
+                .fetch_optional(self.pool.unbound())
                 .await
                 .map_err(sqlx_to_io)?;
 

--- a/pensyve-core/src/storage/postgres.rs
+++ b/pensyve-core/src/storage/postgres.rs
@@ -165,6 +165,22 @@ type EdgeRow = (
 // PostgresBackend
 // ---------------------------------------------------------------------------
 
+/// Binds the namespace GUC that every `namespace_isolation_*` policy in
+/// `postgres_schema.sql` reads.
+///
+/// `false` makes the setting session-scoped rather than transaction-local.
+/// Transaction-local would be discarded before the scoped query ever ran — see
+/// [`PostgresBackend::conn_with_namespace`] for the full reasoning.
+const SET_NAMESPACE_GUC_SQL: &str = "SELECT set_config('pensyve.namespace_id', $1, false)";
+
+/// The namespace GUC value used for connections that are not scoped to any
+/// namespace.
+///
+/// Namespaces are UUIDs, so the empty string matches no row: under enforced
+/// RLS such a connection reads nothing and writes nothing. It fails closed
+/// instead of falling back to whatever the previous checkout left set.
+const UNSCOPED_NAMESPACE: &str = "";
+
 pub struct PostgresBackend {
     pool: PgPool,
     rt: Runtime,
@@ -249,6 +265,30 @@ impl PostgresBackend {
         })
     }
 
+    /// Subject the schema-owning role to its own row-level security policies.
+    ///
+    /// `postgres_schema.sql` enables RLS and declares the
+    /// `namespace_isolation_*` policies, but Postgres exempts a table's owner
+    /// from its own policies, so those policies do nothing for an application
+    /// that connects as the owner. This applies `FORCE ROW LEVEL SECURITY`,
+    /// which removes the exemption.
+    ///
+    /// Deliberately not called by [`Self::new`]: enforcement fails closed, so
+    /// a connection that has not bound a namespace stops seeing rows. Every
+    /// query path must carry a namespace before this is switched on. See
+    /// `postgres_rls_enforce.sql` and `docs/SECURITY.md`.
+    ///
+    /// Requires the connecting role to own the tables. Idempotent.
+    pub fn enforce_rls(&self) -> StorageResult<()> {
+        self.block_on(async {
+            self.pool
+                .execute(raw_sql(RLS_ENFORCE_SCHEMA))
+                .await
+                .map_err(sqlx_to_io)?;
+            Ok(())
+        })
+    }
+
     /// Execute an async future from a sync context.
     ///
     /// If we're already inside a tokio runtime (e.g. the MCP gateway), uses
@@ -266,34 +306,64 @@ impl PostgresBackend {
     /// Acquire a connection from the pool with the namespace GUC set for RLS
     /// enforcement.  All `StorageTrait` methods use this internally so that
     /// every query is scoped to the correct namespace.
-    ///
-    /// The `true` flag passed to `set_config` makes the GUC local to the
-    /// current transaction; outside a transaction it persists for the session
-    /// (i.e. until the connection is returned to the pool).
     async fn scoped_conn(
         &self,
         namespace_id: Uuid,
     ) -> StorageResult<sqlx_core::pool::PoolConnection<sqlx_postgres::Postgres>> {
-        let mut conn = self.pool.acquire().await.map_err(sqlx_to_io)?;
-        query("SELECT set_config('pensyve.namespace_id', $1, true)")
-            .bind(namespace_id.to_string())
-            .execute(&mut *conn)
-            .await
-            .map_err(sqlx_to_io)?;
-        Ok(conn)
+        self.conn_with_namespace(&namespace_id.to_string()).await
     }
 
     /// Acquire a connection, scoping it to `default_namespace` if one has been
     /// configured.  Used for `StorageTrait` methods whose signatures do not
     /// include a `namespace_id` parameter.
+    ///
+    /// With no default namespace configured this still sets the GUC — to
+    /// [`UNSCOPED_NAMESPACE`], which no row can match.  Such a connection
+    /// therefore reads nothing and writes nothing once RLS is enforced, rather
+    /// than inheriting whatever namespace the previous checkout left behind.
     async fn maybe_scoped_conn(
         &self,
     ) -> StorageResult<sqlx_core::pool::PoolConnection<sqlx_postgres::Postgres>> {
-        if let Some(ns) = self.default_namespace {
-            self.scoped_conn(ns).await
-        } else {
-            self.pool.acquire().await.map_err(sqlx_to_io)
+        match self.default_namespace {
+            Some(ns) => self.scoped_conn(ns).await,
+            None => self.conn_with_namespace(UNSCOPED_NAMESPACE).await,
         }
+    }
+
+    /// Acquire a pooled connection and bind the namespace GUC that the RLS
+    /// policies read (see [`SET_NAMESPACE_GUC_SQL`]) before handing it out.
+    ///
+    /// # Why the setting is session-scoped, and why that is safe
+    ///
+    /// The RLS policies read the GUC via `current_setting`, so it has to still
+    /// be in effect when the caller's query runs.  A transaction-local setting
+    /// (`set_config(..., true)`) issued as a standalone statement is discarded
+    /// the moment that statement's implicit transaction commits — i.e. before
+    /// the query it was meant to scope — which left every policy comparing
+    /// against NULL.
+    ///
+    /// A session-scoped setting outlives the checkout, so the risk moves to
+    /// the opposite end: a pooled connection carrying one namespace into the
+    /// next caller.  That is closed by setting the GUC here, on *acquisition*,
+    /// unconditionally and on every path — including the unscoped one.  A
+    /// stale value can never be read, because the first thing any checkout
+    /// does is overwrite it.
+    ///
+    /// The alternative, resetting on release via a pool hook, is strictly
+    /// weaker: release is a cleanup path that a panic, a cancelled future, or
+    /// a pool this backend did not build (see [`Self::from_pool`]) can skip,
+    /// whereas acquisition is on the path of every query by construction.
+    async fn conn_with_namespace(
+        &self,
+        namespace: &str,
+    ) -> StorageResult<sqlx_core::pool::PoolConnection<sqlx_postgres::Postgres>> {
+        let mut conn = self.pool.acquire().await.map_err(sqlx_to_io)?;
+        query(SET_NAMESPACE_GUC_SQL)
+            .bind(namespace)
+            .execute(&mut *conn)
+            .await
+            .map_err(sqlx_to_io)?;
+        Ok(conn)
     }
 
     /// Set the active namespace on a single Postgres connection so that the
@@ -301,14 +371,18 @@ impl PostgresBackend {
     /// rows to that namespace.
     ///
     /// This is the public API for external callers that manage their own
-    /// connections.  The `StorageTrait` methods use [`scoped_conn`] internally,
-    /// so you typically do not need to call this directly.
+    /// connections.  The `StorageTrait` methods scope their own connections
+    /// internally, so you typically do not need to call this directly.
+    ///
+    /// The setting is session-scoped: it stays in effect until this connection
+    /// is scoped again or closed.  A caller that returns the connection to a
+    /// shared pool is responsible for re-scoping it before reuse.
     pub async fn set_namespace_config(
         &self,
         conn: &mut sqlx_postgres::PgConnection,
         namespace_id: uuid::Uuid,
     ) -> StorageResult<()> {
-        query("SELECT set_config('pensyve.namespace_id', $1, true)")
+        query(SET_NAMESPACE_GUC_SQL)
             .bind(namespace_id.to_string())
             .execute(&mut *conn)
             .await
@@ -406,6 +480,9 @@ impl PostgresBackend {
 // ---------------------------------------------------------------------------
 
 const SCHEMA: &str = include_str!("postgres_schema.sql");
+
+/// Applied by [`PostgresBackend::enforce_rls`], not by [`PostgresBackend::new`].
+const RLS_ENFORCE_SCHEMA: &str = include_str!("postgres_rls_enforce.sql");
 
 const LIST_OBSERVATIONS_BY_ENTITY_INSTANCE_SQL: &str = r"SELECT id, namespace_id, episode_id, entity_type, instance, action,
              quantity, unit, content, embedding::text AS embedding, confidence,

--- a/pensyve-core/src/storage/postgres/live_rls.rs
+++ b/pensyve-core/src/storage/postgres/live_rls.rs
@@ -345,8 +345,9 @@ fn seed(fixture: &Fixture, ns_a: &Namespace, ns_b: &Namespace) -> EpisodicMemory
 /// can see, with no `WHERE` clause — so the count reflects RLS alone, not a
 /// query's own namespace predicate.
 ///
-/// Sets the GUC at session level (`is_local = false`) so it survives to the
-/// next statement, which is precisely what `scoped_conn` fails to do.
+/// Sets the GUC directly, at session level (`is_local = false`), rather than
+/// going through `scoped_conn`. Keeping the backend out of it is what makes
+/// this a test of the policies alone.
 fn rows_visible_to_namespace(fixture: &Fixture, namespace_id: Uuid) -> i64 {
     fixture.rt.block_on(async {
         let mut conn = fixture
@@ -446,8 +447,9 @@ fn namespace_scoping_end_to_end() {
 /// `pensyve.namespace_id`, they hide other namespaces' rows completely, with no
 /// help from any `WHERE namespace_id = ...` predicate.
 ///
-/// Pairs with [`scoped_conn_guc_is_discarded_before_the_next_statement`]: the
-/// policies work, the code that is supposed to feed them does not.
+/// Sets the GUC by hand rather than through the backend, so it isolates the
+/// policies themselves from the code that feeds them.
+/// [`scoped_conn_guc_is_visible_to_the_next_statement`] covers the feeding.
 #[test]
 fn rls_policies_isolate_namespaces_when_the_guc_is_set() {
     let Some(admin_opts) = skip_notice("rls_policies_isolate_namespaces_when_the_guc_is_set")

--- a/pensyve-core/src/storage/postgres/live_rls.rs
+++ b/pensyve-core/src/storage/postgres/live_rls.rs
@@ -300,6 +300,17 @@ fn with_admin_pool<T>(
     out
 }
 
+/// Strip `//` comments, so assertions about what Rust source *does* are not
+/// tripped by what it *documents*. The doc comments in `postgres.rs` name the
+/// very patterns [`only_bound_connections_reach_policied_tables`] forbids.
+fn rust_code_only(source: &str) -> String {
+    source
+        .lines()
+        .map(|line| line.split("//").next().unwrap_or(""))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
 /// Strip `--` comments and collapse whitespace, so assertions about what a
 /// schema file *does* are not satisfied by what it merely *documents*.
 fn sql_statements_only(sql: &str) -> String {
@@ -1064,31 +1075,56 @@ fn capturing_delete_is_confined_to_its_namespace() {
     );
 }
 
-/// Every pooled connection must be handed out by `conn_with_namespace`, which
-/// is the single place that binds the namespace GUC.
+/// Only known-safe call sites may take a connection that carries no namespace.
 ///
-/// This is the one assumption the acquisition-time design rests on. Because
-/// the GUC is session-scoped it outlives a checkout, so a connection taken
-/// straight from the pool would run its query under whatever namespace the
-/// previous caller happened to leave set. Binding on acquisition closes that,
-/// but only for as long as every acquisition goes through the one helper.
+/// The compiler does most of this job. `PostgresBackend` holds a
+/// [`super::scoped_pool::ScopedPool`] whose inner `PgPool` is private to that
+/// module, so `postgres.rs` cannot reach the pool directly at all. That closes
+/// the whole family of unbound checkouts, not just the obvious one: `sqlx`
+/// implements `Executor` for `&PgPool` and `Acquire` for `&PgPool`, so
+/// `query(..).fetch_one(&pool)` and `pool.begin()` each take a connection
+/// without ever spelling `acquire`.
 ///
-/// Deliberately a source-level check: the leak it guards against is invisible
-/// until RLS is enforced, by which point the wrong rows have already been
-/// read. `get_namespace_by_name` is unaffected and not counted here — it runs
-/// on the pool directly, but only against `namespaces`, which carries no RLS
-/// policy.
+/// What is left is `ScopedPool::unbound`, the deliberate escape hatch. A
+/// connection from it inherits whatever namespace the previous checkout left
+/// set, so under enforced RLS a query against a policied table would read
+/// another namespace's rows. That is a cross-namespace read rather than a
+/// fail-closed no-op, so the escape hatch is pinned to an allowlist here.
+///
+/// Each entry is safe for a specific reason, and a new one is only safe if it
+/// has the same kind of reason:
+///
+/// * `run_schema` and `enforce_rls` run DDL, which RLS does not apply to.
+/// * `get_namespace_by_name` reads `namespaces`, which carries no policy, and
+///   is how a caller learns the namespace id it would scope by.
+/// * `pool` hands the pool to external callers, who own the scoping contract
+///   documented on `set_namespace_config`.
 #[test]
-fn only_one_place_acquires_a_pooled_connection() {
-    let source = include_str!("../postgres.rs");
-    let acquisitions = source.matches("self.pool.acquire()").count();
+fn only_bound_connections_reach_policied_tables() {
+    const ALLOWED_UNBOUND_USES: usize = 4;
+
+    let source = rust_code_only(include_str!("../postgres.rs"));
+    let unbound = source.matches(".unbound()").count();
     assert_eq!(
-        acquisitions, 1,
-        "expected exactly one `self.pool.acquire()` in postgres.rs (the one inside \
-         `conn_with_namespace`), found {acquisitions}. A connection acquired anywhere else \
-         inherits the previous checkout's namespace GUC; route it through \
-         `scoped_conn` or `maybe_scoped_conn` instead."
+        unbound, ALLOWED_UNBOUND_USES,
+        "postgres.rs has {unbound} uses of `ScopedPool::unbound()`, expected \
+         {ALLOWED_UNBOUND_USES}. An unbound connection carries the previous checkout's \
+         namespace, so a query on a table with a namespace_isolation_* policy would read \
+         another namespace's rows once RLS is enforced. Use `scoped_conn` or \
+         `maybe_scoped_conn` unless the statement is DDL or targets an unpolicied table \
+         (namespaces, edges, activity_events), and update this count if it is."
     );
+
+    // The wrapper is only worth having if the raw pool is genuinely out of
+    // reach, so check that nothing rebuilt a direct path to it.
+    for forbidden in ["self.pool.acquire(", "self.pool.begin(", "&self.pool)"] {
+        assert!(
+            !source.contains(forbidden),
+            "postgres.rs contains `{forbidden}`, which takes a connection without binding a \
+             namespace. Go through `scoped_conn`, `maybe_scoped_conn`, or an allowlisted \
+             `unbound()` call."
+        );
+    }
 }
 
 /// `FORCE ROW LEVEL SECURITY` must cover exactly the tables that carry a

--- a/pensyve-core/src/storage/postgres/live_rls.rs
+++ b/pensyve-core/src/storage/postgres/live_rls.rs
@@ -759,8 +759,8 @@ fn namespace_scoping_end_to_end_under_enforced_rls() {
 /// error, but a success report with no effect — `delete_memories_by_entity`
 /// returns `Ok(0)` and a GDPR erase would report that it had erased something.
 ///
-/// Each assertion here is a work item. When a method starts carrying a
-/// namespace, its assertion flips and has to be moved into
+/// Each assertion here is a work item, tracked by #254. When a method starts
+/// carrying a namespace, its assertion flips and has to be moved into
 /// [`namespace_scoping_end_to_end_under_enforced_rls`]. When the list is
 /// empty, enforcement can become the default.
 #[test]

--- a/pensyve-core/src/storage/postgres/live_rls.rs
+++ b/pensyve-core/src/storage/postgres/live_rls.rs
@@ -760,6 +760,72 @@ fn namespace_scoping_end_to_end_under_enforced_rls() {
     );
 }
 
+/// The capturing delete keeps working with RLS enforced, so it does *not*
+/// belong in [`enforced_rls_fails_closed_for_unscoped_methods`].
+///
+/// It takes a `namespace_id`, so its connection is bound to that namespace
+/// rather than left unscoped. Both halves are worth pinning: it still deletes
+/// and captures its own namespace's rows, and its `WITH CHECK`-constrained
+/// transaction still commits.
+///
+/// [`capturing_delete_is_confined_to_its_namespace`] is the same contract with
+/// RLS inert, which is the configuration that ships. Together they show the
+/// explicit `namespace_id` predicates hold in both modes, which is why they
+/// stay even though the GUC now binds correctly.
+#[test]
+fn capturing_delete_still_works_under_enforced_rls() {
+    let Some(admin_opts) = skip_notice("capturing_delete_still_works_under_enforced_rls") else {
+        return;
+    };
+    let fixture = Fixture::provision(&admin_opts);
+    let backend = &fixture.backend;
+
+    let ns_a = Namespace::new(format!("forget-a-{}", Uuid::new_v4().simple()));
+    let ns_b = Namespace::new(format!("forget-b-{}", Uuid::new_v4().simple()));
+    backend.save_namespace(&ns_a).expect("save namespace A");
+    backend.save_namespace(&ns_b).expect("save namespace B");
+
+    let entity_id = Uuid::new_v4();
+    let mine = EpisodicMemory::new(ns_a.id, Uuid::new_v4(), entity_id, entity_id, "tenant A");
+    backend.save_episodic(&mine).expect("save A's memory");
+    let theirs = EpisodicMemory::new(ns_b.id, Uuid::new_v4(), entity_id, entity_id, "tenant B");
+    backend.save_episodic(&theirs).expect("save B's memory");
+
+    fixture.enforce_rls();
+
+    let snapshot_root = tempfile::tempdir().expect("snapshot tempdir");
+    let outcome = crate::snapshot::forget_entity(
+        backend,
+        entity_id,
+        Some("shared-entity"),
+        ns_a.id,
+        snapshot_root.path(),
+    )
+    .expect("forget in namespace A must still succeed under enforced RLS");
+
+    assert_eq!(
+        outcome.snapshot.memory_ids(),
+        vec![mine.id],
+        "the capturing delete must still capture its own namespace's row under enforced RLS"
+    );
+    assert!(
+        backend
+            .get_all_memories_by_namespace(ns_a.id)
+            .expect("read namespace A")
+            .is_empty(),
+        "namespace A should be empty after the forget"
+    );
+    assert_eq!(
+        memory_ids(
+            &backend
+                .get_all_memories_by_namespace(ns_b.id)
+                .expect("read namespace B")
+        ),
+        vec![theirs.id],
+        "namespace B's row must survive"
+    );
+}
+
 /// Enforcement fails closed, and these `StorageTrait` methods take no
 /// `namespace_id`, so they run on an unscoped connection and quietly stop
 /// working when it is switched on.
@@ -967,13 +1033,17 @@ fn schema_declares_rls_for_every_expected_table() {
 ///
 /// Entity ids are not globally unique in this schema, and nothing stops two
 /// tenants from holding rows keyed to the same id. Without an explicit
-/// `namespace_id` predicate the delete matches on entity id alone: RLS is the
-/// only other filter, and it is inert here (the backend connects as the schema
-/// owner, and `scoped_conn` discards its GUC — see the module docs). The
-/// foreign tenant's rows are then deleted *and* handed to the snapshot
-/// callback, which writes them into this tenant's snapshot file — a
-/// cross-tenant leak into the very artifact that per-namespace directories
-/// exist to prevent.
+/// `namespace_id` predicate the delete matches on entity id alone, leaving RLS
+/// as the only other filter — and RLS is inert in every deployment today,
+/// because the backend connects as the schema owner and nothing has applied
+/// `postgres_rls_enforce.sql`. The foreign tenant's rows are then deleted
+/// *and* handed to the snapshot callback, which writes them into this tenant's
+/// snapshot file — a cross-tenant leak into the very artifact that
+/// per-namespace directories exist to prevent.
+///
+/// So the predicates stay whether or not RLS is enforced. This test runs with
+/// it inert, which is the configuration that actually ships, and therefore
+/// gates the predicates rather than the policies.
 ///
 /// `SQLite` cannot observe this: `forget_snapshot_scope.rs` covers scope parity
 /// there, but only live Postgres exercises the RLS-plus-pool path.

--- a/pensyve-core/src/storage/postgres/live_rls.rs
+++ b/pensyve-core/src/storage/postgres/live_rls.rs
@@ -973,9 +973,12 @@ fn every_rls_table_has_exactly_one_namespace_policy() {
     fixture.enforce_rls();
     let forced: Vec<(String, bool)> = fixture.rt.block_on(async {
         query_as::<Postgres, _>(
+            // Scoped to `public`: `relname` alone is not unique across schemas,
+            // so a same-named relation elsewhere could satisfy the assertion.
             "SELECT relname, relforcerowsecurity
                FROM pg_class
-              WHERE relname = ANY($1)",
+              WHERE relname = ANY($1)
+                AND relnamespace = 'public'::regnamespace",
         )
         .bind(RLS_POLICIES.iter().map(|(t, _)| *t).collect::<Vec<_>>())
         .fetch_all(fixture.backend.pool())
@@ -999,10 +1002,10 @@ fn every_rls_table_has_exactly_one_namespace_policy() {
 /// `PENSYVE_TEST_DATABASE_URL` unset.
 #[test]
 fn schema_declares_rls_for_every_expected_table() {
-    let normalized = super::SCHEMA
-        .split_whitespace()
-        .collect::<Vec<_>>()
-        .join(" ");
+    // Comments stripped, like the enforcement-file test: a rollback note or
+    // example quoting a CREATE POLICY would otherwise satisfy these assertions
+    // without the schema declaring anything.
+    let normalized = sql_statements_only(super::SCHEMA);
     let predicate = "namespace_id::text = current_setting('pensyve.namespace_id', true)";
     for (table, policy) in RLS_POLICIES {
         assert!(

--- a/pensyve-core/src/storage/postgres/live_rls.rs
+++ b/pensyve-core/src/storage/postgres/live_rls.rs
@@ -11,43 +11,54 @@
 //! test provisions its own database plus an unprivileged application role and
 //! drops both afterwards, so nothing is written to the database in the URL.
 //!
-//! # What this covers, and what it cannot yet cover
+//! # The two layers, and which tests gate which
 //!
-//! PR #218 caught `delete_memory_by_id_in_namespace` acquiring its connection
-//! via `maybe_scoped_conn()` instead of `scoped_conn(namespace_id)`. The
-//! intended regression gate is "run the delete under enforced RLS and watch it
-//! no-op". Building that gate surfaced a prior defect that makes it impossible
-//! today:
+//! Namespace isolation is meant to have two independent layers:
 //!
-//! [`PostgresBackend::scoped_conn`] issues
-//! `SELECT set_config('pensyve.namespace_id', $1, true)` as a standalone
-//! statement. The `true` means *transaction-local*, and a standalone statement
-//! is its own implicit transaction, so Postgres discards the setting the moment
-//! that statement commits — before the query it was meant to scope ever runs.
-//! Every `namespace_isolation_*` policy then compares against NULL and matches
-//! nothing. [`scoped_conn_guc_is_discarded_before_the_next_statement`] pins
-//! that behaviour, and [`rls_policies_isolate_namespaces_when_the_guc_is_set`]
-//! shows the policies themselves are correct — only the plumbing that sets the
-//! GUC is broken.
+//! 1. The explicit `namespace_id = $n` predicates in the handwritten SQL.
+//!    This is the load-bearing layer in every deployment.
+//! 2. Row-level security, as a backstop for a query that forgets layer 1 —
+//!    which is exactly the bug PR #218 found in
+//!    `delete_memory_by_id_in_namespace`.
 //!
-//! Two consequences:
+//! Layer 2 needs two things that were missing, and one that still is.
 //!
-//! * The schema's RLS is inert in practice. It is doubly inert in a normal
-//!   deployment: `postgres_schema.sql` never issues
-//!   `FORCE ROW LEVEL SECURITY`, and Postgres exempts a table's owner from its
-//!   own policies, so an application connecting as the schema owner bypasses
-//!   the policies outright.
-//! * Namespace isolation today rests entirely on the explicit
-//!   `namespace_id = $n` predicates in the handwritten SQL, which is exactly
-//!   why the #218 delete had to be fixed by hand.
+//! **Fixed — the GUC now binds.** `scoped_conn` used to issue
+//! `set_config('pensyve.namespace_id', $1, true)` as a standalone statement.
+//! The `true` means *transaction-local*, and a standalone statement is its own
+//! implicit transaction, so Postgres discarded the setting before the query it
+//! was meant to scope ever ran; every policy compared against NULL and matched
+//! nothing. The backend now binds the GUC at session scope on every
+//! acquisition, including the unscoped path.
+//! [`scoped_conn_guc_is_visible_to_the_next_statement`] and
+//! [`scoped_namespace_does_not_leak_into_the_next_checkout`] gate both halves
+//! of that: the setting must survive to the next statement, and must not
+//! survive into the next checkout.
 //!
-//! [`namespace_scoping_end_to_end`] therefore gates what is actually load
-//! bearing right now: the scoped-delete contract, exercised against live
-//! Postgres rather than SQLite. Once `scoped_conn` scopes a real transaction
-//! and the schema forces RLS, that test can be re-run under
-//! [`Fixture::force_row_level_security`] and it becomes the #218 gate as
-//! originally intended.
+//! **Fixed — enforcement is now possible.** Postgres exempts a table's owner
+//! from its own policies, and the application connects as the schema owner, so
+//! `ENABLE ROW LEVEL SECURITY` alone left the policies inert.
+//! `postgres_rls_enforce.sql` adds `FORCE`, applied through
+//! [`PostgresBackend::enforce_rls`] and by [`Fixture::enforce_rls`] here.
+//! [`rls_alone_blocks_cross_namespace_access`] is the payoff: it runs a
+//! storage method's own SQL with the `namespace_id` predicate *deleted* and
+//! shows RLS still blocks the cross-namespace access.
+//!
+//! **Still open — enforcement is not yet the default.** It fails closed, and
+//! several `StorageTrait` methods take no `namespace_id` at all, so they run
+//! on an unscoped connection. Under enforcement they silently read and delete
+//! nothing rather than erroring.
+//! [`enforced_rls_fails_closed_for_unscoped_methods`] pins exactly which ones,
+//! and is the checklist that has to reach zero before `FORCE` can move into
+//! `postgres_schema.sql`. Until then the enforcement file is an explicit
+//! operator step — see `docs/SECURITY.md`.
+//!
+//! Tests therefore come in two flavours: [`Fixture::provision`] mirrors a
+//! current deployment (policies present, not enforced), and a test that wants
+//! layer 2 calls [`Fixture::enforce_rls`] on top.
 
+use chrono::Utc;
+use sqlx_core::query::query;
 use sqlx_core::query_as::query_as;
 use sqlx_core::raw_sql::raw_sql;
 use sqlx_core::sql_str::AssertSqlSafe;
@@ -94,6 +105,17 @@ const RLS_POLICIES: &[(&str, &str)] = &[
 const EXPECTED_POLICY_QUAL: &str =
     "((namespace_id)::text = current_setting('pensyve.namespace_id'::text, true))";
 
+/// One `pg_policies` row: `(tablename, policyname, permissive, cmd, qual,
+/// with_check)`.
+type PolicyRow = (
+    String,
+    String,
+    String,
+    String,
+    Option<String>,
+    Option<String>,
+);
+
 fn admin_connect_options() -> Option<PgConnectOptions> {
     let url = std::env::var(TEST_DATABASE_URL_ENV).ok()?;
     if url.trim().is_empty() {
@@ -138,9 +160,8 @@ async fn exec(pool: &PgPool, sql: impl Into<String>) {
 ///
 /// The role matters: Postgres exempts superusers unconditionally, and table
 /// owners by default, from row-level security. Applying the schema as an
-/// ordinary `NOSUPERUSER NOBYPASSRLS` role is what lets
-/// [`Fixture::force_row_level_security`] produce a connection the policies
-/// actually apply to.
+/// ordinary `NOSUPERUSER NOBYPASSRLS` role is what lets [`Fixture::enforce_rls`]
+/// produce a connection the policies actually apply to.
 struct Fixture {
     rt: Runtime,
     admin: PgPool,
@@ -191,9 +212,17 @@ impl Fixture {
         });
 
         // The unprivileged role applies the schema, so it owns every table.
+        //
+        // One connection, deliberately: every test here is sequential, and a
+        // single-connection pool guarantees that consecutive acquisitions get
+        // the *same* physical backend. That is what lets
+        // [`scoped_namespace_does_not_leak_into_the_next_checkout`] observe
+        // session state carried across checkouts instead of silently testing a
+        // fresh connection, and it makes every other test exercise connection
+        // reuse rather than a clean session.
         let app_pool = rt.block_on(async {
             PgPoolOptions::new()
-                .max_connections(5)
+                .max_connections(1)
                 .connect_with(
                     admin_opts
                         .clone()
@@ -216,26 +245,19 @@ impl Fixture {
         }
     }
 
-    /// Subject the schema owner to its own RLS policies. Without this the
-    /// owning role bypasses every `namespace_isolation_*` policy.
+    /// Subject the schema owner to its own RLS policies, turning layer 2 on.
     ///
-    /// Call this only *after* seeding data: with RLS forced, the backend cannot
-    /// insert at all, because the policies double as `WITH CHECK` constraints
-    /// and `scoped_conn` never manages to set the GUC they read.
-    fn force_row_level_security(&self) {
-        let admin_opts =
-            admin_connect_options().expect("admin options present during provisioning");
-        with_admin_pool(&self.rt, &admin_opts, &self.database, |rt, pool| {
-            rt.block_on(async {
-                for (table, _) in RLS_POLICIES {
-                    exec(
-                        pool,
-                        format!("ALTER TABLE {table} FORCE ROW LEVEL SECURITY"),
-                    )
-                    .await;
-                }
-            });
-        });
+    /// Runs the same `postgres_rls_enforce.sql` an operator would, through the
+    /// same entry point, so these tests gate the real migration rather than a
+    /// test-local imitation of it.
+    ///
+    /// Unlike before, this can be called before seeding: the backend's write
+    /// paths bind the namespace GUC, so the policies' `WITH CHECK` half
+    /// accepts their inserts.
+    fn enforce_rls(&self) {
+        self.backend
+            .enforce_rls()
+            .expect("force row level security");
     }
 }
 
@@ -276,6 +298,18 @@ fn with_admin_pool<T>(
     let out = f(rt, &pool);
     rt.block_on(pool.close());
     out
+}
+
+/// Strip `--` comments and collapse whitespace, so assertions about what a
+/// schema file *does* are not satisfied by what it merely *documents*.
+fn sql_statements_only(sql: &str) -> String {
+    sql.lines()
+        .map(|line| line.split("--").next().unwrap_or(""))
+        .collect::<Vec<_>>()
+        .join(" ")
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 fn memory_ids(memories: &[Memory]) -> Vec<Uuid> {
@@ -339,10 +373,11 @@ fn rows_visible_to_namespace(fixture: &Fixture, namespace_id: Uuid) -> i64 {
 /// readable only through namespace A, and `delete_memory_by_id_in_namespace`
 /// must refuse to delete it through namespace B.
 ///
-/// This runs without `FORCE ROW LEVEL SECURITY`, which mirrors how the backend
-/// is actually deployed (application connects as the schema owner, so the
-/// policies do not apply) and is the only configuration the backend currently
-/// works in — see the module docs.
+/// This runs without `FORCE ROW LEVEL SECURITY`, mirroring a deployment as
+/// shipped today: the application connects as the schema owner, so the policies
+/// do not apply and the SQL predicates are the only thing enforcing isolation.
+/// [`namespace_scoping_end_to_end_under_enforced_rls`] is the same contract
+/// with RLS switched on.
 #[test]
 fn namespace_scoping_end_to_end() {
     let Some(admin_opts) = skip_notice("namespace_scoping_end_to_end") else {
@@ -424,9 +459,7 @@ fn rls_policies_isolate_namespaces_when_the_guc_is_set() {
     let ns_a = Namespace::new(format!("rls-a-{}", Uuid::new_v4().simple()));
     let ns_b = Namespace::new(format!("rls-b-{}", Uuid::new_v4().simple()));
     seed(&fixture, &ns_a, &ns_b);
-
-    // Seed first: with RLS forced the backend can no longer insert.
-    fixture.force_row_level_security();
+    fixture.enforce_rls();
 
     assert_eq!(
         rows_visible_to_namespace(&fixture, ns_a.id),
@@ -440,19 +473,17 @@ fn rls_policies_isolate_namespaces_when_the_guc_is_set() {
     );
 }
 
-/// `scoped_conn` sets `pensyve.namespace_id` with `is_local = true` from
-/// outside any explicit transaction, so Postgres discards it when that
-/// standalone statement commits. Every RLS policy therefore reads NULL.
+/// The GUC `scoped_conn` sets must still be in effect for the statements that
+/// follow it on the same connection — otherwise every `namespace_isolation_*`
+/// policy compares against NULL and matches nothing.
 ///
-/// This test documents the defect rather than the intent. When `scoped_conn`
-/// is fixed — by scoping a real transaction, or by setting the GUC at session
-/// level — this test fails, and that is the signal to enable
-/// [`Fixture::force_row_level_security`] in
-/// [`namespace_scoping_end_to_end`] so it becomes the #218 regression gate.
+/// This is the direct gate on the fix: the original code issued
+/// `set_config(..., true)` (transaction-local) as a standalone statement, which
+/// Postgres discarded at the end of that statement's implicit transaction,
+/// before the query it was meant to scope ever ran.
 #[test]
-fn scoped_conn_guc_is_discarded_before_the_next_statement() {
-    let Some(admin_opts) = skip_notice("scoped_conn_guc_is_discarded_before_the_next_statement")
-    else {
+fn scoped_conn_guc_is_visible_to_the_next_statement() {
+    let Some(admin_opts) = skip_notice("scoped_conn_guc_is_visible_to_the_next_statement") else {
         return;
     };
     let fixture = Fixture::provision(&admin_opts);
@@ -472,12 +503,323 @@ fn scoped_conn_guc_is_discarded_before_the_next_statement() {
         value
     });
 
+    assert_eq!(
+        observed.as_deref(),
+        Some(namespace_id.to_string().as_str()),
+        "scoped_conn must leave pensyve.namespace_id set for the statements that \
+         follow it; the RLS policies read it via current_setting"
+    );
+}
+
+/// A connection scoped to a namespace must not carry that namespace back to
+/// the *next* checkout of the same physical connection.
+///
+/// This is the failure mode that makes a naive session-level `set_config`
+/// worse than the original bug: the GUC would outlive the checkout, and an
+/// unscoped acquisition would inherit the previous tenant's namespace and read
+/// its rows. The fix sets the GUC on every acquisition — including the
+/// unscoped path, which sets it to a value no row can match — so the guarantee
+/// is established when a connection is *taken*, not when it is returned.
+///
+/// The backend PID assertion is what keeps this test honest: on a fresh
+/// physical connection the GUC would be unset no matter what the code does, so
+/// without it the test could pass vacuously.
+#[test]
+fn scoped_namespace_does_not_leak_into_the_next_checkout() {
+    let Some(admin_opts) = skip_notice("scoped_namespace_does_not_leak_into_the_next_checkout")
+    else {
+        return;
+    };
+    let fixture = Fixture::provision(&admin_opts);
+    let namespace_id = Uuid::new_v4();
+
+    let (first_pid, second_pid, observed): (i32, i32, Option<String>) =
+        fixture.rt.block_on(async {
+            let first_pid = {
+                let mut conn = fixture
+                    .backend
+                    .scoped_conn(namespace_id)
+                    .await
+                    .expect("acquire scoped connection");
+                let (pid,): (i32,) = query_as::<Postgres, _>("SELECT pg_backend_pid()")
+                    .fetch_one(&mut *conn)
+                    .await
+                    .expect("read backend pid");
+                pid
+            };
+
+            // The scoped connection is now back in the pool. Take it again
+            // through the *unscoped* path, which is what every `StorageTrait`
+            // method lacking a namespace parameter uses.
+            let mut conn = fixture
+                .backend
+                .maybe_scoped_conn()
+                .await
+                .expect("acquire unscoped connection");
+            let (second_pid,): (i32,) = query_as::<Postgres, _>("SELECT pg_backend_pid()")
+                .fetch_one(&mut *conn)
+                .await
+                .expect("read backend pid");
+            let (value,): (Option<String>,) =
+                query_as::<Postgres, _>("SELECT current_setting('pensyve.namespace_id', true)")
+                    .fetch_one(&mut *conn)
+                    .await
+                    .expect("read namespace GUC");
+            (first_pid, second_pid, value)
+        });
+
+    assert_eq!(
+        first_pid, second_pid,
+        "this test only proves anything if the pool hands back the same physical \
+         connection; it did not, so the assertion below would be vacuous"
+    );
+    assert_ne!(
+        observed.as_deref(),
+        Some(namespace_id.to_string().as_str()),
+        "an unscoped acquisition inherited the previous checkout's namespace — \
+         under enforced RLS it would read that tenant's rows"
+    );
+}
+
+/// The payoff for the whole layer: with RLS enforced, a storage method that
+/// *forgets* its `namespace_id` predicate still cannot reach another
+/// namespace's rows.
+///
+/// `delete_memory_by_id_in_namespace` is the method PR #218 caught doing
+/// exactly this, so its own `DELETE` is the statement under test — reproduced
+/// verbatim except that `AND namespace_id = $2` is deleted. That simulates the
+/// regression: the predicate is gone, and only RLS is left standing between a
+/// connection scoped to namespace B and a row owned by namespace A.
+///
+/// Both halves matter. The sabotaged statement must delete nothing through the
+/// wrong namespace, *and* must delete the row through the right one —
+/// otherwise a statement that simply never matches anything (a typo, a wrong
+/// column) would pass the first assertion and prove nothing.
+#[test]
+fn rls_alone_blocks_cross_namespace_access() {
+    // `delete_memory_by_id_in_namespace`'s statement, minus its namespace
+    // predicate. The real one reads:
+    //     DELETE FROM episodic_memories WHERE id = $1 AND namespace_id = $2
+    const SABOTAGED_DELETE: &str = "DELETE FROM episodic_memories WHERE id = $1";
+
+    let Some(admin_opts) = skip_notice("rls_alone_blocks_cross_namespace_access") else {
+        return;
+    };
+    let fixture = Fixture::provision(&admin_opts);
+    let ns_a = Namespace::new(format!("rls-a-{}", Uuid::new_v4().simple()));
+    let ns_b = Namespace::new(format!("rls-b-{}", Uuid::new_v4().simple()));
+    let memory = seed(&fixture, &ns_a, &ns_b);
+    fixture.enforce_rls();
+
+    let deleted_via_b = fixture.rt.block_on(async {
+        let mut conn = fixture
+            .backend
+            .scoped_conn(ns_b.id)
+            .await
+            .expect("scoped connection for namespace B");
+        query::<Postgres>(SABOTAGED_DELETE)
+            .bind(memory.id)
+            .execute(&mut *conn)
+            .await
+            .expect("run predicate-free delete scoped to namespace B")
+            .rows_affected()
+    });
+    assert_eq!(
+        deleted_via_b, 0,
+        "RLS did not block a predicate-free cross-namespace delete: the row was \
+         reachable from namespace B. Defense in depth is not actually in depth."
+    );
+    assert_eq!(
+        memory_ids(
+            &fixture
+                .backend
+                .get_all_memories_by_namespace(ns_a.id)
+                .expect("re-read namespace A")
+        ),
+        vec![memory.id],
+        "the row must survive a cross-namespace delete"
+    );
+
+    // The same sabotaged statement, through the owning namespace, must work —
+    // otherwise the assertion above is vacuous.
+    let deleted_via_a = fixture.rt.block_on(async {
+        let mut conn = fixture
+            .backend
+            .scoped_conn(ns_a.id)
+            .await
+            .expect("scoped connection for namespace A");
+        query::<Postgres>(SABOTAGED_DELETE)
+            .bind(memory.id)
+            .execute(&mut *conn)
+            .await
+            .expect("run predicate-free delete scoped to namespace A")
+            .rows_affected()
+    });
+    assert_eq!(
+        deleted_via_a, 1,
+        "the predicate-free delete matched nothing even in the owning namespace, \
+         so the cross-namespace assertion above proved nothing"
+    );
+}
+
+/// The end-to-end scoping contract, re-run with RLS enforced.
+///
+/// [`namespace_scoping_end_to_end`] covers a deployment as shipped today, where
+/// the policies are inert and the SQL predicates do all the work. This is the
+/// same contract with layer 2 switched on, and is the #218 regression gate as
+/// originally intended: a scoped delete must no-op through a foreign namespace
+/// even when RLS — not the predicate — is what stops it.
+#[test]
+fn namespace_scoping_end_to_end_under_enforced_rls() {
+    let Some(admin_opts) = skip_notice("namespace_scoping_end_to_end_under_enforced_rls") else {
+        return;
+    };
+    let fixture = Fixture::provision(&admin_opts);
+    let backend = &fixture.backend;
+
+    let ns_a = Namespace::new(format!("rls-a-{}", Uuid::new_v4().simple()));
+    let ns_b = Namespace::new(format!("rls-b-{}", Uuid::new_v4().simple()));
+    let memory = seed(&fixture, &ns_a, &ns_b);
+    fixture.enforce_rls();
+
+    assert_eq!(
+        memory_ids(
+            &backend
+                .get_all_memories_by_namespace(ns_a.id)
+                .expect("read namespace A")
+        ),
+        vec![memory.id],
+        "enforced RLS must not hide a namespace's own rows from it"
+    );
     assert!(
-        observed.is_none() || observed.as_deref() == Some(""),
-        "scoped_conn's transaction-local GUC unexpectedly survived to the next \
-         statement (observed {observed:?}). If `scoped_conn` was fixed, delete \
-         this test and enable Fixture::force_row_level_security in \
-         namespace_scoping_end_to_end so it gates the #218 regression."
+        memory_ids(
+            &backend
+                .get_all_memories_by_namespace(ns_b.id)
+                .expect("read namespace B")
+        )
+        .is_empty(),
+        "memory must be invisible from namespace B"
+    );
+
+    assert!(
+        !backend
+            .delete_memory_by_id_in_namespace(memory.id, ns_b.id)
+            .expect("scoped delete via namespace B"),
+        "delete_memory_by_id_in_namespace must not report success for a foreign namespace"
+    );
+    assert_eq!(
+        memory_ids(
+            &backend
+                .get_all_memories_by_namespace(ns_a.id)
+                .expect("re-read namespace A")
+        ),
+        vec![memory.id],
+        "a cross-namespace delete must leave the row intact"
+    );
+
+    assert!(
+        backend
+            .delete_memory_by_id_in_namespace(memory.id, ns_a.id)
+            .expect("scoped delete via namespace A"),
+        "the scoped delete must still work in its own namespace under enforced RLS"
+    );
+
+    // Writes must keep working: the policies' WITH CHECK half accepts an
+    // insert whose namespace matches the connection's.
+    let replacement = EpisodicMemory::new(
+        ns_a.id,
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+        "written under enforced RLS",
+    );
+    backend
+        .save_episodic(&replacement)
+        .expect("save_episodic must succeed under enforced RLS");
+    assert_eq!(
+        memory_ids(
+            &backend
+                .get_all_memories_by_namespace(ns_a.id)
+                .expect("read namespace A after insert")
+        ),
+        vec![replacement.id],
+        "the row written under enforced RLS should be readable in its namespace"
+    );
+}
+
+/// Enforcement fails closed, and these `StorageTrait` methods take no
+/// `namespace_id`, so they run on an unscoped connection and quietly stop
+/// working when it is switched on.
+///
+/// This is the reason `FORCE ROW LEVEL SECURITY` lives in
+/// `postgres_rls_enforce.sql` as an operator step instead of in
+/// `postgres_schema.sql`. The failure mode is the dangerous kind: not an
+/// error, but a success report with no effect — `delete_memories_by_entity`
+/// returns `Ok(0)` and a GDPR erase would report that it had erased something.
+///
+/// Each assertion here is a work item. When a method starts carrying a
+/// namespace, its assertion flips and has to be moved into
+/// [`namespace_scoping_end_to_end_under_enforced_rls`]. When the list is
+/// empty, enforcement can become the default.
+#[test]
+fn enforced_rls_fails_closed_for_unscoped_methods() {
+    let Some(admin_opts) = skip_notice("enforced_rls_fails_closed_for_unscoped_methods") else {
+        return;
+    };
+    let fixture = Fixture::provision(&admin_opts);
+    let backend = &fixture.backend;
+    let ns_a = Namespace::new(format!("rls-a-{}", Uuid::new_v4().simple()));
+    let ns_b = Namespace::new(format!("rls-b-{}", Uuid::new_v4().simple()));
+    let memory = seed(&fixture, &ns_a, &ns_b);
+    fixture.enforce_rls();
+
+    // Reached from the recall path (retrieval::engine hydrating candidates)
+    // and from the supersede/update-memory REST handlers.
+    assert!(
+        backend
+            .get_episodic(memory.id)
+            .expect("get_episodic must not error")
+            .is_none(),
+        "get_episodic still resolves under enforced RLS — it now carries a \
+         namespace, so move this into the enforced end-to-end test"
+    );
+
+    // Reached from POST /v1/memories/{id}/supersede and PATCH /v1/memories/{id}.
+    assert!(
+        !backend
+            .supersede_memory(memory.id, Uuid::new_v4(), Utc::now())
+            .expect("supersede_memory must not error"),
+        "supersede_memory now takes effect under enforced RLS"
+    );
+
+    // Reached from DELETE /v1/entities/{name}, the A2A memory.forget
+    // capability, GDPR erase, the pensyve_forget MCP tool, and the CLI.
+    assert_eq!(
+        backend
+            .delete_memories_by_entity(memory.about_entity)
+            .expect("delete_memories_by_entity must not error"),
+        0,
+        "delete_memories_by_entity now deletes under enforced RLS"
+    );
+
+    // Reached from the default `purge_namespace` trait implementation, which
+    // PostgresBackend does not override.
+    assert!(
+        !backend
+            .delete_memory_by_id(memory.id)
+            .expect("delete_memory_by_id must not error"),
+        "delete_memory_by_id now deletes under enforced RLS"
+    );
+
+    // The row is untouched by all of the above.
+    assert_eq!(
+        memory_ids(
+            &backend
+                .get_all_memories_by_namespace(ns_a.id)
+                .expect("read namespace A")
+        ),
+        vec![memory.id],
+        "the unscoped methods should have been no-ops, not partial writes"
     );
 }
 
@@ -499,18 +841,17 @@ fn every_rls_table_has_exactly_one_namespace_policy() {
     };
     let fixture = Fixture::provision(&admin_opts);
 
-    let registered: Vec<(String, String, String, String, Option<String>)> =
-        fixture.rt.block_on(async {
-            query_as::<Postgres, _>(
-                "SELECT tablename, policyname, permissive, cmd, qual
+    let registered: Vec<PolicyRow> = fixture.rt.block_on(async {
+        query_as::<Postgres, _>(
+            "SELECT tablename, policyname, permissive, cmd, qual, with_check
                    FROM pg_policies
                   WHERE schemaname = 'public'
                   ORDER BY tablename, policyname",
-            )
-            .fetch_all(fixture.backend.pool())
-            .await
-            .expect("read pg_policies")
-        });
+        )
+        .fetch_all(fixture.backend.pool())
+        .await
+        .expect("read pg_policies")
+    });
 
     for (table, policy) in RLS_POLICIES {
         let on_table: Vec<_> = registered.iter().filter(|row| row.0 == *table).collect();
@@ -525,7 +866,7 @@ fn every_rls_table_has_exactly_one_namespace_policy() {
                 .collect::<Vec<_>>()
         );
 
-        let (_, policyname, permissive, cmd, qual) = on_table[0];
+        let (_, policyname, permissive, cmd, qual, with_check) = on_table[0];
         assert_eq!(policyname, policy, "unexpected policy name on {table}");
         assert_eq!(
             permissive, "PERMISSIVE",
@@ -538,8 +879,38 @@ fn every_rls_table_has_exactly_one_namespace_policy() {
         assert_eq!(
             qual.as_deref(),
             Some(EXPECTED_POLICY_QUAL),
-            "{policy} on {table} no longer isolates by namespace_id via the \
+            "{policy} on {table} no longer isolates reads by namespace_id via the \
              pensyve.namespace_id GUC"
+        );
+        assert_eq!(
+            with_check.as_deref(),
+            Some(EXPECTED_POLICY_QUAL),
+            "{policy} on {table} no longer constrains writes: without WITH CHECK a \
+             connection scoped to one namespace could INSERT or UPDATE a row into another"
+        );
+    }
+
+    // Enforcement is what makes all of the above apply to the schema owner.
+    fixture.enforce_rls();
+    let forced: Vec<(String, bool)> = fixture.rt.block_on(async {
+        query_as::<Postgres, _>(
+            "SELECT relname, relforcerowsecurity
+               FROM pg_class
+              WHERE relname = ANY($1)",
+        )
+        .bind(RLS_POLICIES.iter().map(|(t, _)| *t).collect::<Vec<_>>())
+        .fetch_all(fixture.backend.pool())
+        .await
+        .expect("read pg_class")
+    });
+    for (table, _) in RLS_POLICIES {
+        assert_eq!(
+            forced
+                .iter()
+                .find(|(name, _)| name == table)
+                .map(|(_, f)| *f),
+            Some(true),
+            "enforce_rls did not force RLS on {table}, so its owner still bypasses the policy"
         );
     }
 }
@@ -553,18 +924,26 @@ fn schema_declares_rls_for_every_expected_table() {
         .split_whitespace()
         .collect::<Vec<_>>()
         .join(" ");
+    let predicate = "namespace_id::text = current_setting('pensyve.namespace_id', true)";
     for (table, policy) in RLS_POLICIES {
         assert!(
             normalized.contains(&format!("ALTER TABLE {table} ENABLE ROW LEVEL SECURITY;")),
             "postgres_schema.sql no longer enables RLS on {table}"
         );
+        // DROP before CREATE is what lets an existing database pick up a
+        // corrected policy; the schema is re-applied on every startup, so a
+        // create-if-absent form would leave old policies in place forever.
+        assert!(
+            normalized.contains(&format!("DROP POLICY IF EXISTS {policy} ON {table};")),
+            "postgres_schema.sql no longer drops {policy} before recreating it, so existing \
+             databases would keep whatever policy they already have"
+        );
         assert!(
             normalized.contains(&format!(
-                "CREATE POLICY {policy} ON {table} USING (namespace_id::text = \
-                 current_setting('pensyve.namespace_id', true));"
+                "CREATE POLICY {policy} ON {table} USING ({predicate}) WITH CHECK ({predicate});"
             )),
             "postgres_schema.sql no longer declares {policy} on {table} with the expected \
-             namespace_id predicate"
+             namespace_id predicate on both the read (USING) and write (WITH CHECK) halves"
         );
     }
 }
@@ -680,5 +1059,65 @@ fn capturing_delete_is_confined_to_its_namespace() {
     assert!(
         !reloaded.memory_ids().contains(&theirs.id),
         "namespace B's row leaked into the snapshot file on disk"
+    );
+}
+
+/// Every pooled connection must be handed out by `conn_with_namespace`, which
+/// is the single place that binds the namespace GUC.
+///
+/// This is the one assumption the acquisition-time design rests on. Because
+/// the GUC is session-scoped it outlives a checkout, so a connection taken
+/// straight from the pool would run its query under whatever namespace the
+/// previous caller happened to leave set. Binding on acquisition closes that,
+/// but only for as long as every acquisition goes through the one helper.
+///
+/// Deliberately a source-level check: the leak it guards against is invisible
+/// until RLS is enforced, by which point the wrong rows have already been
+/// read. `get_namespace_by_name` is unaffected and not counted here — it runs
+/// on the pool directly, but only against `namespaces`, which carries no RLS
+/// policy.
+#[test]
+fn only_one_place_acquires_a_pooled_connection() {
+    let source = include_str!("../postgres.rs");
+    let acquisitions = source.matches("self.pool.acquire()").count();
+    assert_eq!(
+        acquisitions, 1,
+        "expected exactly one `self.pool.acquire()` in postgres.rs (the one inside \
+         `conn_with_namespace`), found {acquisitions}. A connection acquired anywhere else \
+         inherits the previous checkout's namespace GUC; route it through \
+         `scoped_conn` or `maybe_scoped_conn` instead."
+    );
+}
+
+/// `FORCE ROW LEVEL SECURITY` must cover exactly the tables that carry a
+/// policy, and must not leak into the schema that runs on every startup.
+///
+/// A table forced without a policy would deny everything; a table with a
+/// policy but never forced keeps the owner exemption that made the policies
+/// inert in the first place.
+#[test]
+fn enforcement_file_forces_every_policied_table_and_only_those() {
+    // Comments are stripped first: both files document the statements they
+    // contain, and the rollback note spells out `NO FORCE ROW LEVEL SECURITY`.
+    let normalized = sql_statements_only(super::RLS_ENFORCE_SCHEMA);
+    for (table, _) in RLS_POLICIES {
+        assert!(
+            normalized.contains(&format!("ALTER TABLE {table} FORCE ROW LEVEL SECURITY;")),
+            "postgres_rls_enforce.sql no longer forces RLS on {table}, leaving the schema \
+             owner exempt from {table}'s policy"
+        );
+    }
+    assert_eq!(
+        normalized.matches("FORCE ROW LEVEL SECURITY;").count(),
+        RLS_POLICIES.len(),
+        "postgres_rls_enforce.sql forces a table that carries no namespace policy; \
+         with no policy to satisfy, RLS denies every row"
+    );
+    assert!(
+        !sql_statements_only(super::SCHEMA).contains("FORCE ROW LEVEL SECURITY"),
+        "FORCE moved into postgres_schema.sql, which runs on every startup. Enforcement \
+         fails closed, so this would silently break every query path that does not carry \
+         a namespace — see enforced_rls_fails_closed_for_unscoped_methods for the list \
+         that must be empty first."
     );
 }

--- a/pensyve-core/src/storage/postgres/scoped_pool.rs
+++ b/pensyve-core/src/storage/postgres/scoped_pool.rs
@@ -1,0 +1,81 @@
+//! A connection pool that hands out connections already bound to a namespace.
+//!
+//! # Why this is its own module
+//!
+//! The namespace GUC the RLS policies read is session-scoped, so it outlives a
+//! checkout. Safety depends on every connection being bound at the moment it
+//! leaves the pool, because a connection taken straight from the pool runs its
+//! query under whatever namespace the previous caller happened to leave set.
+//! Under enforced RLS that is a cross-namespace read, not a fail-closed no-op.
+//!
+//! Keeping that rule by convention did not work, and a test that grepped for
+//! `pool.acquire()` did not either. `sqlx` implements `Executor` for `&Pool`
+//! and `Acquire` for `&Pool`, so `query(..).fetch_one(&pool)` and
+//! `pool.begin()` also check out a connection, spelled nothing like `acquire`.
+//!
+//! [`ScopedPool::inner`] is therefore private to this module. Code outside it
+//! cannot reach the underlying `PgPool` at all, so the only ways to get a
+//! connection are [`ScopedPool::acquire_bound`], which binds the namespace, and
+//! [`ScopedPool::unbound`], which is named to be conspicuous and is asserted on
+//! by `only_bound_connections_reach_policied_tables` in `live_rls.rs`. The
+//! compiler now enforces what that test used to approximate.
+
+use sqlx_core::error::Error as SqlxError;
+use sqlx_core::pool::PoolConnection;
+use sqlx_core::query::query;
+use sqlx_postgres::{PgPool, Postgres};
+
+/// Binds the namespace GUC that every `namespace_isolation_*` policy in
+/// `postgres_schema.sql` reads.
+///
+/// The `false` makes the setting session-scoped rather than transaction-local.
+/// Transaction-local would be discarded when the enclosing statement's implicit
+/// transaction commits, which is before the query it was meant to scope runs.
+pub(super) const SET_NAMESPACE_GUC_SQL: &str =
+    "SELECT set_config('pensyve.namespace_id', $1, false)";
+
+/// A `PgPool` whose connections are namespace-bound on the way out.
+pub(super) struct ScopedPool {
+    /// Private on purpose. See the module docs: reaching this field is exactly
+    /// the mistake this type exists to make impossible.
+    inner: PgPool,
+}
+
+impl ScopedPool {
+    pub(super) fn new(inner: PgPool) -> Self {
+        Self { inner }
+    }
+
+    /// Take a connection and bind `namespace` to it before returning it.
+    ///
+    /// Binding happens on acquisition rather than on release because
+    /// acquisition is on the path of every query by construction, whereas
+    /// release is a cleanup step that a panic, a cancelled future, or a pool
+    /// this backend did not build can skip.
+    pub(super) async fn acquire_bound(
+        &self,
+        namespace: &str,
+    ) -> Result<PoolConnection<Postgres>, SqlxError> {
+        let mut conn = self.inner.acquire().await?;
+        query(SET_NAMESPACE_GUC_SQL)
+            .bind(namespace)
+            .execute(&mut *conn)
+            .await?;
+        Ok(conn)
+    }
+
+    /// The raw pool, with no namespace bound.
+    ///
+    /// A connection from here carries whatever namespace the previous checkout
+    /// left set, so it must never run a statement against a table that carries
+    /// a `namespace_isolation_*` policy. Two uses are legitimate:
+    ///
+    /// * DDL, which RLS does not apply to.
+    /// * Queries against `namespaces`, `edges`, and `activity_events`, none of
+    ///   which carry a policy.
+    ///
+    /// Anything else needs [`Self::acquire_bound`].
+    pub(super) fn unbound(&self) -> &PgPool {
+        &self.inner
+    }
+}

--- a/pensyve-core/src/storage/postgres_rls_enforce.sql
+++ b/pensyve-core/src/storage/postgres_rls_enforce.sql
@@ -22,7 +22,7 @@
 -- Do not apply this until every `StorageTrait` call site in the deployment
 -- passes a namespace. `enforced_rls_fails_closed_for_unscoped_methods` in
 -- `postgres/live_rls.rs` enumerates the methods that still do not, and is the
--- gate on this file becoming the default.
+-- gate on this file becoming the default. Tracked by #254.
 --
 -- Rollback
 -- --------

--- a/pensyve-core/src/storage/postgres_rls_enforce.sql
+++ b/pensyve-core/src/storage/postgres_rls_enforce.sql
@@ -1,0 +1,40 @@
+-- Pensyve Postgres — row-level security enforcement
+--
+-- Applied by `PostgresBackend::enforce_rls`, and by operators as a migration.
+-- Deliberately NOT part of `postgres_schema.sql`, which runs on every startup:
+-- enabling enforcement changes query results, so it must be an explicit act.
+--
+-- What this does
+-- --------------
+-- `postgres_schema.sql` ENABLEs row-level security and declares the
+-- `namespace_isolation_*` policies, but Postgres exempts a table's owner from
+-- its own policies. An application connecting as the role that owns the schema
+-- — the default deployment — therefore bypasses every policy. FORCE removes
+-- that exemption, so the policies apply to the owner too.
+--
+-- Preconditions — read before running
+-- -----------------------------------
+-- Enforcement fails CLOSED. Once forced, any connection that has not bound
+-- `pensyve.namespace_id` sees zero rows and cannot insert. That is the point,
+-- but it means every query path must carry a namespace first. A path that does
+-- not will not error: it will silently read nothing and delete nothing.
+--
+-- Do not apply this until every `StorageTrait` call site in the deployment
+-- passes a namespace. `enforced_rls_fails_closed_for_unscoped_methods` in
+-- `postgres/live_rls.rs` enumerates the methods that still do not, and is the
+-- gate on this file becoming the default.
+--
+-- Rollback
+-- --------
+--   ALTER TABLE <table> NO FORCE ROW LEVEL SECURITY;
+-- for each table below. This is instant and restores the previous behaviour,
+-- because the policies and the data are untouched.
+--
+-- Both statements are idempotent: re-running them is a no-op.
+
+ALTER TABLE entities             FORCE ROW LEVEL SECURITY;
+ALTER TABLE episodes             FORCE ROW LEVEL SECURITY;
+ALTER TABLE episodic_memories    FORCE ROW LEVEL SECURITY;
+ALTER TABLE semantic_memories    FORCE ROW LEVEL SECURITY;
+ALTER TABLE procedural_memories  FORCE ROW LEVEL SECURITY;
+ALTER TABLE observation_memories FORCE ROW LEVEL SECURITY;

--- a/pensyve-core/src/storage/postgres_rls_enforce.sql
+++ b/pensyve-core/src/storage/postgres_rls_enforce.sql
@@ -30,7 +30,7 @@
 -- for each table below. This is instant and restores the previous behaviour,
 -- because the policies and the data are untouched.
 --
--- Both statements are idempotent: re-running them is a no-op.
+-- Every statement below is idempotent, so re-running this file is a no-op.
 
 ALTER TABLE entities             FORCE ROW LEVEL SECURITY;
 ALTER TABLE episodes             FORCE ROW LEVEL SECURITY;

--- a/pensyve-core/src/storage/postgres_schema.sql
+++ b/pensyve-core/src/storage/postgres_schema.sql
@@ -202,11 +202,28 @@ CREATE INDEX IF NOT EXISTS idx_activity_ns_date ON activity_events(namespace_id,
 
 -- ---------------------------------------------------------------------------
 -- Row-Level Security (Postgres only)
--- Namespace isolation: each connection must set pensyve.namespace_id via
---   SELECT set_config('pensyve.namespace_id', '<uuid>', true)
--- before executing queries.  The 'true' flag makes the setting local to
--- the current transaction.  missing_ok=true in current_setting means a NULL
--- is returned (no rows visible) when the GUC is not set.
+--
+-- Namespace isolation.  Each connection binds its namespace via
+--   SELECT set_config('pensyve.namespace_id', '<uuid>', false)
+-- before executing queries; PostgresBackend::conn_with_namespace does this on
+-- every acquisition.  The 'false' makes the setting session-scoped: a
+-- transaction-local setting issued as a standalone statement is discarded when
+-- that statement's implicit transaction commits, i.e. before the query it was
+-- meant to scope ever runs.
+--
+-- missing_ok=true in current_setting yields NULL when the GUC was never set,
+-- and the backend binds the empty string when a connection is not scoped to a
+-- namespace.  Namespaces are UUIDs, so both compare unequal to every row:
+-- an unscoped connection reads nothing and writes nothing.
+--
+-- ENABLE alone does not make these policies apply to the application.
+-- Postgres exempts a table's owner from its own policies, and the application
+-- connects as the role that owns the schema, so the policies below are inert
+-- in a default deployment.  Removing that exemption is a deliberate,
+-- operator-run step -- `postgres_rls_enforce.sql`, applied via
+-- `PostgresBackend::enforce_rls` -- because it fails closed: any query path
+-- that does not carry a namespace stops returning rows.  See docs/SECURITY.md
+-- for the role model, the preconditions, and the migration order.
 -- ---------------------------------------------------------------------------
 
 ALTER TABLE entities             ENABLE ROW LEVEL SECURITY;
@@ -216,32 +233,44 @@ ALTER TABLE semantic_memories    ENABLE ROW LEVEL SECURITY;
 ALTER TABLE procedural_memories  ENABLE ROW LEVEL SECURITY;
 ALTER TABLE observation_memories ENABLE ROW LEVEL SECURITY;
 
-DO $$ BEGIN
-  CREATE POLICY namespace_isolation_entities ON entities
-    USING (namespace_id::text = current_setting('pensyve.namespace_id', true));
-EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+-- DROP + CREATE rather than "create if absent": this file is re-applied on
+-- every startup, so an existing database has to pick up a corrected policy.
+-- The whole schema is sent as one simple-query batch and therefore runs in a
+-- single implicit transaction — no window exists in which a table is
+-- unprotected.
+--
+-- WITH CHECK is spelled out even though Postgres would default it to the USING
+-- expression.  It is what stops a connection scoped to one namespace from
+-- INSERTing or UPDATEing a row into another, and a security control that
+-- important should not rest on an implicit default that a later edit to USING
+-- would silently change.
 
-DO $$ BEGIN
-  CREATE POLICY namespace_isolation_episodes ON episodes
-    USING (namespace_id::text = current_setting('pensyve.namespace_id', true));
-EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+DROP POLICY IF EXISTS namespace_isolation_entities ON entities;
+CREATE POLICY namespace_isolation_entities ON entities
+  USING (namespace_id::text = current_setting('pensyve.namespace_id', true))
+  WITH CHECK (namespace_id::text = current_setting('pensyve.namespace_id', true));
 
-DO $$ BEGIN
-  CREATE POLICY namespace_isolation_episodic ON episodic_memories
-    USING (namespace_id::text = current_setting('pensyve.namespace_id', true));
-EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+DROP POLICY IF EXISTS namespace_isolation_episodes ON episodes;
+CREATE POLICY namespace_isolation_episodes ON episodes
+  USING (namespace_id::text = current_setting('pensyve.namespace_id', true))
+  WITH CHECK (namespace_id::text = current_setting('pensyve.namespace_id', true));
 
-DO $$ BEGIN
-  CREATE POLICY namespace_isolation_semantic ON semantic_memories
-    USING (namespace_id::text = current_setting('pensyve.namespace_id', true));
-EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+DROP POLICY IF EXISTS namespace_isolation_episodic ON episodic_memories;
+CREATE POLICY namespace_isolation_episodic ON episodic_memories
+  USING (namespace_id::text = current_setting('pensyve.namespace_id', true))
+  WITH CHECK (namespace_id::text = current_setting('pensyve.namespace_id', true));
 
-DO $$ BEGIN
-  CREATE POLICY namespace_isolation_procedural ON procedural_memories
-    USING (namespace_id::text = current_setting('pensyve.namespace_id', true));
-EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+DROP POLICY IF EXISTS namespace_isolation_semantic ON semantic_memories;
+CREATE POLICY namespace_isolation_semantic ON semantic_memories
+  USING (namespace_id::text = current_setting('pensyve.namespace_id', true))
+  WITH CHECK (namespace_id::text = current_setting('pensyve.namespace_id', true));
 
-DO $$ BEGIN
-  CREATE POLICY namespace_isolation_observation ON observation_memories
-    USING (namespace_id::text = current_setting('pensyve.namespace_id', true));
-EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+DROP POLICY IF EXISTS namespace_isolation_procedural ON procedural_memories;
+CREATE POLICY namespace_isolation_procedural ON procedural_memories
+  USING (namespace_id::text = current_setting('pensyve.namespace_id', true))
+  WITH CHECK (namespace_id::text = current_setting('pensyve.namespace_id', true));
+
+DROP POLICY IF EXISTS namespace_isolation_observation ON observation_memories;
+CREATE POLICY namespace_isolation_observation ON observation_memories
+  USING (namespace_id::text = current_setting('pensyve.namespace_id', true))
+  WITH CHECK (namespace_id::text = current_setting('pensyve.namespace_id', true));


### PR DESCRIPTION
## Summary

Namespace isolation on the Postgres backend is meant to have two layers. The
first layer is the explicit `namespace_id = $n` predicate written into each
query, and the first layer is what enforces isolation in every deployment
today. The second layer is row-level security, which is meant to catch a query
that leaves the predicate out. PR #218 found exactly such a query in
`delete_memory_by_id_in_namespace`.

The second layer has never worked. Two separate problems stopped it, and this
change fixes both. A third problem remains, and this change documents it and
adds a test that tracks it.

## Problem 1, the namespace setting never reached the query

`scoped_conn` ran `SELECT set_config('pensyve.namespace_id', $1, true)` as a
standalone statement. The `true` makes the setting local to the current
transaction, and a standalone statement is its own implicit transaction, so
Postgres threw the setting away as soon as the statement finished. The setting
was already gone by the time the query it was meant to scope ran. Every
`namespace_isolation_*` policy then compared `namespace_id` against NULL and
matched no rows.

Here is the old behaviour, from the test that now demands the correct one:

```
assertion `left == right` failed: scoped_conn must leave pensyve.namespace_id
set for the statements that follow it
  left: Some("")
 right: Some("bbbf8751-60ea-4308-af2a-4aed66eeb278")
```

## Problem 2, the policies did not apply to the application

`postgres_schema.sql` ran `ENABLE ROW LEVEL SECURITY` but never
`FORCE ROW LEVEL SECURITY`. Postgres exempts a table's owner from that table's
own policies, and the application connects as the role that owns the schema, so
the policies did not apply to it. I confirmed the exemption directly. A
connection scoped to namespace B read a row belonging to namespace A, and the
same read returned nothing once the table was forced.

## How connection scoping works now

The namespace setting is now session-scoped rather than transaction-local, and
the backend binds it every time it takes a connection out of the pool. Binding
happens on every path, including the path for methods that have no namespace to
bind. An unscoped connection is bound to the empty string, and namespaces are
UUIDs, so the empty string matches no row and the connection fails closed.

I considered two other designs and rejected both.

- Return a transaction from `scoped_conn` so the setting and the query share
  one transaction. Leaking becomes impossible by construction, which is the
  strongest property available. I rejected it because it changes the connection
  lifetime for all forty or so `StorageTrait` methods, and a write method that
  forgets to commit loses data silently. The cost is high and the added safety
  over the chosen design is small.
- Set the value at session scope and reset it when the connection returns to
  the pool. I rejected it because resetting on release is a cleanup step, and a
  panic, a cancelled future, or a pool the backend did not build can skip a
  cleanup step. Binding on acquisition cannot be skipped, because every query
  runs on a connection that was acquired.

The tradeoff I accepted is that the chosen design depends on one rule, which is
that every pooled connection must be bound on the way out. A connection taken
any other way runs its query under whatever namespace the previous caller left
set, and under enforced RLS that reads another namespace's rows rather than
failing closed.

I first held that rule with a test that looked for `self.pool.acquire()`. Review
pointed out that the test had a bypass, and it was right. `sqlx` implements
`Executor` and `Acquire` for `&PgPool`, so `query(..).fetch_one(&pool)` and
`pool.begin()` also check out a connection while spelling nothing like
`acquire`. `get_namespace_by_name` already used the first form, safe only
because `namespaces` carries no policy.

The rule is now held by the compiler instead. `PostgresBackend` holds a
`ScopedPool` whose inner `PgPool` is private to its own module, so nothing in
`postgres.rs` can reach the pool at all. The only ways out are
`acquire_bound`, which binds the namespace, and `unbound`, which is named to be
conspicuous and is documented as usable only for DDL and for the three tables
that carry no policy. I checked the boundary by restoring the
`fetch_optional(&self.pool)` form, which now fails to build with
`the trait Executor<'_> is not implemented for &ScopedPool`.

`only_bound_connections_reach_policied_tables` now pins the four allowed
`unbound()` call sites and also fails if `self.pool.acquire(`,
`self.pool.begin(`, or `&self.pool)` reappears.

`scoped_namespace_does_not_leak_into_the_next_checkout` covers the risk the
session-scoped setting creates. I checked that the test works by temporarily
putting the naive fix back, which is a bare `acquire` on the unscoped path, and
the test failed and named the namespace that leaked. The test also asserts that
both checkouts got the same backend process, because on a fresh connection the
setting would be absent no matter what the code did.

## Behavioural change to a public helper, for release notes

`PostgresBackend::set_namespace_config` changes behaviour, and it is public, so
it should be called out alongside the version bump.

It used to set the value with `is_local = true`. Called outside a transaction,
as a standalone statement, Postgres discarded the setting before the next
statement ran, so the helper reliably did nothing. It is now session-scoped,
which is what makes it work at all.

The cost is that the setting no longer clears itself at the end of the
enclosing transaction. An external caller that pools connections and relied on
Postgres clearing the value will now leak the namespace to the next borrower.
Such a caller has to re-scope every connection on checkout, the same way this
backend does. The doc comment on the method says so directly.

I kept the change rather than reverting to transaction-local, because
transaction-local is the defect being fixed here. Reverting would restore a
public helper that silently has no effect.

## Proving the second layer does something

`rls_alone_blocks_cross_namespace_access` is the test that shows the layer
earns its place. It takes the `DELETE` statement from
`delete_memory_by_id_in_namespace`, removes the `AND namespace_id = $2` from
it, and runs it against namespace A's row on a connection scoped to namespace
B. Row-level security is then the only thing left standing between the two
namespaces. The delete removes nothing and the row survives.

The same test then runs the same stripped statement through the owning
namespace and requires it to delete the row. Without the second half, a
statement that simply never matched anything would pass the first half and
prove nothing.

I checked this test the same way, by removing `episodic_memories` from the
enforcement file. The test failed with "RLS did not block a predicate-free
cross-namespace delete", so it measures enforcement and not something else.

## What is still open

Enforcement is not on by default, and the reason is that it fails closed and
several `StorageTrait` methods take no `namespace_id` at all. The methods run
on an unscoped connection, so enforcement stops them working. They do not
raise an error when it does. They report success and do nothing, which is the
more dangerous outcome. Measured against a live database with enforcement on:

| Method | Result with enforcement on | Reached from |
|---|---|---|
| `get_episodic`, `get_semantic`, `get_procedural` | returns nothing | recall, and the supersede and update handlers |
| `get_entity`, `get_observation` | returns nothing | entity forget, inspect, supersede |
| `supersede_memory` | `Ok(false)`, no change written | supersede and update handlers |
| `delete_memories_by_entity` | `Ok(0)`, nothing deleted | entity forget, A2A forget, GDPR erase, CLI, MCP tool |
| `delete_memory_by_id` | `Ok(false)`, nothing deleted | the default `purge_namespace`, which Postgres does not override |

Turning enforcement on today would break recall and would make a GDPR erase
report that it had erased data it had not touched. Giving those methods a
namespace is the same kind of change as PR #247, so I kept it out of this
change and #254 tracks it. `enforced_rls_fails_closed_for_unscoped_methods`
lists every method, and the list has to be empty before enforcement can become
the default, which is the acceptance criterion on #254.

`FORCE ROW LEVEL SECURITY` therefore lives in a separate file,
`postgres_rls_enforce.sql`, which an operator applies. It is also reachable as
`PostgresBackend::enforce_rls`, which is what the tests call, so the tests
exercise the file an operator would run rather than a copy of it.

The `edges` table has no `namespace_id` column, so it carries no policy and is
unaffected. I have not changed it here.

## Deploying this

The schema change on its own is safe and needs no operator action. Applying it
to an existing database changes nothing an application can observe, because
enforcement stays off. I tested the upgrade against a database built from the
current schema on main. The policies were rewritten to include `WITH CHECK`,
the existing rows stayed readable, and no query behaviour changed.

The policies are now written with `DROP POLICY IF EXISTS` followed by
`CREATE POLICY`, replacing a form that created each policy only when it was
absent. The old form meant an existing database kept whatever policy it already
had, so a corrected policy would never reach it. The whole schema is sent as one
batch and runs in a single transaction, so no moment exists where a table has
no policy.

Turning enforcement on is a separate decision, and it should only be made after
every query path carries a namespace, which #254 tracks. It is one step, which
is to apply `postgres_rls_enforce.sql` as the role that owns the tables. Rollback is
`ALTER TABLE <table> NO FORCE ROW LEVEL SECURITY;` for each table, which takes
effect immediately and touches neither the policies nor the data. I tested the
rollback.

I had planned to document running the application as a dedicated non-owner
role, since a non-owner role is subject to the policies whether the table is
forced. It turns out not to be possible yet, and I confirmed it against a live
database. `PostgresBackend::new` applies the schema on every startup, and the
schema runs statements only a table's owner may run, such as
`ALTER TABLE ... ADD COLUMN`, `CREATE INDEX`, and `CREATE POLICY`. A non-owner
role fails at startup with `must be owner of table entities` even when it holds
every table privilege and `CREATE` on the schema. Supporting a non-owner role
needs a code change first, so that applying the schema is separate from serving
traffic, and #254 tracks it. `docs/SECURITY.md` marks the role grants as a
target state rather than instructions, so that nobody follows them into a
deployment that will not start.

Forcing the tables is therefore the only mechanism available today, which is
why `enforce_rls` exists.

Two preconditions are worth knowing before anyone enables enforcement, and
`docs/SECURITY.md` records both. First, Postgres exempts superusers from
row-level security unconditionally, and `FORCE` does not change that, so
enforcement applied on a superuser connection does nothing while still
reporting success. Second, and following from it, reading
`relforcerowsecurity` from `pg_class` is not sufficient proof that enforcement
worked. I checked a superuser-owned database that had applied the enforce
script and it reported true on all six tables while still reading every
namespace. The doc therefore pairs the catalog check with a behavioural one,
which is to bind a namespace id that owns no rows and confirm a count of zero.

If enforcement is applied while query paths are still unscoped, reads come back
empty and writes do nothing, and neither raises an error. Roll back with
`NO FORCE` if that happens.

## Rebase onto #248

#248 landed while this was open and added `delete_memories_by_entity_capturing`
to both backends. One line of it needed changing here.

The method takes a `namespace_id` and applies it as an explicit predicate on
both `DELETE` statements, but it acquired its connection through
`maybe_scoped_conn()`. On this branch that binds the empty namespace, so once
RLS is enforced the deletes match nothing. The forget would report success,
capture no rows, and write an empty snapshot. It now acquires through
`scoped_conn(namespace_id)`. I confirmed the line matters by reverting it,
which fails the new enforced-mode test with an empty capture while #248's
inert-mode test stays green.

The explicit `namespace_id` predicates stay exactly as #248 wrote them. They
are what confines the delete while RLS is inert, which is every deployment
today, and #248 established by measurement that the RLS-only version was not
confined at all.

`capturing_delete_still_works_under_enforced_rls` answers whether the method
belongs in `enforced_rls_fails_closed_for_unscoped_methods`. It does not, since
it carries a namespace and keeps working with RLS forced. The two tests
together now cover the predicates with RLS inert and with it enforced.

## Testing

`cargo test -p pensyve-core --features postgres` against `pgvector/pgvector:pg16`
passes, with 548 library tests and the integration tests green. The command is
the one the `Rust Tests (postgres)` job runs. `cargo test --workspace` passes
with 915 tests and no failures. Formatting and clippy are clean.

The live-Postgres tests go from 5 to 13, counting the one #248 contributed. The
new ones are listed below.

- `scoped_conn_guc_is_visible_to_the_next_statement`, replacing the test that
  recorded the old broken behaviour.
- `scoped_namespace_does_not_leak_into_the_next_checkout`
- `rls_alone_blocks_cross_namespace_access`
- `namespace_scoping_end_to_end_under_enforced_rls`, which is the PR #218
  regression test running the way it was originally meant to
- `enforced_rls_fails_closed_for_unscoped_methods`
- `enforcement_file_forces_every_policied_table_and_only_those`
- `only_bound_connections_reach_policied_tables`
- `capturing_delete_still_works_under_enforced_rls`

The fixture pool now holds one connection. Every test here runs one statement
at a time, and a single connection guarantees that two acquisitions in a row
get the same backend process, which is what lets the leak test see session
state carried between them.

https://claude.ai/code/session_01AsVz67dYuk3dufxA683hJA
