### PR TITLE
test(gateway): replace the remaining set_var reranker guards with seeded cells

### DIFF
--- a/pensyve-mcp-gateway/tests/integration_test.rs
+++ b/pensyve-mcp-gateway/tests/integration_test.rs
@@ -15,33 +15,19 @@ use rmcp::transport::streamable_http_server::{
 use tokio::sync::RwLock;
 use tokio_util::sync::CancellationToken;
 
-/// Prevents the lazily-resolved reranker (`PensyveState::reranker`) from
-/// attempting a real network model download when a test builds a state via
-/// [`create_test_state`] without pre-seeding `reranker_cell`. Tests that
-/// specifically exercise reranker behavior instead pre-seed the cell with
-/// `Reranker::new_mock()` (see [`create_test_state_with_reranker`]), which
-/// bypasses this env check entirely. Uses `Once` so the (unsafe, per Rust
-/// 2024 edition) env mutation happens exactly once, before any reader.
-#[allow(
-    unsafe_code,
-    reason = "test-only env-var guard; std::env::set_var is unsafe in Rust 2024 edition by language design but is safe here because it runs exactly once via std::sync::Once before any reader observes the environment"
-)]
-fn disable_reranker_for_tests() {
-    static INIT: std::sync::Once = std::sync::Once::new();
-    INIT.call_once(|| {
-        // SAFETY: runs exactly once via `Once`, before any concurrent
-        // reader — no data race.
-        unsafe { std::env::set_var("PENSYVE_RERANKER", "0") };
-    });
-}
-
 /// Create a test server state, optionally with a reranker pre-attached
 /// (bypassing lazy resolution entirely — no network call either way).
