### PR TITLE
fix(storage): collect forget's vector-index cleanup with the delete's own scope

### DIFF
--- a/pensyve-core/src/storage/mod.rs
+++ b/pensyve-core/src/storage/mod.rs
@@ -338,11 +338,27 @@ pub trait StorageTrait: Send + Sync {
     /// Implementations must mirror the delete's predicates verbatim — the
     /// namespace one included. Entity ids are not globally unique in this
     /// schema, so an entity-only predicate reaches into other tenants.
+    ///
+    /// The default filters the namespace-wide listing in memory, so external
+    /// backends keep compiling; its fidelity follows the backend's
+    /// [`StorageTrait::get_all_memories_by_namespace_including_superseded`]
+    /// (whose own default degrades to live rows). Both built-in backends
+    /// override this with a single indexed query.
     fn list_memories_by_entity_including_superseded(
         &self,
         entity_id: Uuid,
         namespace_id: Uuid,
-    ) -> StorageResult<Vec<Memory>>;
+    ) -> StorageResult<Vec<Memory>> {
+        Ok(self
+            .get_all_memories_by_namespace_including_superseded(namespace_id)?
+            .into_iter()
+            .filter(|memory| match memory {
+                Memory::Episodic(e) => e.about_entity == entity_id || e.source_entity == entity_id,
+                Memory::Semantic(s) => s.subject == entity_id || s.object_entity == Some(entity_id),
+                _ => false,
+            })
+            .collect())
+    }
 
     /// Mark a live memory as superseded. Returns `false` when no live row matched.
     fn supersede_memory(

--- a/pensyve-core/src/storage/mod.rs
+++ b/pensyve-core/src/storage/mod.rs
@@ -322,6 +322,28 @@ pub trait StorageTrait: Send + Sync {
         self.get_all_memories_by_namespace(namespace_id)
     }
 
+    /// Fetch exactly the rows [`StorageTrait::delete_memories_by_entity`]
+    /// would delete for `(entity_id, namespace_id)`: episodic rows matching
+    /// `about_entity OR source_entity`, semantic rows matching
+    /// `subject OR object_entity`, superseded rows included, confined to
+    /// `namespace_id`.
+    ///
+    /// This exists so callers can collect the ids to strip from a vector index
+    /// before an entity-wide forget (#261). `list_episodic_by_entity` and
+    /// `list_semantic_by_entity` are not a substitute: they look at
+    /// `about_entity` and `subject` alone and skip superseded rows, so every
+    /// source-side episodic, object-side semantic and superseded row kept its
+    /// index entry after its base row was gone.
+    ///
+    /// Implementations must mirror the delete's predicates verbatim — the
+    /// namespace one included. Entity ids are not globally unique in this
+    /// schema, so an entity-only predicate reaches into other tenants.
+    fn list_memories_by_entity_including_superseded(
+        &self,
+        entity_id: Uuid,
+        namespace_id: Uuid,
+    ) -> StorageResult<Vec<Memory>>;
+
     /// Mark a live memory as superseded. Returns `false` when no live row matched.
     fn supersede_memory(
         &self,

--- a/pensyve-core/src/storage/postgres.rs
+++ b/pensyve-core/src/storage/postgres.rs
@@ -1497,6 +1497,55 @@ impl StorageTrait for PostgresBackend {
         self.load_memories_by_namespace(namespace_id, true)
     }
 
+    /// Predicates are copied from [`Self::delete_memories_by_entity`] verbatim,
+    /// namespace included — see the trait docs for why that equality is the
+    /// contract rather than an implementation detail. The connection is bound
+    /// to the namespace for the same reason the delete binds it: the explicit
+    /// `namespace_id = $2` is what confines the read while RLS is inert, and
+    /// the binding is what keeps it working once RLS is enforced.
+    fn list_memories_by_entity_including_superseded(
+        &self,
+        entity_id: Uuid,
+        namespace_id: Uuid,
+    ) -> StorageResult<Vec<Memory>> {
+        self.block_on(async {
+            let mut conn = self.scoped_conn(namespace_id).await?;
+            let mut memories = Vec::new();
+
+            let rows: Vec<EpisodicRow> = query_as::<Postgres, _>(
+                r"SELECT id, namespace_id, episode_id, source_entity, about_entity, content,
+                          summary, embedding::text AS embedding, context_intent, timestamp,
+                          stability, retrievability, access_count, last_accessed, event_time,
+                          superseded_by, invalid_at
+                   FROM episodic_memories
+                   WHERE (about_entity = $1 OR source_entity = $1) AND namespace_id = $2",
+            )
+            .bind(entity_id)
+            .bind(namespace_id)
+            .fetch_all(&mut *conn)
+            .await
+            .map_err(sqlx_to_io)?;
+            memories.extend(rows.into_iter().map(row_to_episodic).map(Memory::Episodic));
+
+            let rows: Vec<SemanticRow> = query_as::<Postgres, _>(
+                r"SELECT id, namespace_id, subject, predicate, object, object_entity,
+                          confidence, valid_at, invalid_at, source_episodes,
+                          embedding::text AS embedding, stability, retrievability,
+                          superseded_by
+                   FROM semantic_memories
+                   WHERE (subject = $1 OR object_entity = $1) AND namespace_id = $2",
+            )
+            .bind(entity_id)
+            .bind(namespace_id)
+            .fetch_all(&mut *conn)
+            .await
+            .map_err(sqlx_to_io)?;
+            memories.extend(rows.into_iter().map(row_to_semantic).map(Memory::Semantic));
+
+            Ok(memories)
+        })
+    }
+
     fn supersede_memory(
         &self,
         id: Uuid,

--- a/pensyve-core/src/storage/postgres/live_rls.rs
+++ b/pensyve-core/src/storage/postgres/live_rls.rs
@@ -352,6 +352,83 @@ fn seed(fixture: &Fixture, ns_a: &Namespace, ns_b: &Namespace) -> EpisodicMemory
     memory
 }
 
+/// What [`seed_entity_scope`] planted, split into the rows the entity-wide
+/// delete removes and the two controls it must leave alone.
+struct EntityScope {
+    entity_id: Uuid,
+    /// Every row `delete_memories_by_entity(entity_id, ns_a)` matches.
+    deletable: Vec<Uuid>,
+    /// A row in `ns_a` naming a different entity.
+    unrelated: Uuid,
+    /// A row in `ns_b` naming the *same* entity id — the collision the
+    /// namespace predicate has to disambiguate.
+    foreign: Uuid,
+}
+
+/// Seed one row of every shape `delete_memories_by_entity` matches into `ns_a`,
+/// plus the two controls. Both namespaces must already be saved.
+fn seed_entity_scope(backend: &PostgresBackend, ns_a: &Namespace, ns_b: &Namespace) -> EntityScope {
+    let entity_id = Uuid::new_v4();
+    let other_id = Uuid::new_v4();
+
+    let about_side = EpisodicMemory::new(ns_a.id, Uuid::new_v4(), other_id, entity_id, "about it");
+    backend.save_episodic(&about_side).expect("save about-side");
+
+    // The target spoke; the row is about someone else.
+    let source_side = EpisodicMemory::new(ns_a.id, Uuid::new_v4(), entity_id, other_id, "from it");
+    backend
+        .save_episodic(&source_side)
+        .expect("save source-side");
+
+    let subject_side = SemanticMemory::new(ns_a.id, entity_id, "likes", "rust", 0.9);
+    backend
+        .save_semantic(&subject_side)
+        .expect("save subject-side");
+
+    // The target is the *object* of someone else's fact.
+    let mut object_side = SemanticMemory::new(ns_a.id, other_id, "manages", "target", 0.9);
+    object_side.object_entity = Some(entity_id);
+    backend
+        .save_semantic(&object_side)
+        .expect("save object-side");
+
+    // The delete ignores `superseded_by`, so the listing must too.
+    let superseded = SemanticMemory::new(ns_a.id, entity_id, "lived_in", "berlin", 0.5);
+    backend.save_semantic(&superseded).expect("save superseded");
+    assert!(
+        backend
+            .supersede_memory(superseded.id, Uuid::new_v4(), Utc::now())
+            .expect("supersede must not error"),
+        "the superseded fixture row must actually be marked superseded"
+    );
+
+    let unrelated = EpisodicMemory::new(ns_a.id, Uuid::new_v4(), other_id, other_id, "no target");
+    backend
+        .save_episodic(&unrelated)
+        .expect("save unrelated row");
+    let foreign = EpisodicMemory::new(
+        ns_b.id,
+        Uuid::new_v4(),
+        entity_id,
+        entity_id,
+        "other tenant",
+    );
+    backend.save_episodic(&foreign).expect("save B's memory");
+
+    EntityScope {
+        entity_id,
+        deletable: vec![
+            about_side.id,
+            source_side.id,
+            subject_side.id,
+            object_side.id,
+            superseded.id,
+        ],
+        unrelated: unrelated.id,
+        foreign: foreign.id,
+    }
+}
+
 /// Count every `episodic_memories` row a connection scoped to `namespace_id`
 /// can see, with no `WHERE` clause — so the count reflects RLS alone, not a
 /// query's own namespace predicate.
@@ -964,6 +1041,80 @@ fn entity_delete_is_confined_to_its_namespace() {
             .expect("read namespace A")
             .is_empty(),
         "namespace A should be empty after the forget"
+    );
+}
+
+/// The accessor callers use to collect vector-index ids before an entity-wide
+/// forget must return exactly what [`entity_delete_is_confined_to_its_namespace`]
+/// deletes — every shape, superseded rows included, and only this namespace's
+/// (#261).
+///
+/// Postgres gets its own coverage because the two backends carry independent
+/// SQL for both halves. An accessor that under-collects here leaves stale
+/// vector-index entries; one that over-collects would hand a caller another
+/// tenant's memory ids.
+#[test]
+fn entity_scoped_listing_matches_the_delete_scope() {
+    let Some(admin_opts) = skip_notice("entity_scoped_listing_matches_the_delete_scope") else {
+        return;
+    };
+    let fixture = Fixture::provision(&admin_opts);
+    let backend = &fixture.backend;
+
+    let ns_a = Namespace::new(format!("listing-a-{}", Uuid::new_v4().simple()));
+    let ns_b = Namespace::new(format!("listing-b-{}", Uuid::new_v4().simple()));
+    backend.save_namespace(&ns_a).expect("save namespace A");
+    backend.save_namespace(&ns_b).expect("save namespace B");
+    let seeded = seed_entity_scope(backend, &ns_a, &ns_b);
+    let entity_id = seeded.entity_id;
+
+    let mut collected = memory_ids(
+        &backend
+            .list_memories_by_entity_including_superseded(entity_id, ns_a.id)
+            .expect("entity-scoped listing must not error"),
+    );
+    collected.sort();
+    let mut expected = seeded.deletable.clone();
+    expected.sort();
+    assert_eq!(
+        collected, expected,
+        "the accessor must return every row the delete removes, and nothing else"
+    );
+
+    let deleted = backend
+        .delete_memories_by_entity(entity_id, ns_a.id)
+        .expect("forget in namespace A");
+    assert_eq!(
+        deleted,
+        collected.len(),
+        "the delete must remove exactly as many rows as the accessor reported"
+    );
+    assert!(
+        backend
+            .list_memories_by_entity_including_superseded(entity_id, ns_a.id)
+            .expect("re-listing must not error")
+            .is_empty(),
+        "nothing may remain in scope after the delete"
+    );
+
+    // Decoys survive.
+    assert_eq!(
+        memory_ids(
+            &backend
+                .get_all_memories_by_namespace(ns_a.id)
+                .expect("read namespace A")
+        ),
+        vec![seeded.unrelated],
+        "the unrelated row must survive"
+    );
+    assert_eq!(
+        memory_ids(
+            &backend
+                .get_all_memories_by_namespace(ns_b.id)
+                .expect("read namespace B")
+        ),
+        vec![seeded.foreign],
+        "namespace B's row must survive"
     );
 }
 

--- a/pensyve-core/src/storage/sqlite.rs
+++ b/pensyve-core/src/storage/sqlite.rs
@@ -1950,6 +1950,48 @@ impl StorageTrait for SqliteBackend {
         load_memories_by_namespace(&conn, namespace_id, true)
     }
 
+    /// Predicates are copied from [`Self::delete_memories_by_entity`] verbatim,
+    /// namespace included — see the trait docs for why that equality is the
+    /// contract rather than an implementation detail.
+    fn list_memories_by_entity_including_superseded(
+        &self,
+        entity_id: Uuid,
+        namespace_id: Uuid,
+    ) -> StorageResult<Vec<Memory>> {
+        let conn = lock_conn!(self);
+        let id_str = entity_id.to_string();
+        let ns_str = namespace_id.to_string();
+        let mut memories = Vec::new();
+
+        let mut stmt = conn.prepare(
+            r"SELECT id, namespace_id, episode_id, source_entity, about_entity, content,
+                      content_type, summary, embedding, context_intent, timestamp,
+                      stability, retrievability, access_count, last_accessed, event_time,
+                      agent_id, user_id, superseded_by, invalid_at
+               FROM episodic_memories
+               WHERE (about_entity = ?1 OR source_entity = ?1) AND namespace_id = ?2",
+        )?;
+        let rows = stmt.query_map(params![&id_str, &ns_str], row_to_episodic)?;
+        for row in rows {
+            memories.push(Memory::Episodic(row??));
+        }
+
+        let mut stmt = conn.prepare(
+            r"SELECT id, namespace_id, subject, predicate, object, content_type,
+                      object_entity, confidence, valid_at, invalid_at,
+                      source_episodes, embedding, stability, retrievability,
+                      agent_id, user_id, superseded_by
+               FROM semantic_memories
+               WHERE (subject = ?1 OR object_entity = ?1) AND namespace_id = ?2",
+        )?;
+        let rows = stmt.query_map(params![&id_str, &ns_str], row_to_semantic)?;
+        for row in rows {
+            memories.push(Memory::Semantic(row??));
+        }
+
+        Ok(memories)
+    }
+
     fn supersede_memory(
         &self,
         id: Uuid,
@@ -4005,6 +4047,110 @@ mod tests {
             1,
             "the other namespace's index entry must survive"
         );
+    }
+
+    /// The accessor callers use to collect vector-index ids before an
+    /// entity-wide forget must cover *exactly* what the delete removes (#261).
+    ///
+    /// Call sites used to assemble that set from `list_episodic_by_entity` and
+    /// `list_semantic_by_entity`, which look at `about_entity` and `subject`
+    /// alone and skip superseded rows. Every source-side episodic, object-side
+    /// semantic and superseded row therefore kept its index entry after its
+    /// base row was deleted.
+    #[test]
+    fn test_list_memories_by_entity_including_superseded_matches_the_delete_scope() {
+        let (_dir, db) = setup();
+        let ns = make_namespace(&db);
+        let foreign_ns = Namespace::new("other");
+        db.save_namespace(&foreign_ns).unwrap();
+        let entity_id = Uuid::new_v4();
+        let other_id = Uuid::new_v4();
+
+        // about-side episodic.
+        let about_side = EpisodicMemory::new(
+            ns.id,
+            Uuid::new_v4(),
+            other_id,
+            entity_id,
+            "about the target",
+        );
+        db.save_episodic(&about_side).unwrap();
+
+        // source-side episodic — the target spoke about someone else.
+        let source_side = EpisodicMemory::new(
+            ns.id,
+            Uuid::new_v4(),
+            entity_id,
+            other_id,
+            "sourced from the target",
+        );
+        db.save_episodic(&source_side).unwrap();
+
+        // subject-side semantic.
+        let subject_side = SemanticMemory::new(ns.id, entity_id, "likes", "rust", 0.9);
+        db.save_semantic(&subject_side).unwrap();
+
+        // object-side semantic — the target is the object of someone's fact.
+        let mut object_side = SemanticMemory::new(ns.id, other_id, "manages", "target", 0.9);
+        object_side.object_entity = Some(entity_id);
+        db.save_semantic(&object_side).unwrap();
+
+        // superseded — the delete ignores `superseded_by`, so this must too.
+        let superseded = SemanticMemory::new(ns.id, entity_id, "lived_in", "berlin", 0.5);
+        db.save_semantic(&superseded).unwrap();
+        db.supersede_memory(superseded.id, Uuid::new_v4(), Utc::now())
+            .unwrap();
+
+        // Decoys: a row for a different entity, and a same-entity row in a
+        // second namespace. Neither is in the delete's scope.
+        let other_entity =
+            EpisodicMemory::new(ns.id, Uuid::new_v4(), other_id, other_id, "no target");
+        db.save_episodic(&other_entity).unwrap();
+        let foreign = EpisodicMemory::new(
+            foreign_ns.id,
+            Uuid::new_v4(),
+            entity_id,
+            entity_id,
+            "another tenant's turn",
+        );
+        db.save_episodic(&foreign).unwrap();
+
+        let mut collected: Vec<Uuid> = db
+            .list_memories_by_entity_including_superseded(entity_id, ns.id)
+            .unwrap()
+            .iter()
+            .map(Memory::id)
+            .collect();
+        collected.sort();
+        let mut expected = vec![
+            about_side.id,
+            source_side.id,
+            subject_side.id,
+            object_side.id,
+            superseded.id,
+        ];
+        expected.sort();
+        assert_eq!(
+            collected, expected,
+            "the accessor must return every row the delete removes, and nothing else"
+        );
+
+        let deleted = db.delete_memories_by_entity(entity_id, ns.id).unwrap();
+        assert_eq!(
+            deleted,
+            collected.len(),
+            "the delete must remove exactly as many rows as the accessor reported"
+        );
+        assert!(
+            db.list_memories_by_entity_including_superseded(entity_id, ns.id)
+                .unwrap()
+                .is_empty(),
+            "nothing may remain in scope after the delete"
+        );
+
+        // Decoys survive.
+        assert!(db.get_episodic(other_entity.id).unwrap().is_some());
+        assert!(db.get_episodic(foreign.id).unwrap().is_some());
     }
 
     // -----------------------------------------------------------------------

--- a/pensyve-mcp-gateway/src/rest.rs
+++ b/pensyve-mcp-gateway/src/rest.rs
@@ -2227,14 +2227,17 @@ async fn gdpr_erase(
         }
     };
 
