### PR TITLE
fix(consolidation): carry committed stats through rerun failures, expose coalescing, close the gate

### DIFF
--- a/pensyve-core/src/consolidation/gate.rs
+++ b/pensyve-core/src/consolidation/gate.rs
@@ -15,6 +15,15 @@
 //! coordinate, [`ConsolidationEngine::run`] dispatches through here, so the
 //! guarantee cannot be bypassed — including by call sites added later.
 //!
+//! That holds outside this crate only because the module is `pub(crate)`. It
+//! was `pub` through #258, which let any dependent claim a namespace here and
+//! starve the engine, making a guarantee stated as unbypassable bypassable by
+//! anyone who was not a call site (#260). Closing it costs the intra-doc
+//! links `run`'s public docs used to point readers here — restricting the
+//! module at all costs them, `#[doc(hidden)]` included, since rustdoc
+//! generates no page for a hidden item either — so those references are now
+//! plain code spans.
+//!
 //! [`ConsolidationEngine::run`]: super::ConsolidationEngine::run
 //!
 //! ## Coalescing, not queueing

--- a/pensyve-core/src/consolidation/mod.rs
+++ b/pensyve-core/src/consolidation/mod.rs
@@ -46,7 +46,13 @@
 //!   contract.
 
 pub mod dmem;
-pub mod gate;
+// Crate-private, or the "cannot be bypassed" guarantee its docs claim would
+// hold only inside this crate: a `pub` gate lets a dependent claim a
+// namespace directly and starve `ConsolidationEngine::run` (#260). The cost
+// is that `run`'s docs can no longer link here — restricting the module at
+// all costs that, `#[doc(hidden)]` included, since rustdoc emits no page for
+// a hidden item either — so those references are plain code spans.
+pub(crate) mod gate;
 pub mod typed_slots;
 
 use std::collections::HashMap;
