### PR TITLE
fix(storage): set-based PostgresBackend purge_namespace that removes superseded rows

### DIFF
--- a/pensyve-core/src/storage/postgres.rs
+++ b/pensyve-core/src/storage/postgres.rs
@@ -1791,6 +1791,62 @@ impl StorageTrait for PostgresBackend {
         })
     }
 
+    /// Set-based purge, mirroring `SQLite`'s override rather than the trait
+    /// default.
+    ///
+    /// The default lists the namespace's memories and deletes them one id at a
+    /// time. Two things are wrong with that here. It is O(n) round trips for
+    /// what four statements express. And it is incomplete: it iterates
+    /// [`Self::get_all_memories_by_namespace`], which filters `superseded_by IS
+    /// NULL`, so a superseded row is neither deleted nor counted — a purge that
+    /// leaves tenant data behind and returns a total saying it did not.
+    ///
+    /// The count is every row removed from the four memory tables, superseded
+    /// rows included, which is exactly what `SQLite`'s `rows_affected` sum
+    /// reports. `purge_namespace_counts_superseded_rows_like_sqlite` pins that
+    /// equality.
+    ///
+    /// # What does not appear here, and why
+    ///
+    /// `SQLite`'s override also cascades the knowledge graph (`kg_triples`,
+    /// `kg_entities`, `kg_passage_entities`) and clears `memory_fts`. Neither
+    /// has an analogue in `postgres_schema.sql`: the KG tables are not part of
+    /// the Postgres schema at all, and full-text search is a generated
+    /// `tsvector` column on each memory table, so deleting the row takes its
+    /// index entry with it. `edges` is untouched on both backends — it carries
+    /// no `namespace_id`, so a namespace-scoped delete is not expressible
+    /// against it.
+    ///
+    /// Every statement names `namespace_id = $1` explicitly even though all
+    /// four run on a namespace-bound connection. That is the #254 convention:
+    /// the predicate is what confines the purge in a deployment as shipped
+    /// (the backend connects as the schema owner, so the policies are inert),
+    /// and RLS backs it up once an operator enforces it.
+    fn purge_namespace(&self, namespace_id: Uuid) -> StorageResult<usize> {
+        self.block_on(async {
+            let mut conn = self.scoped_conn(namespace_id).await?;
+            let mut transaction = (&mut *conn).begin().await.map_err(sqlx_to_io)?;
+            let mut total = 0usize;
+
+            for sql in [
+                "DELETE FROM episodic_memories WHERE namespace_id = $1",
+                "DELETE FROM semantic_memories WHERE namespace_id = $1",
+                "DELETE FROM procedural_memories WHERE namespace_id = $1",
+                "DELETE FROM observation_memories WHERE namespace_id = $1",
+            ] {
+                let result = query::<Postgres>(sql)
+                    .bind(namespace_id)
+                    .execute(&mut *transaction)
+                    .await
+                    .map_err(sqlx_to_io)?;
+                total += result.rows_affected() as usize;
+            }
+
+            transaction.commit().await.map_err(sqlx_to_io)?;
+            Ok(total)
+        })
+    }
+
     fn update_semantic_content(
         &self,
         id: Uuid,

--- a/pensyve-core/src/storage/postgres/live_rls.rs
+++ b/pensyve-core/src/storage/postgres/live_rls.rs
@@ -70,6 +70,8 @@
 //! current deployment (policies present, not enforced), and a test that wants
 //! layer 2 calls [`Fixture::enforce_rls`] on top.
 
+use std::collections::HashMap;
+
 use chrono::Utc;
 use sqlx_core::query::query;
 use sqlx_core::query_as::query_as;
@@ -81,7 +83,9 @@ use uuid::Uuid;
 
 use super::PostgresBackend;
 use crate::storage::StorageTrait;
-use crate::types::{EpisodicMemory, Memory, Namespace, SemanticMemory};
+use crate::types::{
+    EpisodicMemory, Memory, Namespace, ObservationMemory, Outcome, ProceduralMemory, SemanticMemory,
+};
 
 /// Environment variable naming the admin connection string.
 ///
@@ -1126,6 +1130,207 @@ fn entity_scoped_listing_matches_the_delete_scope() {
         ),
         vec![seeded.foreign],
         "namespace B's row must survive"
+    );
+}
+
+/// Seed one live row of every memory kind into `namespace_id`, returning their
+/// ids. Both namespaces must already be saved.
+///
+/// All four kinds are planted deliberately: the purge is four separate
+/// `DELETE`s, so a test seeding only episodic rows would pass against an
+/// implementation that forgot three of them.
+fn seed_one_of_each_kind(backend: &PostgresBackend, namespace_id: Uuid, label: &str) -> Vec<Uuid> {
+    let episodic = EpisodicMemory::new(
+        namespace_id,
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+        format!("{label} episodic"),
+    );
+    backend.save_episodic(&episodic).expect("save episodic");
+
+    let semantic = SemanticMemory::new(namespace_id, Uuid::new_v4(), "likes", label, 0.9);
+    backend.save_semantic(&semantic).expect("save semantic");
+
+    let procedural = ProceduralMemory::new(
+        namespace_id,
+        format!("{label} trigger"),
+        format!("{label} action"),
+        Outcome::Success,
+        HashMap::new(),
+    );
+    backend
+        .save_procedural(&procedural)
+        .expect("save procedural");
+
+    let observation = ObservationMemory::new(
+        namespace_id,
+        Uuid::new_v4(),
+        "kind",
+        label,
+        "did",
+        format!("{label} observation"),
+    );
+    backend
+        .save_observation(&observation)
+        .expect("save observation");
+
+    vec![episodic.id, semantic.id, procedural.id, observation.id]
+}
+
+/// Every id `namespace_id` still holds, superseded rows included, sorted.
+///
+/// Deliberately the *including-superseded* accessor: a purge is only complete
+/// if it leaves nothing at all behind, and the plain accessor filters
+/// `superseded_by IS NULL` — it cannot see the rows
+/// [`purge_namespace_counts_superseded_rows_like_sqlite`] is about.
+fn surviving_ids(backend: &PostgresBackend, namespace_id: Uuid) -> Vec<Uuid> {
+    let mut ids = memory_ids(
+        &backend
+            .get_all_memories_by_namespace_including_superseded(namespace_id)
+            .expect("read namespace including superseded"),
+    );
+    ids.sort();
+    ids
+}
+
+/// The namespace-wide purge behind the REST `purge_all_memories` handler must
+/// not reach across namespaces.
+///
+/// Same reasoning as [`entity_delete_is_confined_to_its_namespace`]: with RLS
+/// inert — the configuration every deployment runs today, because the backend
+/// connects as the schema owner — the explicit `namespace_id = $1` predicate in
+/// each `DELETE` is the only thing confining the purge.
+///
+/// All four memory kinds are seeded on both sides because the purge is four
+/// separate statements, and a single over-broad one would be invisible to a
+/// test that only planted episodic rows.
+#[test]
+fn purge_namespace_is_confined_to_its_namespace() {
+    let Some(admin_opts) = skip_notice("purge_namespace_is_confined_to_its_namespace") else {
+        return;
+    };
+    let fixture = Fixture::provision(&admin_opts);
+    let backend = &fixture.backend;
+
+    let ns_a = Namespace::new(format!("purge-a-{}", Uuid::new_v4().simple()));
+    let ns_b = Namespace::new(format!("purge-b-{}", Uuid::new_v4().simple()));
+    backend.save_namespace(&ns_a).expect("save namespace A");
+    backend.save_namespace(&ns_b).expect("save namespace B");
+
+    let mine = seed_one_of_each_kind(backend, ns_a.id, "tenant-a");
+    let mut theirs = seed_one_of_each_kind(backend, ns_b.id, "tenant-b");
+    theirs.sort();
+
+    assert_eq!(
+        backend
+            .purge_namespace(ns_a.id)
+            .expect("purge namespace A must not error"),
+        mine.len(),
+        "the purge must report one deletion per memory row in its own namespace"
+    );
+
+    assert!(
+        surviving_ids(backend, ns_a.id).is_empty(),
+        "namespace A must hold nothing after its own purge"
+    );
+    assert_eq!(
+        surviving_ids(backend, ns_b.id),
+        theirs,
+        "namespace B's rows must survive a purge issued for namespace A"
+    );
+}
+
+/// The namespace-wide purge keeps working with RLS enforced.
+///
+/// [`purge_namespace_is_confined_to_its_namespace`] is the same contract with
+/// RLS inert, which is the configuration that ships. Both halves matter: the
+/// purge must still take effect in its own namespace once the policies apply
+/// (a purge that silently deletes nothing while returning `Ok(0)` is the
+/// failure mode #254 catalogued), and it must still stop at the boundary.
+#[test]
+fn purge_namespace_still_works_under_enforced_rls() {
+    let Some(admin_opts) = skip_notice("purge_namespace_still_works_under_enforced_rls") else {
+        return;
+    };
+    let fixture = Fixture::provision(&admin_opts);
+    let backend = &fixture.backend;
+
+    let ns_a = Namespace::new(format!("purge-a-{}", Uuid::new_v4().simple()));
+    let ns_b = Namespace::new(format!("purge-b-{}", Uuid::new_v4().simple()));
+    backend.save_namespace(&ns_a).expect("save namespace A");
+    backend.save_namespace(&ns_b).expect("save namespace B");
+
+    let mine = seed_one_of_each_kind(backend, ns_a.id, "tenant-a");
+    let mut theirs = seed_one_of_each_kind(backend, ns_b.id, "tenant-b");
+    theirs.sort();
+
+    fixture.enforce_rls();
+
+    assert_eq!(
+        backend
+            .purge_namespace(ns_a.id)
+            .expect("purge namespace A must not error"),
+        mine.len(),
+        "the purge must take effect in its own namespace under enforced RLS"
+    );
+
+    assert!(
+        surviving_ids(backend, ns_a.id).is_empty(),
+        "namespace A must hold nothing after its own purge"
+    );
+    assert_eq!(
+        surviving_ids(backend, ns_b.id),
+        theirs,
+        "namespace B's rows must survive a purge issued for namespace A"
+    );
+}
+
+/// The purge must delete — and count — superseded rows, matching `SQLite`.
+///
+/// `SQLite`'s override (`sqlite.rs`) issues one `DELETE FROM <table> WHERE
+/// namespace_id = ?1` per memory table and sums `rows_affected`. Those
+/// statements carry no `superseded_by` filter, so the count is *every* row the
+/// namespace holds.
+///
+/// The trait default cannot match that. It purges by iterating
+/// `get_all_memories_by_namespace`, which filters `superseded_by IS NULL`, so
+/// a superseded row is neither counted nor deleted: the purge leaves tenant
+/// data behind and reports a total that says it did not. That makes this the
+/// test that distinguishes the backend override from the default — the other
+/// two pass either way.
+#[test]
+fn purge_namespace_counts_superseded_rows_like_sqlite() {
+    let Some(admin_opts) = skip_notice("purge_namespace_counts_superseded_rows_like_sqlite") else {
+        return;
+    };
+    let fixture = Fixture::provision(&admin_opts);
+    let backend = &fixture.backend;
+
+    let ns = Namespace::new(format!("purge-superseded-{}", Uuid::new_v4().simple()));
+    backend.save_namespace(&ns).expect("save namespace");
+
+    let live = seed_one_of_each_kind(backend, ns.id, "live");
+
+    let superseded = SemanticMemory::new(ns.id, Uuid::new_v4(), "lived_in", "berlin", 0.5);
+    backend.save_semantic(&superseded).expect("save superseded");
+    assert!(
+        backend
+            .supersede_memory_in_namespace(superseded.id, ns.id, Uuid::new_v4(), Utc::now())
+            .expect("supersede must not error"),
+        "the superseded fixture row must actually be marked superseded"
+    );
+
+    assert_eq!(
+        backend
+            .purge_namespace(ns.id)
+            .expect("purge must not error"),
+        live.len() + 1,
+        "the purge must count the superseded row, as SQLite's set-based override does"
+    );
+    assert!(
+        surviving_ids(backend, ns.id).is_empty(),
+        "the purge must delete the superseded row, not just the live ones"
     );
 }
 