-    // Collect memory IDs before deletion so we can remove them from vector index.
-    let mut memory_ids: Vec<Uuid> = Vec::new();
-    if let Ok(mems) = ps.storage.list_episodic_by_entity(entity.id, usize::MAX) {
-        memory_ids.extend(mems.iter().map(|m| m.id));
-    }
-    if let Ok(mems) = ps.storage.list_semantic_by_entity(entity.id, usize::MAX) {
-        memory_ids.extend(mems.iter().map(|m| m.id));
-    }
+    // Collect memory IDs before deletion so we can remove them from vector
+    // index. The accessor mirrors the erasure's own delete predicates
+    // (`about_entity OR source_entity`, `subject OR object_entity`, superseded
+    // rows included) — the per-type `list_*_by_entity` calls that used to stand
+    // in here saw only the about-side, the subject-side and live rows, so every
+    // other deleted row kept its index entry (#261).
+    let memory_ids: Vec<Uuid> = ps
+        .storage
+        .list_memories_by_entity_including_superseded(entity.id, ps.namespace.id)
+        .map(|mems| mems.iter().map(pensyve_core::types::Memory::id).collect())
+        .unwrap_or_default();
 
     let result = pensyve_core::gdpr::erase_entity(ps.storage.as_ref(), entity.id, ps.namespace.id)
         .map_err(|e| {

--- a/pensyve-mcp-gateway/tests/test_rest_forget_index_cleanup.rs
+++ b/pensyve-mcp-gateway/tests/test_rest_forget_index_cleanup.rs
@@ -1,0 +1,323 @@
+//! Entity-wide deletion through the gateway must strip the vector index of
+//! *every* row it deletes (#261).
+//!
+//! The delete matches episodic rows on `about_entity OR source_entity` and
+//! semantic rows on `subject OR object_entity`, superseded rows included.
+//! Index cleanup that collects ids from `list_episodic_by_entity` /
+//! `list_semantic_by_entity` sees only the about-side, the subject-side and
+//! live rows, so source-side, object-side and superseded entries survive their
+//! base rows: they hydrate to nothing on recall, but they bloat the index and
+//! burn candidate slots on every query.
+//!
+//! The REST `remember` route only ever creates subject-side semantic rows, so
+//! the fixture seeds storage directly and inserts the ids into the tenant's
+//! index the way `TenantStateManager` does when it warms one from storage.
+//!
+//! One REST test covers the `forget_entity` handler; the A2A `memory.forget`
+//! capability runs the identical cleanup code in `a2a_forget`, so it is not
+//! duplicated here. `gdpr_erase` has its own handler and its own test below.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use axum::Extension;
+use pensyve_core::config::RetrievalConfig;
+use pensyve_core::embedding::OnnxEmbedder;
+use pensyve_core::storage::StorageTrait;
+use pensyve_core::storage::sqlite::SqliteBackend;
+use pensyve_core::types::{Entity, EntityKind, EpisodicMemory, Namespace, SemanticMemory};
+use pensyve_core::vector::VectorIndex;
+use pensyve_mcp_gateway::AppState;
+use pensyve_mcp_gateway::auth::{AuthContext, AuthValidator};
+use pensyve_mcp_gateway::config::GatewayConfig;
+use pensyve_mcp_gateway::rate_limit::RateLimiter;
+use pensyve_mcp_gateway::rest;
+use pensyve_mcp_gateway::tenant::TenantStateManager;
+use pensyve_mcp_gateway::usage::UsageReporter;
+use pensyve_mcp_gateway::usage_counter::UsageCounter;
+use serde_json::Value;
+use tempfile::TempDir;
+use tokio_util::sync::CancellationToken;
+use uuid::Uuid;
+
+const TEST_TENANT: &str = "test-index-cleanup-tenant";
+const DIMENSIONS: usize = 768;
+
+fn retrieval_config() -> RetrievalConfig {
+    RetrievalConfig {
+        default_limit: 5,
+        max_candidates: 100,
+        weights: [0.30, 0.15, 0.20, 0.10, 0.10, 0.05, 0.05, 0.05],
+        recall_timeout_secs: 5,
+        rrf_k: 60,
+        rrf_weights: [1.0, 0.8, 1.0, 0.8, 0.5, 0.5, 1.2, 1.0],
+        beam_width: 10,
+        max_depth: 4,
+    }
+}
+
+fn gateway_config(dir: &TempDir) -> GatewayConfig {
+    GatewayConfig {
+        host: "127.0.0.1".to_string(),
+        port: 0,
+        storage_path: dir.path().to_path_buf(),
+        namespace: "default".to_string(),
+        api_keys: vec![],
+        rate_limit_per_minute: 300,
+        stripe_api_key: None,
+        admin_key: None,
+        key_user_map: vec![],
+        allowed_hosts: vec![],
+    }
+}
+
+fn app_state(dir: &TempDir, snapshot_root: PathBuf) -> Arc<AppState> {
+    let storage =
+        Arc::new(SqliteBackend::open(dir.path()).expect("open storage")) as Arc<dyn StorageTrait>;
+    let namespace = Namespace::new("default");
+    storage
+        .save_namespace(&namespace)
+        .expect("save default namespace");
+
+    let tenant_mgr = TenantStateManager::new(
+        storage,
+        Arc::new(OnnxEmbedder::new_mock(DIMENSIONS)),
+        retrieval_config(),
+        namespace,
+        VectorIndex::new(DIMENSIONS, 1024),
+        snapshot_root,
+    );
+    let config = gateway_config(dir);
+
+    Arc::new(AppState {
+        auth: AuthValidator::new(&config),
+        rate_limiter: RateLimiter::new(None),
+        usage_reporter: UsageReporter::new(None),
+        usage_counter: UsageCounter::new(),
+        tenant_mgr,
+        auth_required: false,
+        admin_key: None,
+        ct: CancellationToken::new(),
+        redis: None,
+        extractor: None,
+    })
+}
+
+fn auth_context() -> AuthContext {
+    AuthContext {
+        key_id: TEST_TENANT.to_string(),
+        tenant_id: None,
+        user_id: None,
+        scope: "mcp".to_string(),
+        stripe_customer_id: None,
+        plan: "free".to_string(),
+    }
+}
+
+async fn start_test_server(state: Arc<AppState>) -> (String, CancellationToken) {
+    let app = rest::router()
+        .layer(Extension(auth_context()))
+        .with_state(state);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test server");
+    let addr = listener.local_addr().expect("test server address");
+    let cancellation = CancellationToken::new();
+    let shutdown = cancellation.clone();
+
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app)
+            .with_graceful_shutdown(shutdown.cancelled_owned())
+            .await;
+    });
+
+    (format!("http://{addr}"), cancellation)
+}
+
+/// A distinct non-zero embedding per row, so the index holds real vectors
+/// rather than a single shared one.
+fn embedding(seed: f32) -> Vec<f32> {
+    (0..DIMENSIONS).map(|i| seed + (i as f32) * 0.001).collect()
+}
+
+/// The ids the forget must remove from the index, tagged so a failure names the
+/// row shape instead of a bare UUID.
+struct Seeded {
+    target: Entity,
+    deletable: Vec<(&'static str, Uuid)>,
+    /// A row about a different entity — must survive in storage and in the index.
+    survivor: Uuid,
+}
+
+/// Seed one row of every shape the entity-wide delete removes, plus a control,
+/// and index them all the way `TenantStateManager` does when warming a tenant.
+async fn seed(state: &AppState) -> Seeded {
+    let ps = state
+        .tenant_mgr
+        .get_tenant_state(TEST_TENANT)
+        .expect("tenant state");
+    let namespace_id = ps.namespace.id;
+
+    let mut target = Entity::new("alice", EntityKind::User);
+    target.namespace_id = namespace_id;
+    ps.storage.save_entity(&target).expect("save target entity");
+
+    let mut other = Entity::new("bob", EntityKind::User);
+    other.namespace_id = namespace_id;
+    ps.storage.save_entity(&other).expect("save other entity");
+
+    // Source-side episodic: the target spoke, the row is about someone else.
+    let mut source_side = EpisodicMemory::new(
+        namespace_id,
+        Uuid::new_v4(),
+        target.id,
+        other.id,
+        "the target talking about bob",
+    );
+    source_side.embedding = embedding(0.1);
+    ps.storage
+        .save_episodic(&source_side)
+        .expect("save source-side episodic");
+
+    // Object-side semantic: the target is the object of someone else's fact.
+    let mut object_side = SemanticMemory::new(namespace_id, other.id, "manages", "alice", 0.9);
+    object_side.object_entity = Some(target.id);
+    object_side.embedding = embedding(0.2);
+    ps.storage
+        .save_semantic(&object_side)
+        .expect("save object-side semantic");
+
+    // Superseded semantic: the delete ignores `superseded_by`, so cleanup must.
+    let mut superseded = SemanticMemory::new(namespace_id, target.id, "lived_in", "berlin", 0.5);
+    superseded.embedding = embedding(0.3);
+    ps.storage
+        .save_semantic(&superseded)
+        .expect("save superseded semantic");
+    ps.storage
+        .supersede_memory(superseded.id, Uuid::new_v4(), chrono::Utc::now())
+        .expect("supersede");
+
+    // Control: nothing to do with the target.
+    let mut survivor = SemanticMemory::new(namespace_id, other.id, "likes", "go", 0.9);
+    survivor.embedding = embedding(0.4);
+    ps.storage
+        .save_semantic(&survivor)
+        .expect("save unrelated semantic");
+
+    {
+        let mut index = ps.vector_index.write().await;
+        index
+            .add_with_entity(
+                source_side.id,
+                &source_side.embedding,
+                source_side.about_entity,
+            )
+            .expect("index source-side episodic");
+        index
+            .add_with_entity(object_side.id, &object_side.embedding, object_side.subject)
+            .expect("index object-side semantic");
+        index
+            .add_with_entity(superseded.id, &superseded.embedding, superseded.subject)
+            .expect("index superseded semantic");
+        index
+            .add_with_entity(survivor.id, &survivor.embedding, survivor.subject)
+            .expect("index unrelated semantic");
+    }
+
+    Seeded {
+        target,
+        deletable: vec![
+            ("source-side episodic", source_side.id),
+            ("object-side semantic", object_side.id),
+            ("superseded semantic", superseded.id),
+        ],
+        survivor: survivor.id,
+    }
+}
+
+async fn assert_all_indexed(state: &AppState, seeded: &Seeded) {
+    let ps = state
+        .tenant_mgr
+        .get_tenant_state(TEST_TENANT)
+        .expect("tenant state");
+    let index = ps.vector_index.read().await;
+    for (label, id) in &seeded.deletable {
+        assert!(
+            index.get(*id).is_some(),
+            "{label} ({id}) must be indexed before the forget, or its absence \
+             afterwards proves nothing"
+        );
+    }
+    assert!(index.get(seeded.survivor).is_some());
+}
+
+async fn assert_deletable_gone_from_index(state: &AppState, seeded: &Seeded) {
+    let ps = state
+        .tenant_mgr
+        .get_tenant_state(TEST_TENANT)
+        .expect("tenant state");
+    let index = ps.vector_index.read().await;
+    for (label, id) in &seeded.deletable {
+        assert!(
+            index.get(*id).is_none(),
+            "{label} ({id}) was deleted from storage but its vector-index entry survived"
+        );
+    }
+    assert!(
+        index.get(seeded.survivor).is_some(),
+        "the unrelated row's index entry must survive the forget"
+    );
+}
+
+#[tokio::test]
+async fn rest_forget_strips_the_index_of_every_deleted_row_shape() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let state = app_state(&dir, dir.path().join("snapshots"));
+    let seeded = seed(&state).await;
+    assert_all_indexed(&state, &seeded).await;
+
+    let (url, cancellation) = start_test_server(state.clone()).await;
+    let client = reqwest::Client::new();
+    let response = client
+        .delete(format!("{url}/v1/entities/{}", seeded.target.name))
+        .send()
+        .await
+        .expect("forget request");
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    let body: Value = response.json().await.expect("forget response JSON");
+    assert_eq!(
+        body["forgotten_count"],
+        seeded.deletable.len(),
+        "the forget must report every row it deleted"
+    );
+
+    assert_deletable_gone_from_index(&state, &seeded).await;
+    cancellation.cancel();
+}
+
+#[tokio::test]
+async fn gdpr_erase_strips_the_index_of_every_deleted_row_shape() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let state = app_state(&dir, dir.path().join("snapshots"));
+    let seeded = seed(&state).await;
+    assert_all_indexed(&state, &seeded).await;
+
+    let (url, cancellation) = start_test_server(state.clone()).await;
+    let client = reqwest::Client::new();
+    let response = client
+        .delete(format!("{url}/v1/gdpr/erase/{}", seeded.target.name))
+        .send()
+        .await
+        .expect("gdpr erase request");
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    let body: Value = response.json().await.expect("gdpr erase response JSON");
+    assert_eq!(
+        body["memories_deleted"],
+        seeded.deletable.len(),
+        "the erasure must report every row it deleted"
+    );
+
+    assert_deletable_gone_from_index(&state, &seeded).await;
+    cancellation.cancel();
+}

