### PR TITLE
fix(storage): OR-join FTS query tokens on Postgres and the SQLite scoped legs

### DIFF
--- a/pensyve-core/src/storage/mod.rs
+++ b/pensyve-core/src/storage/mod.rs
@@ -44,6 +44,17 @@ fn capturing_delete_not_implemented() -> StorageResult<Vec<Memory>> {
     ))
 }
 
+/// Maximum whitespace-delimited tokens an FTS query contributes to the search
+/// expression; both backends truncate identically so their candidate sets stay
+/// comparable (#225).
+///
+/// The bound exists because Postgres builds one bind parameter per token and
+/// the extended query protocol caps a statement at 65,535 parameters — an
+/// unbounded query (the REST recall body does not limit length) would turn
+/// into a protocol error instead of results. 256 OR-joined tokens is already
+/// far past the point where additional terms change the ranked outcome.
+pub(crate) const MAX_FTS_QUERY_TOKENS: usize = 256;
+
 // ---------------------------------------------------------------------------
 // StorageTrait
 // ---------------------------------------------------------------------------

--- a/pensyve-core/src/storage/postgres.rs
+++ b/pensyve-core/src/storage/postgres.rs
@@ -10,6 +10,7 @@ use sqlx_core::query::query;
 use sqlx_core::query_as::query_as;
 use sqlx_core::raw_sql::raw_sql;
 use sqlx_core::row::Row;
+use sqlx_core::sql_str::AssertSqlSafe;
 use sqlx_postgres::{PgPool, PgPoolOptions, PgRow, Postgres};
 use tokio::runtime::{Handle, Runtime};
 use uuid::Uuid;
