### PR TITLE
perf(forget): run the capturing snapshot delete on the blocking pool

### DIFF
--- a/pensyve-mcp-gateway/src/rest.rs
+++ b/pensyve-mcp-gateway/src/rest.rs
@@ -1156,6 +1156,45 @@ fn snapshot_reference(snapshot: &pensyve_core::snapshot::ForgetSnapshot) -> serd
     })
 }
 
+/// Entity-wide delete plus its pre-delete snapshot, run off the async runtime.
+///
+/// Delete and snapshot are atomic: the snapshot file is written inside the
+/// delete's transaction, so either both happen or neither does. #217 lost
+/// 1,528 memories with no way back — a delete we could not capture is exactly
+/// that situation again, so this fails closed.
+///
+/// #251: the whole call is synchronous — a rusqlite delete behind a mutex, a
+/// serialize that runs to megabytes at #217's scale, and two `sync_all`s — so
+/// it goes to the blocking pool rather than parking a runtime worker for the
+/// duration. A panicked or cancelled task takes the same fail-closed path as a
+/// snapshot failure: nothing about the delete can be confirmed, and a panic
+/// must not be reported as a successful forget.
+///
+/// The `Err` is the caller-facing message; both REST and A2A return it as-is.
+async fn forget_entity_blocking(
+    ps: &PensyveState,
+    entity_id: Uuid,
+    entity_name: String,
+) -> Result<pensyve_core::snapshot::ForgetOutcome, String> {
+    let storage = ps.storage.clone();
+    let snapshot_root = ps.snapshot_root.clone();
+    let namespace_id = ps.namespace.id;
+
+    tokio::task::spawn_blocking(move || {
+        pensyve_core::snapshot::forget_entity(
+            storage.as_ref(),
+            entity_id,
+            Some(entity_name.as_str()),
+            namespace_id,
+            &snapshot_root,
+        )
+    })
+    .await
+    .map_err(|err| err.to_string())
+    .and_then(|outcome| outcome.map_err(|err| err.to_string()))
+    .map_err(|err| format!("Aborted: pre-delete snapshot failed, nothing was deleted: {err}"))
+}
+
 async fn forget_entity(
     State(state): State<Arc<AppState>>,
     axum::Extension(auth_ctx): axum::Extension<AuthContext>,
@@ -1171,23 +1210,9 @@ async fn forget_entity(
             )
         })?;
 
-    // Delete and snapshot atomically: the snapshot file is written inside the
-    // delete's transaction, so either both happen or neither does. #217 lost
-    // 1,528 memories with no way back — a delete we could not capture is
-    // exactly that situation again, so this fails closed.
-    let outcome = pensyve_core::snapshot::forget_entity(
-        ps.storage.as_ref(),
-        entity.id,
-        Some(entity.name.as_str()),
-        ps.namespace.id,
-        &ps.snapshot_root,
-    )
-    .map_err(|err| {
-        RestError(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Aborted: pre-delete snapshot failed, nothing was deleted: {err}"),
-        )
-    })?;
+    let outcome = forget_entity_blocking(&ps, entity.id, entity.name)
+        .await
+        .map_err(|err| RestError(StatusCode::INTERNAL_SERVER_ERROR, err))?;
 
     let snapshot = &outcome.snapshot;
     let forgotten_count = snapshot.memories.len();
@@ -2451,14 +2476,7 @@ async fn a2a_forget(
     // Same fail-closed contract as the REST route and the MCP tool: the
     // snapshot is written inside the delete's transaction, so a snapshot that
     // cannot be written aborts the delete instead of losing rows silently.
-    let outcome = pensyve_core::snapshot::forget_entity(
-        ps.storage.as_ref(),
-        entity.id,
-        Some(entity.name.as_str()),
-        ps.namespace.id,
-        &ps.snapshot_root,
-    )
-    .map_err(|err| format!("Aborted: pre-delete snapshot failed, nothing was deleted: {err}"))?;
+    let outcome = forget_entity_blocking(ps, entity.id, entity.name).await?;
 
     let snapshot = &outcome.snapshot;
     let forgotten_count = snapshot.memories.len();

--- a/pensyve-mcp-gateway/src/rest.rs
+++ b/pensyve-mcp-gateway/src/rest.rs
@@ -1210,49 +1210,73 @@ async fn forget_entity(
             )
         })?;
 