@@ -94,6 +100,56 @@ pub enum ConsolidationError {
     /// shape for `ConsolidationEngine::run` policy violations.
     #[error("Network call denied by policy: {0}")]
     Network(String),
+    /// A run failed after an earlier run of the same [`ConsolidationEngine::run`]
+    /// call had already committed its work.
+    ///
+    /// One call may run several times — a trigger that coalesced while this
+    /// caller owned the namespace schedules a re-run (see the `gate` module
+    /// docs). Each run commits as it goes, so a failure in a later one does
+    /// not undo what the earlier ones wrote. This variant carries that
+    /// committed total alongside the failure, so a caller recording activity
+    /// from the return value does not under-report work that happened.
+    ///
+    /// `run` produces it only when there is committed work to carry: a failure
+    /// with nothing committed behind it propagates as the underlying variant
+    /// unchanged, so the common single-run case keeps its original shape.
+    #[error(
+        "{source} (already committed: {} promoted, {} decayed, {} archived)",
+        .partial.promoted, .partial.decayed, .partial.archived
+    )]
+    Partial {
+        /// Stats for the runs that completed before the failing one. Already
+        /// written to storage — the error does not roll them back.
+        partial: ConsolidationStats,
+        /// The failure that ended the final run.
+        #[source]
+        source: Box<ConsolidationError>,
+    },
+}
+
+impl ConsolidationError {
+    /// The work this failure left committed, if any — see
+    /// [`ConsolidationError::Partial`]. Callers that record activity from a
+    /// run's stats should record this too, or they under-report it.
+    pub fn committed(&self) -> Option<&ConsolidationStats> {
+        match self {
+            Self::Partial { partial, .. } => Some(partial),
+            _ => None,
+        }
+    }
+
+    /// Wrap `source` so it carries the work `committed` before it, unless
+    /// there is nothing to carry — see [`ConsolidationError::Partial`].
+    fn with_committed(committed: ConsolidationStats, source: Self) -> Self {
+        if committed.is_empty() {
+            source
+        } else {
+            Self::Partial {
+                partial: committed,
+                source: Box::new(source),
+            }
+        }
+    }
 }
 
 impl From<NetworkRequiredError> for ConsolidationError {
@@ -116,6 +172,19 @@ pub struct ConsolidationStats {
     pub decayed: usize,
     /// Number of memories archived (retrievability below threshold).
     pub archived: usize,
+    /// True when this call did no work of its own because a run was already
+    /// in flight for the namespace, which will cover its trigger (see the
+    /// `gate` module docs). The counts are zero in that case — as they are
+    /// for a run that found nothing to do, which is why the two situations
+    /// need this flag to be told apart.
+    pub coalesced: bool,
+}
+
+impl ConsolidationStats {
+    /// No work recorded — every counter is zero.
+    fn is_empty(&self) -> bool {
+        self.promoted == 0 && self.decayed == 0 && self.archived == 0
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -172,6 +241,67 @@ impl PromotionGuard {
     }
 }
 
+// Test seam state for `injected_run_failure`. Thread-local rather than
+// global, for the same reason as the `gate` module's release-window seam: the
+// whole test suite shares one process, so a process-wide flag would inject
+// failures into unrelated tests running in parallel. `run` is synchronous, so
+// the arming thread is the one that reaches the seam.
+#[cfg(test)]
+thread_local! {
+    static INJECT_RERUN_FAILURE: std::cell::Cell<RerunFailure> =
+        const { std::cell::Cell::new(RerunFailure::Disarmed) };
+}
+
+#[cfg(test)]
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum RerunFailure {
+    Disarmed,
+    /// Schedule a re-run at the next run's start, and fail that re-run.
+    Armed,
+    /// The scheduled re-run: fail it.
+    FailThisRun,
+}
+
+/// Test seam: let one run commit, then fail the re-run that follows it.
+/// Compiled out of non-test builds.
+///
+/// The state it needs — a re-run scheduled while this caller still owns the
+/// namespace — is not reachable from a test thread. `run` is synchronous, so
+/// by the time a test could mark the namespace pending, the run it wanted the
+/// failure to follow has already returned. The seam marks it from inside the
+/// run instead, with the same `gate::dispatch` call a coalescing trigger
+/// makes, and fails the run that mark schedules.
+#[cfg(test)]
+fn injected_run_failure(namespace_id: Uuid) -> Option<ConsolidationError> {
+    INJECT_RERUN_FAILURE.with(|state| match state.get() {
+        RerunFailure::Disarmed => None,
+        RerunFailure::Armed => {
+            state.set(RerunFailure::FailThisRun);
+            // Claimed by this very caller, so this coalesces and sets the
+            // pending flag — exactly what a concurrent trigger would do.
+            let dispatch = gate::dispatch(namespace_id, || (), |()| false);
+            assert_eq!(
+                dispatch,
+                gate::Dispatch::Coalesced,
+                "the seam must coalesce into the run it is arming, not start one"
+            );
+            None
+        }
+        RerunFailure::FailThisRun => {
+            state.set(RerunFailure::Disarmed);
+            Some(ConsolidationError::Storage(StorageError::Context(
+                "injected re-run failure".to_string(),
+            )))
+        }
+    })
+}
+
+#[cfg(not(test))]
+#[inline]
+fn injected_run_failure(_namespace_id: Uuid) -> Option<ConsolidationError> {
+    None
+}
+
 impl ConsolidationEngine {
     /// Run all consolidation jobs for a namespace.
     ///
@@ -196,7 +326,7 @@ impl ConsolidationEngine {
     /// is ≤500 ms (pre-reg §2 I5).
     ///
     /// At most one run per namespace is in flight at a time, enforced by
-    /// [`gate::dispatch`]: the promotion pass derives its idempotency guard
+    /// `gate::dispatch`: the promotion pass derives its idempotency guard
     /// from a snapshot of the namespace and only then writes, so two
     /// overlapping runs would each see an unpromoted namespace and mint the
     /// same row twice (#226). Dispatch happens here rather than at the call
@@ -206,10 +336,10 @@ impl ConsolidationEngine {
     /// unaffected and proceed in parallel.
     ///
     /// Triggers coalesce rather than queue. A call made while another run is
-    /// in flight for the namespace does no work and returns zeroed stats; the
-    /// run already going will run once more and cover it, so nothing is
-    /// dropped. See the [`gate`] module docs for why queueing was rejected and
-    /// why coalescing is lossless.
+    /// in flight for the namespace does no work and returns zeroed stats with
+    /// [`ConsolidationStats::coalesced`] set; the run already going will run
+    /// once more and cover it, so nothing is dropped. See the `gate` module
+    /// docs for why queueing was rejected and why coalescing is lossless.
     ///
     /// A caller that does own the namespace may therefore perform several
     /// consecutive runs, and the returned stats are the total across them.
@@ -229,8 +359,12 @@ impl ConsolidationEngine {
         let outcome = gate::dispatch(
             namespace_id,
             || {
-                let result =
-                    Self::run_locked(storage, embedder, config, namespace_id, policy, cancel);
+                let result = match injected_run_failure(namespace_id) {
+                    Some(err) => Err(err),
+                    None => {
+                        Self::run_locked(storage, embedder, config, namespace_id, policy, cancel)
+                    }
+                };
                 if let Ok(stats) = &result {
                     total.promoted += stats.promoted;
                     total.decayed += stats.decayed;
@@ -249,19 +383,22 @@ impl ConsolidationEngine {
         match outcome {
             // Zeroed rather than the in-flight run's stats: this call did no
             // work, and reporting another run's promotions here would
-            // double-count them in `log_activity`.
-            gate::Dispatch::Coalesced => Ok(ConsolidationStats::default()),
+            // double-count them in `log_activity`. The flag is what keeps that
+            // distinguishable from a run that found nothing to do.
+            gate::Dispatch::Coalesced => Ok(ConsolidationStats {
+                coalesced: true,
+                ..ConsolidationStats::default()
+            }),
             gate::Dispatch::Ran(Ok(_)) => Ok(total),
-            gate::Dispatch::Ran(Err(err)) => Err(err),
+            // Whatever the failing run itself wrote is unknowable, but every
+            // run before it committed. Carry that total with the error rather
+            // than discard it — see [`ConsolidationError::Partial`].
+            gate::Dispatch::Ran(Err(err)) => Err(ConsolidationError::with_committed(total, err)),
         }
     }
 
     /// The body of [`Self::run`], executed while this caller owns the
     /// namespace.
-    #[allow(
-        clippy::too_many_arguments,
-        reason = "mirrors the public `run` signature it is split out of"
-    )]
     fn run_locked(
         storage: &dyn StorageTrait,
         embedder: &OnnxEmbedder,
@@ -364,10 +501,6 @@ impl ConsolidationEngine {
     /// network-capable summarizer here, per pre-reg §1.2). Today the body
     /// performs only local ONNX inference and `SQLite` writes, so the
     /// policy is unused at the call sites.
-    #[allow(
-        clippy::too_many_arguments,
-        reason = "G1 plumbing: policy + cancel parameters threaded through the engine surface; refactoring into a struct is deferred to G3 when the summarizer attaches"
-    )]
     fn promote_episodic_to_semantic(
         storage: &dyn StorageTrait,
         embedder: &OnnxEmbedder,
@@ -1641,6 +1774,97 @@ mod tests {
         assert_eq!(stats.promoted, 0);
         assert_eq!(stats.decayed, 0);
         assert_eq!(stats.archived, 0);
+    }
+
+    /// A run that fails after an earlier run of the same call committed its
+    /// promotions must report them. The promotions are already in storage —
+    /// dropping them from the return value understates work that happened,
+    /// and every caller that records activity from it under-reports (#260).
+    #[test]
+    fn rerun_failure_carries_the_stats_already_committed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let storage = make_storage(tmp.path().to_str().unwrap());
+        let embedder = OnnxEmbedder::new_mock(64);
+        let (ns, entity_id, source_id) = setup_namespace(&storage);
+
+        // One promotable cluster: identical content clusters under the mock
+        // embedder (cosine 1.0), so the first run promotes exactly once.
+        for i in 0..3 {
+            let episode = Episode::new(ns.id, vec![source_id, entity_id]);
+            storage.save_episode(&episode).unwrap();
+            insert_episodic(
+                &storage,
+                &embedder,
+                &ns,
+                episode.id,
+                source_id,
+                entity_id,
+                "prefers dark mode",
+                i as i64,
+            );
+        }
+
+        INJECT_RERUN_FAILURE.with(|state| state.set(RerunFailure::Armed));
+        let err = ConsolidationEngine::run(
+            &storage,
+            &embedder,
+            &make_config(),
+            ns.id,
+            &NetworkPolicy::Disabled,
+            &CancellationToken::new(),
+        )
+        .expect_err("the seam fails the re-run");
+
+        let ConsolidationError::Partial { partial, source } = err else {
+            panic!("expected the error to carry the committed stats, got {err:?}");
+        };
+        assert_eq!(
+            partial.promoted, 1,
+            "the first run's promotion is committed and must be reported"
+        );
+        assert!(
+            matches!(*source, ConsolidationError::Storage(_)),
+            "the underlying failure must survive the wrap, got {source:?}"
+        );
+
+        let promoted_rows = storage
+            .get_all_memories_by_namespace(ns.id)
+            .unwrap()
+            .into_iter()
+            .filter(|m| matches!(m, Memory::Semantic(sm) if sm.predicate == "mentioned"))
+            .count();
+        assert_eq!(
+            promoted_rows, partial.promoted,
+            "the reported total must match what is actually in storage"
+        );
+    }
+
+    /// A failure with nothing committed behind it keeps its own shape, so the
+    /// common single-run case stays matchable on the underlying variant.
+    #[test]
+    fn failure_with_nothing_committed_propagates_unwrapped() {
+        let tmp = tempfile::tempdir().unwrap();
+        let storage = make_storage(tmp.path().to_str().unwrap());
+        let embedder = OnnxEmbedder::new_mock(64);
+        let ns = Namespace::new("nothing-committed");
+        storage.save_namespace(&ns).unwrap();
+
+        let cancel = CancellationToken::new();
+        cancel.cancel();
+        let err = ConsolidationEngine::run(
+            &storage,
+            &embedder,
+            &make_config(),
+            ns.id,
+            &NetworkPolicy::Disabled,
+            &cancel,
+        )
+        .expect_err("a pre-cancelled token fails the first run");
+
+        assert!(
+            matches!(err, ConsolidationError::Cancelled(_)),
+            "expected the bare cancellation, got {err:?}"
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/pensyve-go/client_test.go
+++ b/pensyve-go/client_test.go
@@ -476,9 +476,10 @@ func TestConsolidate(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(ConsolidateResult{
-			Promoted: 5,
-			Decayed:  3,
-			Archived: 1,
+			Promoted:  5,
+			Decayed:   3,
+			Archived:  1,
+			Coalesced: true,
 		})
 	}))
 	defer server.Close()
@@ -491,7 +492,7 @@ func TestConsolidate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if result.Promoted != 5 || result.Decayed != 3 || result.Archived != 1 {
+	if result.Promoted != 5 || result.Decayed != 3 || result.Archived != 1 || !result.Coalesced {
 		t.Errorf("unexpected result: %+v", result)
 	}
 }

--- a/pensyve-go/types.go
+++ b/pensyve-go/types.go
@@ -49,6 +49,10 @@ type ConsolidateResult struct {
 	Promoted int `json:"promoted"`
 	Decayed  int `json:"decayed"`
 	Archived int `json:"archived"`
+	// Coalesced is true when the request did no work of its own because a
+	// run was already in flight for the namespace; the counts are zero in
+	// that case, as they are for a run that found nothing to do.
+	Coalesced bool `json:"coalesced"`
 }
 
 // HealthResult contains the API health check response.

--- a/pensyve-mcp-gateway/src/main.rs
+++ b/pensyve-mcp-gateway/src/main.rs
@@ -470,6 +470,21 @@ async fn async_main(config: GatewayConfig, res: InitResources) -> Result<()> {
                                 );
                             }
                             Ok(Err(e)) => {
+                                // #260: a failed run may follow runs of the
+                                // same call that already committed. Record
+                                // what they wrote rather than lose it.
+                                if let Some(committed) = e.committed() {
+                                    let _ = storage.log_activity(
+                                        ns_id,
+                                        "consolidate",
+                                        &serde_json::json!({
+                                            "promoted": committed.promoted,
+                                            "decayed": committed.decayed,
+                                            "archived": committed.archived,
+                                            "partial": true,
+                                        }),
+                                    );
+                                }
                                 tracing::warn!(
                                     namespace_id = %ns_id,
                                     error = %e,

--- a/pensyve-mcp-gateway/src/rest.rs
+++ b/pensyve-mcp-gateway/src/rest.rs
@@ -2040,7 +2040,25 @@ async fn episode_end(
                         }),
                     );
                 }
-                Err(e) => tracing::warn!("Post-episode consolidation failed: {e}"),
+                Err(e) => {
+                    // #260: a failed run may follow runs of the same call that
+                    // already committed. Record what they wrote rather than
+                    // lose it.
+                    if let Some(committed) = e.committed() {
+                        let _ = storage.log_activity(
+                            ns_id,
+                            "consolidate",
+                            &serde_json::json!({
+                                "promoted": committed.promoted,
+                                "decayed": committed.decayed,
+                                "archived": committed.archived,
+                                "trigger": "episode_end",
+                                "partial": true,
+                            }),
+                        );
+                    }
+                    tracing::warn!("Post-episode consolidation failed: {e}");
+                }
             }
         });
     }
@@ -2129,13 +2147,32 @@ async fn consolidate(
             StatusCode::INTERNAL_SERVER_ERROR,
             format!("Consolidation task failed: {e}"),
         )
-    })?
-    .map_err(|e| {
-        RestError(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Consolidation error: {e}"),
-        )
     })?;