+///
+/// The `reranker_cell` is constructed already resolved (`OnceLock::from`,
+/// below), so the lazy `PENSYVE_RERANKER` env check never runs in this
+/// binary — with `None` the state simply has no reranker. The former
+/// `set_var("PENSYVE_RERANKER", "0")` guard here was vestigial for exactly
+/// that reason, and `set_var` is process-global and unsafe in edition 2024
+/// besides (#250).
 fn create_test_state_with_reranker(
     dir: &tempfile::TempDir,
     reranker: Option<Arc<Reranker>>,
 ) -> Arc<PensyveState> {
-    disable_reranker_for_tests();
     let storage = SqliteBackend::open(dir.path()).expect("open test storage");
     let namespace = Namespace::new("test");
     storage.save_namespace(&namespace).expect("save namespace");
@@ -917,16 +903,14 @@ async fn test_recall_without_reranker_falls_back_gracefully() {
     ct.cancel();
 }
 
-/// Step 1 (part C): with `PENSYVE_RERANKER=0`, `PensyveState::reranker()`
-/// must resolve to `None` — i.e. the state holds no reranker. This binary
-/// sets the env var once via `disable_reranker_for_tests` (shared by every
-/// test above), so by the time this test runs the variable is already "0";
-/// asserting on `state.reranker()` here pins down the state-level contract
-/// the brief calls out explicitly, on top of the unit-level coverage in
-/// `pensyve_mcp_tools::state::tests`.
+/// Step 1 (part C): a state whose `reranker_cell` is resolved to `None` must
+/// report no reranker from `PensyveState::reranker()`. This binary resolves
+/// the cell at construction (see `create_test_state_with_reranker`), so the
+/// lazy `PENSYVE_RERANKER` env check never runs here; the env-var half of the
+/// contract is pinned at unit level in `pensyve_mcp_tools::state::tests`
+/// (#250 removed this binary's process-global `set_var` guard).
 #[tokio::test]
-async fn test_state_holds_no_reranker_when_disabled_via_env() {
-    disable_reranker_for_tests();
+async fn test_state_holds_no_reranker_when_cell_resolved_to_none() {
     let dir = tempfile::tempdir().expect("tempdir");
     let state = create_test_state(&dir);
     assert!(state.reranker().is_none());

--- a/pensyve-mcp-gateway/tests/test_multi_tenant_propagation.rs
+++ b/pensyve-mcp-gateway/tests/test_multi_tenant_propagation.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 use axum::{Router, extract::State, middleware::Next, response::Response};
 use pensyve_core::config::RetrievalConfig;
 use pensyve_core::embedding::OnnxEmbedder;
+use pensyve_core::reranker::Reranker;
 use pensyve_core::storage::StorageTrait;
 use pensyve_core::storage::sqlite::SqliteBackend;
 use pensyve_core::types::Namespace;
@@ -61,32 +62,14 @@ async fn tenant_middleware(
     CURRENT_TENANT.scope(tenant_id, next.run(req)).await
 }
 
-/// Prevents the lazily-resolved reranker (`PensyveState::reranker`) from
-/// attempting a real network model download the first time this suite's
-/// recall assertions run. Uses `Once` so the (unsafe, per Rust 2024
-/// edition) env mutation happens exactly once, before any reader.
-#[allow(
-    unsafe_code,
-    reason = "test-only env-var guard; std::env::set_var is unsafe in Rust 2024 edition by language design but is safe here because it runs exactly once via std::sync::Once before any reader observes the environment"
-)]
-fn disable_reranker_for_tests() {
-    static INIT: std::sync::Once = std::sync::Once::new();
-    INIT.call_once(|| {
-        // SAFETY: runs exactly once via `Once`, before any concurrent
-        // reader — no data race.
-        unsafe { std::env::set_var("PENSYVE_RERANKER", "0") };
-    });
-}
-
 fn make_mgr(dir: &tempfile::TempDir) -> Arc<TenantStateManager> {
-    disable_reranker_for_tests();
     let storage =
         Arc::new(SqliteBackend::open(dir.path()).expect("open storage")) as Arc<dyn StorageTrait>;
     let ns = Namespace::new("default");
     storage.save_namespace(&ns).expect("save default ns");
     let embedder = Arc::new(OnnxEmbedder::new_mock(768));
     let idx = VectorIndex::new(768, 1024);
-    Arc::new(TenantStateManager::new(
+    let mgr = Arc::new(TenantStateManager::new(
         storage,
         embedder,
         RetrievalConfig {
@@ -102,7 +85,25 @@ fn make_mgr(dir: &tempfile::TempDir) -> Arc<TenantStateManager> {
         ns,
         idx,
         dir.path().join("snapshots"),
-    ))
+    ));
+
+    // Resolve the shared reranker cell up front with a mock, so nothing in
+    // this binary can trigger the real ~280MB model download. Every tenant
+    // state built by this manager clones the same `OnceLock`, so seeding it
+    // through the default state covers tenants created later too.
+    //
+    // This replaces a `PENSYVE_RERANKER=0` env mutation (#250): `set_var` is
+    // process global, and serialising the write behind a `Once` does nothing
+    // about concurrent readers on other test threads.
+    assert!(
+        mgr.default_state()
+            .reranker_cell
+            .set(Some(Arc::new(Reranker::new_mock())))
+            .is_ok(),
+        "reranker cell was already resolved before the test could seed it"
+    );
+
+    mgr
 }
 
 async fn start_test_server(mgr: Arc<TenantStateManager>) -> (String, CancellationToken) {

--- a/pensyve-mcp-gateway/tests/test_rest_recall_contradictions.rs
+++ b/pensyve-mcp-gateway/tests/test_rest_recall_contradictions.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use axum::Extension;
 use pensyve_core::config::RetrievalConfig;
 use pensyve_core::embedding::OnnxEmbedder;
+use pensyve_core::reranker::Reranker;
 use pensyve_core::storage::StorageTrait;
 use pensyve_core::storage::sqlite::SqliteBackend;
 use pensyve_core::types::{Entity, EntityKind, Namespace, SemanticMemory};
@@ -50,25 +51,7 @@ fn gateway_config(dir: &TempDir) -> GatewayConfig {
     }
 }
 
-/// Prevents the lazily-resolved reranker (`PensyveState::reranker`) from
-/// attempting a real network model download the first time this suite's
-/// `/v1/recall` assertions run. Uses `Once` so the (unsafe, per Rust 2024
-/// edition) env mutation happens exactly once, before any reader.
-#[allow(
-    unsafe_code,
-    reason = "test-only env-var guard; std::env::set_var is unsafe in Rust 2024 edition by language design but is safe here because it runs exactly once via std::sync::Once before any reader observes the environment"
-)]
-fn disable_reranker_for_tests() {
-    static INIT: std::sync::Once = std::sync::Once::new();
-    INIT.call_once(|| {
-        // SAFETY: runs exactly once via `Once`, before any concurrent
-        // reader — no data race.
-        unsafe { std::env::set_var("PENSYVE_RERANKER", "0") };
-    });
-}
-
 fn app_state(dir: &TempDir) -> Arc<AppState> {
-    disable_reranker_for_tests();
     let storage =
         Arc::new(SqliteBackend::open(dir.path()).expect("open storage")) as Arc<dyn StorageTrait>;
     let namespace = Namespace::new("default");
@@ -84,6 +67,24 @@ fn app_state(dir: &TempDir) -> Arc<AppState> {
         VectorIndex::new(768, 1024),
         dir.path().join("snapshots"),
     );
+
+    // Resolve the shared reranker cell up front with a mock, so nothing in
+    // this binary can trigger the real ~280MB model download. Every tenant
+    // state built by this manager clones the same `OnceLock`, so seeding it
+    // through the default state covers tenants created later too.
+    //
+    // This replaces a `PENSYVE_RERANKER=0` env mutation (#250): `set_var` is
+    // process global, and serialising the write behind a `Once` does nothing
+    // about concurrent readers on other test threads.
+    assert!(
+        tenant_mgr
+            .default_state()
+            .reranker_cell
+            .set(Some(Arc::new(Reranker::new_mock())))
+            .is_ok(),
+        "reranker cell was already resolved before the test could seed it"
+    );
+
     let config = gateway_config(dir);
 
     Arc::new(AppState {


### PR DESCRIPTION
Closes #250

Converts the remaining gateway test binaries off the process-global `std::env::set_var("PENSYVE_RERANKER", "0")` guard to the #247 pattern: seed the shared reranker cell with `Reranker::new_mock()` through the manager's default state, which every tenant state clones — no model download possible, no unsafe env mutation, no `unsafe_code` allows.

Scoping findings (measured against the tree, not the issue text):

- **The issue's file list was stale.** `test_rest_forget_inspect.rs` no longer carries the pattern; the actual carriers were `test_multi_tenant_propagation.rs`, `test_rest_recall_contradictions.rs`, and `integration_test.rs`. All three converted.
- **`integration_test.rs`'s guard was vestigial**: it constructs `reranker_cell` already resolved via `OnceLock::from`, so the lazy env check never ran in that binary. Removed, with the reasoning recorded in the constructor docs.
- The one test that pinned the env→`None` contract through the guard (`test_state_holds_no_reranker_when_disabled_via_env`) now pins the cell-level contract (`…when_cell_resolved_to_none`); the env half of the contract remains pinned at unit level in `pensyve_mcp_tools::state::tests`, as that test's own docs already noted. (That crate's internal test guard is out of this issue's gateway-only scope.)

No production code touched. Full gateway suite green (all binaries, 0 failures); fmt + clippy `-D warnings` clean; `grep set_var pensyve-mcp-gateway/tests/` returns only comments.