--- a/pensyve-python/src/lib.rs
+++ b/pensyve-python/src/lib.rs
@@ -1910,35 +1910,28 @@ impl PyPensyve {
             ));
         }
 
-        // Collect the doomed ids first: once the rows are gone there is no way
-        // to learn which index entries belonged to them. The accessor mirrors
-        // the delete's own predicates (`about_entity OR source_entity`,
-        // `subject OR object_entity`, superseded rows included) — the per-type
-        // `list_*_by_entity` accessors see only the about-side, the
-        // subject-side and live rows, so the rest kept their index entries
-        // after their base rows were deleted (#261).
-        let doomed: Vec<Uuid> = self
+        // The capturing delete returns exactly the rows it removed, inside its
+        // own transaction — so the id set for index cleanup cannot race a
+        // concurrent writer the way a list-then-delete would, and it covers
+        // every deleted shape (`about_entity OR source_entity`, `subject OR
+        // object_entity`, superseded rows included) that the per-type
+        // `list_*_by_entity` accessors miss (#261).
+        let deleted = self
             .inner
             .storage
-            .list_memories_by_entity_including_superseded(entity.uuid, self.inner.namespace.id)
-            .map_err(|e| PyRuntimeError::new_err(format!("Forget failed: {e}")))?
-            .iter()
-            .map(types::Memory::id)
-            .collect();
-
-        let count = self
-            .inner
-            .storage
-            .delete_memories_by_entity(entity.uuid, self.inner.namespace.id)
+            .delete_memories_by_entity_capturing(entity.uuid, self.inner.namespace.id, &mut |_| {
+                Ok(())
+            })
             .map_err(|e| PyRuntimeError::new_err(format!("Forget failed: {e}")))?;
