### PR TITLE
fix(storage): scope memory reads, supersede, and delete-by-id to their namespace

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -82,19 +82,31 @@ every startup.
 
 Enforcement fails closed, and it fails without raising an error. A query path
 that does not carry a namespace returns no rows, and a delete on that path
-deletes nothing while still returning `Ok`. It does not claim a deletion:
-`delete_memory_by_id` returns `Ok(false)`. The hazard is that the call succeeds
-at all, so a caller that only checks for an error treats a no-op as a completed
-erase. Several `StorageTrait` methods still take no `namespace_id` and run
-unscoped, including the ones behind recall candidate hydration and memory
-supersession. Entity forget left that list in #256, when
-`delete_memories_by_entity` gained a `namespace_id`. GDPR erase is partly off
-it: #256 scoped its memory deletion only, and its observation, graph-edge and
-entity-record steps still match on the entity id alone. Those three are tracked
-by #254 with the rest of the unscoped surface.
-The test `enforced_rls_fails_closed_for_unscoped_methods` in
-`pensyve-core/src/storage/postgres/live_rls.rs` lists them, and the list must
-be empty before enforcement becomes the default.
+deletes nothing while still returning `Ok`. The hazard is that the call
+succeeds at all, so a caller that only checks for an error treats a no-op as a
+completed erase.
+
+The memory read, supersede and delete-by-id paths no longer have that problem.
+Recall candidate hydration, memory supersession and delete-by-id took no
+`namespace_id` until #254, which replaced each with an `_in_namespace` variant;
+entity forget left the same list in #256. `live_rls.rs` now gates each of them
+under enforcement directly, in
+`scoped_memory_reads_still_work_under_enforced_rls`,
+`supersede_still_works_under_enforced_rls`,
+`namespace_scoping_end_to_end_under_enforced_rls` and
+`entity_delete_still_works_under_enforced_rls`, so the old
+`enforced_rls_fails_closed_for_unscoped_methods` checklist is empty and gone.
+
+The rest of the storage surface still runs unscoped and would fail closed the
+same way. Every `StorageTrait` method that reaches a policied table without a
+`namespace_id` is: `get_entity`, `delete_entity`, `list_episodic_by_entity`,
+`list_semantic_by_entity`, `update_episodic_access`, `invalidate_semantic`,
+`update_semantic_content`, `update_procedural_reliability` and
+`delete_observations_by_entity`. One of those is still on the recall path:
+`update_episodic_access` writes the reinforcement stamp. GDPR erase
+reaches three: #256 scoped its memory deletion only, and its observation,
+graph-edge and entity-record steps still match on the entity id alone. All of
+it is tracked by #254.
 
 Do not apply enforcement to a deployment until those paths carry a namespace.
 

--- a/pensyve-core/src/consolidation/mod.rs
+++ b/pensyve-core/src/consolidation/mod.rs
@@ -1482,7 +1482,7 @@ mod tests {
         );
 
         // The memory retrievability should have been updated in storage.
