### PR TITLE
fix(storage): scope entity-wide forget to its namespace and its own FTS rows (#256)

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -83,12 +83,14 @@ every startup.
 Enforcement fails closed, and it fails without raising an error. A query path
 that does not carry a namespace returns no rows, and a delete on that path
 deletes nothing while still returning `Ok`. It does not claim a deletion:
-`delete_memory_by_id` returns `Ok(false)` and `delete_memories_by_entity`
-returns `Ok(0)`. The hazard is that the call succeeds at all, so a caller that
-only checks for an error treats a no-op as a completed erase. Several
-`StorageTrait` methods still take no `namespace_id` and run unscoped, including
-the ones behind recall candidate hydration, memory supersession, entity forget,
-and GDPR erase.
+`delete_memory_by_id` returns `Ok(false)`. The hazard is that the call succeeds
+at all, so a caller that only checks for an error treats a no-op as a completed
+erase. Several `StorageTrait` methods still take no `namespace_id` and run
+unscoped, including the ones behind recall candidate hydration and memory
+supersession. Entity forget left that list in #256, when
+`delete_memories_by_entity` gained a `namespace_id`. GDPR erase is partly off
+it: its memory deletion is scoped, while its observation, graph-edge and
+entity-record steps still match on the entity id alone.
 The test `enforced_rls_fails_closed_for_unscoped_methods` in
 `pensyve-core/src/storage/postgres/live_rls.rs` lists them, and the list must
 be empty before enforcement becomes the default.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -89,8 +89,9 @@ erase. Several `StorageTrait` methods still take no `namespace_id` and run
 unscoped, including the ones behind recall candidate hydration and memory
 supersession. Entity forget left that list in #256, when
 `delete_memories_by_entity` gained a `namespace_id`. GDPR erase is partly off
-it: its memory deletion is scoped, while its observation, graph-edge and
-entity-record steps still match on the entity id alone.
+it: #256 scoped its memory deletion only, and its observation, graph-edge and
+entity-record steps still match on the entity id alone. Those three are tracked
+by #254 with the rest of the unscoped surface.
 The test `enforced_rls_fails_closed_for_unscoped_methods` in
 `pensyve-core/src/storage/postgres/live_rls.rs` lists them, and the list must
 be empty before enforcement becomes the default.

--- a/pensyve-cli/src/main.rs
+++ b/pensyve-cli/src/main.rs
@@ -721,9 +721,9 @@ fn cmd_forget(
     };
 
     if hard {
-        pensyve_core::gdpr::erase_entity(&storage, entity.id)?;
+        pensyve_core::gdpr::erase_entity(&storage, entity.id, ns.id)?;
     } else {
-        storage.delete_memories_by_entity(entity.id)?;
+        storage.delete_memories_by_entity(entity.id, ns.id)?;
     }
 
     match format {

--- a/pensyve-core/src/gdpr.rs
+++ b/pensyve-core/src/gdpr.rs
@@ -46,9 +46,15 @@ pub struct ExportResult {
 /// 3. The entity record itself
 ///
 /// Returns an `ErasureResult` summarizing what was deleted.
+///
+/// `namespace_id` names the tenant the erasure belongs to, matching
+/// [`export_entity_data`]. Only the memory delete carries it today; the
+/// observation, edge and entity steps still match on `entity_id` alone and are
+/// tracked by #254 along with the rest of the unscoped `StorageTrait` surface.
 pub fn erase_entity(
     storage: &dyn StorageTrait,
     entity_id: Uuid,
+    namespace_id: Uuid,
 ) -> Result<ErasureResult, StorageError> {
     let mut result = ErasureResult::default();
 
@@ -64,7 +70,7 @@ pub fn erase_entity(
     }
 
     // Step 2: Delete all episodic / semantic memories about this entity.
-    match storage.delete_memories_by_entity(entity_id) {
+    match storage.delete_memories_by_entity(entity_id, namespace_id) {
         Ok(count) => result.memories_deleted = count,
         Err(e) => result.warnings.push(format!("Memory deletion error: {e}")),
     }
@@ -99,7 +105,7 @@ pub fn erase_namespace(
     let entities = storage.list_entities_by_namespace(namespace_id)?;
 
     for entity in &entities {
-        match erase_entity(storage, entity.id) {
+        match erase_entity(storage, entity.id, namespace_id) {
             Ok(entity_result) => {
                 result.memories_deleted += entity_result.memories_deleted;
                 result.observations_deleted += entity_result.observations_deleted;
@@ -219,7 +225,7 @@ mod tests {
         let storage = SqliteBackend::open(dir.path()).unwrap();
         let entity_id = Uuid::new_v4();
 
-        let result = erase_entity(&storage, entity_id).unwrap();
+        let result = erase_entity(&storage, entity_id, Uuid::new_v4()).unwrap();
         assert_eq!(result.memories_deleted, 0);
         assert!(result.complete);
     }
@@ -244,7 +250,7 @@ mod tests {
         mem.embedding = embedder.embed("test data").unwrap();
         storage.save_episodic(&mem).unwrap();
 
-        let result = erase_entity(&storage, entity.id).unwrap();
+        let result = erase_entity(&storage, entity.id, ns.id).unwrap();
         assert_eq!(result.memories_deleted, 1);
     }
 

--- a/pensyve-core/src/storage/mod.rs
+++ b/pensyve-core/src/storage/mod.rs
@@ -331,7 +331,29 @@ pub trait StorageTrait: Send + Sync {
     ) -> StorageResult<bool>;
 
     // Deletion
-    fn delete_memories_by_entity(&self, entity_id: Uuid) -> StorageResult<usize>;
+
+    /// Delete every episodic and semantic memory attached to `entity_id`
+    /// *within `namespace_id`*, and return the row count.
+    ///
+    /// Episodic rows match on `about_entity` or `source_entity`; semantic rows
+    /// match on `subject` or `object_entity`. Any search-index cleanup must
+    /// cover **exactly** that set: a narrower collection leaves index entries
+    /// behind holding the text of memories the caller was told were deleted.
+    ///
+    /// `namespace_id` is required rather than inferred. Entity ids are not
+    /// globally unique in this schema, so an entity-only predicate reaches into
+    /// other tenants, and the index cleanup has the same problem one level down
+    /// — memory ids collide too, so an unqualified `memory_fts` delete strips a
+    /// foreign namespace's entry (see
+    /// `test_delete_memory_by_id_in_namespace_preserves_foreign_fts_entry`).
+    /// Both predicates must be explicit in the SQL rather than left to
+    /// row-level security, which is defence in depth and inert in every
+    /// deployment shipping today.
+    fn delete_memories_by_entity(
+        &self,
+        entity_id: Uuid,
+        namespace_id: Uuid,
+    ) -> StorageResult<usize>;
 
     /// Same deletion as [`StorageTrait::delete_memories_by_entity`], but the
     /// deleted rows are handed to `persist` **before the delete commits** so
@@ -345,7 +367,7 @@ pub trait StorageTrait: Send + Sync {
     /// then destroys without it ever appearing in the snapshot — the exact
     /// unrecoverable case this feature exists to prevent.
     ///
-    /// Unlike [`StorageTrait::delete_memories_by_entity`], this is scoped to
+    /// Like [`StorageTrait::delete_memories_by_entity`], this is scoped to
     /// `namespace_id`. Entity ids are not globally unique, so matching on the
     /// entity alone reaches into other tenants — and here that is worse than a
     /// stray delete, because the foreign rows also land in the caller's

--- a/pensyve-core/src/storage/postgres.rs
+++ b/pensyve-core/src/storage/postgres.rs
@@ -1607,16 +1607,35 @@ impl StorageTrait for PostgresBackend {
         })
     }
 
-    fn delete_memories_by_entity(&self, entity_id: Uuid) -> StorageResult<usize> {
+    /// Entity-wide delete, confined to `namespace_id`.
+    ///
+    /// The `AND namespace_id = $2` predicates carry the isolation on their own.
+    /// Row-level security cannot: the application connects as the schema owner,
+    /// which Postgres exempts from its own policies, so an entity-only
+    /// predicate would delete across tenants in every deployment shipping
+    /// today. The connection is bound to the namespace as well, which is what
+    /// keeps the statements working once `postgres_rls_enforce.sql` is applied.
+    ///
+    /// There is no full-text cleanup here, unlike the `SQLite` backend: this
+    /// schema indexes through the `fts_content` generated column on each table,
+    /// so deleting the row deletes its index entry. The orphaning half of #256
+    /// is `SQLite`-only for that reason.
+    fn delete_memories_by_entity(
+        &self,
+        entity_id: Uuid,
+        namespace_id: Uuid,
+    ) -> StorageResult<usize> {
         self.block_on(async {
-            let mut conn = self.maybe_scoped_conn().await?;
+            let mut conn = self.scoped_conn(namespace_id).await?;
             let mut total = 0usize;
 
             // Delete episodic memories.
             let result = query::<Postgres>(
-                "DELETE FROM episodic_memories WHERE about_entity = $1 OR source_entity = $1",
+                r"DELETE FROM episodic_memories
+                   WHERE (about_entity = $1 OR source_entity = $1) AND namespace_id = $2",
             )
             .bind(entity_id)
+            .bind(namespace_id)
             .execute(&mut *conn)
             .await
             .map_err(sqlx_to_io)?;
@@ -1624,9 +1643,11 @@ impl StorageTrait for PostgresBackend {
 
             // Delete semantic memories.
             let result = query::<Postgres>(
-                "DELETE FROM semantic_memories WHERE subject = $1 OR object_entity = $1",
+                r"DELETE FROM semantic_memories
+                   WHERE (subject = $1 OR object_entity = $1) AND namespace_id = $2",
             )
             .bind(entity_id)
+            .bind(namespace_id)
             .execute(&mut *conn)
             .await
             .map_err(sqlx_to_io)?;

--- a/pensyve-core/src/storage/postgres/live_rls.rs
+++ b/pensyve-core/src/storage/postgres/live_rls.rs
@@ -826,6 +826,147 @@ fn capturing_delete_still_works_under_enforced_rls() {
     );
 }
 
+/// The plain entity-wide delete keeps working with RLS enforced, so it no
+/// longer belongs in [`enforced_rls_fails_closed_for_unscoped_methods`].
+///
+/// It took no `namespace_id` until #256 and therefore ran on an unscoped
+/// connection, which under enforcement matched nothing — `Ok(0)` reported as
+/// success, with a GDPR erase claiming to have erased something it had not.
+/// Now that the connection is bound, the delete takes effect in its own
+/// namespace and only there.
+///
+/// [`entity_delete_is_confined_to_its_namespace`] is the same contract with RLS
+/// inert, which is the configuration that ships.
+#[test]
+fn entity_delete_still_works_under_enforced_rls() {
+    let Some(admin_opts) = skip_notice("entity_delete_still_works_under_enforced_rls") else {
+        return;
+    };
+    let fixture = Fixture::provision(&admin_opts);
+    let backend = &fixture.backend;
+
+    let ns_a = Namespace::new(format!("forget-a-{}", Uuid::new_v4().simple()));
+    let ns_b = Namespace::new(format!("forget-b-{}", Uuid::new_v4().simple()));
+    backend.save_namespace(&ns_a).expect("save namespace A");
+    backend.save_namespace(&ns_b).expect("save namespace B");
+
+    let entity_id = Uuid::new_v4();
+    let mine = EpisodicMemory::new(ns_a.id, Uuid::new_v4(), entity_id, entity_id, "tenant A");
+    backend.save_episodic(&mine).expect("save A's memory");
+    let theirs = EpisodicMemory::new(ns_b.id, Uuid::new_v4(), entity_id, entity_id, "tenant B");
+    backend.save_episodic(&theirs).expect("save B's memory");
+
+    fixture.enforce_rls();
+
+    assert_eq!(
+        backend
+            .delete_memories_by_entity(entity_id, ns_a.id)
+            .expect("delete_memories_by_entity must not error"),
+        1,
+        "the entity-wide delete must take effect in its own namespace under enforced RLS"
+    );
+    assert!(
+        backend
+            .get_all_memories_by_namespace(ns_a.id)
+            .expect("read namespace A")
+            .is_empty(),
+        "namespace A should be empty after the forget"
+    );
+    assert_eq!(
+        memory_ids(
+            &backend
+                .get_all_memories_by_namespace(ns_b.id)
+                .expect("read namespace B")
+        ),
+        vec![theirs.id],
+        "namespace B's row must survive"
+    );
+}
+
+/// The plain entity-wide delete behind the CLI, the REST `forget_entity`
+/// handler, the A2A `memory.forget` capability, the Python binding and
+/// `gdpr::erase_entity` must not reach across namespaces.
+///
+/// Same shape as [`capturing_delete_is_confined_to_its_namespace`], and the
+/// same reasoning: entity ids are not globally unique, and with RLS inert — the
+/// configuration every deployment runs today, because the backend connects as
+/// the schema owner — an entity-only predicate has nothing else filtering it.
+/// This variant reaches further than the capturing one, which is MCP-only.
+///
+/// Object-side semantic rows are seeded deliberately: the delete has always
+/// matched `subject OR object_entity`, so both must go, and both must stay out
+/// of the other tenant's namespace.
+#[test]
+fn entity_delete_is_confined_to_its_namespace() {
+    let Some(admin_opts) = skip_notice("entity_delete_is_confined_to_its_namespace") else {
+        return;
+    };
+    let fixture = Fixture::provision(&admin_opts);
+    let backend = &fixture.backend;
+
+    let ns_a = Namespace::new(format!("forget-a-{}", Uuid::new_v4().simple()));
+    let ns_b = Namespace::new(format!("forget-b-{}", Uuid::new_v4().simple()));
+    backend.save_namespace(&ns_a).expect("save namespace A");
+    backend.save_namespace(&ns_b).expect("save namespace B");
+
+    // The same entity id in both namespaces — the collision the predicate has
+    // to disambiguate.
+    let entity_id = Uuid::new_v4();
+
+    let mine = EpisodicMemory::new(
+        ns_a.id,
+        Uuid::new_v4(),
+        entity_id,
+        entity_id,
+        "tenant A turn",
+    );
+    backend.save_episodic(&mine).expect("save A's memory");
+
+    let theirs = EpisodicMemory::new(
+        ns_b.id,
+        Uuid::new_v4(),
+        entity_id,
+        entity_id,
+        "tenant B turn",
+    );
+    backend.save_episodic(&theirs).expect("save B's memory");
+
+    // Object-side facts: the entity is the object, not the subject.
+    let mut mine_fact = SemanticMemory::new(ns_a.id, Uuid::new_v4(), "reports to", "a", 0.9);
+    mine_fact.object_entity = Some(entity_id);
+    backend.save_semantic(&mine_fact).expect("save A's fact");
+
+    let mut their_fact = SemanticMemory::new(ns_b.id, Uuid::new_v4(), "reports to", "b", 0.9);
+    their_fact.object_entity = Some(entity_id);
+    backend.save_semantic(&their_fact).expect("save B's fact");
+
+    let deleted = backend
+        .delete_memories_by_entity(entity_id, ns_a.id)
+        .expect("forget in namespace A");
+
+    assert_eq!(
+        deleted, 2,
+        "namespace A's own episodic and object-side semantic rows should have been deleted"
+    );
+
+    let surviving = memory_ids(
+        &backend
+            .get_all_memories_by_namespace(ns_b.id)
+            .expect("read namespace B"),
+    );
+    assert!(
+        surviving.contains(&theirs.id) && surviving.contains(&their_fact.id),
+        "namespace B's rows must survive a forget issued for namespace A; B now holds {surviving:?}"
+    );
+    assert!(
+        backend
+            .get_all_memories_by_namespace(ns_a.id)
+            .expect("read namespace A")
+            .is_empty(),
+        "namespace A should be empty after the forget"
+    );
+}
+
 /// Enforcement fails closed, and these `StorageTrait` methods take no
 /// `namespace_id`, so they run on an unscoped connection and quietly stop
 /// working when it is switched on.
@@ -833,8 +974,8 @@ fn capturing_delete_still_works_under_enforced_rls() {
 /// This is the reason `FORCE ROW LEVEL SECURITY` lives in
 /// `postgres_rls_enforce.sql` as an operator step instead of in
 /// `postgres_schema.sql`. The failure mode is the dangerous kind: not an
-/// error, but a success report with no effect — `delete_memories_by_entity`
-/// returns `Ok(0)` and a GDPR erase would report that it had erased something.
+/// error, but a success report with no effect — `delete_memory_by_id` returns
+/// `Ok(false)` while `purge_namespace`, which is built on it, reports a count.
 ///
 /// Each assertion here is a work item, tracked by #254. When a method starts
 /// carrying a namespace, its assertion flips and has to be moved into
@@ -871,15 +1012,10 @@ fn enforced_rls_fails_closed_for_unscoped_methods() {
         "supersede_memory now takes effect under enforced RLS"
     );
 
-    // Reached from DELETE /v1/entities/{name}, the A2A memory.forget
-    // capability, GDPR erase, the pensyve_forget MCP tool, and the CLI.
-    assert_eq!(
-        backend
-            .delete_memories_by_entity(memory.about_entity)
-            .expect("delete_memories_by_entity must not error"),
-        0,
-        "delete_memories_by_entity now deletes under enforced RLS"
-    );
+    // `delete_memories_by_entity` used to be on this list. It takes a
+    // `namespace_id` as of #256, so its connection is bound and it keeps
+    // working under enforcement — the assertion moved to
+    // [`entity_delete_still_works_under_enforced_rls`].
 
     // Reached from the default `purge_namespace` trait implementation, which
     // PostgresBackend does not override.

--- a/pensyve-core/src/storage/sqlite.rs
+++ b/pensyve-core/src/storage/sqlite.rs
@@ -2274,9 +2274,14 @@ impl StorageTrait for SqliteBackend {
         }
     }
 
-    fn delete_memories_by_entity(&self, entity_id: Uuid) -> StorageResult<usize> {
+    fn delete_memories_by_entity(
+        &self,
+        entity_id: Uuid,
+        namespace_id: Uuid,
+    ) -> StorageResult<usize> {
         let conn = lock_conn!(self);
         let id_str = entity_id.to_string();
+        let ns_str = namespace_id.to_string();
 
         // Run the entire delete in a single transaction for atomicity and speed.
         conn.execute_batch("BEGIN")?;
@@ -2284,41 +2289,52 @@ impl StorageTrait for SqliteBackend {
         let result = (|| -> StorageResult<usize> {
             let mut total = 0usize;
 
-            // Collect IDs to remove from FTS.
+            // Collect the ids to remove from FTS. These `SELECT`s must match
+            // the `DELETE`s below predicate-for-predicate: the semantic one
+            // used to look at `subject` alone while the delete also removed
+            // `object_entity` rows, which left every object-side row's index
+            // entry — content included — behind after its base row was gone.
             let episodic_ids: Vec<String> = {
                 let mut stmt = conn.prepare(
-                    "SELECT id FROM episodic_memories WHERE about_entity = ?1 OR source_entity = ?1",
+                    "SELECT id FROM episodic_memories
+                      WHERE (about_entity = ?1 OR source_entity = ?1) AND namespace_id = ?2",
                 )?;
-                stmt.query_map(params![&id_str], |row| row.get(0))?
+                stmt.query_map(params![&id_str, &ns_str], |row| row.get(0))?
                     .collect::<Result<Vec<_>, _>>()?
             };
 
             let semantic_ids: Vec<String> = {
-                let mut stmt =
-                    conn.prepare("SELECT id FROM semantic_memories WHERE subject = ?1")?;
-                stmt.query_map(params![&id_str], |row| row.get(0))?
+                let mut stmt = conn.prepare(
+                    "SELECT id FROM semantic_memories
+                      WHERE (subject = ?1 OR object_entity = ?1) AND namespace_id = ?2",
+                )?;
+                stmt.query_map(params![&id_str, &ns_str], |row| row.get(0))?
                     .collect::<Result<Vec<_>, _>>()?
             };
 
             // Delete episodic.
             let n = conn.execute(
-                "DELETE FROM episodic_memories WHERE about_entity = ?1 OR source_entity = ?1",
-                params![&id_str],
+                "DELETE FROM episodic_memories
+                  WHERE (about_entity = ?1 OR source_entity = ?1) AND namespace_id = ?2",
+                params![&id_str, &ns_str],
             )?;
             total += n;
 
             // Delete semantic (by subject or object_entity).
             let n = conn.execute(
-                "DELETE FROM semantic_memories WHERE subject = ?1 OR object_entity = ?1",
-                params![&id_str],
+                "DELETE FROM semantic_memories
+                  WHERE (subject = ?1 OR object_entity = ?1) AND namespace_id = ?2",
+                params![&id_str, &ns_str],
             )?;
             total += n;
 
-            // Remove from FTS in bulk.
+            // Remove from FTS in bulk, qualified by namespace — `memory_fts`
+            // is keyed by `memory_id`, which is not unique across namespaces,
+            // so an unqualified delete silently strips another tenant's entry.
             for fts_id in episodic_ids.iter().chain(semantic_ids.iter()) {
                 conn.execute(
-                    "DELETE FROM memory_fts WHERE memory_id = ?1",
-                    params![fts_id],
+                    "DELETE FROM memory_fts WHERE memory_id = ?1 AND namespace_id = ?2",
+                    params![fts_id, &ns_str],
                 )?;
             }
 
@@ -3716,7 +3732,7 @@ mod tests {
         db.save_episodic(&mem1).unwrap();
         db.save_semantic(&mem2).unwrap();
 
-        let deleted = db.delete_memories_by_entity(entity_id).unwrap();
+        let deleted = db.delete_memories_by_entity(entity_id, ns.id).unwrap();
         assert!(deleted > 0);
 
         // Verify gone from storage.
@@ -3761,13 +3777,8 @@ mod tests {
         let subject_id = Uuid::new_v4();
         let object_id = Uuid::new_v4();
 
-        let mut fact = SemanticMemory::new(
-            ns.id,
-            subject_id,
-            "reports to",
-            "orphaned index token",
-            0.9,
-        );
+        let mut fact =
+            SemanticMemory::new(ns.id, subject_id, "reports to", "orphaned index token", 0.9);
         fact.object_entity = Some(object_id);
         db.save_semantic(&fact).unwrap();
 
@@ -3779,7 +3790,7 @@ mod tests {
             "precondition: the fact must be findable before the forget"
         );
 
-        db.delete_memories_by_entity(object_id).unwrap();
+        db.delete_memories_by_entity(object_id, ns.id).unwrap();
 
         assert!(
             db.get_semantic(fact.id).unwrap().is_none(),
@@ -3834,7 +3845,8 @@ mod tests {
         foreign_memory.id = shared_id;
         db.save_episodic(&foreign_memory).unwrap();
 
-        db.delete_memories_by_entity(entity_id).unwrap();
+        db.delete_memories_by_entity(entity_id, owner_ns.id)
+            .unwrap();
 
         let hits = db
             .search_fts("foreign unique token", foreign_ns.id, 10)
@@ -3845,6 +3857,80 @@ mod tests {
             "the other namespace's memory must still be findable"
         );
         assert_eq!(hits[0].id(), shared_id);
+    }
+
+    /// Two namespaces holding rows keyed to the same entity id: a forget
+    /// issued for one must leave the other's rows alone.
+    ///
+    /// Entity ids are server-generated per namespace and callers resolve them
+    /// through the namespace-scoped `get_entity_by_name`, so this collision
+    /// does not arise on its own — nothing prevented it either, and import and
+    /// restore paths carry ids. This is the same footgun #247 and #248 removed
+    /// from their own delete paths.
+    #[test]
+    fn test_delete_memories_by_entity_is_confined_to_its_namespace() {
+        let (_dir, db) = setup();
+        let owner_ns = make_namespace(&db);
+        let foreign_ns = Namespace::new("other");
+        db.save_namespace(&foreign_ns).unwrap();
+        let entity_id = Uuid::new_v4();
+
+        let mine = EpisodicMemory::new(
+            owner_ns.id,
+            Uuid::new_v4(),
+            entity_id,
+            entity_id,
+            "tenant A turn",
+        );
+        db.save_episodic(&mine).unwrap();
+
+        let theirs = EpisodicMemory::new(
+            foreign_ns.id,
+            Uuid::new_v4(),
+            entity_id,
+            entity_id,
+            "tenant B turn",
+        );
+        db.save_episodic(&theirs).unwrap();
+
+        // Object-side facts, which the delete also matches.
+        let mut my_fact = SemanticMemory::new(owner_ns.id, Uuid::new_v4(), "reports to", "a", 0.9);
+        my_fact.object_entity = Some(entity_id);
+        db.save_semantic(&my_fact).unwrap();
+
+        let mut their_fact =
+            SemanticMemory::new(foreign_ns.id, Uuid::new_v4(), "reports to", "b", 0.9);
+        their_fact.object_entity = Some(entity_id);
+        db.save_semantic(&their_fact).unwrap();
+
+        let deleted = db
+            .delete_memories_by_entity(entity_id, owner_ns.id)
+            .unwrap();
+
+        assert_eq!(
+            deleted, 2,
+            "only the owning namespace's two rows are deleted"
+        );
+        assert!(db.get_episodic(mine.id).unwrap().is_none());
+        assert!(db.get_semantic(my_fact.id).unwrap().is_none());
+        assert!(
+            db.get_episodic(theirs.id).unwrap().is_some(),
+            "the other namespace's episodic row must survive"
+        );
+        assert!(
+            db.get_semantic(their_fact.id).unwrap().is_some(),
+            "the other namespace's object-side fact must survive"
+        );
+        assert_eq!(
+            fts_rows_for(&db, theirs.id),
+            1,
+            "the other namespace's index entry must survive"
+        );
+        assert_eq!(
+            fts_rows_for(&db, their_fact.id),
+            1,
+            "the other namespace's index entry must survive"
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/pensyve-core/src/storage/sqlite.rs
+++ b/pensyve-core/src/storage/sqlite.rs
@@ -3731,6 +3731,122 @@ mod tests {
         assert_eq!(fts_sem.len(), 0);
     }
 
+    /// Count the `memory_fts` rows carrying `memory_id`, regardless of
+    /// namespace. Used by the delete tests to look at the search index
+    /// directly: every read path joins back to the base table, so an orphaned
+    /// index row is invisible through `search_fts` and only visible here.
+    fn fts_rows_for(db: &SqliteBackend, memory_id: Uuid) -> i64 {
+        let conn = db.conn.lock().unwrap();
+        conn.query_row(
+            "SELECT count(*) FROM memory_fts WHERE memory_id = ?1",
+            params![memory_id.to_string()],
+            |row| row.get(0),
+        )
+        .unwrap()
+    }
+
+    /// A semantic fact in which the forgotten entity is the *object* must have
+    /// its search-index entry removed along with its row.
+    ///
+    /// The row delete matches `subject = ?1 OR object_entity = ?1`, but the
+    /// FTS id collection only ever selected `WHERE subject = ?1`. Object-side
+    /// rows were therefore deleted from `semantic_memories` while their
+    /// `memory_fts` entry — which holds the fact's text — stayed behind. A user
+    /// who retracts a fact through `pensyve_forget` is told it is gone while a
+    /// copy of its content is still sitting in the index.
+    #[test]
+    fn test_delete_memories_by_entity_removes_object_side_fts_entry() {
+        let (_dir, db) = setup();
+        let ns = make_namespace(&db);
+        let subject_id = Uuid::new_v4();
+        let object_id = Uuid::new_v4();
+
+        let mut fact = SemanticMemory::new(
+            ns.id,
+            subject_id,
+            "reports to",
+            "orphaned index token",
+            0.9,
+        );
+        fact.object_entity = Some(object_id);
+        db.save_semantic(&fact).unwrap();
+
+        assert_eq!(
+            db.search_fts("orphaned index token", ns.id, 10)
+                .unwrap()
+                .len(),
+            1,
+            "precondition: the fact must be findable before the forget"
+        );
+
+        db.delete_memories_by_entity(object_id).unwrap();
+
+        assert!(
+            db.get_semantic(fact.id).unwrap().is_none(),
+            "the object-side row itself is deleted"
+        );
+        assert_eq!(
+            fts_rows_for(&db, fact.id),
+            0,
+            "the retracted fact's text is still in memory_fts"
+        );
+        assert_eq!(
+            db.search_fts("orphaned index token", ns.id, 10)
+                .unwrap()
+                .len(),
+            0,
+            "the retracted fact must not be findable"
+        );
+    }
+
+    /// Forgetting an entity must not strip another namespace's search-index
+    /// entry that happens to share a memory id.
+    ///
+    /// `memory_fts` is keyed by `memory_id`, which is not unique across
+    /// namespaces — the same reason
+    /// `test_delete_memory_by_id_in_namespace_preserves_foreign_fts_entry`
+    /// exists. The entity-wide delete issued an unqualified
+    /// `DELETE FROM memory_fts WHERE memory_id = ?1`, so a colliding id took
+    /// the other tenant's row out of the index while leaving its base row in
+    /// place: findable content silently stops being findable.
+    #[test]
+    fn test_delete_memories_by_entity_preserves_foreign_fts_entry() {
+        let (_dir, db) = setup();
+        let owner_ns = make_namespace(&db);
+        let foreign_ns = Namespace::new("other");
+        db.save_namespace(&foreign_ns).unwrap();
+        let shared_id = Uuid::new_v4();
+        let entity_id = Uuid::new_v4();
+
+        let mut owner_memory =
+            SemanticMemory::new(owner_ns.id, entity_id, "owns", "local token", 0.9);
+        owner_memory.id = shared_id;
+        db.save_semantic(&owner_memory).unwrap();
+
+        // Different entity ids, so only the FTS cleanup can reach this row.
+        let mut foreign_memory = EpisodicMemory::new(
+            foreign_ns.id,
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            "foreign unique token",
+        );
+        foreign_memory.id = shared_id;
+        db.save_episodic(&foreign_memory).unwrap();
+
+        db.delete_memories_by_entity(entity_id).unwrap();
+
+        let hits = db
+            .search_fts("foreign unique token", foreign_ns.id, 10)
+            .unwrap();
+        assert_eq!(
+            hits.len(),
+            1,
+            "the other namespace's memory must still be findable"
+        );
+        assert_eq!(hits[0].id(), shared_id);
+    }
+
     // -----------------------------------------------------------------------
     // Bulk retrieval
     // -----------------------------------------------------------------------

--- a/pensyve-core/src/storage/sqlite.rs
+++ b/pensyve-core/src/storage/sqlite.rs
@@ -2239,9 +2239,11 @@ impl StorageTrait for SqliteBackend {
             }
 
             // Strip the FTS rows for exactly what we just deleted, qualified by
-            // each row's own namespace — `memory_fts` is keyed by `memory_id`,
-            // which is not unique across namespaces, so an unqualified delete
-            // would silently strip another tenant's search index entry.
+            // each row's own namespace and type — `memory_fts` is keyed by
+            // `memory_id`, which identifies nothing on its own. Ids repeat
+            // across namespaces, and within one namespace the same id can name
+            // both an episodic and a semantic row, so an under-qualified delete
+            // strips an index entry whose base row is still live.
             for memory in &memories {
                 let row_namespace = match memory {
                     Memory::Episodic(m) => m.namespace_id,
@@ -2250,8 +2252,13 @@ impl StorageTrait for SqliteBackend {
                     Memory::Observation(m) => m.namespace_id,
                 };
                 conn.execute(
-                    "DELETE FROM memory_fts WHERE memory_id = ?1 AND namespace_id = ?2",
-                    params![memory.id().to_string(), row_namespace.to_string()],
+                    "DELETE FROM memory_fts
+                      WHERE memory_id = ?1 AND namespace_id = ?2 AND memory_type = ?3",
+                    params![
+                        memory.id().to_string(),
+                        row_namespace.to_string(),
+                        memory.type_name()
+                    ],
                 )?;
             }
 
@@ -2328,13 +2335,21 @@ impl StorageTrait for SqliteBackend {
             )?;
             total += n;
 
-            // Remove from FTS in bulk, qualified by namespace — `memory_fts`
-            // is keyed by `memory_id`, which is not unique across namespaces,
-            // so an unqualified delete silently strips another tenant's entry.
-            for fts_id in episodic_ids.iter().chain(semantic_ids.iter()) {
+            // Remove from FTS in bulk. `memory_fts` is keyed by `memory_id`
+            // alone, which identifies nothing on its own: ids repeat across
+            // namespaces, and within one namespace the same id can name both an
+            // episodic and a semantic row. Both halves of the key are therefore
+            // pinned, or the cleanup strips an index entry whose base row is
+            // still live and leaves that memory unsearchable.
+            for (fts_id, memory_type) in episodic_ids
+                .iter()
+                .map(|id| (id, "episodic"))
+                .chain(semantic_ids.iter().map(|id| (id, "semantic")))
+            {
                 conn.execute(
-                    "DELETE FROM memory_fts WHERE memory_id = ?1 AND namespace_id = ?2",
-                    params![fts_id, &ns_str],
+                    "DELETE FROM memory_fts
+                      WHERE memory_id = ?1 AND namespace_id = ?2 AND memory_type = ?3",
+                    params![fts_id, &ns_str, memory_type],
                 )?;
             }
 
@@ -3855,6 +3870,65 @@ mod tests {
             hits.len(),
             1,
             "the other namespace's memory must still be findable"
+        );
+        assert_eq!(hits[0].id(), shared_id);
+    }
+
+    /// The other axis of the same key problem: one namespace holding an
+    /// episodic and a semantic row that share a memory id.
+    ///
+    /// `memory_fts` is keyed by `memory_id` alone, so namespace-qualifying the
+    /// cleanup is only half the fix — within a namespace the id still names two
+    /// rows. Forgetting the entity behind the episodic one must not take the
+    /// unrelated semantic row's index entry with it and leave live content
+    /// unsearchable. (`test_delete_memory_by_id_in_namespace_rolls_back_partial_delete`
+    /// builds the same shared-id shape.)
+    #[test]
+    fn test_delete_memories_by_entity_preserves_other_memory_type_fts_entry() {
+        let (_dir, db) = setup();
+        let ns = make_namespace(&db);
+        let shared_id = Uuid::new_v4();
+        let entity_id = Uuid::new_v4();
+
+        let mut episodic = EpisodicMemory::new(
+            ns.id,
+            Uuid::new_v4(),
+            entity_id,
+            entity_id,
+            "episodic to forget",
+        );
+        episodic.id = shared_id;
+        db.save_episodic(&episodic).unwrap();
+
+        // Same id, same namespace, unrelated entity — only the FTS cleanup can
+        // reach it.
+        let mut semantic = SemanticMemory::new(
+            ns.id,
+            Uuid::new_v4(),
+            "keeps",
+            "unrelated survivor token",
+            0.9,
+        );
+        semantic.id = shared_id;
+        db.save_semantic(&semantic).unwrap();
+
+        db.delete_memories_by_entity(entity_id, ns.id).unwrap();
+
+        assert!(
+            db.get_episodic(shared_id).unwrap().is_none(),
+            "the forgotten episodic row is deleted"
+        );
+        assert!(
+            db.get_semantic(shared_id).unwrap().is_some(),
+            "the unrelated semantic row is not attached to the entity"
+        );
+        let hits = db
+            .search_fts("unrelated survivor token", ns.id, 10)
+            .unwrap();
+        assert_eq!(
+            hits.len(),
+            1,
+            "the surviving semantic row must still be findable"
         );
         assert_eq!(hits[0].id(), shared_id);
     }

--- a/pensyve-mcp-gateway/src/rest.rs
+++ b/pensyve-mcp-gateway/src/rest.rs
@@ -1152,7 +1152,7 @@ async fn forget_entity(
 
     let forgotten_count = ps
         .storage
-        .delete_memories_by_entity(entity.id)
+        .delete_memories_by_entity(entity.id, ps.namespace.id)
         .map_err(|err| {
             RestError(
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -2171,12 +2171,13 @@ async fn gdpr_erase(
         memory_ids.extend(mems.iter().map(|m| m.id));
     }
 
-    let result = pensyve_core::gdpr::erase_entity(ps.storage.as_ref(), entity.id).map_err(|e| {
-        RestError(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("GDPR erasure error: {e}"),
-        )
-    })?;
+    let result = pensyve_core::gdpr::erase_entity(ps.storage.as_ref(), entity.id, ps.namespace.id)
+        .map_err(|e| {
+            RestError(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("GDPR erasure error: {e}"),
+            )
+        })?;
 
     // Clean vector index.
     if result.memories_deleted > 0 {
@@ -2356,7 +2357,10 @@ async fn a2a_task(
 
             match ps.storage.get_entity_by_name(&entity_name, ps.namespace.id) {
                 Ok(Some(entity)) => {
-                    let count = ps.storage.delete_memories_by_entity(entity.id).unwrap_or(0);
+                    let count = ps
+                        .storage
+                        .delete_memories_by_entity(entity.id, ps.namespace.id)
+                        .unwrap_or(0);
                     json!({"forgotten_count": count})
                 }
                 _ => json!({"forgotten_count": 0}),

--- a/pensyve-mcp/tests/integration_test.rs
+++ b/pensyve-mcp/tests/integration_test.rs
@@ -242,7 +242,7 @@ async fn test_forget_removes_all_memories_for_entity() {
     // forget: delete memories.
     let forgotten = state
         .storage
-        .delete_memories_by_entity(entity.id)
+        .delete_memories_by_entity(entity.id, state.namespace.id)
         .expect("delete memories");
     assert_eq!(forgotten, 2, "should have deleted exactly 2 memories");
 

--- a/pensyve-python/src/lib.rs
+++ b/pensyve-python/src/lib.rs
@@ -1913,7 +1913,7 @@ impl PyPensyve {
         let count = self
             .inner
             .storage
-            .delete_memories_by_entity(entity.uuid)
+            .delete_memories_by_entity(entity.uuid, self.inner.namespace.id)
             .map_err(|e| PyRuntimeError::new_err(format!("Forget failed: {e}")))?;
 
         let dict = PyDict::new(py);


### PR DESCRIPTION
## What this fixes

`delete_memories_by_entity` — the entity-wide forget behind the CLI, the Python
binding, the gateway's `forget_entity` and A2A `memory.forget` handlers, and
`gdpr::erase_entity` — carried two defects. One of them ships today.

### 1. Orphaned FTS entries (SQLite)

The index cleanup collected ids with `WHERE subject = ?1` while the row delete
removed `WHERE subject = ?1 OR object_entity = ?1`. Every object-side semantic
row was deleted from `semantic_memories` while its `memory_fts` entry — which
stores the fact's text — stayed behind. A user who retracted a fact was told it
was gone while a copy of its content remained in the index.

The cleanup was also unqualified: `DELETE FROM memory_fts WHERE memory_id = ?1`.
`memory_id` is not unique across namespaces — the reason
`test_delete_memory_by_id_in_namespace_preserves_foreign_fts_entry` exists — so
a colliding id stripped another namespace's index entry, quietly making that
tenant's live content unfindable.

**Severity, stated precisely.** The issue says the retracted content "remains
findable through search". It does not, and I checked rather than assumed: every
SQLite read path (`search_fts`, `search_fts_scoped`, and `search_fts_scoped_by_pair`
which delegates to `search_fts`) either `EXISTS`-guards or `JOIN`s back to the
base table, so an orphaned index row is filtered out. I removed the index-row
assertion from the failing test and re-ran it — the search assertion passed.
What is live is **retention**: content the user retracted is still stored in the
database. That is still a correctness and data-retention problem for a delete
path whose whole purpose is retraction, but it is not findability.

### 2. No namespace predicate on the row deletes (both backends)

Neither backend applied `namespace_id`; the delete matched on entity id alone.

* **SQLite** — latent, as the issue says. Entity UUIDs are server-generated per
  namespace and callers resolve through the namespace-scoped `get_entity_by_name`,
  so a collision needs the same UUID in two namespaces. Fixed as footgun removal.
* **Postgres** — live, and measured. `entity_delete_is_confined_to_its_namespace`
  deleted **4 rows instead of 2** against a real Postgres before the fix: a forget
  issued for namespace A took namespace B's rows with it, the same shape #248
  measured for the capturing variant.

## What changed

**`StorageTrait`** — `delete_memories_by_entity(entity_id, namespace_id)`. The
signature change is deliberate and unshimmed: the old API *is* the defect, and a
fail-closed default would convert a build failure into a production one.

**SQLite** — the FTS id collection now mirrors the delete predicate-for-predicate
(`subject OR object_entity`), the `memory_fts` delete is qualified by namespace,
and both row deletes carry `AND namespace_id = ?2`.

**Postgres** — both row deletes carry `AND namespace_id = $2`, and the connection
is bound with `scoped_conn(namespace_id)` instead of `maybe_scoped_conn()`, so
the method keeps working once `postgres_rls_enforce.sql` is applied rather than
silently deleting nothing. No FTS cleanup is needed: that schema indexes through
the `fts_content` generated column on each table, so the row delete takes the
index entry with it. The orphaning half of this issue is SQLite-only.

**Callers** — `pensyve-cli` `cmd_forget`, `pensyve-python` `PyPensyve::forget`,
gateway `forget_entity` / `gdpr_erase` / A2A `memory.forget`, and
`gdpr::erase_entity`, which gains a `namespace_id` to match its neighbour
`export_entity_data`. Threading it was cheap — two non-test call sites, both of
which already had the namespace in hand.

**Left unscoped, deliberately.** `erase_entity`'s other three steps —
`delete_observations_by_entity`, `get_edges_for_entity`, `delete_entity` — still
match on entity id alone. Scoping them means changing three more `StorageTrait`
methods, which is #254's job, not this PR's. Documented on `erase_entity` and in
`docs/SECURITY.md`.

**Adjacent finding, not fixed here.** `search_fts`'s base-table `EXISTS` guard
and its hydration `SELECT` are not namespace-qualified. An orphaned index row in
namespace A whose `memory_id` collides with a live row in namespace B would match
in A's search and hydrate B's row — a cross-namespace read. This PR removes the
orphans that would fuel it; qualifying those two queries is a separate change.

## TDD

Both regression tests were written and committed red first (commit `aa3b6d8`),
against the pre-change one-argument signature.

```
running 3 tests
test storage::sqlite::tests::test_delete_memories_by_entity_removes_object_side_fts_entry ... FAILED
test storage::sqlite::tests::test_delete_memories_by_entity ... ok
test storage::sqlite::tests::test_delete_memories_by_entity_preserves_foreign_fts_entry ... FAILED

failures:

---- storage::sqlite::tests::test_delete_memories_by_entity_removes_object_side_fts_entry stdout ----

thread 'storage::sqlite::tests::test_delete_memories_by_entity_removes_object_side_fts_entry' (2166430) panicked at pensyve-core/src/storage/sqlite.rs:3788:9:
assertion `left == right` failed: the retracted fact's text is still in memory_fts
  left: 1
 right: 0
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- storage::sqlite::tests::test_delete_memories_by_entity_preserves_foreign_fts_entry stdout ----

thread 'storage::sqlite::tests::test_delete_memories_by_entity_preserves_foreign_fts_entry' (2166429) panicked at pensyve-core/src/storage/sqlite.rs:3842:9:
assertion `left == right` failed: the other namespace's memory must still be findable
  left: 0
 right: 1


failures:
    storage::sqlite::tests::test_delete_memories_by_entity_preserves_foreign_fts_entry
    storage::sqlite::tests::test_delete_memories_by_entity_removes_object_side_fts_entry

test result: FAILED. 1 passed; 2 failed; 0 ignored; 0 measured; 538 filtered out; finished in 0.60s
```

The Postgres test was likewise proved red, by reverting only the two `postgres.rs`
predicates and re-running against a live `pgvector/pgvector:pg16`:

```
running 1 test
test storage::postgres::live_rls::entity_delete_is_confined_to_its_namespace ... FAILED

---- storage::postgres::live_rls::entity_delete_is_confined_to_its_namespace stdout ----
thread 'storage::postgres::live_rls::entity_delete_is_confined_to_its_namespace' (2205767) panicked at pensyve-core/src/storage/postgres/live_rls.rs:947:5:
assertion `left == right` failed: namespace A's own episodic and object-side semantic rows should have been deleted
  left: 4
 right: 2
```

## Coverage added

SQLite (`storage/sqlite.rs`):

* `test_delete_memories_by_entity_removes_object_side_fts_entry`
* `test_delete_memories_by_entity_preserves_foreign_fts_entry`
* `test_delete_memories_by_entity_is_confined_to_its_namespace`

Live Postgres (`storage/postgres/live_rls.rs`), modelled on #248's
`capturing_delete_is_confined_to_its_namespace`:

* `entity_delete_is_confined_to_its_namespace` — RLS inert, the configuration
  that ships, so this gates the predicates rather than the policies.
* `entity_delete_still_works_under_enforced_rls` — the flipped assertion, moved
  out of `enforced_rls_fails_closed_for_unscoped_methods` exactly as that test's
  docs require now that the method carries a namespace.

Both **ran** rather than skipped — no `SKIP …` notice appears in the run below,
and it appears when `PENSYVE_TEST_DATABASE_URL` is unset:

```
running 15 tests
test storage::postgres::live_rls::entity_delete_still_works_under_enforced_rls ... ok
test storage::postgres::live_rls::entity_delete_is_confined_to_its_namespace ... ok
…
test result: ok. 15 passed; 0 failed; 0 ignored; 0 measured; 546 filtered out; finished in 0.86s
```

## Verification

| Command | Result |
| --- | --- |
| `cargo test --workspace` | 960 passed, 0 failed, 9 ignored |
| `cargo test -p pensyve-core --features postgres` (live pgvector) | 686 passed, 0 failed, 9 ignored |
| `cargo clippy --workspace -- -D warnings` | clean |
| `cargo clippy -p pensyve-core --features postgres --all-targets -- -D warnings` | clean |
| `cargo fmt --all --check` | clean |

No crate versions bumped, no `CHANGELOG` entry — release-prep only, per the
contributing guide. `docs/SECURITY.md`'s pre-enforcement checklist is updated to
match the new state.

Closes #256

https://claude.ai/code/session_01AsVz67dYuk3dufxA683hJA

---

### Update after review (`83232b8`)

Two review findings taken, two declined — reasoning in [this comment](https://github.com/major7apps/pensyve/pull/259#issuecomment-5309064593).

The taken one matters enough to fold into the summary above: the FTS cleanup now
qualifies on `memory_type` as well as `namespace_id`. `memory_fts` is keyed by
`memory_id`, which identifies nothing on its own, and within a namespace the same
id can name both an episodic and a semantic row. Qualifying only by namespace
still stripped the other row's index entry and left live content unsearchable —
the same defect this PR fixes, one axis over. The capturing variant from #248 had
the identical gap and is fixed alongside it.

Adds `test_delete_memories_by_entity_preserves_other_memory_type_fts_entry`,
proved red against the namespace-only predicate. Revised counts:
`cargo test --workspace` 961 passed / 0 failed / 9 ignored;
`cargo test -p pensyve-core --features postgres` against live pgvector
687 passed / 0 failed / 9 ignored; clippy, fmt clean.