+        let count = deleted.len();
 
         // Only after the delete commits — a failed delete must leave the index
         // agreeing with storage. Rows that were never indexed (no embedding)
         // return `NotFound`, which is not an error here.
         {
             let mut vi = self.inner.vector_index.lock().unwrap();
-            for id in doomed {
-                let _ = vi.remove(id);
+            for memory in &deleted {
+                let _ = vi.remove(memory.id());
             }
         }
 

--- a/pensyve-python/src/lib.rs
+++ b/pensyve-python/src/lib.rs
@@ -1910,11 +1910,37 @@ impl PyPensyve {
             ));
         }
 
+        // Collect the doomed ids first: once the rows are gone there is no way
+        // to learn which index entries belonged to them. The accessor mirrors
+        // the delete's own predicates (`about_entity OR source_entity`,
+        // `subject OR object_entity`, superseded rows included) — the per-type
+        // `list_*_by_entity` accessors see only the about-side, the
+        // subject-side and live rows, so the rest kept their index entries
+        // after their base rows were deleted (#261).
+        let doomed: Vec<Uuid> = self
+            .inner
+            .storage
+            .list_memories_by_entity_including_superseded(entity.uuid, self.inner.namespace.id)
+            .map_err(|e| PyRuntimeError::new_err(format!("Forget failed: {e}")))?
+            .iter()
+            .map(types::Memory::id)
+            .collect();
+
         let count = self
             .inner
             .storage
             .delete_memories_by_entity(entity.uuid, self.inner.namespace.id)
             .map_err(|e| PyRuntimeError::new_err(format!("Forget failed: {e}")))?;
