### PR TITLE
docs: record the API-break exception in AGENTS.md hard rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,13 @@ Python env setup: `uv sync --extra dev && uv run maturin develop --manifest-path
 ## Hard rules
 
 - Do not commit secrets, API keys, or `.env` files. Use `git add` with specific filenames.
-- Do not break the public API surface without a deprecation cycle.
+- Do not break the public API surface without a deprecation cycle — **unless the old API is itself the defect**.
+  A deprecation cycle assumes the old entry point still works and is merely superseded. When it cannot be
+  called safely at all (an unscoped deletion that has no namespace to scope to, a documented-but-inert safety
+  switch), keeping it for a release ships the defect with a compiler warning as its only mitigation. Break it,
+  bump the major version at release prep, and call it out in the release notes. Do not add a fail-closed shim
+  that errors at runtime: for a trait downstream code *implements*, that turns a build failure into a
+  production one. Precedent: PRs #247, #253, #259 (2026-08-16).
 - Do not regress test counts (274+ across Rust/Python/TypeScript/Go). New code adds tests.
 - Match existing style: Rust edition 2024, MSRV 1.88, clippy pedantic. Python ruff (line-length 100), pyright basic. TypeScript eslint. Go `go vet`, stdlib only.
 - Run `make check` before pushing. CI runs the same gate.


### PR DESCRIPTION
`AGENTS.md` states "Do not break the public API surface without a deprecation cycle" absolutely. Three PRs merged today (#247, #253, #259) broke `StorageTrait` signatures under a maintainer ruling that a deprecation cycle is the wrong tool when the old API *is* the defect — it assumes the old entry point still works and is merely superseded, which is false when it cannot be called safely at all.

Codex raised this as a P1 on #259 citing `AGENTS.md:L71`, and it was right to: the rule as written does not carry the exception, so it contradicts what the repo actually does and will keep producing that finding on every future security PR.

A stated rule the project does not follow is the same defect shape this week's work has been removing elsewhere — documentation that confidently asserts something untrue. This records the exception, the reasoning (including why a fail-closed runtime shim is worse than a compile error for a trait downstream code implements), and the precedent PRs.

No code change.

https://claude.ai/code/session_01AsVz67dYuk3dufxA683hJA