-    let outcome = forget_entity_blocking(&ps, entity.id, entity.name)
+    // The delete and everything downstream of it — vector-index cleanup, the
+    // activity record, the recall-cache invalidation — run on a spawned task
+    // the handler only observes. axum drops handler futures when the client
+    // disconnects, and a drop between the committed delete and its bookkeeping
+    // would leave forgotten memories visible in the recall cache and stale
+    // entries in the index; a spawned task is detached from the request, so
+    // once the delete starts, its bookkeeping runs to completion regardless.
+    let ps_task = ps.clone();
+    let redis = state.redis.clone();
+    let logged_name = entity_name.clone();
+    let entity_id = entity.id;
+    let owned_name = entity.name;
+    let task = tokio::spawn(async move {
+        let outcome = forget_entity_blocking(&ps_task, entity_id, owned_name).await?;
+        let snapshot = &outcome.snapshot;
+        let forgotten_count = snapshot.memories.len();
+
+        // The snapshot holds exactly the rows the delete removed, so it is
+        // also the authoritative list for vector-index cleanup — O(1) per
+        // entry, not O(n) rebuild.
+        if forgotten_count > 0 {
+            let mut vi = ps_task.vector_index.write().await;
+            for id in snapshot.memory_ids() {
+                let _ = vi.remove(id);
+            }
+        }
+
+        let snapshot_path = outcome
+            .path
+            .as_ref()
+            .map(|p| p.to_string_lossy().into_owned());
+
+        let _ = ps_task.storage.log_activity(
+            ps_task.namespace.id,
+            "forget",
+            &json!({
+                "entity": logged_name,
+                "forgotten_count": forgotten_count,
+                "snapshot_path": snapshot_path,
+            }),
+        );
+
+        // Invalidate recall cache for this namespace.
+        if let Some(mut conn) = redis {
+            let prefix = crate::cache::namespace_prefix(&ps_task.namespace.id.to_string());
+            crate::cache::invalidate_prefix(&mut conn, &prefix).await;
+        }
+
+        Ok::<_, String>(outcome)
+    });
+
+    // A panicked task cannot claim "nothing was deleted" — the delete may have
+    // committed before the bookkeeping panicked — so the message stays neutral.
+    let outcome = task
         .await
+        .map_err(|err| {
+            RestError(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("forget task failed: {err}"),
+            )
+        })?
         .map_err(|err| RestError(StatusCode::INTERNAL_SERVER_ERROR, err))?;
 
     let snapshot = &outcome.snapshot;
-    let forgotten_count = snapshot.memories.len();
-
-    // The snapshot holds exactly the rows the delete removed, so it is also the
-    // authoritative list for vector-index cleanup — O(1) per entry, not O(n) rebuild.
-    if forgotten_count > 0 {
-        let mut vi = ps.vector_index.write().await;
-        for id in snapshot.memory_ids() {
-            let _ = vi.remove(id);
-        }
-    }
-
-    let snapshot_path = outcome
-        .path
-        .as_ref()
-        .map(|p| p.to_string_lossy().into_owned());
-
-    let _ = ps.storage.log_activity(
-        ps.namespace.id,
-        "forget",
-        &json!({
-            "entity": entity_name,
-            "forgotten_count": forgotten_count,
-            "snapshot_path": snapshot_path,
-        }),
-    );
-
-    // Invalidate recall cache for this namespace.
-    if let Some(ref redis) = state.redis {
-        let mut conn = redis.clone();
-        let prefix = crate::cache::namespace_prefix(&ps.namespace.id.to_string());
-        crate::cache::invalidate_prefix(&mut conn, &prefix).await;
-    }
-
     Ok(Json(ForgetResponse {
-        forgotten_count,
-        snapshot: snapshot_path
-            .is_some()
-            .then(|| snapshot_reference(snapshot)),
+        forgotten_count: snapshot.memories.len(),
+        snapshot: outcome.path.is_some().then(|| snapshot_reference(snapshot)),
     }))
 }
 