+
+        // Only after the delete commits — a failed delete must leave the index
+        // agreeing with storage. Rows that were never indexed (no embedding)
+        // return `NotFound`, which is not an error here.
+        {
+            let mut vi = self.inner.vector_index.lock().unwrap();
+            for id in doomed {
+                let _ = vi.remove(id);
+            }
+        }
 
         let dict = PyDict::new(py);
         dict.set_item("forgotten_count", count)?;

--- a/tests/python/test_forget_index_cleanup.py
+++ b/tests/python/test_forget_index_cleanup.py
@@ -13,8 +13,8 @@ and stale index entries are invisible through `recall` — the retrieval engine
 hydrates every vector hit from storage and silently drops the misses. So this
 test pins the half Python can observe: every deletable row shape leaves storage
 and stops coming back from recall, and unrelated rows survive. The index half of
-#261 is pinned in Rust, by
-`pensyve-core/src/storage/sqlite.rs::test_list_memories_by_entity_including_superseded_matches_the_delete_scope`
+#261 is pinned in Rust, by the sqlite storage test
+`test_list_memories_by_entity_including_superseded_matches_the_delete_scope`
 and `pensyve-mcp-gateway/tests/test_rest_forget_index_cleanup.rs`.
 
 Object-side semantic and superseded rows are not reachable through the Python