+
+    let consolidation_result = match consolidation_result {
+        Ok(consolidated) => consolidated,
+        Err(e) => {
+            // #260: a failed run may follow runs of the same call that already
+            // committed. The request fails either way, but the activity record
+            // must not lose what was written.
+            if let Some(committed) = e.committed() {
+                let _ = ps.storage.log_activity(
+                    ps.namespace.id,
+                    "consolidate",
+                    &json!({
+                        "promoted": committed.promoted,
+                        "decayed": committed.decayed,
+                        "archived": committed.archived,
+                        "partial": true,
+                    }),
+                );
+            }
+            return Err(RestError(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Consolidation error: {e}"),
+            ));
+        }
+    };
 
     let _ = ps.storage.log_activity(
         ps.namespace.id,
@@ -2151,6 +2188,9 @@ async fn consolidate(
         "promoted": consolidation_result.promoted,
         "decayed": consolidation_result.decayed,
         "archived": consolidation_result.archived,
+        // #260: zeroed counts alone cannot tell a request that coalesced into
+        // a run already in flight from one that ran and found nothing to do.
+        "coalesced": consolidation_result.coalesced,
     })))
 }
 

--- a/pensyve-mcp-gateway/tests/test_rest_consolidate_coalesced.rs
+++ b/pensyve-mcp-gateway/tests/test_rest_consolidate_coalesced.rs
@@ -1,0 +1,248 @@
+//! `/v1/consolidate` must say whether it coalesced into a run already in
+//! flight or ran itself (#260).
+//!
+//! The three counts cannot answer that on their own: a trigger that coalesced
+//! reports zeros, and so does a run that found nothing to do. A client that
+//! cannot tell "someone else is handling it" from "nothing to do" has no basis
+//! for deciding whether to look again.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use axum::Extension;
+use chrono::Utc;
+use pensyve_core::config::{ConsolidationConfig, RetrievalConfig};
+use pensyve_core::consolidation::ConsolidationEngine;
+use pensyve_core::embedding::OnnxEmbedder;
+use pensyve_core::network_policy::NetworkPolicy;
+use pensyve_core::storage::StorageTrait;
+use pensyve_core::storage::sqlite::SqliteBackend;
+use pensyve_core::types::{Episode, EpisodicMemory, Memory, Namespace};
+use pensyve_core::vector::VectorIndex;
+use pensyve_mcp_gateway::AppState;
+use pensyve_mcp_gateway::auth::{AuthContext, AuthValidator};
+use pensyve_mcp_gateway::config::GatewayConfig;
+use pensyve_mcp_gateway::rate_limit::RateLimiter;
+use pensyve_mcp_gateway::rest;
+use pensyve_mcp_gateway::tenant::TenantStateManager;
+use pensyve_mcp_gateway::usage::UsageReporter;
+use pensyve_mcp_gateway::usage_counter::UsageCounter;
+use serde_json::Value;
+use tempfile::TempDir;
+use tokio_util::sync::CancellationToken;
+use uuid::Uuid;
+
+const TEST_TENANT: &str = "test-consolidate-tenant";
+
+/// Promotable clusters seeded before the in-flight run starts. Large enough
+/// that the run is still going when the coalescing request arrives, the same
+/// way the engine-level coalescing tests size their namespace.
+const CLUSTERS: usize = 96;
+
+const EMBEDDING_DIMS: usize = 768;
+
+fn retrieval_config() -> RetrievalConfig {
+    RetrievalConfig {
+        default_limit: 5,
+        max_candidates: 100,
+        weights: [0.30, 0.15, 0.20, 0.10, 0.10, 0.05, 0.05, 0.05],
+        recall_timeout_secs: 5,
+        rrf_k: 60,
+        rrf_weights: [1.0, 0.8, 1.0, 0.8, 0.5, 0.5, 1.2, 1.0],
+        beam_width: 10,
+        max_depth: 4,
+    }
+}
+
+fn gateway_config(dir: &TempDir) -> GatewayConfig {
+    GatewayConfig {
+        host: "127.0.0.1".to_string(),
+        port: 0,
+        storage_path: dir.path().to_path_buf(),
+        namespace: "default".to_string(),
+        api_keys: vec![],
+        rate_limit_per_minute: 300,
+        stripe_api_key: None,
+        admin_key: None,
+        key_user_map: vec![],
+        allowed_hosts: vec![],
+    }
+}
+
+fn app_state(dir: &TempDir) -> Arc<AppState> {
+    let storage =
+        Arc::new(SqliteBackend::open(dir.path()).expect("open storage")) as Arc<dyn StorageTrait>;
+    let namespace = Namespace::new("default");
+    storage
+        .save_namespace(&namespace)
+        .expect("save default namespace");
+
+    let tenant_mgr = TenantStateManager::new(
+        storage,
+        Arc::new(OnnxEmbedder::new_mock(EMBEDDING_DIMS)),
+        retrieval_config(),
+        namespace,
+        VectorIndex::new(EMBEDDING_DIMS, 1024),
+        dir.path().join("snapshots"),
+    );
+    let config = gateway_config(dir);
+
+    Arc::new(AppState {
+        auth: AuthValidator::new(&config),
+        rate_limiter: RateLimiter::new(None),
+        usage_reporter: UsageReporter::new(None),
+        usage_counter: UsageCounter::new(),
+        tenant_mgr,
+        auth_required: false,
+        admin_key: None,
+        ct: CancellationToken::new(),
+        redis: None,
+        extractor: None,
+    })
+}
+
+fn auth_context() -> AuthContext {
+    AuthContext {
+        key_id: TEST_TENANT.to_string(),
+        tenant_id: None,
+        user_id: None,
+        scope: "mcp".to_string(),
+        stripe_customer_id: None,
+        plan: "free".to_string(),
+    }
+}
+
+async fn start_test_server(dir: &TempDir) -> (String, Arc<AppState>) {
+    let state = app_state(dir);
+    let app = rest::router()
+        .layer(Extension(auth_context()))
+        .with_state(state.clone());
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test server");
+    let addr = listener.local_addr().expect("test server address");
+
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+
+    (format!("http://{addr}"), state)
+}
+
+async fn consolidate(client: &reqwest::Client, url: &str) -> Value {
+    let response = client
+        .post(format!("{url}/v1/consolidate"))
+        .send()
+        .await
+        .expect("consolidate request");
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    response.json().await.expect("consolidate response JSON")
+}
+
+/// Live `mentioned` rows in `ns` — the promotion pass's output.
+fn promoted_rows(storage: &dyn StorageTrait, ns: Uuid) -> usize {
+    storage
+        .get_all_memories_by_namespace(ns)
+        .expect("get_all_memories_by_namespace")
+        .into_iter()
+        .filter(|m| matches!(m, Memory::Semantic(sm) if sm.predicate == "mentioned"))
+        .count()
+}
+
+/// Seed `CLUSTERS` promotable clusters: two identical episodes under a fresh
+/// entity each. The mock embedder returns identical vectors for identical
+/// text, so every pair clusters and is worth exactly one promotion.
+fn seed_clusters(storage: &dyn StorageTrait, embedder: &OnnxEmbedder, ns: Uuid) {
+    for c in 0..CLUSTERS {
+        let entity_id = Uuid::new_v4();
+        let source_id = Uuid::new_v4();
+        let episode = Episode::new(ns, vec![source_id, entity_id]);
+        storage.save_episode(&episode).unwrap();
+        let content = format!("prefers configuration variant {c}");
+        for i in 0..2 {
+            let mut mem =
+                EpisodicMemory::new(ns, episode.id, source_id, entity_id, content.as_str());
+            mem.embedding = embedder.embed(&mem.content).unwrap();
+            mem.timestamp = Utc::now() - chrono::Duration::seconds(i);
+            storage.save_episodic(&mem).unwrap();
+        }
+    }
+}
+
+/// A request that coalesces into a run already in flight reports
+/// `coalesced: true`; one that runs itself reports `coalesced: false`. Both
+/// report zero promotions here, which is exactly why the flag is needed.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn consolidate_reports_whether_the_request_coalesced() {
+    let dir = TempDir::new().expect("temp dir");
+    let (url, state) = start_test_server(&dir).await;
+    let client = reqwest::Client::new();
+
+    let ps = state
+        .tenant_mgr
+        .get_tenant_state(TEST_TENANT)
+        .expect("tenant state");
+    let ns_id = ps.namespace.id;
+    seed_clusters(ps.storage.as_ref(), ps.embedder.as_ref(), ns_id);
+
+    // The run this request has to coalesce into. Started off the runtime, as
+    // the engine is synchronous.
+    let owner = {
+        let storage = ps.storage.clone();
+        let embedder = ps.embedder.clone();
+        std::thread::spawn(move || {
+            ConsolidationEngine::run(
+                storage.as_ref(),
+                &embedder,
+                &ConsolidationConfig::default(),
+                ns_id,
+                &NetworkPolicy::Disabled,
+                &CancellationToken::new(),
+            )
+            .expect("owner consolidation run")
+        })
+    };
+
+    // Wait for proof that the owner holds the namespace rather than guessing
+    // with a sleep: its first promoted row can only exist once it does. That
+    // row lands after roughly one of CLUSTERS clusters, so nearly the whole
+    // run is still ahead of the request below.
+    let deadline = Instant::now() + Duration::from_secs(60);
+    while promoted_rows(ps.storage.as_ref(), ns_id) == 0 {
+        assert!(Instant::now() < deadline, "owner never began promoting");
+        std::thread::sleep(Duration::from_millis(1));
+    }
+
+    let coalesced = consolidate(&client, &url).await;
+    assert!(
+        coalesced["coalesced"].is_boolean(),
+        "the response must carry the coalesced flag, got {coalesced}"
+    );
+    assert_eq!(
+        coalesced["coalesced"],
+        Value::Bool(true),
+        "the request ran instead of coalescing, so this test did not exercise \
+         coalescing at all — raise CLUSTERS"
+    );
+    assert_eq!(
+        coalesced["promoted"], 0,
+        "a coalesced request does no work of its own"
+    );
+
+    let owner_stats = owner.join().expect("owner thread");
+    assert_eq!(
+        owner_stats.promoted, CLUSTERS,
+        "the owner's total should span both of its runs"
+    );
+
+    // Nothing in flight now, and nothing left to promote: the same three zeros
+    // as above, with the flag telling the two situations apart.
+    let ran = consolidate(&client, &url).await;
+    assert_eq!(
+        ran["coalesced"],
+        Value::Bool(false),
+        "a request that ran must not report itself as coalesced"
+    );
+    assert_eq!(ran["promoted"], 0, "everything was already promoted");
+}