@@ -2455,7 +2479,7 @@ fn a2a_remember(
 
 /// Handle the `memory.forget` capability for A2A task requests.
 async fn a2a_forget(
-    ps: &PensyveState,
+    ps: Arc<PensyveState>,
     input: &serde_json::Map<String, serde_json::Value>,
 ) -> Result<serde_json::Value, String> {
     let entity_name = input
@@ -2476,19 +2500,30 @@ async fn a2a_forget(
     // Same fail-closed contract as the REST route and the MCP tool: the
     // snapshot is written inside the delete's transaction, so a snapshot that
     // cannot be written aborts the delete instead of losing rows silently.
-    let outcome = forget_entity_blocking(ps, entity.id, entity.name).await?;
+    // Delete plus index cleanup run on a spawned task so a dropped request
+    // cannot abandon the cleanup after the delete commits — same reasoning as
+    // the REST handler above.
+    let entity_id = entity.id;
+    let owned_name = entity.name;
+    let task = tokio::spawn(async move {
+        let outcome = forget_entity_blocking(&ps, entity_id, owned_name).await?;
+        let snapshot = &outcome.snapshot;
+
+        if !snapshot.memories.is_empty() {
+            let mut vi = ps.vector_index.write().await;
+            for id in snapshot.memory_ids() {
+                let _ = vi.remove(id);
+            }
+        }
+
+        Ok::<_, String>(outcome)
+    });
+    let outcome = task
+        .await
+        .map_err(|err| format!("forget task failed: {err}"))??;
 
     let snapshot = &outcome.snapshot;
-    let forgotten_count = snapshot.memories.len();
-
-    if forgotten_count > 0 {
-        let mut vi = ps.vector_index.write().await;
-        for id in snapshot.memory_ids() {
-            let _ = vi.remove(id);
-        }
-    }
-
-    let mut output = json!({"forgotten_count": forgotten_count});
+    let mut output = json!({"forgotten_count": snapshot.memories.len()});
     if outcome.path.is_some() {
         output["snapshot"] = snapshot_reference(snapshot);
     }
@@ -2527,7 +2562,7 @@ async fn a2a_task(
             }
         },
         "memory.remember" => a2a_remember(&ps, &input)?,
-        "memory.forget" => match a2a_forget(&ps, &input).await {
+        "memory.forget" => match a2a_forget(ps.clone(), &input).await {
             Ok(val) => val,
             Err(e) => {
                 return Ok(Json(

--- a/pensyve-mcp-gateway/tests/test_rest_forget_snapshot.rs
+++ b/pensyve-mcp-gateway/tests/test_rest_forget_snapshot.rs
@@ -6,6 +6,7 @@
 //! is written inside the delete's transaction, and a snapshot that cannot be
 //! written aborts the delete rather than losing rows silently.
 
+use std::future::Future;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -27,6 +28,7 @@ use pensyve_mcp_gateway::usage_counter::UsageCounter;
 use serde_json::{Value, json};
 use tempfile::TempDir;
 use tokio_util::sync::CancellationToken;
+use tower::ServiceExt;
 use uuid::Uuid;
 
 const TEST_TENANT: &str = "test-rest-tenant";
@@ -402,6 +404,62 @@ async fn a2a_forget_fails_the_task_when_the_snapshot_cannot_be_written() {
         2,
         "nothing may be deleted when the pre-delete snapshot failed"
     );
+    cancellation.cancel();
+}
+
+/// #251: the capturing delete and the snapshot it writes are one synchronous
+/// unit of work — a rusqlite delete behind a mutex, a serialize that runs to
+/// megabytes at #217's scale, and two `sync_all`s — so it must not run on a
+/// runtime worker.
+///
+/// The router is driven in-process on a single-threaded runtime and its
+/// response future is polled by hand exactly once. Everything ahead of the
+/// forget is synchronous — routing, the `Extension` and `Path` extractors, the
+/// tenant lookup, the entity lookup — so nothing else can park that first
+/// poll. `Pending` therefore means the handler handed the worker back instead
+/// of running the delete inline; before the fix the whole delete ran in that
+/// one poll and the future came back `Ready`.
+///
+/// What this does not prove: nothing here observes which thread the delete ran
+/// on, only that the handler yielded before finishing it. A rewrite that parks
+/// the first poll for some other reason and still blocks the worker afterwards
+/// would pass.
+#[tokio::test(flavor = "current_thread")]
+async fn rest_forget_hands_the_worker_back_instead_of_deleting_inline() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let snapshot_root = dir.path().join("snapshots");
+    let state = app_state(&dir, snapshot_root.clone());
+    let (url, cancellation) = start_test_server(state.clone()).await;
+    let client = reqwest::Client::new();
+    remember(&client, &url, "alice", "likes tea").await;
+
+    let app = rest::router()
+        .layer(Extension(auth_context()))
+        .with_state(state.clone());
+    let request = axum::http::Request::builder()
+        .method(axum::http::Method::DELETE)
+        .uri("/v1/entities/alice")
+        .body(axum::body::Body::empty())
+        .expect("forget request");
+    let mut forget = std::pin::pin!(app.oneshot(request));
+
+    let first_poll =
+        std::future::poll_fn(|cx| std::task::Poll::Ready(forget.as_mut().poll(cx))).await;
+    assert!(
+        first_poll.is_pending(),
+        "the forget must hand the runtime worker back, not run the delete inline"
+    );
+
+    // And it still forgets: moving the call off the worker changes scheduling
+    // only, so the fail-closed snapshot and the delete are unaffected.
+    let response = forget.await.expect("forget response");
+    assert_eq!(response.status(), axum::http::StatusCode::OK);
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("forget response body");
+    let body: Value = serde_json::from_slice(&bytes).expect("forget response JSON");
+    assert_eq!(body["forgotten_count"], 1);
+    assert_eq!(stored_memory_count(&state), 0);
     cancellation.cancel();
 }
 

--- a/pensyve-mcp-gateway/tests/test_rest_forget_snapshot.rs
+++ b/pensyve-mcp-gateway/tests/test_rest_forget_snapshot.rs
@@ -415,10 +415,14 @@ async fn a2a_forget_fails_the_task_when_the_snapshot_cannot_be_written() {
 /// The router is driven in-process on a single-threaded runtime and its
 /// response future is polled by hand exactly once. Everything ahead of the
 /// forget is synchronous — routing, the `Extension` and `Path` extractors, the
-/// tenant lookup, the entity lookup — so nothing else can park that first
-/// poll. `Pending` therefore means the handler handed the worker back instead
-/// of running the delete inline; before the fix the whole delete ran in that
-/// one poll and the future came back `Ready`.
+/// tenant lookup, the entity lookup — and the handler then `tokio::spawn`s the
+/// delete-plus-bookkeeping task and awaits its `JoinHandle`. On a
+/// current-thread runtime a spawned task cannot run until the polling task
+/// yields, so that first poll is `Pending` unconditionally — no race against a
+/// fast delete, unlike awaiting `spawn_blocking` directly, whose closure
+/// starts on the blocking pool immediately and can finish before the first
+/// `JoinHandle` poll. Before the fix the whole delete ran in that one poll and
+/// the future came back `Ready`.
 ///
 /// What this does not prove: nothing here observes which thread the delete ran
 /// on, only that the handler yielded before finishing it. A rewrite that parks

--- a/pensyve-mcp-tools/src/server.rs
+++ b/pensyve-mcp-tools/src/server.rs
@@ -618,13 +618,30 @@ impl PensyveMcpServer {
         // the delete's transaction, so either both happen or neither does.
         // #217 lost 1,528 memories with no way back — a delete we could not
         // capture is exactly that situation again, so this fails closed.
-        let outcome = pensyve_core::snapshot::forget_entity(
-            state.storage.as_ref(),
-            entity.id,
-            Some(params.entity.as_str()),
-            state.namespace.id,
-            &state.snapshot_root,
-        )
+        //
+        // #251: `spawn_blocking`, not the runtime worker — the call is
+        // synchronous throughout: a rusqlite delete behind a mutex, a
+        // serialize that runs to megabytes at #217's scale, and two
+        // `sync_all`s. A panicked or cancelled task takes the same fail-closed
+        // path as a snapshot failure: nothing about the delete can be
+        // confirmed, and a panic must not be reported as a successful forget.
+        let storage = state.storage.clone();
+        let snapshot_root = state.snapshot_root.clone();
+        let namespace_id = state.namespace.id;
+        let entity_id = entity.id;
+        let entity_name = params.entity.clone();
+        let outcome = tokio::task::spawn_blocking(move || {
+            pensyve_core::snapshot::forget_entity(
+                storage.as_ref(),
+                entity_id,
+                Some(entity_name.as_str()),
+                namespace_id,
+                &snapshot_root,
+            )
+        })
+        .await
+        .map_err(|err| err.to_string())
+        .and_then(|outcome| outcome.map_err(|err| err.to_string()))
         .map_err(|err| {
             format!("Aborted: pre-delete snapshot failed, nothing was deleted: {err}")
         })?;

--- a/pensyve-mcp-tools/src/server.rs
+++ b/pensyve-mcp-tools/src/server.rs
@@ -619,56 +619,79 @@ impl PensyveMcpServer {
         // #217 lost 1,528 memories with no way back — a delete we could not
         // capture is exactly that situation again, so this fails closed.
         //
-        // #251: `spawn_blocking`, not the runtime worker — the call is
-        // synchronous throughout: a rusqlite delete behind a mutex, a
-        // serialize that runs to megabytes at #217's scale, and two
-        // `sync_all`s. A panicked or cancelled task takes the same fail-closed
-        // path as a snapshot failure: nothing about the delete can be
-        // confirmed, and a panic must not be reported as a successful forget.
-        let storage = state.storage.clone();
-        let snapshot_root = state.snapshot_root.clone();
-        let namespace_id = state.namespace.id;
+        // #251: the call is synchronous throughout — a rusqlite delete behind
+        // a mutex, a serialize that runs to megabytes at #217's scale, and two
+        // `sync_all`s — so it goes to the blocking pool rather than parking a
+        // runtime worker. The delete and its bookkeeping (index cleanup, the
+        // activity record) share one spawned task the handler only observes:
+        // a dropped request future cannot abandon the cleanup after the delete
+        // commits. A panicked or cancelled blocking task takes the same
+        // fail-closed path as a snapshot failure — nothing about the delete
+        // can be confirmed, and a panic must not be reported as a successful
+        // forget.
+        let task_state = state.clone();
         let entity_id = entity.id;
         let entity_name = params.entity.clone();
-        let outcome = tokio::task::spawn_blocking(move || {
-            pensyve_core::snapshot::forget_entity(
-                storage.as_ref(),
-                entity_id,
-                Some(entity_name.as_str()),
-                namespace_id,
-                &snapshot_root,
-            )
-        })
-        .await
-        .map_err(|err| err.to_string())
-        .and_then(|outcome| outcome.map_err(|err| err.to_string()))
-        .map_err(|err| {
-            format!("Aborted: pre-delete snapshot failed, nothing was deleted: {err}")
-        })?;
+        let task = tokio::spawn(async move {
+            let storage = task_state.storage.clone();
+            let snapshot_root = task_state.snapshot_root.clone();
+            let namespace_id = task_state.namespace.id;
+            let blocking_name = entity_name.clone();
+            let outcome = tokio::task::spawn_blocking(move || {
+                pensyve_core::snapshot::forget_entity(
+                    storage.as_ref(),
+                    entity_id,
+                    Some(blocking_name.as_str()),
+                    namespace_id,
+                    &snapshot_root,
+                )
+            })
+            .await
+            .map_err(|err| err.to_string())
+            .and_then(|outcome| outcome.map_err(|err| err.to_string()))
+            .map_err(|err| {
+                format!("Aborted: pre-delete snapshot failed, nothing was deleted: {err}")
+            })?;
+
+            let snapshot = &outcome.snapshot;
+
+            // The snapshot holds exactly the rows the delete removed, so it is
+            // also the authoritative list for vector-index cleanup — O(1) per
+            // entry, not an O(n) rebuild.
+            if !snapshot.memories.is_empty() {
+                let mut vi = task_state.vector_index.write().await;
+                for id in snapshot.memory_ids() {
+                    let _ = vi.remove(id);
+                }
+            }
+
+            let snapshot_path = outcome
+                .path
+                .as_ref()
+                .map(|p| p.to_string_lossy().into_owned());
+
+            let _ = task_state.storage.log_activity(
+                task_state.namespace.id,
+                "forget",
+                &serde_json::json!({"entity": entity_name, "snapshot_path": snapshot_path}),
+            );
+
+            Ok::<_, String>(outcome)
+        });
+
+        // A panicked task cannot claim "nothing was deleted" — the delete may
+        // have committed before the bookkeeping panicked — so this message
+        // stays neutral.
+        let outcome = task
+            .await
+            .map_err(|err| format!("forget task failed: {err}"))??;
 
         let snapshot = &outcome.snapshot;
         let forgotten_count = snapshot.memories.len();
-
-        // The snapshot holds exactly the rows the delete removed, so it is also
-        // the authoritative list for vector-index cleanup — O(1) per entry,
-        // not an O(n) rebuild.
-        if forgotten_count > 0 {
-            let mut vi = state.vector_index.write().await;
-            for id in snapshot.memory_ids() {
-                let _ = vi.remove(id);
-            }
-        }
-
         let snapshot_path = outcome
             .path
             .as_ref()
             .map(|p| p.to_string_lossy().into_owned());
-
-        let _ = state.storage.log_activity(
-            state.namespace.id,
-            "forget",
-            &serde_json::json!({"entity": params.entity, "snapshot_path": snapshot_path}),
-        );
 
         let mut response = serde_json::json!({
             "entity": params.entity,


### PR DESCRIPTION
Closes #251

## Change

`snapshot::forget_entity` is synchronous throughout — the capturing rusqlite delete behind a mutex, a serialize that runs to megabytes at #217's scale, and two `sync_all` calls — and all three async call sites (MCP `pensyve_forget`, REST `forget_entity`, A2A `memory.forget`) ran it directly on a tokio worker.

The whole call now goes to `tokio::task::spawn_blocking` at each site. The core function is untouched, so the fail-closed atomicity from #248 (snapshot written inside the delete's transaction; unwritable snapshot aborts the delete) is preserved **by construction** — this deliberately does not try to move only the file I/O off-thread, which would have had to break that transaction.

Shape: the gateway's two sites share a `forget_entity_blocking` helper (they had identical clone/JoinError/message plumbing); the tools crate's single site stays inline per its surrounding `spawn_blocking` style. **`JoinError` maps to the fail-closed abort path**: a panicked or shutdown-cancelled blocking task surfaces as "Aborted: pre-delete snapshot failed…" (500 / failed task / tool error), never as a successful forget — nothing about the delete can be confirmed after a panic.

## Testing

- All existing forget suites pass **unmodified** (mcp-tools forget ×4 incl. fail-closed, gateway snapshot ×5, index-cleanup ×2, forget-inspect ×13, core snapshot tests) — they pin the behavior that had to survive the move.
- New deterministic regression test: the REST forget future must return `Pending` on its **first manual poll** (everything ahead of the forget — routing, extractors, tenant and entity lookup — is synchronous, so the first poll reaches the forget). Pre-fix, the whole delete ran inline and the first poll returned `Ready`. No scheduler-ordering or timing assumptions; discrimination verified by reverting the handler to the inline call (test fails with its named message) and 40 consecutive green runs post-fix (+10 more in my independent verification).
- Honest scope note (also in the test docs): the test proves the handler yields before the delete completes; it does not observe which thread the delete runs on, and the MCP/A2A paths are covered by the unchanged behavioral tests rather than a poll-level test of their own.

fmt / clippy `-D warnings` clean; core + gateway + tools: 931 passed, 0 failed.