--- a/tests/python/test_forget_index_cleanup.py
+++ b/tests/python/test_forget_index_cleanup.py
@@ -1,0 +1,102 @@
+"""`Pensyve.forget` must clear every row shape the entity-wide delete removes (#261).
+
+The delete matches episodic rows on `about_entity OR source_entity` and
+semantic rows on `subject OR object_entity`, superseded rows included. The
+binding used to hand its vector-index cleanup nothing at all, and the gateway
+handlers assembled it from `list_episodic_by_entity` / `list_semantic_by_entity`,
+which see only the about-side, the subject-side and live rows. Both now collect
+through `list_memories_by_entity_including_superseded`, whose contract is that
+its result equals the delete's.
+
+Scope note for reviewers: the binding exposes no vector-index introspection,
+and stale index entries are invisible through `recall` — the retrieval engine
+hydrates every vector hit from storage and silently drops the misses. So this
+test pins the half Python can observe: every deletable row shape leaves storage
+and stops coming back from recall, and unrelated rows survive. The index half of
+#261 is pinned in Rust, by
+`pensyve-core/src/storage/sqlite.rs::test_list_memories_by_entity_including_superseded_matches_the_delete_scope`
+and `pensyve-mcp-gateway/tests/test_rest_forget_index_cleanup.rs`.
+
+Object-side semantic and superseded rows are not reachable through the Python
+API (no `object_entity` argument, no supersede call), so the shapes seeded here
+are the ones the binding can actually produce.
+"""
+
+import tempfile
+
+import pensyve
+
+ALICE_EPISODIC_SOURCE = "the marmalade recipe uses seville oranges"
+ALICE_EPISODIC_ABOUT = "the kayak was stored in the garage rafters"
+ALICE_SEMANTIC = "prefers oat milk in coffee"
+BOB_EPISODIC = "the telescope needs recollimating before winter"
+BOB_SEMANTIC = "runs the observatory on tuesdays"
+
+ALICE_MARKERS = (ALICE_EPISODIC_SOURCE, ALICE_EPISODIC_ABOUT, ALICE_SEMANTIC)
+BOB_MARKERS = (BOB_EPISODIC, BOB_SEMANTIC)
+
+
+def _contents(p, query):
+    """Every memory content string recall surfaces for `query`."""
+    return [m.content for m in p.recall(query, limit=20)]
+
+
+def _seen(p, marker):
+    """True when `marker` still comes back from recall."""
+    # Query with the marker itself so both the lexical and the vector list
+    # rank it first if it is still there.
+    return any(marker in content for content in _contents(p, marker))
+
+
+def test_forget_clears_every_reachable_row_shape():
+    with tempfile.TemporaryDirectory() as d:
+        p = pensyve.Pensyve(path=d)
+        alice = p.entity("alice", kind="user")
+        bob = p.entity("bob", kind="agent")
+        carol = p.entity("carol", kind="user")
+
+        # Source-side episodic: the first participant is the source, so this
+        # row names alice as `source_entity` and bob as `about_entity`.
+        with p.episode(alice, bob) as ep:
+            ep.message("user", ALICE_EPISODIC_SOURCE)
+
+        # About-side episodic: participants reversed, so alice is
+        # `about_entity` here.
+        with p.episode(bob, alice) as ep:
+            ep.message("agent", ALICE_EPISODIC_ABOUT)
+
+        # Subject-side semantic.
+        p.remember(alice, ALICE_SEMANTIC)
+
+        # Controls: nothing to do with alice, so nothing here may be touched.
+        with p.episode(bob, carol) as ep:
+            ep.message("agent", BOB_EPISODIC)
+        p.remember(bob, BOB_SEMANTIC)
+
+        for marker in ALICE_MARKERS + BOB_MARKERS:
+            assert _seen(p, marker), (
+                f"{marker!r} must be recallable before the forget, "
+                "or its absence afterwards proves nothing"
+            )
+
+        result = p.forget(alice)
+
+        assert result["forgotten_count"] == len(ALICE_MARKERS), (
+            "the forget must report every row shape it deleted, source-side "
+            f"episodic included; got {result['forgotten_count']}"
+        )
+
+        for marker in ALICE_MARKERS:
+            assert not _seen(p, marker), (
+                f"{marker!r} was reported deleted but recall still returns it"
+            )
+        for marker in BOB_MARKERS:
+            assert _seen(p, marker), f"{marker!r} is unrelated to alice and must survive the forget"
+
+        stats = p.stats()
+        assert stats["episodic"] == 1, (
+            f"only bob's episodic row may remain; got {stats['episodic']}"
+        )
+        assert stats["semantic"] == 1, (
+            f"only bob's semantic row may remain; got {stats['semantic']}"
+        )