-        let updated = storage.get_episodic(mem.id).unwrap();
+        let updated = storage.get_episodic_in_namespace(mem.id, ns.id).unwrap();
         assert!(
             updated.is_some(),
             "Memory should still exist after decay pass"

--- a/pensyve-core/src/retrieval/engine.rs
+++ b/pensyve-core/src/retrieval/engine.rs
@@ -1187,11 +1187,15 @@ impl<'a> RecallEngine<'a> {
         }
         for (id, _) in &vector_hits {
             if !candidates.contains_key(id) {
-                if let Ok(Some(m)) = self.storage.get_episodic(*id) {
+                if let Ok(Some(m)) = self.storage.get_episodic_in_namespace(*id, namespace_id) {
                     candidates.insert(*id, Memory::Episodic(m));
-                } else if let Ok(Some(m)) = self.storage.get_semantic(*id) {
+                } else if let Ok(Some(m)) =
+                    self.storage.get_semantic_in_namespace(*id, namespace_id)
+                {
                     candidates.insert(*id, Memory::Semantic(m));
-                } else if let Ok(Some(m)) = self.storage.get_procedural(*id) {
+                } else if let Ok(Some(m)) =
+                    self.storage.get_procedural_in_namespace(*id, namespace_id)
+                {
                     candidates.insert(*id, Memory::Procedural(m));
                 }
             }
@@ -1255,11 +1259,15 @@ impl<'a> RecallEngine<'a> {
             // Hydrate vector hits into candidate map.
             for (id, _) in &entity_hits {
                 if !candidates.contains_key(id) {
-                    if let Ok(Some(m)) = self.storage.get_episodic(*id) {
+                    if let Ok(Some(m)) = self.storage.get_episodic_in_namespace(*id, namespace_id) {
                         candidates.insert(*id, Memory::Episodic(m));
-                    } else if let Ok(Some(m)) = self.storage.get_semantic(*id) {
+                    } else if let Ok(Some(m)) =
+                        self.storage.get_semantic_in_namespace(*id, namespace_id)
+                    {
                         candidates.insert(*id, Memory::Semantic(m));
-                    } else if let Ok(Some(m)) = self.storage.get_procedural(*id) {
+                    } else if let Ok(Some(m)) =
+                        self.storage.get_procedural_in_namespace(*id, namespace_id)
+                    {
                         candidates.insert(*id, Memory::Procedural(m));
                     }
                 }
@@ -1289,11 +1297,15 @@ impl<'a> RecallEngine<'a> {
         // Hydrate broad vector hits into candidate map.
         for (id, _) in &broad_vector_hits {
             if !candidates.contains_key(id) {
-                if let Ok(Some(m)) = self.storage.get_episodic(*id) {
+                if let Ok(Some(m)) = self.storage.get_episodic_in_namespace(*id, namespace_id) {
                     candidates.insert(*id, Memory::Episodic(m));
-                } else if let Ok(Some(m)) = self.storage.get_semantic(*id) {
+                } else if let Ok(Some(m)) =
+                    self.storage.get_semantic_in_namespace(*id, namespace_id)
+                {
                     candidates.insert(*id, Memory::Semantic(m));
-                } else if let Ok(Some(m)) = self.storage.get_procedural(*id) {
+                } else if let Ok(Some(m)) =
+                    self.storage.get_procedural_in_namespace(*id, namespace_id)
+                {
                     candidates.insert(*id, Memory::Procedural(m));
                 }
             }
@@ -1926,7 +1938,7 @@ mod tests {
         assert!(!result.memories.is_empty());
 
         // Fetch the memory again and check access_count increased.
-        let updated = storage.get_episodic(mem.id).unwrap();
+        let updated = storage.get_episodic_in_namespace(mem.id, ns.id).unwrap();
         let updated_access = updated.map(|m| m.access_count).unwrap_or(0);
         assert!(
             updated_access > initial_access,

--- a/pensyve-core/src/storage/mod.rs
+++ b/pensyve-core/src/storage/mod.rs
@@ -36,12 +36,6 @@ pub enum StorageError {
 
 pub type StorageResult<T> = Result<T, StorageError>;
 
-fn scoped_delete_not_implemented() -> StorageResult<bool> {
-    Err(StorageError::Context(
-        "storage backend does not implement atomic scoped deletion".to_string(),
-    ))
-}
-
 fn capturing_delete_not_implemented() -> StorageResult<Vec<Memory>> {
     Err(StorageError::Context(
         "storage backend does not implement capturing entity deletion, \
@@ -105,7 +99,26 @@ pub trait StorageTrait: Send + Sync {
 
     // Episodic Memory
     fn save_episodic(&self, mem: &EpisodicMemory) -> StorageResult<()>;
-    fn get_episodic(&self, id: Uuid) -> StorageResult<Option<EpisodicMemory>>;
+
+    /// Fetch an episodic memory only when it belongs to `namespace_id`.
+    ///
+    /// There is deliberately no unscoped `get_episodic`. One backend instance
+    /// is shared by every tenant of the gateway, so a lookup keyed on `id`
+    /// alone resolves across namespaces — and under enforced row-level security
+    /// it resolves to nothing at all, because the connection carrying no
+    /// namespace matches no row (#254). Requiring the namespace here is what
+    /// lets recall hydration and the REST memory reads work the same way in
+    /// both configurations.
+    ///
+    /// Backends must implement this as a single `id AND namespace_id` query.
+    /// Callers should treat `Ok(None)` as "not found" without distinguishing
+    /// "owned by someone else", so the result is not an existence oracle.
+    fn get_episodic_in_namespace(
+        &self,
+        id: Uuid,
+        namespace_id: Uuid,
+    ) -> StorageResult<Option<EpisodicMemory>>;
+
     fn list_episodic_by_entity(
         &self,
         about_entity: Uuid,
@@ -145,7 +158,16 @@ pub trait StorageTrait: Send + Sync {
 
     // Semantic Memory
     fn save_semantic(&self, mem: &SemanticMemory) -> StorageResult<()>;
-    fn get_semantic(&self, id: Uuid) -> StorageResult<Option<SemanticMemory>>;
+
+    /// Fetch a semantic memory only when it belongs to `namespace_id`. Same
+    /// contract as [`StorageTrait::get_episodic_in_namespace`], including the
+    /// "not an existence oracle" caveat.
+    fn get_semantic_in_namespace(
+        &self,
+        id: Uuid,
+        namespace_id: Uuid,
+    ) -> StorageResult<Option<SemanticMemory>>;
+
     fn list_semantic_by_entity(
         &self,
         subject: Uuid,
@@ -155,7 +177,16 @@ pub trait StorageTrait: Send + Sync {
 
     // Procedural Memory
     fn save_procedural(&self, mem: &ProceduralMemory) -> StorageResult<()>;
-    fn get_procedural(&self, id: Uuid) -> StorageResult<Option<ProceduralMemory>>;
+
+    /// Fetch a procedural memory only when it belongs to `namespace_id`. Same
+    /// contract as [`StorageTrait::get_episodic_in_namespace`], including the
+    /// "not an existence oracle" caveat.
+    fn get_procedural_in_namespace(
+        &self,
+        id: Uuid,
+        namespace_id: Uuid,
+    ) -> StorageResult<Option<ProceduralMemory>>;
+
     fn update_procedural_reliability(
         &self,
         id: Uuid,
@@ -176,7 +207,14 @@ pub trait StorageTrait: Send + Sync {
         ))
     }
 
-    fn get_observation(&self, _id: Uuid) -> StorageResult<Option<ObservationMemory>> {
+    /// Fetch an observation only when it belongs to `namespace_id`. Same
+    /// contract as [`StorageTrait::get_episodic_in_namespace`], including the
+    /// "not an existence oracle" caveat.
+    fn get_observation_in_namespace(
+        &self,
+        _id: Uuid,
+        _namespace_id: Uuid,
+    ) -> StorageResult<Option<ObservationMemory>> {
         Ok(None)
     }
 
@@ -360,10 +398,23 @@ pub trait StorageTrait: Send + Sync {
             .collect())
     }
 
-    /// Mark a live memory as superseded. Returns `false` when no live row matched.
-    fn supersede_memory(
+    /// Mark a live memory as superseded, but only when it belongs to
+    /// `namespace_id`. Returns `false` when no live row in that namespace
+    /// matched.
+    ///
+    /// There is deliberately no unscoped `supersede_memory`. Memory ids are not
+    /// globally unique in this schema, so an id-only `UPDATE` stamps whichever
+    /// tenant's row happens to carry the id — and under enforced row-level
+    /// security it stamps nothing while still reporting `Ok(false)`, which a
+    /// caller cannot tell from a genuine supersession race (#254).
+    ///
+    /// Backends must put both predicates in the SQL rather than leave the
+    /// namespace to row-level security, which is defence in depth and inert in
+    /// every deployment shipping today.
+    fn supersede_memory_in_namespace(
         &self,
         id: Uuid,
+        namespace_id: Uuid,
         superseded_by: Uuid,
         invalid_at: DateTime<Utc>,
     ) -> StorageResult<bool>;
@@ -430,21 +481,20 @@ pub trait StorageTrait: Send + Sync {
         capturing_delete_not_implemented()
     }
 
-    /// Delete a single memory by its UUID (episodic, semantic, or procedural).
-    fn delete_memory_by_id(&self, id: Uuid) -> StorageResult<bool>;
-
-    /// Delete a single memory only when it belongs to `namespace_id`.
+    /// Delete a single memory (episodic, semantic, procedural or observation)
+    /// only when it belongs to `namespace_id`.
     ///
-    /// Backends must override this with an atomic namespace-qualified delete.
-    /// The default preserves source compatibility for third-party backends but
-    /// fails closed rather than falling back to an unscoped delete.
-    fn delete_memory_by_id_in_namespace(
-        &self,
-        _id: Uuid,
-        _namespace_id: Uuid,
-    ) -> StorageResult<bool> {
-        scoped_delete_not_implemented()
-    }
+    /// There is deliberately no unscoped `delete_memory_by_id`. Memory ids
+    /// repeat across namespaces, so an id-only `DELETE` destroys whichever
+    /// tenant's row carries the id, and under enforced row-level security it
+    /// destroys nothing while returning `Ok(false)` — a no-op reported as a
+    /// completed erase (#254).
+    ///
+    /// Backends must implement this as an atomic namespace-qualified delete,
+    /// search-index cleanup included: `memory_fts` is keyed by memory id alone,
+    /// so an unqualified cleanup strips a foreign namespace's entry.
+    fn delete_memory_by_id_in_namespace(&self, id: Uuid, namespace_id: Uuid)
+    -> StorageResult<bool>;
 
     /// Delete all memories in a namespace. Returns the count of deleted memories.
     fn purge_namespace(&self, namespace_id: Uuid) -> StorageResult<usize> {
@@ -452,7 +502,10 @@ pub trait StorageTrait: Send + Sync {
         let memories = self.get_all_memories_by_namespace(namespace_id)?;
         let mut count = 0;
         for mem in &memories {
-            if self.delete_memory_by_id(mem.id()).unwrap_or(false) {
+            if self
+                .delete_memory_by_id_in_namespace(mem.id(), namespace_id)
+                .unwrap_or(false)
+            {
                 count += 1;
             }
         }
@@ -596,11 +649,15 @@ pub fn memory_matches_scope(
 mod tests {
     use super::*;
 
+    /// The one remaining fail-closed default: a backend that cannot capture
+    /// atomically must error rather than let an entity-wide delete be treated
+    /// as recoverable. (Its sibling `scoped_delete_not_implemented` went away
+    /// in #254, when `delete_memory_by_id_in_namespace` became required.)
     #[test]
-    fn scoped_delete_not_implemented_fails_closed() {
-        let error = scoped_delete_not_implemented().unwrap_err();
+    fn capturing_delete_not_implemented_fails_closed() {
+        let error = capturing_delete_not_implemented().unwrap_err();
 
         assert!(matches!(error, StorageError::Context(_)));
-        assert!(error.to_string().contains("atomic scoped deletion"));
+        assert!(error.to_string().contains("capturing entity deletion"));
     }
 }

--- a/pensyve-core/src/storage/postgres.rs
+++ b/pensyve-core/src/storage/postgres.rs
@@ -883,16 +883,21 @@ impl StorageTrait for PostgresBackend {
         })
     }
 
-    fn get_episodic(&self, id: Uuid) -> StorageResult<Option<EpisodicMemory>> {
+    fn get_episodic_in_namespace(
+        &self,
+        id: Uuid,
+        namespace_id: Uuid,
+    ) -> StorageResult<Option<EpisodicMemory>> {
         self.block_on(async {
-            let mut conn = self.maybe_scoped_conn().await?;
+            let mut conn = self.scoped_conn(namespace_id).await?;
             let row: Option<EpisodicRow> = query_as::<Postgres, _>(
                 r"SELECT id, namespace_id, episode_id, source_entity, about_entity, content,
                           summary, embedding::text AS embedding, context_intent, timestamp, stability, retrievability,
                           access_count, last_accessed, event_time, superseded_by, invalid_at
-                   FROM episodic_memories WHERE id = $1",
+                   FROM episodic_memories WHERE id = $1 AND namespace_id = $2",
             )
             .bind(id)
+            .bind(namespace_id)
             .fetch_optional(&mut *conn)
             .await
             .map_err(sqlx_to_io)?;
@@ -1021,16 +1026,21 @@ impl StorageTrait for PostgresBackend {
         })
     }
 
-    fn get_semantic(&self, id: Uuid) -> StorageResult<Option<SemanticMemory>> {
+    fn get_semantic_in_namespace(
+        &self,
+        id: Uuid,
+        namespace_id: Uuid,
+    ) -> StorageResult<Option<SemanticMemory>> {
         self.block_on(async {
-            let mut conn = self.maybe_scoped_conn().await?;
+            let mut conn = self.scoped_conn(namespace_id).await?;
             let row: Option<SemanticRow> = query_as::<Postgres, _>(
                 r"SELECT id, namespace_id, subject, predicate, object, object_entity, confidence,
                           valid_at, invalid_at, source_episodes, embedding::text, stability,
                           retrievability, superseded_by
-                   FROM semantic_memories WHERE id = $1",
+                   FROM semantic_memories WHERE id = $1 AND namespace_id = $2",
             )
             .bind(id)
+            .bind(namespace_id)
             .fetch_optional(&mut *conn)
             .await
             .map_err(sqlx_to_io)?;
@@ -1123,16 +1133,21 @@ impl StorageTrait for PostgresBackend {
         })
     }
 
-    fn get_procedural(&self, id: Uuid) -> StorageResult<Option<ProceduralMemory>> {
+    fn get_procedural_in_namespace(
+        &self,
+        id: Uuid,
+        namespace_id: Uuid,
+    ) -> StorageResult<Option<ProceduralMemory>> {
         self.block_on(async {
-            let mut conn = self.maybe_scoped_conn().await?;
+            let mut conn = self.scoped_conn(namespace_id).await?;
             let row: Option<ProceduralRow> = query_as::<Postgres, _>(
                 r"SELECT id, namespace_id, trigger_text, action, outcome, context, reliability,
                           trial_count, success_count, source_episodes, embedding::text, created_at,
                           last_used, superseded_by, invalid_at
-                   FROM procedural_memories WHERE id = $1",
+                   FROM procedural_memories WHERE id = $1 AND namespace_id = $2",
             )
             .bind(id)
+            .bind(namespace_id)
             .fetch_optional(&mut *conn)
             .await
             .map_err(sqlx_to_io)?;
@@ -1212,16 +1227,21 @@ impl StorageTrait for PostgresBackend {
         })
     }
 
-    fn get_observation(&self, id: Uuid) -> StorageResult<Option<ObservationMemory>> {
+    fn get_observation_in_namespace(
+        &self,
+        id: Uuid,
+        namespace_id: Uuid,
+    ) -> StorageResult<Option<ObservationMemory>> {
         self.block_on(async {
-            let mut conn = self.maybe_scoped_conn().await?;
+            let mut conn = self.scoped_conn(namespace_id).await?;
             let row: Option<ObservationRow> = query_as::<Postgres, _>(
                 r"SELECT id, namespace_id, episode_id, entity_type, instance, action, quantity,
                           unit, content, embedding::text AS embedding, confidence, event_time, created_at,
                           stability, retrievability, superseded_by, invalid_at
-                   FROM observation_memories WHERE id = $1",
+                   FROM observation_memories WHERE id = $1 AND namespace_id = $2",
             )
             .bind(id)
+            .bind(namespace_id)
             .fetch_optional(&mut *conn)
             .await
             .map_err(sqlx_to_io)?;
@@ -1546,28 +1566,30 @@ impl StorageTrait for PostgresBackend {
         })
     }
 
-    fn supersede_memory(
+    fn supersede_memory_in_namespace(
         &self,
         id: Uuid,
+        namespace_id: Uuid,
         superseded_by: Uuid,
         invalid_at: DateTime<Utc>,
     ) -> StorageResult<bool> {
         self.block_on(async {
-            let mut conn = self.maybe_scoped_conn().await?;
+            let mut conn = self.scoped_conn(namespace_id).await?;
             for sql in [
                 "UPDATE episodic_memories SET superseded_by = $1, invalid_at = $2 \
-                 WHERE id = $3 AND superseded_by IS NULL",
+                 WHERE id = $3 AND namespace_id = $4 AND superseded_by IS NULL",
                 "UPDATE semantic_memories SET superseded_by = $1, invalid_at = $2 \
-                 WHERE id = $3 AND superseded_by IS NULL",
+                 WHERE id = $3 AND namespace_id = $4 AND superseded_by IS NULL",
                 "UPDATE procedural_memories SET superseded_by = $1, invalid_at = $2 \
-                 WHERE id = $3 AND superseded_by IS NULL",
+                 WHERE id = $3 AND namespace_id = $4 AND superseded_by IS NULL",
                 "UPDATE observation_memories SET superseded_by = $1, invalid_at = $2 \
-                 WHERE id = $3 AND superseded_by IS NULL",
+                 WHERE id = $3 AND namespace_id = $4 AND superseded_by IS NULL",
             ] {
                 let result = query::<Postgres>(sql)
                     .bind(superseded_by)
                     .bind(invalid_at)
                     .bind(id)
+                    .bind(namespace_id)
                     .execute(&mut *conn)
                     .await
                     .map_err(sqlx_to_io)?;
@@ -1703,51 +1725,6 @@ impl StorageTrait for PostgresBackend {
             total += result.rows_affected() as usize;
 
             Ok(total)
-        })
-    }
-
-    fn delete_memory_by_id(&self, id: Uuid) -> StorageResult<bool> {
-        self.block_on(async {
-            let mut conn = self.maybe_scoped_conn().await?;
-            let mut deleted = false;
-
-            let result = query::<Postgres>("DELETE FROM episodic_memories WHERE id = $1")
-                .bind(id)
-                .execute(&mut *conn)
-                .await
-                .map_err(sqlx_to_io)?;
-            if result.rows_affected() > 0 {
-                deleted = true;
-            }
-
-            let result = query::<Postgres>("DELETE FROM semantic_memories WHERE id = $1")
-                .bind(id)
-                .execute(&mut *conn)
-                .await
-                .map_err(sqlx_to_io)?;
-            if result.rows_affected() > 0 {
-                deleted = true;
-            }
-
-            let result = query::<Postgres>("DELETE FROM procedural_memories WHERE id = $1")
-                .bind(id)
-                .execute(&mut *conn)
-                .await
-                .map_err(sqlx_to_io)?;
-            if result.rows_affected() > 0 {
-                deleted = true;
-            }
-
-            let result = query::<Postgres>("DELETE FROM observation_memories WHERE id = $1")
-                .bind(id)
-                .execute(&mut *conn)
-                .await
-                .map_err(sqlx_to_io)?;
-            if result.rows_affected() > 0 {
-                deleted = true;
-            }
-
-            Ok(deleted)
         })
     }
 

--- a/pensyve-core/src/storage/postgres/live_rls.rs
+++ b/pensyve-core/src/storage/postgres/live_rls.rs
@@ -44,13 +44,26 @@
 //! storage method's own SQL with the `namespace_id` predicate *deleted* and
 //! shows RLS still blocks the cross-namespace access.
 //!
-//! **Still open — enforcement is not yet the default.** It fails closed, and
-//! several `StorageTrait` methods take no `namespace_id` at all, so they run
-//! on an unscoped connection. Under enforcement they silently read and delete
-//! nothing rather than erroring.
-//! [`enforced_rls_fails_closed_for_unscoped_methods`] pins exactly which ones,
-//! and is the checklist that has to reach zero before `FORCE` can move into
-//! `postgres_schema.sql`. Until then the enforcement file is an explicit
+//! **Fixed — every method this file pinned now carries a namespace.** The
+//! checklist `enforced_rls_fails_closed_for_unscoped_methods` used to assert
+//! that `get_episodic`, `supersede_memory` and `delete_memory_by_id` read and
+//! deleted nothing under enforcement while still reporting success. #254
+//! replaced all three with `_in_namespace` variants, so each assertion flipped
+//! and moved into the enforced test for its own method:
+//! [`scoped_memory_reads_still_work_under_enforced_rls`],
+//! [`supersede_still_works_under_enforced_rls`] and, for the scoped delete,
+//! [`namespace_scoping_end_to_end_under_enforced_rls`]. The checklist is empty
+//! and therefore gone; the per-method tests are the standing gate in its place.
+//!
+//! **Still open — enforcement is not yet the default.** Two things remain.
+//! The rest of the storage surface still runs unscoped and fails closed the
+//! same way; `docs/SECURITY.md` enumerates it. And the role matters:
+//! `PostgresBackend::new` applies the schema on every startup, which is
+//! owner-only DDL, so the application has to connect as the table owner — and
+//! a managed-Postgres owner role typically also carries `BYPASSRLS`, which
+//! exempts it from the policies whether or not `FORCE` is set. Separating
+//! schema application from serving traffic is the other #254 work item. Until
+//! both land, `FORCE` stays in `postgres_rls_enforce.sql` as an explicit
 //! operator step — see `docs/SECURITY.md`.
 //!
 //! Tests therefore come in two flavours: [`Fixture::provision`] mirrors a
@@ -397,7 +410,7 @@ fn seed_entity_scope(backend: &PostgresBackend, ns_a: &Namespace, ns_b: &Namespa
     backend.save_semantic(&superseded).expect("save superseded");
     assert!(
         backend
-            .supersede_memory(superseded.id, Uuid::new_v4(), Utc::now())
+            .supersede_memory_in_namespace(superseded.id, ns_a.id, Uuid::new_v4(), Utc::now())
             .expect("supersede must not error"),
         "the superseded fixture row must actually be marked superseded"
     );
@@ -837,8 +850,7 @@ fn namespace_scoping_end_to_end_under_enforced_rls() {
     );
 }
 
-/// The capturing delete keeps working with RLS enforced, so it does *not*
-/// belong in [`enforced_rls_fails_closed_for_unscoped_methods`].
+/// The capturing delete keeps working with RLS enforced.
 ///
 /// It takes a `namespace_id`, so its connection is bound to that namespace
 /// rather than left unscoped. Both halves are worth pinning: it still deletes
@@ -903,8 +915,7 @@ fn capturing_delete_still_works_under_enforced_rls() {
     );
 }
 
-/// The plain entity-wide delete keeps working with RLS enforced, so it no
-/// longer belongs in [`enforced_rls_fails_closed_for_unscoped_methods`].
+/// The plain entity-wide delete keeps working with RLS enforced.
 ///
 /// It took no `namespace_id` until #256 and therefore ran on an unscoped
 /// connection, which under enforcement matched nothing — `Ok(0)` reported as
@@ -1118,23 +1129,77 @@ fn entity_scoped_listing_matches_the_delete_scope() {
     );
 }
 
-/// Enforcement fails closed, and these `StorageTrait` methods take no
-/// `namespace_id`, so they run on an unscoped connection and quietly stop
-/// working when it is switched on.
+/// Recall's candidate hydration keeps working with RLS enforced.
 ///
-/// This is the reason `FORCE ROW LEVEL SECURITY` lives in
-/// `postgres_rls_enforce.sql` as an operator step instead of in
-/// `postgres_schema.sql`. The failure mode is the dangerous kind: not an
-/// error, but a success report with no effect — `delete_memory_by_id` returns
-/// `Ok(false)` while `purge_namespace`, which is built on it, reports a count.
+/// `get_episodic` took no `namespace_id` and therefore ran on an unscoped
+/// connection, which under enforcement matched nothing. That is the failure
+/// the issue called out as the most invisible: `retrieval::engine` hydrates
+/// every vector-only candidate through this accessor, so recall would have
+/// returned an empty result set and reported success. `get_semantic` and
+/// `get_procedural` sit in the same `else if` chain and are pinned with it.
 ///
-/// Each assertion here is a work item, tracked by #254. When a method starts
-/// carrying a namespace, its assertion flips and has to be moved into
-/// [`namespace_scoping_end_to_end_under_enforced_rls`]. When the list is
-/// empty, enforcement can become the default.
+/// The foreign-namespace half matters as much as the own-namespace half: the
+/// vector index is not partitioned by namespace, so a hydration keyed on `id`
+/// alone is a cross-namespace read whenever RLS is *not* enforced, which is
+/// every deployment shipping today.
 #[test]
-fn enforced_rls_fails_closed_for_unscoped_methods() {
-    let Some(admin_opts) = skip_notice("enforced_rls_fails_closed_for_unscoped_methods") else {
+fn scoped_memory_reads_still_work_under_enforced_rls() {
+    let Some(admin_opts) = skip_notice("scoped_memory_reads_still_work_under_enforced_rls") else {
+        return;
+    };
+    let fixture = Fixture::provision(&admin_opts);
+    let backend = &fixture.backend;
+    let ns_a = Namespace::new(format!("rls-a-{}", Uuid::new_v4().simple()));
+    let ns_b = Namespace::new(format!("rls-b-{}", Uuid::new_v4().simple()));
+    let memory = seed(&fixture, &ns_a, &ns_b);
+    let fact = SemanticMemory::new(ns_a.id, Uuid::new_v4(), "likes", "rust", 0.9);
+    backend.save_semantic(&fact).expect("save A's fact");
+    fixture.enforce_rls();
+
+    assert_eq!(
+        backend
+            .get_episodic_in_namespace(memory.id, ns_a.id)
+            .expect("read A's episodic memory")
+            .map(|m| m.id),
+        Some(memory.id),
+        "hydration must still resolve a namespace's own row under enforced RLS"
+    );
+    assert!(
+        backend
+            .get_episodic_in_namespace(memory.id, ns_b.id)
+            .expect("read A's episodic memory through B")
+            .is_none(),
+        "hydration must not resolve another namespace's row"
+    );
+
+    assert_eq!(
+        backend
+            .get_semantic_in_namespace(fact.id, ns_a.id)
+            .expect("read A's fact")
+            .map(|m| m.id),
+        Some(fact.id),
+        "the semantic arm of the hydration chain must resolve its own row"
+    );
+    assert!(
+        backend
+            .get_semantic_in_namespace(fact.id, ns_b.id)
+            .expect("read A's fact through B")
+            .is_none(),
+        "the semantic arm must not resolve another namespace's row"
+    );
+}
+
+/// Supersession keeps working with RLS enforced.
+///
+/// `supersede_memory` took no `namespace_id`, so under enforcement it stamped
+/// nothing and returned `Ok(false)` — which `perform_supersession` in the REST
+/// gateway reads as "someone else superseded this first" and turns into a 409,
+/// after having already written the replacement row. Both halves are pinned:
+/// the stamp lands in its own namespace, and a foreign namespace cannot stamp
+/// a row it does not own.
+#[test]
+fn supersede_still_works_under_enforced_rls() {
+    let Some(admin_opts) = skip_notice("supersede_still_works_under_enforced_rls") else {
         return;
     };
     let fixture = Fixture::provision(&admin_opts);
@@ -1144,40 +1209,12 @@ fn enforced_rls_fails_closed_for_unscoped_methods() {
     let memory = seed(&fixture, &ns_a, &ns_b);
     fixture.enforce_rls();
 
-    // Reached from the recall path (retrieval::engine hydrating candidates)
-    // and from the supersede/update-memory REST handlers.
-    assert!(
-        backend
-            .get_episodic(memory.id)
-            .expect("get_episodic must not error")
-            .is_none(),
-        "get_episodic still resolves under enforced RLS — it now carries a \
-         namespace, so move this into the enforced end-to-end test"
-    );
-
-    // Reached from POST /v1/memories/{id}/supersede and PATCH /v1/memories/{id}.
     assert!(
         !backend
-            .supersede_memory(memory.id, Uuid::new_v4(), Utc::now())
-            .expect("supersede_memory must not error"),
-        "supersede_memory now takes effect under enforced RLS"
+            .supersede_memory_in_namespace(memory.id, ns_b.id, Uuid::new_v4(), Utc::now())
+            .expect("supersede through namespace B"),
+        "a foreign namespace must not stamp another namespace's row"
     );
-
-    // `delete_memories_by_entity` used to be on this list. It takes a
-    // `namespace_id` as of #256, so its connection is bound and it keeps
-    // working under enforcement — the assertion moved to
-    // [`entity_delete_still_works_under_enforced_rls`].
-
-    // Reached from the default `purge_namespace` trait implementation, which
-    // PostgresBackend does not override.
-    assert!(
-        !backend
-            .delete_memory_by_id(memory.id)
-            .expect("delete_memory_by_id must not error"),
-        "delete_memory_by_id now deletes under enforced RLS"
-    );
-
-    // The row is untouched by all of the above.
     assert_eq!(
         memory_ids(
             &backend
@@ -1185,7 +1222,23 @@ fn enforced_rls_fails_closed_for_unscoped_methods() {
                 .expect("read namespace A")
         ),
         vec![memory.id],
-        "the unscoped methods should have been no-ops, not partial writes"
+        "a cross-namespace supersede must leave the row live"
+    );
+
+    let successor = Uuid::new_v4();
+    assert!(
+        backend
+            .supersede_memory_in_namespace(memory.id, ns_a.id, successor, Utc::now())
+            .expect("supersede through namespace A"),
+        "the scoped supersede must still take effect in its own namespace"
+    );
+    assert_eq!(
+        backend
+            .get_episodic_in_namespace(memory.id, ns_a.id)
+            .expect("re-read the superseded row")
+            .and_then(|m| m.superseded_by),
+        Some(successor),
+        "the stamp must be the one this namespace wrote"
     );
 }
 
@@ -1515,7 +1568,7 @@ fn enforcement_file_forces_every_policied_table_and_only_those() {
         !sql_statements_only(super::SCHEMA).contains("FORCE ROW LEVEL SECURITY"),
         "FORCE moved into postgres_schema.sql, which runs on every startup. Enforcement \
          fails closed, so this would silently break every query path that does not carry \
-         a namespace — see enforced_rls_fails_closed_for_unscoped_methods for the list \
-         that must be empty first."
+         a namespace — see the module docs and docs/SECURITY.md for the paths that still \
+         do not, and for the role the application has to stop connecting as."
     );
 }

--- a/pensyve-core/src/storage/postgres_rls_enforce.sql
+++ b/pensyve-core/src/storage/postgres_rls_enforce.sql
@@ -20,9 +20,12 @@
 -- not will not error: it will silently read nothing and delete nothing.
 --
 -- Do not apply this until every `StorageTrait` call site in the deployment
--- passes a namespace. `enforced_rls_fails_closed_for_unscoped_methods` in
--- `postgres/live_rls.rs` enumerates the methods that still do not, and is the
--- gate on this file becoming the default. Tracked by #254.
+-- passes a namespace. The memory read, supersede and delete-by-id paths do as
+-- of #254 — `postgres/live_rls.rs` gates each of them under enforcement — but
+-- part of the surface still does not, and the application still connects as an
+-- owner role that a managed Postgres usually also grants `BYPASSRLS`, which
+-- exempts it from the policies regardless of FORCE. `docs/SECURITY.md`
+-- enumerates both. Tracked by #254.
 --
 -- Rollback
 -- --------

--- a/pensyve-core/src/storage/sqlite.rs
+++ b/pensyve-core/src/storage/sqlite.rs
@@ -700,71 +700,60 @@ fn str_to_dt(s: &str) -> DateTime<Utc> {
 fn delete_memory_by_id_with_namespace(
     conn: &Connection,
     id: Uuid,
-    namespace_id: Option<Uuid>,
+    namespace_id: Uuid,
 ) -> StorageResult<bool> {
     let transaction = conn.unchecked_transaction()?;
     let id_str = id.to_string();
-    let namespace_id = namespace_id.map(|namespace_id| namespace_id.to_string());
+    let namespace_id = namespace_id.to_string();
     let mut deleted = false;
 
     let n = transaction.execute(
-        "DELETE FROM episodic_memories
-         WHERE id = ?1 AND (?2 IS NULL OR namespace_id = ?2)",
-        params![&id_str, namespace_id.as_deref()],
+        "DELETE FROM episodic_memories WHERE id = ?1 AND namespace_id = ?2",
+        params![&id_str, &namespace_id],
     )?;
     if n > 0 {
         deleted = true;
     }
 
     let n = transaction.execute(
-        "DELETE FROM semantic_memories
-         WHERE id = ?1 AND (?2 IS NULL OR namespace_id = ?2)",
-        params![&id_str, namespace_id.as_deref()],
+        "DELETE FROM semantic_memories WHERE id = ?1 AND namespace_id = ?2",
+        params![&id_str, &namespace_id],
     )?;
     if n > 0 {
         deleted = true;
     }
 
     let n = transaction.execute(
-        "DELETE FROM procedural_memories
-         WHERE id = ?1 AND (?2 IS NULL OR namespace_id = ?2)",
-        params![&id_str, namespace_id.as_deref()],
+        "DELETE FROM procedural_memories WHERE id = ?1 AND namespace_id = ?2",
+        params![&id_str, &namespace_id],
     )?;
     if n > 0 {
         deleted = true;
     }
 
     let n = transaction.execute(
-        "DELETE FROM observation_memories
-         WHERE id = ?1 AND (?2 IS NULL OR namespace_id = ?2)",
-        params![&id_str, namespace_id.as_deref()],
+        "DELETE FROM observation_memories WHERE id = ?1 AND namespace_id = ?2",
+        params![&id_str, &namespace_id],
     )?;
     if n > 0 {
         deleted = true;
         // Observations are the only memory type represented in the KG tables.
         transaction.execute(
-            "DELETE FROM kg_triples
-             WHERE passage_id = ?1 AND (?2 IS NULL OR namespace_id = ?2)",
-            params![&id_str, namespace_id.as_deref()],
+            "DELETE FROM kg_triples WHERE passage_id = ?1 AND namespace_id = ?2",
+            params![&id_str, &namespace_id],
         )?;
         transaction.execute(
             "DELETE FROM kg_passage_entities
              WHERE passage_id = ?1
-               AND (
-                   ?2 IS NULL
-                   OR entity_id IN (
-                       SELECT id FROM kg_entities WHERE namespace_id = ?2
-                   )
-               )",
-            params![&id_str, namespace_id.as_deref()],
+               AND entity_id IN (SELECT id FROM kg_entities WHERE namespace_id = ?2)",
+            params![&id_str, &namespace_id],
         )?;
     }
 
     if deleted {
         transaction.execute(
-            "DELETE FROM memory_fts
-             WHERE memory_id = ?1 AND (?2 IS NULL OR namespace_id = ?2)",
-            params![&id_str, namespace_id.as_deref()],
+            "DELETE FROM memory_fts WHERE memory_id = ?1 AND namespace_id = ?2",
+            params![&id_str, &namespace_id],
         )?;
     }
 
@@ -1104,7 +1093,11 @@ impl StorageTrait for SqliteBackend {
         Ok(())
     }
 
-    fn get_episodic(&self, id: Uuid) -> StorageResult<Option<EpisodicMemory>> {
+    fn get_episodic_in_namespace(
+        &self,
+        id: Uuid,
+        namespace_id: Uuid,
+    ) -> StorageResult<Option<EpisodicMemory>> {
         let conn = lock_conn!(self);
         let result = conn
             .query_row(
@@ -1112,8 +1105,8 @@ impl StorageTrait for SqliteBackend {
                           content_type, summary, embedding, context_intent, timestamp,
                           stability, retrievability, access_count, last_accessed, event_time,
                           agent_id, user_id, superseded_by, invalid_at
-                   FROM episodic_memories WHERE id = ?1",
-                params![id.to_string()],
+                   FROM episodic_memories WHERE id = ?1 AND namespace_id = ?2",
+                params![id.to_string(), namespace_id.to_string()],
                 row_to_episodic,
             )
             .optional()?;
@@ -1243,7 +1236,11 @@ impl StorageTrait for SqliteBackend {
         }
     }
 
-    fn get_semantic(&self, id: Uuid) -> StorageResult<Option<SemanticMemory>> {
+    fn get_semantic_in_namespace(
+        &self,
+        id: Uuid,
+        namespace_id: Uuid,
+    ) -> StorageResult<Option<SemanticMemory>> {
         let conn = lock_conn!(self);
         let result = conn
             .query_row(
@@ -1251,8 +1248,8 @@ impl StorageTrait for SqliteBackend {
                           object_entity, confidence, valid_at, invalid_at,
                           source_episodes, embedding, stability, retrievability,
                           agent_id, user_id, superseded_by
-                   FROM semantic_memories WHERE id = ?1",
-                params![id.to_string()],
+                   FROM semantic_memories WHERE id = ?1 AND namespace_id = ?2",
+                params![id.to_string(), namespace_id.to_string()],
                 row_to_semantic,
             )
             .optional()?;
@@ -1380,15 +1377,19 @@ impl StorageTrait for SqliteBackend {
         Ok(())
     }
 
-    fn get_procedural(&self, id: Uuid) -> StorageResult<Option<ProceduralMemory>> {
+    fn get_procedural_in_namespace(
+        &self,
+        id: Uuid,
+        namespace_id: Uuid,
+    ) -> StorageResult<Option<ProceduralMemory>> {
         let conn = lock_conn!(self);
         let result = conn
             .query_row(
                 r"SELECT id, namespace_id, trigger_text, action, outcome, context, reliability,
                           trial_count, success_count, source_episodes, embedding, created_at, last_used,
                           agent_id, user_id, superseded_by, invalid_at
-                   FROM procedural_memories WHERE id = ?1",
-                params![id.to_string()],
+                   FROM procedural_memories WHERE id = ?1 AND namespace_id = ?2",
+                params![id.to_string(), namespace_id.to_string()],
                 row_to_procedural,
             )
             .optional()?;
@@ -1489,15 +1490,19 @@ impl StorageTrait for SqliteBackend {
         }
     }
 
-    fn get_observation(&self, id: Uuid) -> StorageResult<Option<ObservationMemory>> {
+    fn get_observation_in_namespace(
+        &self,
+        id: Uuid,
+        namespace_id: Uuid,
+    ) -> StorageResult<Option<ObservationMemory>> {
         let conn = lock_conn!(self);
         let result = conn
             .query_row(
                 r"SELECT id, namespace_id, episode_id, entity_type, instance, action, quantity,
                           unit, content, embedding, confidence, event_time, created_at,
                           stability, retrievability, agent_id, user_id, superseded_by, invalid_at
-                   FROM observation_memories WHERE id = ?1",
-                params![id.to_string()],
+                   FROM observation_memories WHERE id = ?1 AND namespace_id = ?2",
+                params![id.to_string(), namespace_id.to_string()],
                 row_to_observation,
             )
             .optional()?;
@@ -1992,14 +1997,16 @@ impl StorageTrait for SqliteBackend {
         Ok(memories)
     }
 
-    fn supersede_memory(
+    fn supersede_memory_in_namespace(
         &self,
         id: Uuid,
+        namespace_id: Uuid,
         superseded_by: Uuid,
         invalid_at: DateTime<Utc>,
     ) -> StorageResult<bool> {
         let conn = lock_conn!(self);
         let id = id.to_string();
+        let namespace_id = namespace_id.to_string();
         let superseded_by = superseded_by.to_string();
         let invalid_at = invalid_at.to_rfc3339();
 
@@ -2012,9 +2019,9 @@ impl StorageTrait for SqliteBackend {
             let updated = conn.execute(
                 &format!(
                     "UPDATE {table} SET superseded_by = ?1, invalid_at = ?2 \
-                     WHERE id = ?3 AND superseded_by IS NULL"
+                     WHERE id = ?3 AND namespace_id = ?4 AND superseded_by IS NULL"
                 ),
-                params![&superseded_by, &invalid_at, &id],
+                params![&superseded_by, &invalid_at, &id, &namespace_id],
             )?;
             if updated > 0 {
                 return Ok(true);
@@ -2410,18 +2417,13 @@ impl StorageTrait for SqliteBackend {
         }
     }
 
-    fn delete_memory_by_id(&self, id: Uuid) -> StorageResult<bool> {
-        let conn = lock_conn!(self);
-        delete_memory_by_id_with_namespace(&conn, id, None)
-    }
-
     fn delete_memory_by_id_in_namespace(
         &self,
         id: Uuid,
         namespace_id: Uuid,
     ) -> StorageResult<bool> {
         let conn = lock_conn!(self);
-        delete_memory_by_id_with_namespace(&conn, id, Some(namespace_id))
+        delete_memory_by_id_with_namespace(&conn, id, namespace_id)
     }
 
     fn purge_namespace(&self, namespace_id: Uuid) -> StorageResult<usize> {
@@ -3348,7 +3350,10 @@ mod tests {
         );
         db.save_episodic(&mem).unwrap();
 
-        let fetched = db.get_episodic(mem.id).unwrap().unwrap();
+        let fetched = db
+            .get_episodic_in_namespace(mem.id, ns.id)
+            .unwrap()
+            .unwrap();
         assert_eq!(fetched.id, mem.id);
         assert_eq!(fetched.content, "the user prefers light theme");
         assert!((fetched.stability - 1.0).abs() < f32::EPSILON);
@@ -3421,7 +3426,10 @@ mod tests {
 
         db.update_episodic_access(mem.id, 0.8, 0.7).unwrap();
 
-        let fetched = db.get_episodic(mem.id).unwrap().unwrap();
+        let fetched = db
+            .get_episodic_in_namespace(mem.id, ns.id)
+            .unwrap()
+            .unwrap();
         assert!((fetched.stability - 0.8).abs() < 0.001);
         assert!((fetched.retrievability - 0.7).abs() < 0.001);
         assert_eq!(fetched.access_count, 1);
@@ -3456,11 +3464,14 @@ mod tests {
         mem.event_time = Some(when);
 
         db.save_episodic(&mem).unwrap();
-        let fetched = db.get_episodic(mem.id).unwrap().unwrap();
+        let fetched = db
+            .get_episodic_in_namespace(mem.id, ns.id)
+            .unwrap()
+            .unwrap();
         assert_eq!(
             fetched.event_time,
             Some(when),
-            "event_time must round-trip through save_episodic/get_episodic"
+            "event_time must round-trip through save_episodic/get_episodic_in_namespace"
         );
     }
 
@@ -3484,7 +3495,10 @@ mod tests {
         );
 
         db.save_episodic(&mem).unwrap();
-        let fetched = db.get_episodic(mem.id).unwrap().unwrap();
+        let fetched = db
+            .get_episodic_in_namespace(mem.id, ns.id)
+            .unwrap()
+            .unwrap();
         assert!(
             fetched.event_time.is_none(),
             "event_time must stay None through save/get when not set at construction"
@@ -3494,7 +3508,7 @@ mod tests {
     #[test]
     fn test_list_episodic_by_entity_preserves_event_time() {
         // list_episodic_by_entity has its own SELECT statement separate
-        // from get_episodic — must also read event_time.
+        // from get_episodic_in_namespace — must also read event_time.
         let (_dir, db) = setup();
         let ns = make_namespace(&db);
         let about = Uuid::new_v4();
@@ -3534,7 +3548,10 @@ mod tests {
         let mem = SemanticMemory::new(ns.id, subject, "speaks", "Rust", 0.95);
         db.save_semantic(&mem).unwrap();
 
-        let fetched = db.get_semantic(mem.id).unwrap().unwrap();
+        let fetched = db
+            .get_semantic_in_namespace(mem.id, ns.id)
+            .unwrap()
+            .unwrap();
         assert_eq!(fetched.id, mem.id);
         assert_eq!(fetched.predicate, "speaks");
         assert_eq!(fetched.object, "Rust");
@@ -3570,7 +3587,7 @@ mod tests {
         db.save_semantic(&mem).unwrap();
 
         assert!(
-            db.get_semantic(mem.id)
+            db.get_semantic_in_namespace(mem.id, ns.id)
                 .unwrap()
                 .unwrap()
                 .invalid_at
@@ -3578,7 +3595,7 @@ mod tests {
         );
         db.invalidate_semantic(mem.id).unwrap();
         assert!(
-            db.get_semantic(mem.id)
+            db.get_semantic_in_namespace(mem.id, ns.id)
                 .unwrap()
                 .unwrap()
                 .invalid_at
@@ -3604,7 +3621,10 @@ mod tests {
         );
         db.save_procedural(&mem).unwrap();
 
-        let fetched = db.get_procedural(mem.id).unwrap().unwrap();
+        let fetched = db
+            .get_procedural_in_namespace(mem.id, ns.id)
+            .unwrap()
+            .unwrap();
         assert_eq!(fetched.id, mem.id);
         assert_eq!(fetched.trigger, "on_timeout");
         assert_eq!(fetched.action, "retry_with_backoff");
@@ -3630,7 +3650,10 @@ mod tests {
         db.update_procedural_reliability(mem.id, 0.75, 4, 3)
             .unwrap();
 
-        let fetched = db.get_procedural(mem.id).unwrap().unwrap();
+        let fetched = db
+            .get_procedural_in_namespace(mem.id, ns.id)
+            .unwrap()
+            .unwrap();
         assert!((fetched.reliability - 0.75).abs() < 0.001);
         assert_eq!(fetched.trial_count, 4);
         assert_eq!(fetched.success_count, 3);
@@ -3793,8 +3816,16 @@ mod tests {
         assert!(deleted > 0);
 
         // Verify gone from storage.
-        assert!(db.get_episodic(mem1.id).unwrap().is_none());
-        assert!(db.get_semantic(mem2.id).unwrap().is_none());
+        assert!(
+            db.get_episodic_in_namespace(mem1.id, ns.id)
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            db.get_semantic_in_namespace(mem2.id, ns.id)
+                .unwrap()
+                .is_none()
+        );
 
         // Verify gone from FTS.
         let fts_ep = db.search_fts("delete me episodic", ns.id, 10).unwrap();
@@ -3850,7 +3881,9 @@ mod tests {
         db.delete_memories_by_entity(object_id, ns.id).unwrap();
 
         assert!(
-            db.get_semantic(fact.id).unwrap().is_none(),
+            db.get_semantic_in_namespace(fact.id, ns.id)
+                .unwrap()
+                .is_none(),
             "the object-side row itself is deleted"
         );
         assert_eq!(
@@ -3957,11 +3990,15 @@ mod tests {
         db.delete_memories_by_entity(entity_id, ns.id).unwrap();
 
         assert!(
-            db.get_episodic(shared_id).unwrap().is_none(),
+            db.get_episodic_in_namespace(shared_id, ns.id)
+                .unwrap()
+                .is_none(),
             "the forgotten episodic row is deleted"
         );
         assert!(
-            db.get_semantic(shared_id).unwrap().is_some(),
+            db.get_semantic_in_namespace(shared_id, ns.id)
+                .unwrap()
+                .is_some(),
             "the unrelated semantic row is not attached to the entity"
         );
         let hits = db
@@ -4027,14 +4064,26 @@ mod tests {
             deleted, 2,
             "only the owning namespace's two rows are deleted"
         );
-        assert!(db.get_episodic(mine.id).unwrap().is_none());
-        assert!(db.get_semantic(my_fact.id).unwrap().is_none());
         assert!(
-            db.get_episodic(theirs.id).unwrap().is_some(),
+            db.get_episodic_in_namespace(mine.id, owner_ns.id)
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            db.get_semantic_in_namespace(my_fact.id, owner_ns.id)
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            db.get_episodic_in_namespace(theirs.id, foreign_ns.id)
+                .unwrap()
+                .is_some(),
             "the other namespace's episodic row must survive"
         );
         assert!(
-            db.get_semantic(their_fact.id).unwrap().is_some(),
+            db.get_semantic_in_namespace(their_fact.id, foreign_ns.id)
+                .unwrap()
+                .is_some(),
             "the other namespace's object-side fact must survive"
         );
         assert_eq!(
@@ -4098,7 +4147,7 @@ mod tests {
         // superseded — the delete ignores `superseded_by`, so this must too.
         let superseded = SemanticMemory::new(ns.id, entity_id, "lived_in", "berlin", 0.5);
         db.save_semantic(&superseded).unwrap();
-        db.supersede_memory(superseded.id, Uuid::new_v4(), Utc::now())
+        db.supersede_memory_in_namespace(superseded.id, ns.id, Uuid::new_v4(), Utc::now())
             .unwrap();
 
         // Decoys: a row for a different entity, and a same-entity row in a
@@ -4149,8 +4198,16 @@ mod tests {
         );
 
         // Decoys survive.
-        assert!(db.get_episodic(other_entity.id).unwrap().is_some());
-        assert!(db.get_episodic(foreign.id).unwrap().is_some());
+        assert!(
+            db.get_episodic_in_namespace(other_entity.id, ns.id)
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            db.get_episodic_in_namespace(foreign.id, foreign_ns.id)
+                .unwrap()
+                .is_some()
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -4228,7 +4285,10 @@ mod tests {
         mem.content_type = ContentType::Code;
         db.save_episodic(&mem).unwrap();
 
-        let fetched = db.get_episodic(mem.id).unwrap().unwrap();
+        let fetched = db
+            .get_episodic_in_namespace(mem.id, ns.id)
+            .unwrap()
+            .unwrap();
         assert_eq!(fetched.content_type, ContentType::Code);
     }
 
@@ -4241,7 +4301,10 @@ mod tests {
         mem.content_type = ContentType::Image;
         db.save_semantic(&mem).unwrap();
 
-        let fetched = db.get_semantic(mem.id).unwrap().unwrap();
+        let fetched = db
+            .get_semantic_in_namespace(mem.id, ns.id)
+            .unwrap()
+            .unwrap();
         assert_eq!(fetched.content_type, ContentType::Image);
     }
 
@@ -4259,7 +4322,10 @@ mod tests {
         );
         db.save_episodic(&mem).unwrap();
 
-        let fetched = db.get_episodic(mem.id).unwrap().unwrap();
+        let fetched = db
+            .get_episodic_in_namespace(mem.id, ns.id)
+            .unwrap()
+            .unwrap();
         assert_eq!(fetched.content_type, ContentType::Text);
     }
 
@@ -4301,7 +4367,10 @@ mod tests {
         obs.embedding = vec![0.1, 0.2, 0.3];
         db.save_observation(&obs).unwrap();
 
-        let fetched = db.get_observation(obs.id).unwrap().unwrap();
+        let fetched = db
+            .get_observation_in_namespace(obs.id, ns.id)
+            .unwrap()
+            .unwrap();
         assert_eq!(fetched.id, obs.id);
         assert_eq!(fetched.episode_id, episode_id);
         assert_eq!(fetched.entity_type, "game_played");
@@ -4316,7 +4385,9 @@ mod tests {
     #[test]
     fn test_observation_missing_returns_none() {
         let (_dir, db) = setup();
-        let result = db.get_observation(Uuid::new_v4()).unwrap();
+        let result = db
+            .get_observation_in_namespace(Uuid::new_v4(), Uuid::new_v4())
+            .unwrap();
         assert!(result.is_none());
     }
 
@@ -4505,7 +4576,7 @@ mod tests {
     }
 
     #[test]
-    fn test_delete_memory_by_id_handles_observation() {
+    fn test_delete_memory_by_id_in_namespace_handles_observation() {
         let (_dir, db) = setup();
         let ns = make_namespace(&db);
         let ep = Uuid::new_v4();
@@ -4514,9 +4585,13 @@ mod tests {
         db.save_observation(&obs).unwrap();
         let obs_id = obs.id;
 
-        let deleted = db.delete_memory_by_id(obs_id).unwrap();
+        let deleted = db.delete_memory_by_id_in_namespace(obs_id, ns.id).unwrap();
         assert!(deleted);
-        assert!(db.get_observation(obs_id).unwrap().is_none());
+        assert!(
+            db.get_observation_in_namespace(obs_id, ns.id)
+                .unwrap()
+                .is_none()
+        );
     }
 
     #[test]
@@ -4534,7 +4609,11 @@ mod tests {
             .unwrap();
 
         assert!(!deleted);
-        assert!(db.get_observation(obs.id).unwrap().is_some());
+        assert!(
+            db.get_observation_in_namespace(obs.id, owner_ns.id)
+                .unwrap()
+                .is_some()
+        );
     }
 
     #[test]
@@ -4547,7 +4626,140 @@ mod tests {
         let deleted = db.delete_memory_by_id_in_namespace(obs.id, ns.id).unwrap();
 
         assert!(deleted);
-        assert!(db.get_observation(obs.id).unwrap().is_none());
+        assert!(
+            db.get_observation_in_namespace(obs.id, ns.id)
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    /// Every by-id read carries its namespace in the SQL, so one tenant's id
+    /// resolves to nothing for another (#254).
+    ///
+    /// Hosted `SQLite` puts every tenant in one file, so there is no second
+    /// layer here the way Postgres has row-level security: the predicate is
+    /// the whole of the isolation (#247). All four memory shapes are covered
+    /// because the REST `load_memory` helper and recall's candidate hydration
+    /// walk the same chain, and a single unscoped arm reopens the leak for
+    /// whichever shape it reads.
+    #[test]
+    fn test_memory_reads_are_confined_to_their_namespace() {
+        let (_dir, db) = setup();
+        let owner_ns = make_namespace(&db);
+        let foreign_ns = Namespace::new("other");
+        db.save_namespace(&foreign_ns).unwrap();
+
+        let episodic = EpisodicMemory::new(
+            owner_ns.id,
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            "tenant A turn",
+        );
+        db.save_episodic(&episodic).unwrap();
+        let semantic = SemanticMemory::new(owner_ns.id, Uuid::new_v4(), "likes", "rust", 0.9);
+        db.save_semantic(&semantic).unwrap();
+        let procedural = ProceduralMemory::new(
+            owner_ns.id,
+            "on_timeout",
+            "retry",
+            Outcome::Success,
+            HashMap::new(),
+        );
+        db.save_procedural(&procedural).unwrap();
+        let observation =
+            ObservationMemory::new(owner_ns.id, Uuid::new_v4(), "x", "y", "z", "content");
+        db.save_observation(&observation).unwrap();
+
+        assert!(
+            db.get_episodic_in_namespace(episodic.id, foreign_ns.id)
+                .unwrap()
+                .is_none(),
+            "an episodic row must not resolve through a foreign namespace"
+        );
+        assert!(
+            db.get_semantic_in_namespace(semantic.id, foreign_ns.id)
+                .unwrap()
+                .is_none(),
+            "a semantic row must not resolve through a foreign namespace"
+        );
+        assert!(
+            db.get_procedural_in_namespace(procedural.id, foreign_ns.id)
+                .unwrap()
+                .is_none(),
+            "a procedural row must not resolve through a foreign namespace"
+        );
+        assert!(
+            db.get_observation_in_namespace(observation.id, foreign_ns.id)
+                .unwrap()
+                .is_none(),
+            "an observation row must not resolve through a foreign namespace"
+        );
+
+        // The owning namespace still sees all four, so the predicate filters
+        // by namespace rather than matching nothing.
+        assert!(
+            db.get_episodic_in_namespace(episodic.id, owner_ns.id)
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            db.get_semantic_in_namespace(semantic.id, owner_ns.id)
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            db.get_procedural_in_namespace(procedural.id, owner_ns.id)
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            db.get_observation_in_namespace(observation.id, owner_ns.id)
+                .unwrap()
+                .is_some()
+        );
+    }
+
+    /// Supersession is a write, so an unscoped one is worse than a stray read:
+    /// it stamps another tenant's live row as invalid and hands the caller a
+    /// `true` that a REST client reads as its own edit landing (#254).
+    #[test]
+    fn test_supersede_memory_in_namespace_is_confined_to_its_namespace() {
+        let (_dir, db) = setup();
+        let owner_ns = make_namespace(&db);
+        let foreign_ns = Namespace::new("other");
+        db.save_namespace(&foreign_ns).unwrap();
+
+        let mem = SemanticMemory::new(owner_ns.id, Uuid::new_v4(), "drinks", "tea", 0.9);
+        db.save_semantic(&mem).unwrap();
+
+        assert!(
+            !db.supersede_memory_in_namespace(mem.id, foreign_ns.id, Uuid::new_v4(), Utc::now())
+                .unwrap(),
+            "a foreign namespace must not stamp another namespace's row"
+        );
+        assert!(
+            db.get_semantic_in_namespace(mem.id, owner_ns.id)
+                .unwrap()
+                .unwrap()
+                .superseded_by
+                .is_none(),
+            "the row must still be live after the cross-namespace attempt"
+        );
+
+        let successor = Uuid::new_v4();
+        assert!(
+            db.supersede_memory_in_namespace(mem.id, owner_ns.id, successor, Utc::now())
+                .unwrap(),
+            "the owning namespace must still be able to supersede"
+        );
+        assert_eq!(
+            db.get_semantic_in_namespace(mem.id, owner_ns.id)
+                .unwrap()
+                .unwrap()
+                .superseded_by,
+            Some(successor)
+        );
     }
 
     #[test]
@@ -4618,8 +4830,16 @@ mod tests {
         let result = db.delete_memory_by_id_in_namespace(shared_id, ns.id);
 
         assert!(result.is_err());
-        assert!(db.get_episodic(shared_id).unwrap().is_some());
-        assert!(db.get_semantic(shared_id).unwrap().is_some());
+        assert!(
+            db.get_episodic_in_namespace(shared_id, ns.id)
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            db.get_semantic_in_namespace(shared_id, ns.id)
+                .unwrap()
+                .is_some()
+        );
     }
 
     #[test]
@@ -4771,7 +4991,7 @@ mod tests {
     // contract. The cascade paths we exercise are:
     //   - delete_observations_by_episode
     //   - delete_observations_by_entity
-    //   - delete_memory_by_id (observation case)
+    //   - delete_memory_by_id_in_namespace (observation case)
     //   - purge_namespace
     // -----------------------------------------------------------------------
 
@@ -4938,7 +5158,7 @@ mod tests {
     }
 
     #[test]
-    fn delete_memory_by_id_cascades_kg_rows_for_observation() {
+    fn delete_memory_by_id_in_namespace_cascades_kg_rows_for_observation() {
         let (_dir, db) = setup();
         let ns = make_namespace(&db);
         let ep = Uuid::new_v4();
@@ -4950,18 +5170,18 @@ mod tests {
         let o = seed_kg_entity(&db, ns.id, "O");
         seed_kg_triple(&db, ns.id, obs.id, s, o);
 
-        let deleted = db.delete_memory_by_id(obs.id).unwrap();
+        let deleted = db.delete_memory_by_id_in_namespace(obs.id, ns.id).unwrap();
         assert!(deleted);
 
         assert_eq!(
             kg_triples_count_for_passage(&db, obs.id),
             0,
-            "kg_triples must cascade with delete_memory_by_id(observation)"
+            "kg_triples must cascade with delete_memory_by_id_in_namespace(observation)"
         );
         assert_eq!(
             kg_passage_entities_count_for_passage(&db, obs.id),
             0,
-            "kg_passage_entities must cascade with delete_memory_by_id(observation)"
+            "kg_passage_entities must cascade with delete_memory_by_id_in_namespace(observation)"
         );
         // Namespace-scoped entities survive.
         assert_eq!(kg_entities_count_for_namespace(&db, ns.id), 2);
@@ -5019,7 +5239,10 @@ mod tests {
         episodic.superseded_by = Some(successor);
         episodic.invalid_at = Some(invalid_at);
         db.save_episodic(&episodic).unwrap();
-        let episodic_read = db.get_episodic(episodic.id).unwrap().unwrap();
+        let episodic_read = db
+            .get_episodic_in_namespace(episodic.id, ns.id)
+            .unwrap()
+            .unwrap();
         assert_eq!(episodic_read.superseded_by, Some(successor));
         assert_eq!(episodic_read.invalid_at, Some(invalid_at));
 
@@ -5027,7 +5250,10 @@ mod tests {
         semantic.superseded_by = Some(successor);
         semantic.invalid_at = Some(invalid_at);
         db.save_semantic(&semantic).unwrap();
-        let semantic_read = db.get_semantic(semantic.id).unwrap().unwrap();
+        let semantic_read = db
+            .get_semantic_in_namespace(semantic.id, ns.id)
+            .unwrap()
+            .unwrap();
         assert_eq!(semantic_read.superseded_by, Some(successor));
         assert_eq!(semantic_read.invalid_at, Some(invalid_at));
 
@@ -5036,7 +5262,10 @@ mod tests {
         procedural.superseded_by = Some(successor);
         procedural.invalid_at = Some(invalid_at);
         db.save_procedural(&procedural).unwrap();
-        let procedural_read = db.get_procedural(procedural.id).unwrap().unwrap();
+        let procedural_read = db
+            .get_procedural_in_namespace(procedural.id, ns.id)
+            .unwrap()
+            .unwrap();
         assert_eq!(procedural_read.superseded_by, Some(successor));
         assert_eq!(procedural_read.invalid_at, Some(invalid_at));
 
@@ -5051,7 +5280,10 @@ mod tests {
         observation.superseded_by = Some(successor);
         observation.invalid_at = Some(invalid_at);
         db.save_observation(&observation).unwrap();
-        let observation_read = db.get_observation(observation.id).unwrap().unwrap();
+        let observation_read = db
+            .get_observation_in_namespace(observation.id, ns.id)
+            .unwrap()
+            .unwrap();
         assert_eq!(observation_read.superseded_by, Some(successor));
         assert_eq!(observation_read.invalid_at, Some(invalid_at));
     }
@@ -5125,7 +5357,10 @@ mod tests {
             (old_procedural.id, new_procedural.id),
             (old_observation.id, new_observation.id),
         ] {
-            assert!(db.supersede_memory(old_id, new_id, Utc::now()).unwrap());
+            assert!(
+                db.supersede_memory_in_namespace(old_id, ns.id, new_id, Utc::now())
+                    .unwrap()
+            );
         }
 
         assert_eq!(db.count_memories_by_namespace(ns.id).unwrap(), (1, 1, 1));
@@ -5170,7 +5405,10 @@ mod tests {
         let new = SemanticMemory::new(ns.id, subject, "currenttoken", "value", 0.9);
         db.save_semantic(&old).unwrap();
         db.save_semantic(&new).unwrap();
-        assert!(db.supersede_memory(old.id, new.id, Utc::now()).unwrap());
+        assert!(
+            db.supersede_memory_in_namespace(old.id, ns.id, new.id, Utc::now())
+                .unwrap()
+        );
 
         let live = db.get_all_memories_by_namespace(ns.id).unwrap();
         assert_eq!(live.len(), 1);

--- a/pensyve-core/tests/forget_snapshot_scope.rs
+++ b/pensyve-core/tests/forget_snapshot_scope.rs
@@ -102,7 +102,12 @@ fn seed() -> Fixture {
     labels.insert(superseded_episodic.id, "episodic superseded");
     storage.save_episodic(&superseded_episodic).unwrap();
     storage
-        .supersede_memory(superseded_episodic.id, Uuid::new_v4(), chrono::Utc::now())
+        .supersede_memory_in_namespace(
+            superseded_episodic.id,
+            namespace.id,
+            Uuid::new_v4(),
+            chrono::Utc::now(),
+        )
         .unwrap();
 
     // --- in delete scope: semantic_memories WHERE subject OR object_entity
@@ -124,7 +129,12 @@ fn seed() -> Fixture {
     labels.insert(superseded_semantic.id, "semantic superseded");
     storage.save_semantic(&superseded_semantic).unwrap();
     storage
-        .supersede_memory(superseded_semantic.id, Uuid::new_v4(), chrono::Utc::now())
+        .supersede_memory_in_namespace(
+            superseded_semantic.id,
+            namespace.id,
+            Uuid::new_v4(),
+            chrono::Utc::now(),
+        )
         .unwrap();
 
     // --- controls: outside delete scope, must survive and must NOT be snapshotted

--- a/pensyve-core/tests/test_consolidation_supersession_guard.rs
+++ b/pensyve-core/tests/test_consolidation_supersession_guard.rs
@@ -179,7 +179,7 @@ fn superseded_promotion_is_not_reminted_from_unchanged_evidence() {
     storage.save_semantic(&correction).unwrap();
     assert!(
         storage
-            .supersede_memory(promoted_id, correction.id, corrected_at)
+            .supersede_memory_in_namespace(promoted_id, ns.id, correction.id, corrected_at)
             .unwrap(),
         "supersession must mark the promoted row"
     );
@@ -243,7 +243,7 @@ fn new_evidence_still_promotes_after_supersession() {
     storage.save_semantic(&correction).unwrap();
     assert!(
         storage
-            .supersede_memory(promoted_id, correction.id, corrected_at)
+            .supersede_memory_in_namespace(promoted_id, ns.id, correction.id, corrected_at)
             .unwrap()
     );
 
@@ -317,7 +317,7 @@ fn new_evidence_reasserting_same_content_promotes_after_supersession() {
     storage.save_semantic(&correction).unwrap();
     assert!(
         storage
-            .supersede_memory(promoted_id, correction.id, corrected_at)
+            .supersede_memory_in_namespace(promoted_id, ns.id, correction.id, corrected_at)
             .unwrap()
     );
     assert_eq!(
@@ -418,7 +418,7 @@ fn superseded_episodic_evidence_cannot_support_a_cluster() {
     );
     assert!(
         storage
-            .supersede_memory(first, replacement, Utc::now())
+            .supersede_memory_in_namespace(first, ns.id, replacement, Utc::now())
             .unwrap()
     );
 

--- a/pensyve-mcp-gateway/src/rest.rs
+++ b/pensyve-mcp-gateway/src/rest.rs
@@ -385,27 +385,38 @@ fn memory_superseded_by(memory: &Memory) -> Option<Uuid> {
     }
 }
 
-fn load_memory(storage: &dyn StorageTrait, id: Uuid) -> Result<Option<Memory>, RestError> {
+/// Resolve a memory by id within `namespace_id`, trying each memory table in
+/// turn.
+///
+/// Every lookup carries the namespace, so a memory owned by another tenant is
+/// simply not found. That is a property of the query rather than of a check the
+/// caller remembers to make, and it is what keeps this path working once
+/// Postgres row-level security is enforced (#254).
+fn load_memory(
+    storage: &dyn StorageTrait,
+    id: Uuid,
+    namespace_id: Uuid,
+) -> Result<Option<Memory>, RestError> {
     if let Some(memory) = storage
-        .get_episodic(id)
+        .get_episodic_in_namespace(id, namespace_id)
         .map_err(|err| storage_fetch_error(&err))?
     {
         return Ok(Some(Memory::Episodic(memory)));
     }
     if let Some(memory) = storage
-        .get_semantic(id)
+        .get_semantic_in_namespace(id, namespace_id)
         .map_err(|err| storage_fetch_error(&err))?
     {
         return Ok(Some(Memory::Semantic(memory)));
     }
     if let Some(memory) = storage
-        .get_procedural(id)
+        .get_procedural_in_namespace(id, namespace_id)
         .map_err(|err| storage_fetch_error(&err))?
     {
         return Ok(Some(Memory::Procedural(memory)));
     }
     if let Some(memory) = storage
-        .get_observation(id)
+        .get_observation_in_namespace(id, namespace_id)
         .map_err(|err| storage_fetch_error(&err))?
     {
         return Ok(Some(Memory::Observation(memory)));
@@ -608,25 +619,15 @@ async fn perform_supersession(
     requested_content: Option<String>,
     confidence: Option<f64>,
 ) -> Result<SupersedeMemoryResponse, RestError> {
-    let old = load_memory(ps.storage.as_ref(), memory_id)?.ok_or_else(|| {
+    // The lookup is namespace-scoped, so another tenant's memory is already a
+    // 404 here rather than something to compare after the fact.
+    let old = load_memory(ps.storage.as_ref(), memory_id, ps.namespace.id)?.ok_or_else(|| {
         RestError(
             StatusCode::NOT_FOUND,
             format!("Memory {memory_id} not found"),
         )
     })?;
 
-    let old_namespace = match &old {
-        Memory::Episodic(memory) => memory.namespace_id,
-        Memory::Semantic(memory) => memory.namespace_id,
-        Memory::Procedural(memory) => memory.namespace_id,
-        Memory::Observation(memory) => memory.namespace_id,
-    };
-    if old_namespace != ps.namespace.id {
-        return Err(RestError(
-            StatusCode::NOT_FOUND,
-            format!("Memory {memory_id} not found"),
-        ));
-    }
     if memory_superseded_by(&old).is_some() {
         return Err(RestError(
             StatusCode::CONFLICT,
@@ -659,7 +660,7 @@ async fn perform_supersession(
     save_memory(ps.storage.as_ref(), &new)?;
     let stamped = ps
         .storage
-        .supersede_memory(memory_id, new_id, Utc::now())
+        .supersede_memory_in_namespace(memory_id, ps.namespace.id, new_id, Utc::now())
         .map_err(|err| {
             RestError(
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -667,7 +668,10 @@ async fn perform_supersession(
             )
         })?;
     if !stamped {
-        if let Err(err) = ps.storage.delete_memory_by_id(new_id) {
+        if let Err(err) = ps
+            .storage
+            .delete_memory_by_id_in_namespace(new_id, ps.namespace.id)
+        {
             tracing::warn!(
                 "Supersession race rollback failed for old memory {memory_id} and replacement {new_id}: {err}"
             );

--- a/pensyve-mcp-gateway/tests/integration_test.rs
+++ b/pensyve-mcp-gateway/tests/integration_test.rs
@@ -314,7 +314,7 @@ async fn test_mcp_forget_memory_rejects_foreign_namespace() {
     assert!(
         state
             .storage
-            .get_observation(foreign_memory.id)
+            .get_observation_in_namespace(foreign_memory.id, foreign_namespace.id)
             .expect("load foreign memory")
             .is_some()
     );

--- a/pensyve-mcp-gateway/tests/test_rest_forget_index_cleanup.rs
+++ b/pensyve-mcp-gateway/tests/test_rest_forget_index_cleanup.rs
@@ -195,7 +195,12 @@ async fn seed(state: &AppState) -> Seeded {
         .save_semantic(&superseded)
         .expect("save superseded semantic");
     ps.storage
-        .supersede_memory(superseded.id, Uuid::new_v4(), chrono::Utc::now())
+        .supersede_memory_in_namespace(
+            superseded.id,
+            namespace_id,
+            Uuid::new_v4(),
+            chrono::Utc::now(),
+        )
         .expect("supersede");
 
     // Control: nothing to do with the target.

--- a/pensyve-mcp-gateway/tests/test_rest_forget_inspect.rs
+++ b/pensyve-mcp-gateway/tests/test_rest_forget_inspect.rs
@@ -445,7 +445,7 @@ async fn foreign_namespace_entity_uuid_returns_not_found_without_deleting_memori
     assert!(
         foreign_state
             .storage
-            .get_semantic(foreign_memory.id)
+            .get_semantic_in_namespace(foreign_memory.id, foreign_state.namespace.id)
             .expect("foreign memory lookup after forget")
             .is_some()
     );
@@ -455,7 +455,7 @@ async fn foreign_namespace_entity_uuid_returns_not_found_without_deleting_memori
     assert!(
         foreign_state
             .storage
-            .get_semantic(foreign_memory.id)
+            .get_semantic_in_namespace(foreign_memory.id, foreign_state.namespace.id)
             .expect("foreign memory lookup after inspect")
             .is_some()
     );
@@ -518,7 +518,7 @@ async fn supersede_creates_live_replacement_and_excludes_old_from_retrieval_inde
 
     let old = pensyve_state
         .storage
-        .get_semantic(old_id)
+        .get_semantic_in_namespace(old_id, pensyve_state.namespace.id)
         .expect("old lookup")
         .expect("old row preserved");
     assert_eq!(old.predicate, "legacytoken");
@@ -528,7 +528,7 @@ async fn supersede_creates_live_replacement_and_excludes_old_from_retrieval_inde
 
     let new = pensyve_state
         .storage
-        .get_semantic(new_id)
+        .get_semantic_in_namespace(new_id, pensyve_state.namespace.id)
         .expect("new lookup")
         .expect("new row exists before old pointer is visible");
     assert_eq!(new.predicate, "currenttoken");
@@ -605,14 +605,14 @@ async fn patch_delegates_to_supersession_and_preserves_old_content() {
         .expect("tenant state");
     let old = pensyve_state
         .storage
-        .get_semantic(old_id)
+        .get_semantic_in_namespace(old_id, pensyve_state.namespace.id)
         .expect("old lookup")
         .expect("old row preserved");
     assert_eq!(old.object, "tea");
     assert_eq!(old.superseded_by, Some(new_id));
     let new = pensyve_state
         .storage
-        .get_semantic(new_id)
+        .get_semantic_in_namespace(new_id, pensyve_state.namespace.id)
         .expect("new lookup")
         .expect("new row");
     assert_eq!(new.object, "coffee");


### PR DESCRIPTION
Refs #254 (advances the code half; deliberately does **not** close it — see below)

## Problem

Under `FORCE ROW LEVEL SECURITY`, `StorageTrait` methods that take no `namespace_id` run on an unscoped connection and **fail silently** — `get_episodic` returns `None`, `supersede_memory` returns `Ok(false)`, `delete_memory_by_id` reports a no-op as success. The executable checklist `enforced_rls_fails_closed_for_unscoped_methods` pinned those three; `get_semantic` / `get_procedural` / `get_observation` sit in the same `else if let` hydration chains (recall engine ×3, gateway `load_memory`) and are scoped together with them — scoping only the pinned arm would have left those chains half-scoped, with the caller-side namespace comparison looking redundant while still load-bearing.

## Change

Per the recorded API-break policy (AGENTS.md, #262 precedent; prior art `get_episode_in_namespace`, #218's scoped delete): the unscoped methods are **replaced**, not shadowed. `get_*_in_namespace` ×4, `supersede_memory_in_namespace`, and `delete_memory_by_id_in_namespace` (now required; the fail-closed default and `scoped_delete_not_implemented` are gone, and its SQLite `(?2 IS NULL OR …)` opt-out is removed — FTS cleanup is namespace-qualified too).

Both backends carry the namespace predicate **in the SQL**: explicit scoping is what enforces isolation in every deployment shipping today, and the RLS policy becomes defence in depth under enforcement. Postgres additionally runs them on a namespace-bound connection. Callers updated across recall hydration, the gateway supersede/update/delete handlers (whose post-hoc `old_namespace != ps.namespace.id` 404 check is now dead and removed), and the `purge_namespace` default. `pensyve-wasm` checked standalone (outside the workspace): no `StorageTrait` dependency, untouched.

## Tests

- The checklist test is replaced by per-method enforced-mode tests: `scoped_memory_reads_still_work_under_enforced_rls`, `supersede_still_works_under_enforced_rls` (style of `capturing_delete_still_works_under_enforced_rls`). All 17 live-RLS tests **ran** (zero skips) against a local Postgres and pass.
- New SQLite cross-namespace tests: `test_memory_reads_are_confined_to_their_namespace`, `test_supersede_memory_in_namespace_is_confined_to_its_namespace`.
- Sabotage-checked twice, independently: neutering only the `namespace_id` predicate (tautology, parameter count preserved) fails exactly the confinement tests; restoring brings them back green.
- Full verification: fmt; clippy `-D warnings` (workspace + `--features postgres`); `pensyve-core` 545 lib + 23 integration binaries, 0 failed; gateway + mcp-tools 0 failed; `uv run pytest tests/python/` 122 passed.

## Why #254 stays open — two findings from this work

1. **The checklist under-pinned the problem.** It seeded one episodic row, so it could only catch what that row touched. A mechanical audit of `maybe_scoped_conn()` call sites found nine more unscoped methods (`get_entity`, `delete_entity`, `list_episodic_by_entity`, `list_semantic_by_entity`, `update_episodic_access` — still on the recall path — `invalidate_semantic`, `update_semantic_content`, `update_procedural_reliability`, `delete_observations_by_entity`). Now enumerated in `docs/SECURITY.md` instead of the checklist's too-strong "when this list is empty, enforcement can become the default" claim.
2. **The production role precondition fails** (verified live, details on #254): prod connects as the BYPASSRLS table owner, so `FORCE` would be silently inert today. The operator runbook for a `NOBYPASSRLS` app role is on the issue awaiting sign-off.

`FORCE` therefore stays an operator step (`postgres_rls_enforce.sql`); this PR moves the pinned checklist to zero without changing the shipped default.