### PR TITLE
fix(gateway): route REST forget_entity and A2A memory.forget through the pre-delete snapshot

### DIFF
--- a/pensyve-core/src/a2a.rs
+++ b/pensyve-core/src/a2a.rs
@@ -134,7 +134,21 @@ impl AgentCard {
                     output_schema: serde_json::json!({
                         "type": "object",
                         "properties": {
-                            "forgotten_count": {"type": "integer"}
+                            "forgotten_count": {"type": "integer"},
+                            "snapshot": {
+                                "type": "object",
+                                "description": "Reference to the pre-delete snapshot the deleted rows can be recovered from. Absent when nothing was deleted.",
+                                "properties": {
+                                    "snapshot_id": {"type": "string"},
+                                    "path": {"type": "string"},
+                                    "format_version": {"type": "integer"},
+                                    "captured_at": {"type": "string"},
+                                    "owner_only": {"type": "boolean"},
+                                    "memory_count": {"type": "integer"},
+                                    "episodic_count": {"type": "integer"},
+                                    "semantic_count": {"type": "integer"}
+                                }
+                            }
                         }
                     }),
                 },

--- a/pensyve-core/src/a2a.rs
+++ b/pensyve-core/src/a2a.rs
@@ -137,10 +137,9 @@ impl AgentCard {
                             "forgotten_count": {"type": "integer"},
                             "snapshot": {
                                 "type": "object",
-                                "description": "Reference to the pre-delete snapshot the deleted rows can be recovered from. Absent when nothing was deleted.",
+                                "description": "Recovery reference; absent for zero deletes.",
                                 "properties": {
                                     "snapshot_id": {"type": "string"},
-                                    "path": {"type": "string"},
                                     "format_version": {"type": "integer"},
                                     "captured_at": {"type": "string"},
                                     "owner_only": {"type": "boolean"},

--- a/pensyve-mcp-gateway/src/rest.rs
+++ b/pensyve-mcp-gateway/src/rest.rs
@@ -151,6 +151,10 @@ pub struct EntityResponse {
 #[derive(Debug, Serialize)]
 pub struct ForgetResponse {
     pub forgotten_count: usize,
+    /// Reference to the pre-delete snapshot the caller can recover from.
+    /// Absent when nothing was deleted — there is no file to point at.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub snapshot: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Serialize)]
@@ -1126,6 +1130,30 @@ async fn create_entity(
     ))
 }
 
+/// Constant-size reference to a pre-delete snapshot, in the same shape the
+/// `pensyve_forget` MCP tool returns. The rows are referenced rather than
+/// inlined: they carry their embeddings, so a full payload runs to megabytes,
+/// while a reference still lets a caller recover from the file on its own.
+fn snapshot_reference(
+    snapshot: &pensyve_core::snapshot::ForgetSnapshot,
+    path: &str,
+) -> serde_json::Value {
+    let counts = snapshot.counts();
+    json!({
+        "snapshot_id": snapshot.snapshot_id.to_string(),
+        "path": path,
+        "format_version": snapshot.format_version,
+        "captured_at": snapshot.captured_at.to_rfc3339(),
+        // False on platforms where the file could not be restricted to its
+        // owner — the caller holding this reference is the one who needs to
+        // know the artifact is readable by others.
+        "owner_only": snapshot.owner_only,
+        "memory_count": counts.total,
+        "episodic_count": counts.episodic,
+        "semantic_count": counts.semantic,
+    })
+}
+
 async fn forget_entity(
     State(state): State<Arc<AppState>>,
     axum::Extension(auth_ctx): axum::Extension<AuthContext>,
@@ -1141,37 +1169,49 @@ async fn forget_entity(
             )
         })?;
 
-    // Collect memory IDs before deletion so we can remove them from the vector index.
-    let mut memory_ids: Vec<Uuid> = Vec::new();
-    if let Ok(mems) = ps.storage.list_episodic_by_entity(entity.id, usize::MAX) {
-        memory_ids.extend(mems.iter().map(|m| m.id));
-    }
-    if let Ok(mems) = ps.storage.list_semantic_by_entity(entity.id, usize::MAX) {
-        memory_ids.extend(mems.iter().map(|m| m.id));
-    }
+    // Delete and snapshot atomically: the snapshot file is written inside the
+    // delete's transaction, so either both happen or neither does. #217 lost
+    // 1,528 memories with no way back — a delete we could not capture is
+    // exactly that situation again, so this fails closed.
+    let outcome = pensyve_core::snapshot::forget_entity(
+        ps.storage.as_ref(),
+        entity.id,
+        Some(entity.name.as_str()),
+        ps.namespace.id,
+        &ps.snapshot_root,
+    )
+    .map_err(|err| {
+        RestError(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Aborted: pre-delete snapshot failed, nothing was deleted: {err}"),
+        )
+    })?;
 
-    let forgotten_count = ps
-        .storage
-        .delete_memories_by_entity(entity.id, ps.namespace.id)
-        .map_err(|err| {
-            RestError(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Error deleting memories: {err}"),
-            )
-        })?;
+    let snapshot = &outcome.snapshot;
+    let forgotten_count = snapshot.memories.len();
 
-    // Remove deleted entries from vector index — O(1) per entry, not O(n) rebuild.
+    // The snapshot holds exactly the rows the delete removed, so it is also the
+    // authoritative list for vector-index cleanup — O(1) per entry, not O(n) rebuild.
     if forgotten_count > 0 {
         let mut vi = ps.vector_index.write().await;
-        for id in &memory_ids {
-            let _ = vi.remove(*id);
+        for id in snapshot.memory_ids() {
+            let _ = vi.remove(id);
         }
     }
+
+    let snapshot_path = outcome
+        .path
+        .as_ref()
+        .map(|p| p.to_string_lossy().into_owned());
 
     let _ = ps.storage.log_activity(
         ps.namespace.id,
         "forget",
-        &json!({"entity": entity_name, "forgotten_count": forgotten_count}),
+        &json!({
+            "entity": entity_name,
+            "forgotten_count": forgotten_count,
+            "snapshot_path": snapshot_path,
+        }),
     );
 
     // Invalidate recall cache for this namespace.
@@ -1181,7 +1221,12 @@ async fn forget_entity(
         crate::cache::invalidate_prefix(&mut conn, &prefix).await;
     }
 
-    Ok(Json(ForgetResponse { forgotten_count }))
+    Ok(Json(ForgetResponse {
+        forgotten_count,
+        snapshot: snapshot_path
+            .as_deref()
+            .map(|path| snapshot_reference(snapshot, path)),
+    }))
 }
 
 async fn delete_memory(
@@ -2338,6 +2383,50 @@ fn a2a_remember(
     Ok(json!({"memory_id": mem.id.to_string()}))
 }
 
+/// Handle the `memory.forget` capability for A2A task requests.
+async fn a2a_forget(
+    ps: &PensyveState,
+    input: &serde_json::Map<String, serde_json::Value>,
+) -> Result<serde_json::Value, String> {
+    let entity_name = input
+        .get("entity")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    let Ok(Some(entity)) = ps.storage.get_entity_by_name(&entity_name, ps.namespace.id) else {
+        return Ok(json!({"forgotten_count": 0}));
+    };
+
+    // Same fail-closed contract as the REST route and the MCP tool: the
+    // snapshot is written inside the delete's transaction, so a snapshot that
+    // cannot be written aborts the delete instead of losing rows silently.
+    let outcome = pensyve_core::snapshot::forget_entity(
+        ps.storage.as_ref(),
+        entity.id,
+        Some(entity.name.as_str()),
+        ps.namespace.id,
+        &ps.snapshot_root,
+    )
+    .map_err(|err| format!("Aborted: pre-delete snapshot failed, nothing was deleted: {err}"))?;
+
+    let snapshot = &outcome.snapshot;
+    let forgotten_count = snapshot.memories.len();
+
+    if forgotten_count > 0 {
+        let mut vi = ps.vector_index.write().await;
+        for id in snapshot.memory_ids() {
+            let _ = vi.remove(id);
+        }
+    }
+
+    let mut output = json!({"forgotten_count": forgotten_count});
+    if let Some(path) = outcome.path.as_ref() {
+        output["snapshot"] = snapshot_reference(snapshot, &path.to_string_lossy());
+    }
+    Ok(output)
+}
+
 async fn a2a_agent_card() -> impl IntoResponse {
     let endpoint = std::env::var("PENSYVE_GATEWAY_URL")
         .unwrap_or_else(|_| "http://localhost:8000".to_string());
@@ -2370,24 +2459,20 @@ async fn a2a_task(
             }
         },
         "memory.remember" => a2a_remember(&ps, &input)?,
-        "memory.forget" => {
-            let entity_name = input
-                .get("entity")
-                .and_then(|v| v.as_str())
-                .unwrap_or("")
-                .to_string();
-
-            match ps.storage.get_entity_by_name(&entity_name, ps.namespace.id) {
-                Ok(Some(entity)) => {
-                    let count = ps
-                        .storage
-                        .delete_memories_by_entity(entity.id, ps.namespace.id)
-                        .unwrap_or(0);
-                    json!({"forgotten_count": count})
-                }
-                _ => json!({"forgotten_count": 0}),
+        "memory.forget" => match a2a_forget(&ps, &input).await {
+            Ok(val) => val,
+            Err(e) => {
+                return Ok(Json(
+                    serde_json::to_value(pensyve_core::a2a::A2ATaskResponse {
+                        task_id: body.task_id,
+                        status: "failed".to_string(),
+                        output: json!({}),
+                        error: Some(e),
+                    })
+                    .unwrap_or_default(),
+                ));
             }
-        }
+        },
         other => {
             return Ok(Json(
                 serde_json::to_value(pensyve_core::a2a::A2ATaskResponse {

--- a/pensyve-mcp-gateway/src/rest.rs
+++ b/pensyve-mcp-gateway/src/rest.rs
@@ -2394,8 +2394,13 @@ async fn a2a_forget(
         .unwrap_or("")
         .to_string();
 
-    let Ok(Some(entity)) = ps.storage.get_entity_by_name(&entity_name, ps.namespace.id) else {
-        return Ok(json!({"forgotten_count": 0}));
+    // A lookup failure is not a missing entity: reporting it as a completed
+    // zero-delete would tell the caller the forget succeeded when nothing was
+    // checked, so only `Ok(None)` gets the zero-count path.
+    let entity = match ps.storage.get_entity_by_name(&entity_name, ps.namespace.id) {
+        Ok(Some(entity)) => entity,
+        Ok(None) => return Ok(json!({"forgotten_count": 0})),
+        Err(err) => return Err(format!("Error looking up entity: {err}")),
     };
 
     // Same fail-closed contract as the REST route and the MCP tool: the

--- a/pensyve-mcp-gateway/src/rest.rs
+++ b/pensyve-mcp-gateway/src/rest.rs
@@ -1130,18 +1130,16 @@ async fn create_entity(
     ))
 }
 
-/// Constant-size reference to a pre-delete snapshot, in the same shape the
-/// `pensyve_forget` MCP tool returns. The rows are referenced rather than
-/// inlined: they carry their embeddings, so a full payload runs to megabytes,
-/// while a reference still lets a caller recover from the file on its own.
-fn snapshot_reference(
-    snapshot: &pensyve_core::snapshot::ForgetSnapshot,
-    path: &str,
-) -> serde_json::Value {
+/// Constant-size reference to a pre-delete snapshot. The rows are referenced
+/// rather than inlined: they carry their embeddings, so a full payload runs to
+/// megabytes. Unlike the co-located MCP tool, REST and A2A callers are remote —
+/// a server-local filesystem path is useless to them and leaks the snapshot
+/// layout, so the reference is by id only; the path is recorded in the
+/// activity log for the operator who performs the restore.
+fn snapshot_reference(snapshot: &pensyve_core::snapshot::ForgetSnapshot) -> serde_json::Value {
     let counts = snapshot.counts();
     json!({
         "snapshot_id": snapshot.snapshot_id.to_string(),
-        "path": path,
         "format_version": snapshot.format_version,
         "captured_at": snapshot.captured_at.to_rfc3339(),
         // False on platforms where the file could not be restricted to its
@@ -1224,8 +1222,8 @@ async fn forget_entity(
     Ok(Json(ForgetResponse {
         forgotten_count,
         snapshot: snapshot_path
-            .as_deref()
-            .map(|path| snapshot_reference(snapshot, path)),
+            .is_some()
+            .then(|| snapshot_reference(snapshot)),
     }))
 }
 
@@ -2426,8 +2424,8 @@ async fn a2a_forget(
     }
 
     let mut output = json!({"forgotten_count": forgotten_count});
-    if let Some(path) = outcome.path.as_ref() {
-        output["snapshot"] = snapshot_reference(snapshot, &path.to_string_lossy());
+    if outcome.path.is_some() {
+        output["snapshot"] = snapshot_reference(snapshot);
     }
     Ok(output)
 }

--- a/pensyve-mcp-gateway/tests/test_rest_forget_snapshot.rs
+++ b/pensyve-mcp-gateway/tests/test_rest_forget_snapshot.rs
@@ -211,18 +211,24 @@ fn assert_reference_matches_file(
     namespace_id: Uuid,
     expected: &[Uuid],
 ) -> pensyve_core::snapshot::ForgetSnapshot {
-    let path = PathBuf::from(
-        reference["path"]
-            .as_str()
-            .expect("snapshot reference carries a path"),
-    );
-    assert_eq!(
-        path.parent().expect("snapshot path has a parent"),
-        pensyve_core::snapshot::namespace_dir(snapshot_root, namespace_id),
-        "snapshot must land under its own namespace, not a shared directory"
+    // The reference is by id only: remote callers cannot use a server-local
+    // filesystem path, so exposing one would only leak the snapshot layout.
+    assert!(
+        reference.get("path").is_none(),
+        "the server-local snapshot path must stay out of remote responses"
     );
 
-    let snapshot = pensyve_core::snapshot::read_file(&path).expect("snapshot round-trips");
+    // The artifact must land under its own namespace, not a shared directory.
+    let dir = pensyve_core::snapshot::namespace_dir(snapshot_root, namespace_id);
+    let entries: Vec<PathBuf> = std::fs::read_dir(&dir)
+        .expect("namespace snapshot dir exists")
+        .map(|entry| entry.expect("dir entry").path())
+        .collect();
+    let [path] = entries.as_slice() else {
+        panic!("expected exactly one snapshot artifact, found {entries:?}");
+    };
+
+    let snapshot = pensyve_core::snapshot::read_file(path).expect("snapshot round-trips");
     let mut got = snapshot.memory_ids();
     got.sort();
     let mut want = expected.to_vec();

--- a/pensyve-mcp-gateway/tests/test_rest_forget_snapshot.rs
+++ b/pensyve-mcp-gateway/tests/test_rest_forget_snapshot.rs
@@ -187,6 +187,22 @@ async fn a2a_forget(client: &reqwest::Client, url: &str, entity: &str) -> Value 
     response.json().await.expect("a2a forget response JSON")
 }
 
+/// Asserts every id is present in the vector index. Run before a forget so the
+/// absence checks afterward prove removal rather than never-indexed ids.
+async fn assert_indexed(state: &AppState, ids: &[Uuid]) {
+    let ps = state
+        .tenant_mgr
+        .get_tenant_state(TEST_TENANT)
+        .expect("tenant state");
+    let vector_index = ps.vector_index.read().await;
+    for id in ids {
+        assert!(
+            vector_index.get(*id).is_some(),
+            "memory {id} must be indexed before the forget"
+        );
+    }
+}
+
 /// Asserts the reference points at a real snapshot holding exactly `expected`
 /// and returns the parsed artifact.
 fn assert_reference_matches_file(
@@ -238,6 +254,7 @@ async fn rest_forget_writes_a_snapshot_and_returns_its_reference() {
     let client = reqwest::Client::new();
     let tea = remember(&client, &url, "alice", "likes tea").await;
     let rust = remember(&client, &url, "alice", "uses rust").await;
+    assert_indexed(&state, &[tea, rust]).await;
 
     let response = forget(&client, &url, "alice").await;
     assert_eq!(response.status(), reqwest::StatusCode::OK);
@@ -316,6 +333,7 @@ async fn a2a_forget_writes_a_snapshot_and_returns_its_reference() {
     let client = reqwest::Client::new();
     let tea = remember(&client, &url, "alice", "likes tea").await;
     let rust = remember(&client, &url, "alice", "uses rust").await;
+    assert_indexed(&state, &[tea, rust]).await;
 
     let body = a2a_forget(&client, &url, "alice").await;
     assert_eq!(body["status"], "completed");

--- a/pensyve-mcp-gateway/tests/test_rest_forget_snapshot.rs
+++ b/pensyve-mcp-gateway/tests/test_rest_forget_snapshot.rs
@@ -1,0 +1,400 @@
+//! Entity-wide deletion through the gateway must be recoverable (#249).
+//!
+//! `pensyve_forget` gained a fail-closed pre-delete snapshot in #248, but only
+//! on the MCP tool. The REST route and the A2A `memory.forget` capability reach
+//! the same entity-wide delete, so they need the same guarantee: the snapshot
+//! is written inside the delete's transaction, and a snapshot that cannot be
+//! written aborts the delete rather than losing rows silently.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use axum::Extension;
+use pensyve_core::config::RetrievalConfig;
+use pensyve_core::embedding::OnnxEmbedder;
+use pensyve_core::storage::StorageTrait;
+use pensyve_core::storage::sqlite::SqliteBackend;
+use pensyve_core::types::Namespace;
+use pensyve_core::vector::VectorIndex;
+use pensyve_mcp_gateway::AppState;
+use pensyve_mcp_gateway::auth::{AuthContext, AuthValidator};
+use pensyve_mcp_gateway::config::GatewayConfig;
+use pensyve_mcp_gateway::rate_limit::RateLimiter;
+use pensyve_mcp_gateway::rest;
+use pensyve_mcp_gateway::tenant::TenantStateManager;
+use pensyve_mcp_gateway::usage::UsageReporter;
+use pensyve_mcp_gateway::usage_counter::UsageCounter;
+use serde_json::{Value, json};
+use tempfile::TempDir;
+use tokio_util::sync::CancellationToken;
+use uuid::Uuid;
+
+const TEST_TENANT: &str = "test-rest-tenant";
+
+fn retrieval_config() -> RetrievalConfig {
+    RetrievalConfig {
+        default_limit: 5,
+        max_candidates: 100,
+        weights: [0.30, 0.15, 0.20, 0.10, 0.10, 0.05, 0.05, 0.05],
+        recall_timeout_secs: 5,
+        rrf_k: 60,
+        rrf_weights: [1.0, 0.8, 1.0, 0.8, 0.5, 0.5, 1.2, 1.0],
+        beam_width: 10,
+        max_depth: 4,
+    }
+}
+
+fn gateway_config(dir: &TempDir) -> GatewayConfig {
+    GatewayConfig {
+        host: "127.0.0.1".to_string(),
+        port: 0,
+        storage_path: dir.path().to_path_buf(),
+        namespace: "default".to_string(),
+        api_keys: vec![],
+        rate_limit_per_minute: 300,
+        stripe_api_key: None,
+        admin_key: None,
+        key_user_map: vec![],
+        allowed_hosts: vec![],
+    }
+}
+
+/// The snapshot root is injected through the tenant manager rather than read
+/// from the environment, so each test owns its own directory without mutating
+/// process-wide state (#250).
+fn app_state(dir: &TempDir, snapshot_root: PathBuf) -> Arc<AppState> {
+    let storage =
+        Arc::new(SqliteBackend::open(dir.path()).expect("open storage")) as Arc<dyn StorageTrait>;
+    let namespace = Namespace::new("default");
+    storage
+        .save_namespace(&namespace)
+        .expect("save default namespace");
+
+    let tenant_mgr = TenantStateManager::new(
+        storage,
+        Arc::new(OnnxEmbedder::new_mock(768)),
+        retrieval_config(),
+        namespace,
+        VectorIndex::new(768, 1024),
+        snapshot_root,
+    );
+    let config = gateway_config(dir);
+
+    Arc::new(AppState {
+        auth: AuthValidator::new(&config),
+        rate_limiter: RateLimiter::new(None),
+        usage_reporter: UsageReporter::new(None),
+        usage_counter: UsageCounter::new(),
+        tenant_mgr,
+        auth_required: false,
+        admin_key: None,
+        ct: CancellationToken::new(),
+        redis: None,
+        extractor: None,
+    })
+}
+
+fn auth_context() -> AuthContext {
+    AuthContext {
+        key_id: TEST_TENANT.to_string(),
+        tenant_id: None,
+        user_id: None,
+        scope: "mcp".to_string(),
+        stripe_customer_id: None,
+        plan: "free".to_string(),
+    }
+}
+
+async fn start_test_server(state: Arc<AppState>) -> (String, CancellationToken) {
+    let app = rest::router()
+        .layer(Extension(auth_context()))
+        .with_state(state);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test server");
+    let addr = listener.local_addr().expect("test server address");
+    let cancellation = CancellationToken::new();
+    let shutdown = cancellation.clone();
+
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app)
+            .with_graceful_shutdown(shutdown.cancelled_owned())
+            .await;
+    });
+
+    (format!("http://{addr}"), cancellation)
+}
+
+fn tenant_namespace_id(state: &AppState) -> Uuid {
+    state
+        .tenant_mgr
+        .get_tenant_state(TEST_TENANT)
+        .expect("tenant state")
+        .namespace
+        .id
+}
+
+fn stored_memory_count(state: &AppState) -> usize {
+    let ps = state
+        .tenant_mgr
+        .get_tenant_state(TEST_TENANT)
+        .expect("tenant state");
+    ps.storage
+        .get_all_memories_by_namespace(ps.namespace.id)
+        .expect("namespace memories")
+        .len()
+}
+
+async fn remember(client: &reqwest::Client, url: &str, entity: &str, fact: &str) -> Uuid {
+    let response = client
+        .post(format!("{url}/v1/remember"))
+        .json(&json!({
+            "entity": entity,
+            "fact": fact,
+            "confidence": 0.9,
+        }))
+        .send()
+        .await
+        .expect("remember request");
+
+    assert_eq!(response.status(), reqwest::StatusCode::CREATED);
+    let body: Value = response.json().await.expect("remember response JSON");
+    Uuid::parse_str(body["id"].as_str().expect("remembered memory id")).expect("valid memory id")
+}
+
+async fn forget(client: &reqwest::Client, url: &str, entity: &str) -> reqwest::Response {
+    client
+        .delete(format!("{url}/v1/entities/{entity}"))
+        .send()
+        .await
+        .expect("forget request")
+}
+
+async fn a2a_forget(client: &reqwest::Client, url: &str, entity: &str) -> Value {
+    let response = client
+        .post(format!("{url}/v1/a2a/task"))
+        .json(&json!({
+            "task_id": "task-forget",
+            "capability": "memory.forget",
+            "input": { "entity": entity },
+            "from_agent": "test-agent",
+        }))
+        .send()
+        .await
+        .expect("a2a forget request");
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    response.json().await.expect("a2a forget response JSON")
+}
+
+/// Asserts the reference points at a real snapshot holding exactly `expected`
+/// and returns the parsed artifact.
+fn assert_reference_matches_file(
+    reference: &Value,
+    snapshot_root: &std::path::Path,
+    namespace_id: Uuid,
+    expected: &[Uuid],
+) -> pensyve_core::snapshot::ForgetSnapshot {
+    let path = PathBuf::from(
+        reference["path"]
+            .as_str()
+            .expect("snapshot reference carries a path"),
+    );
+    assert_eq!(
+        path.parent().expect("snapshot path has a parent"),
+        pensyve_core::snapshot::namespace_dir(snapshot_root, namespace_id),
+        "snapshot must land under its own namespace, not a shared directory"
+    );
+
+    let snapshot = pensyve_core::snapshot::read_file(&path).expect("snapshot round-trips");
+    let mut got = snapshot.memory_ids();
+    got.sort();
+    let mut want = expected.to_vec();
+    want.sort();
+    assert_eq!(got, want, "snapshot must hold exactly the deleted rows");
+
+    assert_eq!(reference["snapshot_id"], snapshot.snapshot_id.to_string());
+    assert_eq!(reference["format_version"], snapshot.format_version);
+    assert_eq!(reference["captured_at"], snapshot.captured_at.to_rfc3339());
+    assert_eq!(reference["memory_count"], expected.len());
+    assert_eq!(reference["semantic_count"], expected.len());
+    assert_eq!(reference["episodic_count"], 0);
+    assert_eq!(
+        reference["owner_only"],
+        pensyve_core::snapshot::OWNER_ONLY_SUPPORTED,
+        "the response must state whether the artifact is owner-only"
+    );
+
+    snapshot
+}
+
+#[tokio::test]
+async fn rest_forget_writes_a_snapshot_and_returns_its_reference() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let snapshot_root = dir.path().join("snapshots");
+    let state = app_state(&dir, snapshot_root.clone());
+    let namespace_id = tenant_namespace_id(&state);
+    let (url, cancellation) = start_test_server(state.clone()).await;
+    let client = reqwest::Client::new();
+    let tea = remember(&client, &url, "alice", "likes tea").await;
+    let rust = remember(&client, &url, "alice", "uses rust").await;
+
+    let response = forget(&client, &url, "alice").await;
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    let body: Value = response.json().await.expect("forget response JSON");
+    assert_eq!(body["forgotten_count"], 2);
+
+    let snapshot = assert_reference_matches_file(
+        &body["snapshot"],
+        &snapshot_root,
+        namespace_id,
+        &[tea, rust],
+    );
+
+    // The snapshot is a real recovery path, not just a receipt.
+    assert_eq!(stored_memory_count(&state), 0);
+    let ps = state
+        .tenant_mgr
+        .get_tenant_state(TEST_TENANT)
+        .expect("tenant state");
+    pensyve_core::snapshot::restore(ps.storage.as_ref(), &snapshot).expect("restore");
+    assert_eq!(stored_memory_count(&state), 2);
+
+    let vector_index = ps.vector_index.read().await;
+    assert!(vector_index.get(tea).is_none());
+    assert!(vector_index.get(rust).is_none());
+    drop(vector_index);
+    cancellation.cancel();
+}
+
+#[tokio::test]
+async fn rest_forget_aborts_the_delete_when_the_snapshot_cannot_be_written() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let snapshot_root = dir.path().join("snapshots");
+    let state = app_state(&dir, snapshot_root.clone());
+    let namespace_id = tenant_namespace_id(&state);
+    // A regular file where the namespace's snapshot directory must go.
+    // `create_dir_all` fails for every user, root included, so this is
+    // deterministic in CI.
+    std::fs::create_dir_all(&snapshot_root).expect("create snapshot root");
+    std::fs::write(
+        pensyve_core::snapshot::namespace_dir(&snapshot_root, namespace_id),
+        b"not a directory",
+    )
+    .expect("block the namespace snapshot directory");
+
+    let (url, cancellation) = start_test_server(state.clone()).await;
+    let client = reqwest::Client::new();
+    remember(&client, &url, "alice", "likes tea").await;
+    remember(&client, &url, "alice", "uses rust").await;
+
+    let response = forget(&client, &url, "alice").await;
+    assert_eq!(
+        response.status(),
+        reqwest::StatusCode::INTERNAL_SERVER_ERROR
+    );
+    let error = response.text().await.expect("forget error body");
+    assert!(
+        error.contains("snapshot"),
+        "error should name the snapshot as the cause: {error}"
+    );
+    assert_eq!(
+        stored_memory_count(&state),
+        2,
+        "nothing may be deleted when the pre-delete snapshot failed"
+    );
+    cancellation.cancel();
+}
+
+#[tokio::test]
+async fn a2a_forget_writes_a_snapshot_and_returns_its_reference() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let snapshot_root = dir.path().join("snapshots");
+    let state = app_state(&dir, snapshot_root.clone());
+    let namespace_id = tenant_namespace_id(&state);
+    let (url, cancellation) = start_test_server(state.clone()).await;
+    let client = reqwest::Client::new();
+    let tea = remember(&client, &url, "alice", "likes tea").await;
+    let rust = remember(&client, &url, "alice", "uses rust").await;
+
+    let body = a2a_forget(&client, &url, "alice").await;
+    assert_eq!(body["status"], "completed");
+    assert_eq!(body["output"]["forgotten_count"], 2);
+
+    let snapshot = assert_reference_matches_file(
+        &body["output"]["snapshot"],
+        &snapshot_root,
+        namespace_id,
+        &[tea, rust],
+    );
+
+    assert_eq!(stored_memory_count(&state), 0);
+    let ps = state
+        .tenant_mgr
+        .get_tenant_state(TEST_TENANT)
+        .expect("tenant state");
+    pensyve_core::snapshot::restore(ps.storage.as_ref(), &snapshot).expect("restore");
+    assert_eq!(stored_memory_count(&state), 2);
+
+    let vector_index = ps.vector_index.read().await;
+    assert!(vector_index.get(tea).is_none());
+    assert!(vector_index.get(rust).is_none());
+    drop(vector_index);
+    cancellation.cancel();
+}
+
+#[tokio::test]
+async fn a2a_forget_fails_the_task_when_the_snapshot_cannot_be_written() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let snapshot_root = dir.path().join("snapshots");
+    let state = app_state(&dir, snapshot_root.clone());
+    let namespace_id = tenant_namespace_id(&state);
+    std::fs::create_dir_all(&snapshot_root).expect("create snapshot root");
+    std::fs::write(
+        pensyve_core::snapshot::namespace_dir(&snapshot_root, namespace_id),
+        b"not a directory",
+    )
+    .expect("block the namespace snapshot directory");
+
+    let (url, cancellation) = start_test_server(state.clone()).await;
+    let client = reqwest::Client::new();
+    remember(&client, &url, "alice", "likes tea").await;
+    remember(&client, &url, "alice", "uses rust").await;
+
+    let body = a2a_forget(&client, &url, "alice").await;
+    assert_eq!(
+        body["status"], "failed",
+        "a snapshot failure must not be reported as a completed forget"
+    );
+    let error = body["error"]
+        .as_str()
+        .expect("failed task carries an error");
+    assert!(
+        error.contains("snapshot"),
+        "error should name the snapshot as the cause: {error}"
+    );
+    assert_eq!(
+        stored_memory_count(&state),
+        2,
+        "nothing may be deleted when the pre-delete snapshot failed"
+    );
+    cancellation.cancel();
+}
+
+#[tokio::test]
+async fn a2a_forget_on_an_unknown_entity_reports_zero_and_writes_no_snapshot() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let snapshot_root = dir.path().join("snapshots");
+    let state = app_state(&dir, snapshot_root.clone());
+    let (url, cancellation) = start_test_server(state.clone()).await;
+    let client = reqwest::Client::new();
+    remember(&client, &url, "alice", "likes tea").await;
+
+    let body = a2a_forget(&client, &url, "nobody").await;
+    assert_eq!(body["status"], "completed");
+    assert_eq!(body["output"]["forgotten_count"], 0);
+    assert!(body["output"].get("snapshot").is_none());
+    assert!(!snapshot_root.exists());
+    assert_eq!(stored_memory_count(&state), 1);
+    cancellation.cancel();
+}


### PR DESCRIPTION
Closes #249

## Problem

PR #248 made entity-wide deletion recoverable by capturing a fail-closed pre-delete snapshot, but wired it only into the MCP `pensyve_forget` tool. Two gateway paths still deleted entity-wide with no snapshot:

- REST `DELETE /v1/entities/{entity_name}` (`forget_entity`)
- A2A `memory.forget` — which additionally swallowed delete errors via `unwrap_or(0)` and never cleaned the vector index

Data destroyed through either route was unrecoverable: the same hole #217 was about, still open on live routes.

## Change

Both paths now route through `pensyve_core::snapshot::forget_entity`, inheriting #248's contract: the snapshot file is written inside the delete's transaction, so either both happen or neither does. A snapshot that cannot be written aborts the delete — REST returns 500, A2A returns a failed task — rather than deleting unrecoverably. Vector-index cleanup now uses `snapshot.memory_ids()` (the exact rows the delete removed) on both paths.

The REST `ForgetResponse` gains an optional `snapshot` reference field (same shape as the MCP tool's response, `skip_serializing_if` so zero-delete responses are byte-identical to the old contract). The A2A success output carries the same reference.

## Tests (written first, verified failing pre-fix)

Five integration tests in `pensyve-mcp-gateway/tests/test_rest_forget_snapshot.rs`:

- REST/A2A success: snapshot file lands under `<snapshot_root>/<namespace_id>/`, round-trips via `snapshot::read_file`, holds exactly the deleted rows, and `snapshot::restore` actually brings them back; response reference matches the file; vector index entries removed.
- REST/A2A fail-closed: with the namespace snapshot dir blocked by a regular file, REST returns 500 and A2A returns a failed task, and **all rows are still present**.
- A2A unknown entity: reports 0, writes nothing.

Pre-fix, the four regression tests fail with `200`/`"completed"` — i.e. both routes deleted the rows anyway with an unwritable snapshot directory. Sabotage-checked: reverting only `src/rest.rs` makes exactly those four fail while the behavior-preserving test passes.

`cargo test -p pensyve-mcp-gateway`: 160 passed. `cargo test -p pensyve-mcp-tools`: 16 passed (the #248 forget tests untouched). fmt + clippy (`-D warnings`) clean. Snapshot root is injected via `TenantStateManager::new` in tests — no `std::env::set_var` (per #250).

## Out of scope, assessed per the issue checklist

- **`gdpr::erase_entity`**: not modified. Its scope is materially wider than `forget` (observations, the entity row itself, and it is four independent storage calls with partial-success semantics, not one capturing transaction), so a fail-closed erase snapshot needs its own format and atomicity decision — plus a GDPR retention question a forget snapshot doesn't have (a full-fidelity copy of erased personal data needs a retention policy or the snapshot itself becomes the compliance issue). Detailed assessment posted on #249.
- Pre-existing A2A gaps left as-is (no recall-cache invalidation, no `log_activity` on that path) — they predate this change and are orthogonal to the snapshot contract.