### PR DESCRIPTION
Closes #261

## Problem

Entity-wide deletes remove episodic rows matching `about_entity OR source_entity` and semantic rows matching `subject OR object_entity`, superseded rows included. Vector-index cleanup collected ids from `list_episodic_by_entity` / `list_semantic_by_entity`, which see only the about-side, the subject-side, and live rows — so source-side episodic, object-side semantic, and superseded rows kept their index entries after their base rows were deleted. Index bloat and wasted recall work, not a leak: stale candidates hydrate to nothing.

## Scoping findings (measured, not assumed)

- The issue's "ready-made accessor" `list_memories_by_entity_including_superseded` **does not exist in the tree** — evidently removed when #248 switched to `DELETE … RETURNING`. Recreated here.
- REST `forget_entity` and A2A `memory.forget` were **already fixed by #263** (`snapshot.memory_ids()` is exactly the deleted set); they get a regression test, not a re-fix.
- The remaining broken sites were the gateway's `gdpr_erase` handler and the Python binding's `forget` — which cleaned **nothing at all** despite the binding maintaining its own in-process `VectorIndex`.
- Both backends' `delete_memories_by_entity` predicates were compared: identical, no divergence to reconcile.

## Change

- `StorageTrait::list_memories_by_entity_including_superseded(entity_id, namespace_id)` on both backends, with the contract stated in the docs: its result equals what `delete_memories_by_entity` deletes, namespace predicate included (entity ids are not globally unique — an entity-only predicate reaches into other tenants). Postgres runs it on a namespace-scoped connection, consistent with the RLS work.
- `gdpr_erase` collects through the accessor before erasing.
- Python `forget` collects the doomed ids before the delete and strips them from the binding's vector index after it commits.