### PR DESCRIPTION
Closes #255

## Problem — worse than filed

`PostgresBackend` fell through to the `purge_namespace` trait default: per-row deletes over `get_all_memories_by_namespace`. The issue filed this as robustness/efficiency, but measurement found a correctness bug on top: that listing filters `superseded_by IS NULL`, so **a superseded row is neither deleted nor counted** — a Postgres purge leaves tenant data behind on a GDPR-adjacent path while reporting success. (SQLite is unaffected; its set-based override has always deleted unconditionally.)

Pre-fix failing evidence, against the default:

```
test purge_namespace_counts_superseded_rows_like_sqlite ... FAILED
  left: 4 / right: 5   — the purge must count the superseded row
```

## Change

`PostgresBackend::purge_namespace`: four `DELETE … WHERE namespace_id = $1` statements in one transaction on a namespace-bound connection — the #254 convention (explicit predicate enforces in deployments as shipped; RLS backs it under enforcement). Count = `rows_affected` summed over the four memory tables, matching SQLite's contract exactly, superseded rows included.

Divergences from SQLite's override, each verified against `postgres_schema.sql` rather than assumed: no KG cascade (those tables don't exist on Postgres), no FTS statement (generated `tsvector` column — the row delete carries it), `edges` untouched on both backends (no `namespace_id` column).

## Tests

Three new live-RLS tests (ran against a live Postgres, zero skips — suite is now 20): purge confined to its namespace, purge under enforced RLS, and the superseded-count parity test. The two isolation tests pass against the trait default too, so a wiring proof was run during development (temporary `panic!()` in the override — all three tests hit it), and the parity test is the standing guard that the override is the live path. Independently sabotage-checked: widening one DELETE's predicate fails exactly the confinement test.

fmt / clippy (`-D warnings`, workspace + postgres feature) clean; `pensyve-core` 545 lib, gateway 162, all green.

## Flagged, not fixed

The gateway's purge route (`purge_all_memories`, rest.rs:1280) has no dedicated gateway-level test — these live-RLS tests are the only coverage of the purge path. Worth a follow-up if the route contract should be pinned at the HTTP layer.