--- a/pensyve-mcp-tools/src/server.rs
+++ b/pensyve-mcp-tools/src/server.rs
@@ -439,7 +439,25 @@ impl PensyveMcpServer {
                             }),
                         );
                     }
-                    Err(e) => tracing::warn!("Post-episode consolidation failed: {e}"),
+                    Err(e) => {
+                        // #260: a failed run may follow runs of the same call
+                        // that already committed. Record what they wrote
+                        // rather than lose it.
+                        if let Some(committed) = e.committed() {
+                            let _ = storage.log_activity(
+                                ns_id,
+                                "consolidate",
+                                &serde_json::json!({
+                                    "promoted": committed.promoted,
+                                    "decayed": committed.decayed,
+                                    "archived": committed.archived,
+                                    "trigger": "episode_end",
+                                    "partial": true,
+                                }),
+                            );
+                        }
+                        tracing::warn!("Post-episode consolidation failed: {e}");
+                    }
                 }
             });
         }

--- a/pensyve-python/python/pensyve/_core.pyi
+++ b/pensyve-python/python/pensyve/_core.pyi
@@ -352,11 +352,13 @@ class Pensyve:
         """
         ...
 
-    def consolidate(self) -> dict[str, int]:
+    def consolidate(self) -> dict[str, int | bool]:
         """Run consolidation (episodic->semantic promotion, FSRS decay, archival).
 
         Returns:
-            Dict with keys: promoted, decayed, archived (counts).
+            Dict with keys: promoted, decayed, archived (counts), and
+            coalesced (True when the request did no work because a run was
+            already in flight for the namespace).
         """
         ...
 

--- a/pensyve-python/src/lib.rs
+++ b/pensyve-python/src/lib.rs
@@ -1782,6 +1782,7 @@ impl PyPensyve {
         dict.set_item("promoted", stats.promoted)?;
         dict.set_item("decayed", stats.decayed)?;
         dict.set_item("archived", stats.archived)?;
+        dict.set_item("coalesced", stats.coalesced)?;
         Ok(dict)
     }
 

--- a/pensyve-ts/src/index.test.ts
+++ b/pensyve-ts/src/index.test.ts
@@ -737,7 +737,7 @@ describe("forget()", () => {
 describe("consolidate()", () => {
   test("returns camelCase consolidation stats", async () => {
     const fetchFn = mock(async () =>
-      jsonResponse({ promoted: 2, decayed: 5, archived: 1 })
+      jsonResponse({ promoted: 2, decayed: 5, archived: 1, coalesced: true })
     );
 
     const client = makeClient(fetchFn);
@@ -746,6 +746,7 @@ describe("consolidate()", () => {
     expect(result.promoted).toBe(2);
     expect(result.decayed).toBe(5);
     expect(result.archived).toBe(1);
+    expect(result.coalesced).toBe(true);
   });
 
   test("sends POST to /v1/consolidate", async () => {

--- a/pensyve-ts/src/index.ts
+++ b/pensyve-ts/src/index.ts
@@ -218,6 +218,12 @@ export interface ConsolidateResult {
   promoted: number;
   decayed: number;
   archived: number;
+  /**
+   * True when the request did no work of its own because a run was already
+   * in flight for the namespace; the counts are zero in that case, as they
+   * are for a run that found nothing to do.
+   */
+  coalesced: boolean;
 }
 
 export interface HealthResult {


### PR DESCRIPTION
Closes #260

All four deferred findings from #258's review, each TDD-first.

## 1. Rerun failures no longer discard committed work

`ConsolidationEngine::run` accumulates totals across reruns; a later rerun's `Err` threw the accumulated count away even though earlier reruns' promotions were already committed — the operation reported something that didn't match what it did. Errors now carry the committed stats via `ConsolidationError::Partial { partial, source }`, with a deliberate conditional: the variant is produced **only when there is committed work**, so a plain single-run failure keeps its original variant and every existing `matches!` (including the five cancellation tests) stays correct. `Display` appends the committed counts, so log-only callers benefit for free.

Caller audit (all five): the four that record activity (`episode_end` spawns in gateway and mcp-tools, the periodic sweep, `/v1/consolidate`) previously logged **nothing** on the error path; they now log the committed counts with an additive `"partial": true` marker. The Python binding needed no change — the error message now names the counts.

Failing-first: the new test drives a real commit-then-failing-rerun sequence via a `#[cfg(test)]` thread-local seam modeled on the gate's existing release-window seam (the state — a rerun scheduled while the caller owns the namespace — is not reachable from a test thread, since `run` is synchronous; the seam coalesces into its own run exactly as a concurrent trigger would). Independently sabotage-checked: dropping the `with_committed` wrap fails exactly that test.

## 2. `/v1/consolidate` distinguishes coalesced from no-op

`ConsolidationStats` gains `coalesced` (set only on `Dispatch::Coalesced`), surfaced as an additive response field. New handler-level test follows the #258 idiom — a real owner run over seeded clusters, polled past its guard snapshot rather than slept, then the coalescing request; stable across 5 consecutive runs.

## 3. `gate` is now `pub(crate)`

`pub mod gate` let external code claim a namespace directly and starve the engine — contradicting the module's own "cannot be bypassed" claim (proved with a compile+run of external `gate::dispatch` before; `E0603` after). The issue suggested `#[doc(hidden)]` to preserve intra-doc links; tested and rejected — rustdoc emits no page for hidden items, so the links rendered as literal brackets either way. `pub(crate)` closes the hole; the four public-doc references became plain code spans, leaving `cargo doc` at its pre-existing warning count.

## 4. Inert clippy allows removed

`run_locked` (6 params) and `promote_episodic_to_semantic` (7) against a threshold of 8 — both allows removed, `clippy --workspace -D warnings` clean without them. Allows elsewhere untouched.

Verification: fmt clean; clippy `-D warnings` clean; core + gateway + mcp-tools: 930 passed, 0 failed across 39 suites; no added line over 100 chars.