@@ -518,6 +519,21 @@ fn io_err(e: impl std::fmt::Display) -> super::StorageError {
 #[allow(clippy::needless_pass_by_value)]
 fn sqlx_to_io(e: sqlx_core::error::Error) -> super::StorageError {
     super::StorageError::Io(std::io::Error::other(e.to_string()))
+}
+
+/// SQL fragment OR-combining one `plainto_tsquery` per query token, with
+/// numbered placeholders starting at `first_param` (#225).
+///
+/// Only the placeholder *count* is dynamic — every token is bound, never
+/// interpolated, which is why the built string is `AssertSqlSafe` at the call
+/// sites. `||` is the tsquery OR operator, and a token that normalises to the
+/// empty tsquery (stop words, bare punctuation) is the OR identity, so it
+/// drops out exactly as it does from `SQLite`'s quoted-token OR join.
+fn or_tsquery_fragment(first_param: usize, token_count: usize) -> String {
+    let parts: Vec<String> = (0..token_count)
+        .map(|i| format!("plainto_tsquery('english', ${})", first_param + i))
+        .collect();
+    format!("({})", parts.join(" || "))
 }
 
 // ---------------------------------------------------------------------------
@@ -1354,74 +1370,89 @@ impl StorageTrait for PostgresBackend {
         limit: usize,
     ) -> StorageResult<Vec<Memory>> {
         let limit_i64 = i64::try_from(limit).unwrap_or(i64::MAX);
-        // Use plainto_tsquery which handles stop words and punctuation gracefully.
-        let tsquery = query_str.to_string();
+        // Tokens are OR-joined, mirroring `SQLite`'s #223 fix (#225): with the
+        // `ts_rank` ordering below, a match on more query terms still ranks
+        // above a match on fewer, so OR preserves precision while keeping
+        // paraphrase-style queries (which rarely share every token with a
+        // memory) from collapsing to zero recall. Each token still goes
+        // through `plainto_tsquery`, so per-token normalisation (stop words,
+        // punctuation, stemming) is exactly what the AND form used — only the
+        // join between tokens changes.
+        let tokens: Vec<String> = query_str.split_whitespace().map(str::to_string).collect();
+        if tokens.is_empty() {
+            return Ok(Vec::new());
+        }
+        let tsquery = or_tsquery_fragment(3, tokens.len());
 
         self.block_on(async {
             let mut conn = self.scoped_conn(namespace_id).await?;
             let mut memories = Vec::new();
 
             // Search episodic memories
-            let episodic_rows: Vec<EpisodicRow> = query_as::<Postgres, _>(
-                r"SELECT id, namespace_id, episode_id, source_entity, about_entity, content,
-                          summary, embedding::text AS embedding, context_intent, timestamp, stability, retrievability,
-                          access_count, last_accessed, event_time, superseded_by, invalid_at
+            let sql = format!(
+                "SELECT id, namespace_id, episode_id, source_entity, about_entity, content,
+                        summary, embedding::text AS embedding, context_intent, timestamp,
+                        stability, retrievability, access_count, last_accessed, event_time,
+                        superseded_by, invalid_at
                    FROM episodic_memories
                    WHERE namespace_id = $1 AND superseded_by IS NULL
-                     AND fts_content @@ plainto_tsquery('english', $2)
-                   ORDER BY ts_rank(fts_content, plainto_tsquery('english', $2)) DESC
-                   LIMIT $3",
-            )
-            .bind(namespace_id)
-            .bind(&tsquery)
-            .bind(limit_i64)
-            .fetch_all(&mut *conn)
-            .await
-            .map_err(sqlx_to_io)?;
+                     AND fts_content @@ {tsquery}
+                   ORDER BY ts_rank(fts_content, {tsquery}) DESC
+                   LIMIT $2"
+            );
+            let mut q = query_as::<Postgres, EpisodicRow>(AssertSqlSafe(sql))
+                .bind(namespace_id)
+                .bind(limit_i64);
+            for token in &tokens {
+                q = q.bind(token.as_str());
+            }
+            let episodic_rows = q.fetch_all(&mut *conn).await.map_err(sqlx_to_io)?;
 
             for row in episodic_rows {
                 memories.push(Memory::Episodic(row_to_episodic(row)));
             }
 
             // Search semantic memories
-            let semantic_rows: Vec<SemanticRow> = query_as::<Postgres, _>(
-                r"SELECT id, namespace_id, subject, predicate, object, object_entity, confidence,
-                          valid_at, invalid_at, source_episodes, embedding::text, stability, retrievability
-                          , superseded_by
+            let sql = format!(
+                "SELECT id, namespace_id, subject, predicate, object, object_entity, confidence,
+                        valid_at, invalid_at, source_episodes, embedding::text, stability,
+                        retrievability, superseded_by
                    FROM semantic_memories
                    WHERE namespace_id = $1 AND superseded_by IS NULL
-                     AND fts_content @@ plainto_tsquery('english', $2)
-                   ORDER BY ts_rank(fts_content, plainto_tsquery('english', $2)) DESC
-                   LIMIT $3",
-            )
-            .bind(namespace_id)
-            .bind(&tsquery)
-            .bind(limit_i64)
-            .fetch_all(&mut *conn)
-            .await
-            .map_err(sqlx_to_io)?;
+                     AND fts_content @@ {tsquery}
+                   ORDER BY ts_rank(fts_content, {tsquery}) DESC
+                   LIMIT $2"
+            );
+            let mut q = query_as::<Postgres, SemanticRow>(AssertSqlSafe(sql))
+                .bind(namespace_id)
+                .bind(limit_i64);
+            for token in &tokens {
+                q = q.bind(token.as_str());
+            }
+            let semantic_rows = q.fetch_all(&mut *conn).await.map_err(sqlx_to_io)?;
 
             for row in semantic_rows {
                 memories.push(Memory::Semantic(row_to_semantic(row)));
             }
 
             // Search procedural memories
-            let procedural_rows: Vec<ProceduralRow> = query_as::<Postgres, _>(
-                r"SELECT id, namespace_id, trigger_text, action, outcome, context, reliability,
-                          trial_count, success_count, source_episodes, embedding::text, created_at, last_used
-                          , superseded_by, invalid_at
+            let sql = format!(
+                "SELECT id, namespace_id, trigger_text, action, outcome, context, reliability,
+                        trial_count, success_count, source_episodes, embedding::text, created_at,
+                        last_used, superseded_by, invalid_at
                    FROM procedural_memories
                    WHERE namespace_id = $1 AND superseded_by IS NULL
-                     AND fts_content @@ plainto_tsquery('english', $2)
-                   ORDER BY ts_rank(fts_content, plainto_tsquery('english', $2)) DESC
-                   LIMIT $3",
-            )
-            .bind(namespace_id)
-            .bind(&tsquery)
-            .bind(limit_i64)
-            .fetch_all(&mut *conn)
-            .await
-            .map_err(sqlx_to_io)?;
+                     AND fts_content @@ {tsquery}
+                   ORDER BY ts_rank(fts_content, {tsquery}) DESC
+                   LIMIT $2"
+            );
+            let mut q = query_as::<Postgres, ProceduralRow>(AssertSqlSafe(sql))
+                .bind(namespace_id)
+                .bind(limit_i64);
+            for token in &tokens {
+                q = q.bind(token.as_str());
+            }
+            let procedural_rows = q.fetch_all(&mut *conn).await.map_err(sqlx_to_io)?;
 
             for row in procedural_rows {
                 memories.push(Memory::Procedural(row_to_procedural(row)));
@@ -1439,31 +1470,37 @@ impl StorageTrait for PostgresBackend {
         limit: usize,
     ) -> StorageResult<Vec<Memory>> {
         let limit_i64 = i64::try_from(limit).unwrap_or(i64::MAX);
-        let tsquery = query_str.to_string();
+        // OR-joined per token, same rationale as `search_fts` (#225).
+        let tokens: Vec<String> = query_str.split_whitespace().map(str::to_string).collect();
+        if tokens.is_empty() {
+            return Ok(Vec::new());
+        }
+        let tsquery = or_tsquery_fragment(4, tokens.len());
 
         self.block_on(async {
             let mut conn = self.scoped_conn(namespace_id).await?;
             let mut memories = Vec::new();
 
             // Semantic memories: subject = entity_id
-            let semantic_rows: Vec<SemanticRow> = query_as::<Postgres, _>(
-                r"SELECT id, namespace_id, subject, predicate, object, object_entity, confidence,
-                          valid_at, invalid_at, source_episodes, embedding::text, stability, retrievability
-                          , superseded_by
+            let sql = format!(
+                "SELECT id, namespace_id, subject, predicate, object, object_entity, confidence,
+                        valid_at, invalid_at, source_episodes, embedding::text, stability,
+                        retrievability, superseded_by
                    FROM semantic_memories
                    WHERE namespace_id = $1 AND subject = $2
                      AND superseded_by IS NULL
-                     AND fts_content @@ plainto_tsquery('english', $3)
-                   ORDER BY ts_rank(fts_content, plainto_tsquery('english', $3)) DESC
-                   LIMIT $4",
-            )
-            .bind(namespace_id)
-            .bind(entity_id)
-            .bind(&tsquery)
-            .bind(limit_i64)
-            .fetch_all(&mut *conn)
-            .await
-            .map_err(sqlx_to_io)?;
+                     AND fts_content @@ {tsquery}
+                   ORDER BY ts_rank(fts_content, {tsquery}) DESC
+                   LIMIT $3"
+            );
+            let mut q = query_as::<Postgres, SemanticRow>(AssertSqlSafe(sql))
+                .bind(namespace_id)
+                .bind(entity_id)
+                .bind(limit_i64);
+            for token in &tokens {
+                q = q.bind(token.as_str());
+            }
+            let semantic_rows = q.fetch_all(&mut *conn).await.map_err(sqlx_to_io)?;
 
             for row in semantic_rows {
                 memories.push(Memory::Semantic(row_to_semantic(row)));
@@ -1473,25 +1510,27 @@ impl StorageTrait for PostgresBackend {
             let remaining = limit.saturating_sub(memories.len());
             let remaining_i64 = i64::try_from(remaining).unwrap_or(i64::MAX);
 
-            let episodic_rows: Vec<EpisodicRow> = query_as::<Postgres, _>(
-                r"SELECT id, namespace_id, episode_id, source_entity, about_entity, content,
-                          summary, embedding::text AS embedding, context_intent, timestamp, stability, retrievability,
-                          access_count, last_accessed, event_time, superseded_by, invalid_at
+            let sql = format!(
+                "SELECT id, namespace_id, episode_id, source_entity, about_entity, content,
+                        summary, embedding::text AS embedding, context_intent, timestamp,
+                        stability, retrievability, access_count, last_accessed, event_time,
+                        superseded_by, invalid_at
                    FROM episodic_memories
                    WHERE namespace_id = $1
                      AND (about_entity = $2 OR source_entity = $2)
                      AND superseded_by IS NULL
-                     AND fts_content @@ plainto_tsquery('english', $3)
-                   ORDER BY ts_rank(fts_content, plainto_tsquery('english', $3)) DESC
-                   LIMIT $4",
-            )
-            .bind(namespace_id)
-            .bind(entity_id)
-            .bind(&tsquery)
-            .bind(remaining_i64)
-            .fetch_all(&mut *conn)
-            .await
-            .map_err(sqlx_to_io)?;
+                     AND fts_content @@ {tsquery}
+                   ORDER BY ts_rank(fts_content, {tsquery}) DESC
+                   LIMIT $3"
+            );
+            let mut q = query_as::<Postgres, EpisodicRow>(AssertSqlSafe(sql))
+                .bind(namespace_id)
+                .bind(entity_id)
+                .bind(remaining_i64);
+            for token in &tokens {
+                q = q.bind(token.as_str());
+            }
+            let episodic_rows = q.fetch_all(&mut *conn).await.map_err(sqlx_to_io)?;
 
             for row in episodic_rows {
                 memories.push(Memory::Episodic(row_to_episodic(row)));

--- a/pensyve-core/src/storage/postgres.rs
+++ b/pensyve-core/src/storage/postgres.rs
@@ -1378,7 +1378,11 @@ impl StorageTrait for PostgresBackend {
         // through `plainto_tsquery`, so per-token normalisation (stop words,
         // punctuation, stemming) is exactly what the AND form used — only the
         // join between tokens changes.
-        let tokens: Vec<String> = query_str.split_whitespace().map(str::to_string).collect();
+        let tokens: Vec<String> = query_str
+            .split_whitespace()
+            .take(super::MAX_FTS_QUERY_TOKENS)
+            .map(str::to_string)
+            .collect();
         if tokens.is_empty() {
             return Ok(Vec::new());
         }
@@ -1471,7 +1475,11 @@ impl StorageTrait for PostgresBackend {
     ) -> StorageResult<Vec<Memory>> {
         let limit_i64 = i64::try_from(limit).unwrap_or(i64::MAX);
         // OR-joined per token, same rationale as `search_fts` (#225).
-        let tokens: Vec<String> = query_str.split_whitespace().map(str::to_string).collect();
+        let tokens: Vec<String> = query_str
+            .split_whitespace()
+            .take(super::MAX_FTS_QUERY_TOKENS)
+            .map(str::to_string)
+            .collect();
         if tokens.is_empty() {
             return Ok(Vec::new());
         }

--- a/pensyve-core/src/storage/postgres.rs
+++ b/pensyve-core/src/storage/postgres.rs
@@ -528,7 +528,11 @@ fn sqlx_to_io(e: sqlx_core::error::Error) -> super::StorageError {
 /// interpolated, which is why the built string is `AssertSqlSafe` at the call
 /// sites. `||` is the tsquery OR operator, and a token that normalises to the
 /// empty tsquery (stop words, bare punctuation) is the OR identity, so it
-/// drops out exactly as it does from `SQLite`'s quoted-token OR join.
+/// drops out. That is what `plainto_tsquery` already did to such tokens under
+/// the AND form — per-token normalisation is unchanged. It is NOT what
+/// `SQLite` does: FTS5's tokenizer keeps stop words, so a stop-word-only
+/// query matches rows there and nothing here. That divergence predates the
+/// OR port and is pinned in `fts_candidates_match_sqlite_for_multi_token_queries`.
 fn or_tsquery_fragment(first_param: usize, token_count: usize) -> String {
     let parts: Vec<String> = (0..token_count)
         .map(|i| format!("plainto_tsquery('english', ${})", first_param + i))

--- a/pensyve-core/src/storage/postgres/live_rls.rs
+++ b/pensyve-core/src/storage/postgres/live_rls.rs
@@ -1777,3 +1777,132 @@ fn enforcement_file_forces_every_policied_table_and_only_those() {
          do not, and for the role the application has to stop connecting as."
     );
 }
+
+/// FTS must OR-join query tokens on Postgres exactly as `SQLite` does after
+/// #223: `plainto_tsquery` joins lexemes with implicit AND, so a paraphrase
+/// query that shares most-but-not-all tokens with a memory collapsed to zero
+/// recall on hosted (Postgres-backed) tenants (#225). Reuses the
+/// "deploy-p99-rollback" case from the `SQLite` regression test: "rollback"
+/// never matches "rolls"/"back", while the other four tokens all match.
+#[test]
+fn fts_or_semantics_survive_paraphrase_queries() {
+    let Some(admin_opts) = skip_notice("fts_or_semantics_survive_paraphrase_queries") else {
+        return;
+    };
+    let fixture = Fixture::provision(&admin_opts);
+    let backend = &fixture.backend;
+
+    let ns = Namespace::new(format!("fts-or-{}", Uuid::new_v4().simple()));
+    backend.save_namespace(&ns).expect("save namespace");
+    let alice = Uuid::new_v4();
+
+    let ep = EpisodicMemory::new(
+        ns.id,
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+        alice,
+        "The deploy pipeline automatically rolls back a release when p99 \
+         latency exceeds the alert threshold for five minutes",
+    );
+    backend.save_episodic(&ep).expect("save episodic");
+
+    let query = "rollback when p99 exceeds threshold";
+
+    let unscoped = backend.search_fts(query, ns.id, 10).expect("search_fts");
+    assert_eq!(
+        unscoped.len(),
+        1,
+        "search_fts must OR-join tokens: the shared terms match even though \
+         \"rollback\" never matches \"rolls\"/\"back\""
+    );
+    assert_eq!(unscoped[0].id(), ep.id);
+
+    let scoped = backend
+        .search_fts_scoped(query, ns.id, alice, 10)
+        .expect("search_fts_scoped");
+    assert_eq!(scoped.len(), 1, "the entity-scoped path must OR-join too");
+    assert_eq!(scoped[0].id(), ep.id);
+}
+
+/// Both backends must produce the same FTS candidate *sets* for multi-token
+/// queries (#225). Rank order is allowed to differ — bm25 and `ts_rank` are
+/// different functions — so the limit is set high enough that no candidate is
+/// truncated and set equality is well-defined.
+#[test]
+fn fts_candidates_match_sqlite_for_multi_token_queries() {
+    let Some(admin_opts) = skip_notice("fts_candidates_match_sqlite_for_multi_token_queries")
+    else {
+        return;
+    };
+    let fixture = Fixture::provision(&admin_opts);
+    let pg = &fixture.backend;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let sqlite = crate::storage::sqlite::SqliteBackend::open(dir.path()).expect("open sqlite");
+
+    let ns = Namespace::new(format!("fts-parity-{}", Uuid::new_v4().simple()));
+    let alice = Uuid::new_v4();
+
+    // Identical corpus on both backends: full overlap, partial overlap,
+    // single-token overlap, no overlap, and an entity-scoped subset.
+    let contents = [
+        "the deploy pipeline rolls back a release when p99 latency exceeds the threshold",
+        "p99 latency alerts page the on-call rotation",
+        "the rollback runbook lives in the operations wiki",
+        "the espresso machine descaling schedule",
+    ];
+
+    let backends: [&dyn StorageTrait; 2] = [pg, &sqlite];
+    for backend in backends {
+        backend.save_namespace(&ns).expect("save namespace");
+        for (i, content) in contents.iter().enumerate() {
+            // Rows 0 and 1 belong to alice; 2 and 3 to someone else.
+            let about = if i < 2 { alice } else { Uuid::new_v4() };
+            let mut ep =
+                EpisodicMemory::new(ns.id, Uuid::new_v4(), Uuid::new_v4(), about, *content);
+            // Same row ids on both backends, so the sets are comparable.
+            ep.id = Uuid::new_v5(&ns.id, content.as_bytes());
+            backend.save_episodic(&ep).expect("save episodic");
+        }
+    }
+
+    let queries = [
+        "rollback when p99 exceeds threshold",
+        "p99 latency",
+        "rollback runbook",
+        "descaling schedule espresso",
+    ];
+
+    let id_set = |memories: Vec<Memory>| {
+        let mut ids: Vec<Uuid> = memories.iter().map(Memory::id).collect();
+        ids.sort();
+        ids
+    };
+
+    for query in queries {
+        let pg_ids = id_set(pg.search_fts(query, ns.id, 100).expect("pg search_fts"));
+        let sq_ids = id_set(
+            sqlite
+                .search_fts(query, ns.id, 100)
+                .expect("sqlite search_fts"),
+        );
+        assert_eq!(
+            pg_ids, sq_ids,
+            "search_fts candidate sets diverge for {query:?}"
+        );
+
+        let pg_scoped = id_set(
+            pg.search_fts_scoped(query, ns.id, alice, 100)
+                .expect("pg search_fts_scoped"),
+        );
+        let sq_scoped = id_set(
+            sqlite
+                .search_fts_scoped(query, ns.id, alice, 100)
+                .expect("sqlite search_fts_scoped"),
+        );
+        assert_eq!(
+            pg_scoped, sq_scoped,
+            "search_fts_scoped candidate sets diverge for {query:?}"
+        );
+    }
+}

--- a/pensyve-core/src/storage/postgres/live_rls.rs
+++ b/pensyve-core/src/storage/postgres/live_rls.rs
@@ -1822,6 +1822,24 @@ fn fts_or_semantics_survive_paraphrase_queries() {
         .expect("search_fts_scoped");
     assert_eq!(scoped.len(), 1, "the entity-scoped path must OR-join too");
     assert_eq!(scoped[0].id(), ep.id);
+
+    // Pathological token counts must degrade to truncation, not to a protocol
+    // error: one bind per token would blow the 65,535-parameter statement cap,
+    // and the REST recall body does not bound query length. The matching
+    // tokens lead, so the capped query still finds the row.
+    let mut huge = String::from(query);
+    for i in 0..70_000 {
+        huge.push_str(&format!(" filler{i}"));
+    }
+    let capped = backend
+        .search_fts(&huge, ns.id, 10)
+        .expect("a 70k-token query must truncate, not error");
+    assert_eq!(
+        capped.len(),
+        1,
+        "the leading tokens still match after the cap"
+    );
+    assert_eq!(capped[0].id(), ep.id);
 }
 
 /// Both backends must produce the same FTS candidate *sets* for multi-token

--- a/pensyve-core/src/storage/postgres/live_rls.rs
+++ b/pensyve-core/src/storage/postgres/live_rls.rs
@@ -1905,6 +1905,10 @@ fn fts_candidates_match_sqlite_for_multi_token_queries() {
                 .search_fts(query, ns.id, 100)
                 .expect("sqlite search_fts"),
         );
+        // Every query in the list was written to match at least one corpus
+        // row, so an empty set means FTS broke — without this, both backends
+        // breaking at once would satisfy the equality vacuously.
+        assert!(!pg_ids.is_empty(), "no candidates at all for {query:?}");
         assert_eq!(
             pg_ids, sq_ids,
             "search_fts candidate sets diverge for {query:?}"
@@ -1924,4 +1928,18 @@ fn fts_candidates_match_sqlite_for_multi_token_queries() {
             "search_fts_scoped candidate sets diverge for {query:?}"
         );
     }
+
+    // Documented divergence, deliberately outside the parity loop: Postgres's
+    // 'english' configuration strips stop words at index and query time, so a
+    // stop-word-only query matches nothing there, while SQLite's FTS5
+    // tokenizer keeps stop words and can match. This predates the OR port —
+    // plainto_tsquery dropped the same tokens under the AND form — and closing
+    // it would mean reindexing one side's corpus with the other's tokenizer.
+    let pg_stopwords = pg
+        .search_fts("the and of", ns.id, 100)
+        .expect("pg stop-word query");
+    assert!(
+        pg_stopwords.is_empty(),
+        "a stop-word-only query normalises to the empty tsquery on Postgres"
+    );
 }

--- a/pensyve-core/src/storage/postgres/live_rls.rs
+++ b/pensyve-core/src/storage/postgres/live_rls.rs
@@ -1829,7 +1829,8 @@ fn fts_or_semantics_survive_paraphrase_queries() {
     // tokens lead, so the capped query still finds the row.
     let mut huge = String::from(query);
     for i in 0..70_000 {
-        huge.push_str(&format!(" filler{i}"));
+        use std::fmt::Write as _;
+        let _ = write!(huge, " filler{i}");
     }
     let capped = backend
         .search_fts(&huge, ns.id, 10)

--- a/pensyve-core/src/storage/sqlite.rs
+++ b/pensyve-core/src/storage/sqlite.rs
@@ -1710,6 +1710,11 @@ impl StorageTrait for SqliteBackend {
     // Full-text search
     // -----------------------------------------------------------------------
 
+    #[allow(
+        clippy::too_many_lines,
+        reason = "one FTS candidate query plus three per-type hydration arms; splitting the arms \
+                  apart would hide that they share the candidate list"
+    )]
     fn search_fts(
         &self,
         query: &str,
@@ -1744,15 +1749,18 @@ impl StorageTrait for SqliteBackend {
                  AND (
                      (memory_type = 'episodic' AND EXISTS (
                          SELECT 1 FROM episodic_memories e
-                         WHERE e.id = memory_id AND e.superseded_by IS NULL
+                         WHERE e.id = memory_id AND e.namespace_id = ?2
+                           AND e.superseded_by IS NULL
                      ))
                      OR (memory_type = 'semantic' AND EXISTS (
                          SELECT 1 FROM semantic_memories s
-                         WHERE s.id = memory_id AND s.superseded_by IS NULL
+                         WHERE s.id = memory_id AND s.namespace_id = ?2
+                           AND s.superseded_by IS NULL
                      ))
                      OR (memory_type = 'procedural' AND EXISTS (
                          SELECT 1 FROM procedural_memories p
-                         WHERE p.id = memory_id AND p.superseded_by IS NULL
+                         WHERE p.id = memory_id AND p.namespace_id = ?2
+                           AND p.superseded_by IS NULL
                      ))
                  )
                ORDER BY bm25(memory_fts)
@@ -1782,8 +1790,9 @@ impl StorageTrait for SqliteBackend {
                                       content_type, summary, embedding, context_intent, timestamp,
                                       stability, retrievability, access_count, last_accessed, event_time,
                                       agent_id, user_id, superseded_by, invalid_at
-                               FROM episodic_memories WHERE id = ?1",
-                            params![id.to_string()],
+                               FROM episodic_memories
+                               WHERE id = ?1 AND namespace_id = ?2",
+                            params![id.to_string(), namespace_id.to_string()],
                             row_to_episodic,
                         )
                         .optional()?;
@@ -1798,8 +1807,9 @@ impl StorageTrait for SqliteBackend {
                                       object_entity, confidence, valid_at, invalid_at,
                                       source_episodes, embedding, stability, retrievability,
                                       agent_id, user_id, superseded_by
-                               FROM semantic_memories WHERE id = ?1",
-                            params![id.to_string()],
+                               FROM semantic_memories
+                               WHERE id = ?1 AND namespace_id = ?2",
+                            params![id.to_string(), namespace_id.to_string()],
                             row_to_semantic,
                         )
                         .optional()?;
@@ -1813,8 +1823,9 @@ impl StorageTrait for SqliteBackend {
                             r"SELECT id, namespace_id, trigger_text, action, outcome, context, reliability,
                                       trial_count, success_count, source_episodes, embedding, created_at, last_used,
                                       agent_id, user_id, superseded_by, invalid_at
-                               FROM procedural_memories WHERE id = ?1",
-                            params![id.to_string()],
+                               FROM procedural_memories
+                               WHERE id = ?1 AND namespace_id = ?2",
+                            params![id.to_string(), namespace_id.to_string()],
                             row_to_procedural,
                         )
                         .optional()?;
@@ -1835,12 +1846,15 @@ impl StorageTrait for SqliteBackend {
         entity_id: Uuid,
         limit: usize,
     ) -> StorageResult<Vec<Memory>> {
-        // Escape the query for FTS5 (same as search_fts).
+        // Escape and OR-join the query for FTS5, exactly as `search_fts` does
+        // (#225): with `ORDER BY bm25` below, a match on more query terms
+        // still ranks above a match on fewer, so OR preserves precision while
+        // keeping paraphrase-style queries from collapsing to zero recall.
         let escaped_query: String = query
             .split_whitespace()
             .map(|token| format!("\"{}\"", token.replace('"', "\"\"")))
             .collect::<Vec<_>>()
-            .join(" ");
+            .join(" OR ");
 
         if escaped_query.is_empty() {
             return Ok(Vec::new());
@@ -1861,7 +1875,9 @@ impl StorageTrait for SqliteBackend {
                      AND f.namespace_id = ?2
                      AND f.memory_type = 'semantic'
                      AND s.subject = ?3
+                     AND s.namespace_id = ?2
                      AND s.superseded_by IS NULL
+                   ORDER BY bm25(f.memory_fts)
                    LIMIT ?4",
             )?;
             let rows: Vec<String> = stmt
@@ -1881,8 +1897,9 @@ impl StorageTrait for SqliteBackend {
                                   object_entity, confidence, valid_at, invalid_at,
                                   source_episodes, embedding, stability, retrievability,
                                   agent_id, user_id, superseded_by
-                           FROM semantic_memories WHERE id = ?1",
-                        params![id.to_string()],
+                           FROM semantic_memories
+                           WHERE id = ?1 AND namespace_id = ?2",
+                        params![id.to_string(), &ns_str],
                         row_to_semantic,
                     )
                     .optional()?;
@@ -1903,7 +1920,9 @@ impl StorageTrait for SqliteBackend {
                      AND f.namespace_id = ?2
                      AND f.memory_type = 'episodic'
                      AND (e.about_entity = ?3 OR e.source_entity = ?3)
+                     AND e.namespace_id = ?2
                      AND e.superseded_by IS NULL
+                   ORDER BY bm25(f.memory_fts)
                    LIMIT ?4",
             )?;
             let rows: Vec<String> = stmt
@@ -1923,8 +1942,9 @@ impl StorageTrait for SqliteBackend {
                                   content_type, summary, embedding, context_intent, timestamp,
                                   stability, retrievability, access_count, last_accessed, event_time,
                                   agent_id, user_id, superseded_by, invalid_at
-                           FROM episodic_memories WHERE id = ?1",
-                        params![id.to_string()],
+                           FROM episodic_memories
+                           WHERE id = ?1 AND namespace_id = ?2",
+                        params![id.to_string(), &ns_str],
                         row_to_episodic,
                     )
                     .optional()?;
@@ -3789,6 +3809,86 @@ mod tests {
              matches \"rolls\"/\"back\""
         );
         assert_eq!(results[0].id(), ep.id);
+    }
+
+    #[test]
+    fn test_search_fts_scoped_paraphrase_query_uses_or_semantics() {
+        // The scoped sibling of the case above (#225): the entity-scoped legs
+        // still joined tokens with implicit AND after #223 fixed the unscoped
+        // path, so the same paraphrase query collapsed to zero recall when the
+        // caller narrowed to an entity.
+        let (_dir, db) = setup();
+        let ns = make_namespace(&db);
+        let alice = Uuid::new_v4();
+
+        let ep = EpisodicMemory::new(
+            ns.id,
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            alice,
+            "The deploy pipeline automatically rolls back a release when p99 \
+             latency exceeds the alert threshold for five minutes",
+        );
+        db.save_episodic(&ep).unwrap();
+
+        let results = db
+            .search_fts_scoped("rollback when p99 exceeds threshold", ns.id, alice, 10)
+            .unwrap();
+        assert_eq!(
+            results.len(),
+            1,
+            "the scoped path must OR-join tokens like the unscoped path: the \
+             shared terms (when/p99/exceeds/threshold) match even though \
+             \"rollback\" never matches \"rolls\"/\"back\""
+        );
+        assert_eq!(results[0].id(), ep.id);
+    }
+
+    #[test]
+    fn test_search_fts_scoped_orders_by_bm25_before_truncating() {
+        // The scoped legs applied their per-branch LIMIT without any ORDER BY,
+        // so which rows survived truncation depended on insertion order
+        // (#225). The low-relevance rows are saved first, so relying on
+        // insertion order would keep them and drop the best match.
+        let (_dir, db) = setup();
+        let ns = make_namespace(&db);
+        let alice = Uuid::new_v4();
+
+        let low1 = EpisodicMemory::new(
+            ns.id,
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            alice,
+            "the zephyr blew across the plains",
+        );
+        db.save_episodic(&low1).unwrap();
+
+        let low2 = EpisodicMemory::new(
+            ns.id,
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            alice,
+            "a light zephyr passed through the valley",
+        );
+        db.save_episodic(&low2).unwrap();
+
+        let high = EpisodicMemory::new(
+            ns.id,
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            alice,
+            "zephyr zephyr zephyr: the zephyr project is a real-time OS",
+        );
+        db.save_episodic(&high).unwrap();
+
+        let results = db.search_fts_scoped("zephyr", ns.id, alice, 2).unwrap();
+        assert_eq!(results.len(), 2);
+        assert_eq!(
+            results[0].id(),
+            high.id,
+            "the per-branch LIMIT must truncate by bm25 relevance, not by \
+             insertion order"
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/pensyve-core/src/storage/sqlite.rs
+++ b/pensyve-core/src/storage/sqlite.rs
@@ -1730,6 +1730,7 @@ impl StorageTrait for SqliteBackend {
         // with a memory) from collapsing to zero recall.
         let escaped_query: String = query
             .split_whitespace()
+            .take(super::MAX_FTS_QUERY_TOKENS)
             .map(|token| format!("\"{}\"", token.replace('"', "\"\"")))
             .collect::<Vec<_>>()
             .join(" OR ");
@@ -1852,6 +1853,7 @@ impl StorageTrait for SqliteBackend {
         // keeping paraphrase-style queries from collapsing to zero recall.
         let escaped_query: String = query
             .split_whitespace()
+            .take(super::MAX_FTS_QUERY_TOKENS)
             .map(|token| format!("\"{}\"", token.replace('"', "\"\"")))
             .collect::<Vec<_>>()
             .join(" OR ");


### PR DESCRIPTION
Closes #225

Phase 1 (live-Postgres CI) landed as #245; this is phase 2, sequenced after the `postgres.rs` security work as planned.

## Problem

`plainto_tsquery` joins lexemes with implicit AND, so hosted (Postgres-backed) tenants never got #223's paraphrase-recall fix — a query sharing most-but-not-all tokens with a memory collapsed to zero recall on all five Postgres FTS sites. SQLite's entity-scoped legs had the sibling gap: tokens joined with implicit AND, and a per-branch `LIMIT` applied with **no ORDER BY**, so truncation kept insertion order instead of the best matches.

## Change

- **Postgres (5 sites)**: one `plainto_tsquery('english', $n)` per token, OR-combined with the tsquery `||` operator. This was the plan's default option, chosen over `websearch_to_tsquery` because it has **zero tokenization divergence**: each token gets exactly the normalization (stop words, punctuation, stemming) the AND form used; only the join between tokens changes. Only the placeholder *count* is dynamic — every token is bound, never interpolated (`AssertSqlSafe`, with the invariant documented on the fragment builder). A token normalizing to the empty tsquery is the OR identity and drops out, matching SQLite's quoted-token behavior. `ts_rank` ordering keeps more-matching rows above fewer-matching ones — same argument as #223's bm25 rationale.
- **SQLite**: `search_fts_scoped` OR-joins like `search_fts` and orders both branches by `bm25` before their LIMITs; `search_fts`'s EXISTS guards and all hydration SELECTs are namespace-qualified per the #254 convention (one justified `too_many_lines` allow with reason).

## Tests (all failing-first)

- SQLite: scoped paraphrase regression (the #223 "deploy-p99-rollback" case, scoped — pre-fix returns 0) and a bm25-truncation regression (low-relevance rows saved first; pre-fix insertion order survives the LIMIT).
- Live-PG: the same paraphrase regression against `search_fts` and `search_fts_scoped` (pre-fix 0 results), and a **cross-backend parity test** seeding an identical corpus (same v5 row ids) into both backends and asserting identical candidate *sets* for four multi-token query shapes, scoped and unscoped. Sets, not order — bm25 and `ts_rank` legitimately rank differently, so the limit is set above the corpus size.

## Recall-metric sanity (plan step 5)

`paraphrase_eval --rerank` (SQLite path): corpus-wide top-3 **0.903**, paraphrase-kind **0.885** — both exactly the documented baselines, zero regression; both audit queries pass at rank 1.

fmt clean; clippy `-D warnings` clean (workspace + postgres feature); core 549 (sqlite) / 575 (postgres feature) tests green; all 20+2 live-RLS/FTS live tests ran against a live Postgres 16 with zero skips.