## Tests (TDD, sabotage-checked)

- **Storage**: sqlite test seeding the full shape matrix (about-side, source-side, subject-side, object-side, superseded, plus same-namespace and cross-namespace decoys), asserting the accessor's id set equals exactly what the delete removes. Live-Postgres sibling in `live_rls.rs` runs in the `Rust Tests (postgres)` CI job (self-skips without a `DATABASE_URL`, compiles under `--features postgres`).
- **Gateway**: new `test_rest_forget_index_cleanup.rs` seeds storage directly (the REST remember route can only create subject-side rows) and indexes the ids the way `TenantStateManager` warms an index. REST `forget_entity` and `gdpr_erase` each assert every deleted shape leaves the index and an unrelated survivor stays. A2A shares `a2a_forget`'s identical cleanup code and is deliberately not duplicated (noted in the file docs).
- **Sabotage-checked**: reverting only the `gdpr_erase` hunk fails exactly the gdpr test while the REST test (guarding #263's cleanup) still passes; the accessor's pre-fix state is a compile failure.
- **Python**: `tests/python/test_forget_index_cleanup.py` (the directory CI actually runs). Honest scope note: the binding exposes no index introspection and recall hydrates away stale hits, so the Python test pins the storage/recall half; the index contract is pinned by the Rust tests. Documented in the docstring rather than shipping a silently-vacuous assertion.

Verification: fmt, clippy `-D warnings` (default and `--features postgres`), `cargo test -p pensyve-core` (543 passed), `-p pensyve-mcp-gateway` (all green incl. the 2 new), `-p pensyve-mcp-tools`, `uv run pytest tests/python/` (122 passed).

## Deliberately out of scope

- A Python-side index introspection hook (would enable a true index-level Python test) — needs its own API decision.
- The MCP tool path (already correct via `snapshot.memory_ids()` since #248).