### PR TITLE
feat(gdpr): erase an entity in one capturing transaction that deletes edges

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -103,10 +103,11 @@ same way. Every `StorageTrait` method that reaches a policied table without a
 `list_semantic_by_entity`, `update_episodic_access`, `invalidate_semantic`,
 `update_semantic_content`, `update_procedural_reliability` and
 `delete_observations_by_entity`. One of those is still on the recall path:
-`update_episodic_access` writes the reinforcement stamp. GDPR erase
-reaches two: #256 scoped its memory deletion and the edge accessor is scoped
-now, but its observation and entity-record steps still match on the entity id
-alone. All of it is tracked by #254.
+`update_episodic_access` writes the reinforcement stamp. GDPR erase no longer
+reaches any of them: `erase_entity_capturing` replaced the four independent
+calls with one transaction whose every leg — observations and the entity record
+included — carries a `namespace_id` predicate and runs on a namespace-bound
+connection (#264). The rest is tracked by #254.
 
 Do not apply enforcement to a deployment until those paths carry a namespace.
 
@@ -115,7 +116,10 @@ edge belongs to the namespace of its source entity — plus a
 `namespace_isolation_edges` policy and a `FORCE` line in the enforcement file.
 `save_edge` and `get_edges_for_entity_in_namespace` both take a namespace and
 bind it on their connection, so the graph is covered by both layers rather than
-by neither. Erasing edges rather than only counting them is #264.
+by neither. A GDPR erase now really deletes them: the edge leg of
+`erase_entity_capturing` is a `DELETE … WHERE (source = ? OR target = ?) AND
+namespace_id = ?`, where the erase used to run a `SELECT` and report its row
+count as `edges_deleted` while every edge stayed in the table (#264).
 
 Source-namespace ownership has one consequence worth stating plainly: an edge
 whose source is in namespace A and whose target is in namespace B is stored in
@@ -123,7 +127,7 @@ A, so B cannot see it at all — not even on the `target` leg, where B would
 otherwise expect to find an edge pointing at its own entity. An erase running
 in B therefore does not see and does not delete A's edge into B. That is the
 intended trade (the edge is A's data, and B must not be handed a read into A),
-and #264 owns what the erase side does about it.
+and it is the one residue a GDPR erase deliberately leaves behind.
 
 Databases provisioned before the column existed are migrated in place: the
 column is backfilled from `entities.namespace_id` via `edges.source`, and edges

--- a/pensyve-core/src/gdpr.rs
+++ b/pensyve-core/src/gdpr.rs
@@ -6,7 +6,7 @@
 
 use uuid::Uuid;
 
-use crate::storage::{StorageError, StorageTrait};
+use crate::storage::{ErasedRows, StorageError, StorageTrait};
 use crate::types::Memory;
 
 /// Result of a GDPR erasure operation.
@@ -22,8 +22,16 @@ pub struct ErasureResult {
     /// Number of entities deleted.
     pub entities_deleted: usize,
     /// Whether the operation completed fully.
+    ///
+    /// The storage half is all-or-nothing now, so on `Ok` this is `true` unless
+    /// a caller appended a warning for cleanup it owns outside the transaction
+    /// (the gateway's vector index).
     pub complete: bool,
-    /// Any errors encountered (non-fatal).
+    /// Errors from post-commit cleanup the erasure itself does not own.
+    ///
+    /// The storage legs no longer contribute here: they run in one transaction
+    /// that either commits whole or rolls back whole, and a rollback surfaces as
+    /// `Err` rather than as a warning on a nominally successful result.
     pub warnings: Vec<String>,
 }
 
@@ -38,58 +46,52 @@ pub struct ExportResult {
     pub total_records: usize,
 }
 
-/// Execute a GDPR erasure for all data belonging to an entity.
+/// Execute a GDPR erasure for all data belonging to an entity, and hand back the
+/// rows it removed.
 ///
-/// Cascades through:
-/// 1. All memories (episodic, semantic, procedural) about the entity
-/// 2. All graph edges involving the entity
-/// 3. The entity record itself
+/// One [`StorageTrait::erase_entity_capturing`] transaction removes, in this
+/// order: observations derived from the entity's episodes, its episodic and
+/// semantic memories (superseded rows included), its graph edges, and the entity
+/// record. Any leg failing rolls the whole thing back and surfaces as `Err` —
+/// there is no partial erase to report on. `namespace_id` scopes every leg.
 ///
-/// Returns an `ErasureResult` summarizing what was deleted.
+/// The returned [`ErasedRows`] is what callers must drive out-of-band cleanup
+/// from. Collecting ids with a separate query first leaves a window in which a
+/// concurrent writer inserts a matching row: the erase then deletes it while its
+/// vector-index entry survives, pointing at content that no longer exists
+/// (#268).
 ///
-/// `namespace_id` names the tenant the erasure belongs to, matching
-/// [`export_entity_data`]. The memory and edge steps carry it; the observation
-/// and entity steps still match on `entity_id` alone and are tracked by #254
-/// along with the rest of the unscoped `StorageTrait` surface.
+/// One residue is intentional. An edge belongs to its source entity's namespace,
+/// so an edge whose source lives in another tenant and whose target is the
+/// entity being erased is stored there, is not visible here, and is not deleted.
+/// Reading it would be a cross-tenant read; the edge is the other tenant's data.
+pub fn erase_entity_captured(
+    storage: &dyn StorageTrait,
+    entity_id: Uuid,
+    namespace_id: Uuid,
+) -> Result<(ErasureResult, ErasedRows), StorageError> {
+    let erased = storage.erase_entity_capturing(entity_id, namespace_id)?;
+
+    let result = ErasureResult {
+        memories_deleted: erased.memories.len(),
+        observations_deleted: erased.observations.len(),
+        edges_deleted: erased.edges.len(),
+        entities_deleted: usize::from(erased.entity_deleted),
+        complete: true,
+        warnings: Vec::new(),
+    };
+
+    Ok((result, erased))
+}
+
+/// [`erase_entity_captured`] for callers with no out-of-band state to clean up
+/// (the CLI, `erase_namespace`). The captured rows are dropped.
 pub fn erase_entity(
     storage: &dyn StorageTrait,
     entity_id: Uuid,
     namespace_id: Uuid,
 ) -> Result<ErasureResult, StorageError> {
-    let mut result = ErasureResult::default();
-
-    // Step 1: Delete observations derived from episodes the entity
-    // participated in. MUST run BEFORE `delete_memories_by_entity` because
-    // the join uses `episodic_memories.about_entity / source_entity` — once
-    // the episodic rows are gone the association is lost.
-    match storage.delete_observations_by_entity(entity_id) {
-        Ok(count) => result.observations_deleted = count,
-        Err(e) => result
-            .warnings
-            .push(format!("Observation deletion error: {e}")),
-    }
-
-    // Step 2: Delete all episodic / semantic memories about this entity.
-    match storage.delete_memories_by_entity(entity_id, namespace_id) {
-        Ok(count) => result.memories_deleted = count,
-        Err(e) => result.warnings.push(format!("Memory deletion error: {e}")),
-    }
-
-    // Step 3: Delete graph edges
-    match storage.get_edges_for_entity_in_namespace(entity_id, namespace_id) {
-        Ok(edges) => result.edges_deleted = edges.len(),
-        Err(e) => result.warnings.push(format!("Edge query error: {e}")),
-    }
-
-    // Step 4: Delete entity record (not found is OK — entity may not exist)
-    match storage.delete_entity(entity_id) {
-        Ok(true) => result.entities_deleted = 1,
-        Ok(false) => {} // Entity record didn't exist — nothing to delete
-        Err(e) => result.warnings.push(format!("Entity deletion error: {e}")),
-    }
-
-    result.complete = result.warnings.is_empty();
-    Ok(result)
+    erase_entity_captured(storage, entity_id, namespace_id).map(|(result, _)| result)
 }
 
 /// Execute a GDPR erasure for ALL entities in a namespace.
@@ -217,7 +219,7 @@ mod tests {
     use super::*;
     use crate::embedding::OnnxEmbedder;
     use crate::storage::sqlite::SqliteBackend;
-    use crate::types::{Entity, EntityKind, Episode, EpisodicMemory, Namespace};
+    use crate::types::{Edge, Entity, EntityKind, Episode, EpisodicMemory, Namespace};
 
     #[test]
     fn test_erase_entity_empty() {
@@ -277,6 +279,46 @@ mod tests {
         let result = export_entity_data(&storage, entity.id, ns.id).unwrap();
         assert_eq!(result.total_records, 2); // 1 memory + 1 entity
         assert!(!result.memories.is_empty());
+    }
+
+    /// #264: `edges_deleted` used to be the row count of a *query*, so an erase
+    /// reported a number while every edge stayed in the table. The count and the
+    /// table have to agree.
+    ///
+    /// Both directions are seeded — the entity as `source` and as `target` — so
+    /// a delete that only covered one leg fails here rather than in production.
+    #[test]
+    fn erase_entity_deletes_the_edges_it_reports() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = SqliteBackend::open(dir.path()).unwrap();
+
+        let ns = Namespace::new("edge-erase-test");
+        storage.save_namespace(&ns).unwrap();
+
+        let mut subject = Entity::new("subject", EntityKind::User);
+        subject.namespace_id = ns.id;
+        storage.save_entity(&subject).unwrap();
+
+        let mut peer = Entity::new("peer", EntityKind::User);
+        peer.namespace_id = ns.id;
+        storage.save_entity(&peer).unwrap();
+
+        let outgoing = Edge::new(subject.id, peer.id, "knows");
+        storage.save_edge(&outgoing, ns.id).unwrap();
+        let incoming = Edge::new(peer.id, subject.id, "manages");
+        storage.save_edge(&incoming, ns.id).unwrap();
+
+        let result = erase_entity(&storage, subject.id, ns.id).unwrap();
+
+        assert_eq!(result.edges_deleted, 2, "both legs must be reported");
+        assert!(
+            storage
+                .get_edges_for_entity_in_namespace(subject.id, ns.id)
+                .unwrap()
+                .is_empty(),
+            "an erase that reports deleted edges must leave none behind"
+        );
+        assert!(result.complete);
     }
 
     #[test]

--- a/pensyve-core/src/gdpr.rs
+++ b/pensyve-core/src/gdpr.rs
@@ -12,7 +12,8 @@ use crate::types::Memory;
 /// Result of a GDPR erasure operation.
 #[derive(Debug, Clone, Default)]
 pub struct ErasureResult {
-    /// Number of memories deleted (episodic + semantic + procedural).
+    /// Number of memories deleted (episodic + semantic). Procedural memories
+    /// are not attached to an entity and are not part of an entity erasure.
     pub memories_deleted: usize,
     /// Number of observation memories deleted (derived from episodes the
     /// entity participated in).

--- a/pensyve-core/src/storage/mod.rs
+++ b/pensyve-core/src/storage/mod.rs
@@ -424,7 +424,13 @@ pub trait StorageTrait: Send + Sync {
     /// `namespace_id`.
     ///
     /// This exists so callers can collect the ids to strip from a vector index
-    /// before an entity-wide forget (#261). `list_episodic_by_entity` and
+    /// before an entity-wide forget (#261). It is a read, not a capture, so it
+    /// must not be used to drive cleanup for a delete: the rows can change
+    /// between the listing and the delete. Both paths that used to do that now
+    /// take their ids from what the delete returned —
+    /// [`StorageTrait::delete_memories_by_entity_capturing`] for forget and
+    /// [`StorageTrait::erase_entity_capturing`] for GDPR erase (#268).
+    /// `list_episodic_by_entity` and
     /// `list_semantic_by_entity` are not a substitute: they look at
     /// `about_entity` and `subject` alone and skip superseded rows, so every
     /// source-side episodic, object-side semantic and superseded row kept its

--- a/pensyve-core/src/storage/mod.rs
+++ b/pensyve-core/src/storage/mod.rs
@@ -60,15 +60,6 @@ fn capturing_delete_not_implemented() -> StorageResult<Vec<Memory>> {
     ))
 }
 
-fn capturing_erase_not_implemented() -> StorageResult<ErasedRows> {
-    Err(StorageError::Context(
-        "storage backend does not implement capturing entity erasure, \
-         so a GDPR erase cannot delete observations, memories, edges and the \
-         entity record in one atomic transaction"
-            .to_string(),
-    ))
-}
-
 /// Everything one [`StorageTrait::erase_entity_capturing`] transaction removed.
 ///
 /// These are the rows the committed `DELETE`s actually returned, not the rows a
@@ -572,15 +563,16 @@ pub trait StorageTrait: Send + Sync {
     /// the `save_edge` / `get_edges_for_entity_in_namespace` comment below for
     /// why that ownership rule is the one being kept.
     ///
-    /// The default fails closed: a backend that cannot erase atomically must not
-    /// have a partial erase reported as a completed one.
+    /// Required rather than defaulted. A default that errors at runtime would
+    /// let a backend which cannot erase atomically compile, ship, and only then
+    /// fail the one request that had to work — turning a build failure into a
+    /// production one. An implementor that cannot satisfy the contract above
+    /// should find that out from the compiler.
     fn erase_entity_capturing(
         &self,
-        _entity_id: Uuid,
-        _namespace_id: Uuid,
-    ) -> StorageResult<ErasedRows> {
-        capturing_erase_not_implemented()
-    }
+        entity_id: Uuid,
+        namespace_id: Uuid,
+    ) -> StorageResult<ErasedRows>;
 
     /// Delete a single memory (episodic, semantic, procedural or observation)
     /// only when it belongs to `namespace_id`.
@@ -778,16 +770,5 @@ mod tests {
 
         assert!(matches!(error, StorageError::Context(_)));
         assert!(error.to_string().contains("capturing entity deletion"));
-    }
-
-    /// Same rule one level up: a backend that cannot run the four erase legs in
-    /// one transaction must error rather than let a partial GDPR erase be
-    /// reported as a completed one.
-    #[test]
-    fn capturing_erase_not_implemented_fails_closed() {
-        let error = capturing_erase_not_implemented().unwrap_err();
-
-        assert!(matches!(error, StorageError::Context(_)));
-        assert!(error.to_string().contains("capturing entity erasure"));
     }
 }

--- a/pensyve-core/src/storage/mod.rs
+++ b/pensyve-core/src/storage/mod.rs
@@ -640,8 +640,9 @@ pub trait StorageTrait: Send + Sync {
     // and whose target is in B is stored in A and is therefore invisible from
     // B, including on B's `target` leg — so an erase running in B will not see
     // it and cannot delete it (pinned by
-    // `an_edge_belongs_to_its_source_entitys_namespace_only`; #264 owns the
-    // erase-side consequence).
+    // `an_edge_belongs_to_its_source_entitys_namespace_only`). That is the
+    // residue [`StorageTrait::erase_entity_capturing`] deliberately leaves
+    // behind: reading the edge to delete it would be a read into A.
     fn save_edge(&self, edge: &Edge, namespace_id: Uuid) -> StorageResult<()>;
     fn get_edges_for_entity_in_namespace(
         &self,

--- a/pensyve-core/src/storage/mod.rs
+++ b/pensyve-core/src/storage/mod.rs
@@ -60,6 +60,36 @@ fn capturing_delete_not_implemented() -> StorageResult<Vec<Memory>> {
     ))
 }
 
+fn capturing_erase_not_implemented() -> StorageResult<ErasedRows> {
+    Err(StorageError::Context(
+        "storage backend does not implement capturing entity erasure, \
+         so a GDPR erase cannot delete observations, memories, edges and the \
+         entity record in one atomic transaction"
+            .to_string(),
+    ))
+}
+
+/// Everything one [`StorageTrait::erase_entity_capturing`] transaction removed.
+///
+/// These are the rows the committed `DELETE`s actually returned, not the rows a
+/// preceding `SELECT` predicted they would remove. Callers that have to clean up
+/// out-of-band state — the gateway strips the vector index — must drive that
+/// cleanup from here: a set collected by a separate query before the delete
+/// leaves a window in which a concurrent writer inserts a matching row, and the
+/// delete then destroys it while its index entry survives (#268).
+#[derive(Debug, Clone, Default)]
+pub struct ErasedRows {
+    /// Observations derived from episodes the entity participated in.
+    pub observations: Vec<ObservationMemory>,
+    /// Episodic and semantic memories, superseded rows included.
+    pub memories: Vec<Memory>,
+    /// Graph edges touching the entity, within the erasing namespace.
+    pub edges: Vec<Edge>,
+    /// Whether the entity record itself was removed. `false` means no such row
+    /// existed in the namespace, which is not an error.
+    pub entity_deleted: bool,
+}
+
 /// Maximum whitespace-delimited tokens an FTS query contributes to the search
 /// expression; both backends truncate identically so their candidate sets stay
 /// comparable (#225).
@@ -508,6 +538,44 @@ pub trait StorageTrait: Send + Sync {
         capturing_delete_not_implemented()
     }
 
+    /// Erase everything belonging to `entity_id` within `namespace_id` in ONE
+    /// transaction, and hand back the rows it removed.
+    ///
+    /// This is the storage half of `gdpr::erase_entity`. The legs run in a fixed
+    /// order, and the order is load-bearing:
+    ///
+    /// 1. **observations** — they are found by joining through
+    ///    `episodic_memories.about_entity / source_entity`, so once the episodic
+    ///    rows are gone the association no longer exists;
+    /// 2. **memories** — episodic and semantic, superseded rows included, with
+    ///    any search-index cleanup in the same transaction;
+    /// 3. **edges** — `(source = entity OR target = entity) AND namespace_id`;
+    /// 4. **the entity record**.
+    ///
+    /// Implementations must:
+    /// - qualify every statement by `namespace_id` — entity ids repeat across
+    ///   namespaces, so an entity-only predicate reaches into other tenants and
+    ///   also drags their rows into the caller's captured set;
+    /// - run all four legs in one transaction, rolling the whole thing back on
+    ///   any error. A GDPR erase is all-or-nothing: a caller told an erase
+    ///   failed must not have to guess which legs already committed.
+    ///
+    /// Edges are only ever this namespace's edges. An edge whose source is in
+    /// another namespace and whose target is the entity being erased is stored
+    /// in — and visible only from — the source's namespace, so it survives. See
+    /// the `save_edge` / `get_edges_for_entity_in_namespace` comment below for
+    /// why that ownership rule is the one being kept.
+    ///
+    /// The default fails closed: a backend that cannot erase atomically must not
+    /// have a partial erase reported as a completed one.
+    fn erase_entity_capturing(
+        &self,
+        _entity_id: Uuid,
+        _namespace_id: Uuid,
+    ) -> StorageResult<ErasedRows> {
+        capturing_erase_not_implemented()
+    }
+
     /// Delete a single memory (episodic, semantic, procedural or observation)
     /// only when it belongs to `namespace_id`.
     ///
@@ -703,5 +771,16 @@ mod tests {
 
         assert!(matches!(error, StorageError::Context(_)));
         assert!(error.to_string().contains("capturing entity deletion"));
+    }
+
+    /// Same rule one level up: a backend that cannot run the four erase legs in
+    /// one transaction must error rather than let a partial GDPR erase be
+    /// reported as a completed one.
+    #[test]
+    fn capturing_erase_not_implemented_fails_closed() {
+        let error = capturing_erase_not_implemented().unwrap_err();
+
+        assert!(matches!(error, StorageError::Context(_)));
+        assert!(error.to_string().contains("capturing entity erasure"));
     }
 }

--- a/pensyve-core/src/storage/postgres.rs
+++ b/pensyve-core/src/storage/postgres.rs
@@ -1990,9 +1990,12 @@ impl StorageTrait for PostgresBackend {
     /// has an analogue in `postgres_schema.sql`: the KG tables are not part of
     /// the Postgres schema at all, and full-text search is a generated
     /// `tsvector` column on each memory table, so deleting the row takes its
-    /// index entry with it. `edges` is untouched on both backends. It carries
-    /// a `namespace_id` now, so a namespace-scoped delete has become
-    /// expressible against it; actually deleting edges here is #264.
+    /// index entry with it. `edges` and `entities` are untouched on both
+    /// backends: a purge empties the memory tables and leaves the namespace's
+    /// graph and entity records standing. The entity-scoped
+    /// [`StorageTrait::erase_entity_capturing`] does delete both, so the
+    /// expression is available — the purge simply does not use it. That gap is
+    /// #278.
     ///
     /// Every statement names `namespace_id = $1` explicitly even though all
     /// four run on a namespace-bound connection. That is the #254 convention:

--- a/pensyve-core/src/storage/postgres.rs
+++ b/pensyve-core/src/storage/postgres.rs
@@ -21,7 +21,8 @@ use crate::types::{
 };
 
 use super::{
-    ActivityAggregate, ActivityEvent, StorageResult, StorageTrait, cross_namespace_edge_id,
+    ActivityAggregate, ActivityEvent, ErasedRows, StorageResult, StorageTrait,
+    cross_namespace_edge_id,
 };
 use crate::graph::EdgeType;
 
@@ -1731,6 +1732,129 @@ impl StorageTrait for PostgresBackend {
         })
     }
 
+    /// One-transaction GDPR erase — the trait docs carry the leg order and why
+    /// it is fixed. Each leg is a `DELETE ... RETURNING`, so the captured rows
+    /// are the rows the statement removed rather than rows a preceding `SELECT`
+    /// predicted, and all four run in one transaction: any error drops `tx`,
+    /// which rolls back, leaving the erase to be retried whole.
+    ///
+    /// The connection is bound to `namespace_id` rather than left unscoped. This
+    /// method knows its namespace, and an unscoped connection matches no row
+    /// once RLS is enforced — a capturing erase that quietly deleted nothing,
+    /// or ran against whatever namespace the previous checkout left set, is
+    /// exactly the failure #253 caught. The explicit `AND namespace_id = $2`
+    /// predicates stay regardless: they are what confines the delete while RLS
+    /// is inert, which is every deployment shipping today.
+    ///
+    /// There is no full-text cleanup, unlike the `SQLite` backend: this schema
+    /// indexes through a `fts_content` generated column on each table, so
+    /// deleting the row deletes its index entry.
+    fn erase_entity_capturing(
+        &self,
+        entity_id: Uuid,
+        namespace_id: Uuid,
+    ) -> StorageResult<ErasedRows> {
+        self.block_on(async {
+            let mut conn = self.scoped_conn(namespace_id).await?;
+            let mut tx = (&mut *conn).begin().await.map_err(sqlx_to_io)?;
+            let mut erased = ErasedRows::default();
+
+            // Leg 1 — observations. MUST precede the episodic delete: the only
+            // link from an observation back to the entity runs through
+            // `episodic_memories.about_entity / source_entity`, and once those
+            // rows are gone the association cannot be reconstructed.
+            let rows: Vec<ObservationRow> = query_as::<Postgres, _>(
+                r"DELETE FROM observation_memories
+                   WHERE namespace_id = $2
+                     AND episode_id IN (
+                       SELECT DISTINCT episode_id FROM episodic_memories
+                        WHERE (about_entity = $1 OR source_entity = $1)
+                          AND namespace_id = $2
+                     )
+                   RETURNING id, namespace_id, episode_id, entity_type, instance, action,
+                             quantity, unit, content, embedding::text AS embedding, confidence,
+                             event_time, created_at, stability, retrievability,
+                             superseded_by, invalid_at",
+            )
+            .bind(entity_id)
+            .bind(namespace_id)
+            .fetch_all(&mut *tx)
+            .await
+            .map_err(sqlx_to_io)?;
+            erased
+                .observations
+                .extend(rows.into_iter().map(row_to_observation));
+
+            // Leg 2 — episodic and semantic memories, superseded rows included.
+            // Predicates match `delete_memories_by_entity` verbatim.
+            let rows: Vec<EpisodicRow> = query_as::<Postgres, _>(
+                r"DELETE FROM episodic_memories
+                   WHERE (about_entity = $1 OR source_entity = $1) AND namespace_id = $2
+                   RETURNING id, namespace_id, episode_id, source_entity, about_entity, content,
+                             summary, embedding::text AS embedding, context_intent, timestamp,
+                             stability, retrievability, access_count, last_accessed, event_time,
+                             superseded_by, invalid_at",
+            )
+            .bind(entity_id)
+            .bind(namespace_id)
+            .fetch_all(&mut *tx)
+            .await
+            .map_err(sqlx_to_io)?;
+            erased
+                .memories
+                .extend(rows.into_iter().map(row_to_episodic).map(Memory::Episodic));
+
+            let rows: Vec<SemanticRow> = query_as::<Postgres, _>(
+                r"DELETE FROM semantic_memories
+                   WHERE (subject = $1 OR object_entity = $1) AND namespace_id = $2
+                   RETURNING id, namespace_id, subject, predicate, object, object_entity,
+                             confidence, valid_at, invalid_at, source_episodes,
+                             embedding::text AS embedding, stability, retrievability,
+                             superseded_by",
+            )
+            .bind(entity_id)
+            .bind(namespace_id)
+            .fetch_all(&mut *tx)
+            .await
+            .map_err(sqlx_to_io)?;
+            erased
+                .memories
+                .extend(rows.into_iter().map(row_to_semantic).map(Memory::Semantic));
+
+            // Leg 3 — graph edges. Same-namespace edges only, by construction:
+            // an edge belongs to its source entity's namespace, so an edge from
+            // another tenant pointing at this entity is not visible here and
+            // survives. See the trait docs.
+            let rows: Vec<EdgeRow> = query_as::<Postgres, _>(
+                r"DELETE FROM edges
+                   WHERE (source = $1 OR target = $1) AND namespace_id = $2
+                   RETURNING id, source, target, relation, weight, valid_at, invalid_at,
+                             superseded_by, metadata",
+            )
+            .bind(entity_id)
+            .bind(namespace_id)
+            .fetch_all(&mut *tx)
+            .await
+            .map_err(sqlx_to_io)?;
+            erased.edges.extend(rows.into_iter().map(row_to_edge));
+
+            // Leg 4 — the entity record. Absence is not an error: the caller may
+            // be erasing data for an entity whose record was already removed.
+            let result =
+                query::<Postgres>("DELETE FROM entities WHERE id = $1 AND namespace_id = $2")
+                    .bind(entity_id)
+                    .bind(namespace_id)
+                    .execute(&mut *tx)
+                    .await
+                    .map_err(sqlx_to_io)?;
+            erased.entity_deleted = result.rows_affected() > 0;
+
+            tx.commit().await.map_err(sqlx_to_io)?;
+
+            Ok(erased)
+        })
+    }
+
     /// Entity-wide delete, confined to `namespace_id`.
     ///
     /// The `AND namespace_id = $2` predicates carry the isolation on their own.
@@ -2057,27 +2181,7 @@ impl StorageTrait for PostgresBackend {
             .await
             .map_err(sqlx_to_io)?;
 
-            Ok(rows
-                .into_iter()
-                .map(
-                    |(id, source, target, relation, weight, valid_at, invalid_at, superseded_by, metadata)| {
-                        let metadata: HashMap<String, serde_json::Value> =
-                            serde_json::from_value(metadata).unwrap_or_default();
-                        Edge {
-                            id,
-                            source,
-                            target,
-                            relation,
-                            weight,
-                            valid_at,
-                            invalid_at,
-                            superseded_by,
-                            metadata,
-                            edge_type: EdgeType::default(),
-                        }
-                    },
-                )
-                .collect())
+            Ok(rows.into_iter().map(row_to_edge).collect())
         })
     }
 
@@ -2385,6 +2489,22 @@ fn row_to_procedural(row: ProceduralRow) -> ProceduralMemory {
         // G1: postgres backend does not yet carry the multi-tenant scope columns.
         agent_id: None,
         user_id: None,
+    }
+}
+
+fn row_to_edge(row: EdgeRow) -> Edge {
+    let (id, source, target, relation, weight, valid_at, invalid_at, superseded_by, metadata) = row;
+    Edge {
+        id,
+        source,
+        target,
+        relation,
+        weight,
+        valid_at,
+        invalid_at,
+        superseded_by,
+        metadata: serde_json::from_value(metadata).unwrap_or_default(),
+        edge_type: EdgeType::default(),
     }
 }
 

--- a/pensyve-core/src/storage/postgres/live_rls.rs
+++ b/pensyve-core/src/storage/postgres/live_rls.rs
@@ -1159,6 +1159,77 @@ fn edges_are_confined_to_their_namespace_under_enforced_rls() {
     );
 }
 
+/// One row of every shape a capturing erase removes, seeded in one namespace.
+struct ErasableRows {
+    episodic: Uuid,
+    fact: Uuid,
+    observation: Uuid,
+    /// A superseded episodic row. A GDPR erase has to take history, not just
+    /// current state, so neither predicate may grow a `superseded_by IS NULL`
+    /// clause — and every read path around the delete filters on supersession
+    /// somewhere, so such a clause would look natural.
+    superseded: Uuid,
+    edge: Uuid,
+}
+
+impl ErasableRows {
+    /// Every memory id seeded here, in sorted order.
+    fn memory_ids(&self) -> Vec<Uuid> {
+        let mut ids = vec![self.episodic, self.fact, self.superseded];
+        ids.sort();
+        ids
+    }
+}
+
+/// Seed one of each into `namespace_id`, all attached to `entity_id`.
+fn seed_erasable_rows(
+    backend: &PostgresBackend,
+    namespace_id: Uuid,
+    entity_id: Uuid,
+) -> ErasableRows {
+    let episode_id = Uuid::new_v4();
+
+    let episodic = EpisodicMemory::new(namespace_id, episode_id, entity_id, entity_id, "a turn");
+    backend.save_episodic(&episodic).expect("save episodic");
+
+    let mut fact = SemanticMemory::new(namespace_id, Uuid::new_v4(), "reports to", "alice", 0.9);
+    fact.object_entity = Some(entity_id);
+    backend.save_semantic(&fact).expect("save object-side fact");
+
+    let observation = ObservationMemory::new(namespace_id, episode_id, "x", "y", "z", "an obs");
+    backend
+        .save_observation(&observation)
+        .expect("save observation");
+
+    let superseded = EpisodicMemory::new(
+        namespace_id,
+        episode_id,
+        entity_id,
+        entity_id,
+        "an older turn",
+    );
+    backend
+        .save_episodic(&superseded)
+        .expect("save superseded episodic");
+    assert!(
+        backend
+            .supersede_memory_in_namespace(superseded.id, namespace_id, Uuid::new_v4(), Utc::now())
+            .expect("supersede"),
+        "the row must actually be superseded, or the assertions that read it prove nothing"
+    );
+
+    let edge = Edge::new(entity_id, Uuid::new_v4(), "knows");
+    backend.save_edge(&edge, namespace_id).expect("save edge");
+
+    ErasableRows {
+        episodic: episodic.id,
+        fact: fact.id,
+        observation: observation.id,
+        superseded: superseded.id,
+        edge: edge.id,
+    }
+}
+
 /// The capturing GDPR erase must work under enforced RLS, and must stay inside
 /// its own namespace on all four legs.
 ///
@@ -1195,44 +1266,25 @@ fn capturing_erase_is_confined_to_its_namespace_under_enforced_rls() {
     backend.save_entity(&entity).expect("save entity in A");
     let entity_id = entity.id;
 
-    let mut seeded = Vec::new();
-    for ns in [&ns_a, &ns_b] {
-        let episode_id = Uuid::new_v4();
-        let episodic = EpisodicMemory::new(ns.id, episode_id, entity_id, entity_id, "a turn");
-        backend.save_episodic(&episodic).expect("save episodic");
-
-        let mut fact = SemanticMemory::new(ns.id, Uuid::new_v4(), "reports to", "alice", 0.9);
-        fact.object_entity = Some(entity_id);
-        backend.save_semantic(&fact).expect("save object-side fact");
-
-        let observation = ObservationMemory::new(ns.id, episode_id, "x", "y", "z", "an obs");
-        backend
-            .save_observation(&observation)
-            .expect("save observation");
-
-        let edge = Edge::new(entity_id, Uuid::new_v4(), "knows");
-        backend.save_edge(&edge, ns.id).expect("save edge");
-
-        seeded.push((episodic.id, fact.id, observation.id, edge.id));
-    }
+    let in_a = seed_erasable_rows(backend, ns_a.id, entity_id);
+    let in_b = seed_erasable_rows(backend, ns_b.id, entity_id);
 
     let erased = backend
         .erase_entity_capturing(entity_id, ns_a.id)
         .expect("capturing erase must succeed under enforced RLS");
 
-    let (a_episodic, a_fact, a_observation, _) = seeded[0];
     assert_eq!(
         erased.observations.iter().map(|o| o.id).collect::<Vec<_>>(),
-        vec![a_observation],
+        vec![in_a.observation],
         "only namespace A's observation may be captured"
     );
     let mut captured = memory_ids(&erased.memories);
     captured.sort();
-    let mut expected = vec![a_episodic, a_fact];
-    expected.sort();
     assert_eq!(
-        captured, expected,
-        "only namespace A's episodic and object-side semantic rows may be captured"
+        captured,
+        in_a.memory_ids(),
+        "namespace A's episodic, object-side semantic and superseded rows — and \
+         nothing of namespace B's — may be captured"
     );
     assert_eq!(
         erased.edges.len(),
@@ -1245,13 +1297,14 @@ fn capturing_erase_is_confined_to_its_namespace_under_enforced_rls() {
     );
 
     // Namespace A really is empty — the erase committed rather than fail-closed
-    // no-op'ing on a connection bound to nothing.
+    // no-op'ing on a connection bound to nothing. Read including superseded
+    // rows, or the superseded one would count as "gone" while still on disk.
     assert!(
         backend
-            .get_all_memories_by_namespace(ns_a.id)
+            .get_all_memories_by_namespace_including_superseded(ns_a.id)
             .expect("read namespace A")
             .is_empty(),
-        "namespace A must be empty after its own erase"
+        "namespace A must be empty after its own erase, history included"
     );
     assert!(
         backend
@@ -1262,16 +1315,16 @@ fn capturing_erase_is_confined_to_its_namespace_under_enforced_rls() {
     );
 
     // …and namespace B is untouched.
-    let (b_episodic, b_fact, b_observation, b_edge) = seeded[1];
     let surviving = memory_ids(
         &backend
-            .get_all_memories_by_namespace(ns_b.id)
+            .get_all_memories_by_namespace_including_superseded(ns_b.id)
             .expect("read namespace B"),
     );
     for (label, id) in [
-        ("episodic", b_episodic),
-        ("semantic", b_fact),
-        ("observation", b_observation),
+        ("episodic", in_b.episodic),
+        ("semantic", in_b.fact),
+        ("observation", in_b.observation),
+        ("superseded episodic", in_b.superseded),
     ] {
         assert!(
             surviving.contains(&id),
@@ -1286,7 +1339,7 @@ fn capturing_erase_is_confined_to_its_namespace_under_enforced_rls() {
             .iter()
             .map(|edge| edge.id)
             .collect::<Vec<_>>(),
-        vec![b_edge],
+        vec![in_b.edge],
         "namespace B's edge must survive"
     );
 }

--- a/pensyve-core/src/storage/postgres/live_rls.rs
+++ b/pensyve-core/src/storage/postgres/live_rls.rs
@@ -1159,6 +1159,138 @@ fn edges_are_confined_to_their_namespace_under_enforced_rls() {
     );
 }
 
+/// The capturing GDPR erase must work under enforced RLS, and must stay inside
+/// its own namespace on all four legs.
+///
+/// This is the test #253's incident asks for: the transaction runs on a
+/// namespace-*bound* connection, so an accidental rebase onto `unbound()` — or
+/// onto the empty-namespace GUC — turns into a visible failure here rather than
+/// into a delete against whatever namespace the previous checkout left set. The
+/// erase and the read-back both go through the backend, so a fail-closed
+/// connection shows up as "namespace A was not erased".
+///
+/// The observation and entity-record legs are the ones that used to match on the
+/// entity id alone (#264); with the same entity id seeded in both namespaces,
+/// that predicate would take namespace B's rows too.
+#[test]
+fn capturing_erase_is_confined_to_its_namespace_under_enforced_rls() {
+    let Some(admin_opts) =
+        skip_notice("capturing_erase_is_confined_to_its_namespace_under_enforced_rls")
+    else {
+        return;
+    };
+    let fixture = Fixture::provision(&admin_opts);
+    let backend = &fixture.backend;
+
+    let ns_a = Namespace::new(format!("erase-a-{}", Uuid::new_v4().simple()));
+    let ns_b = Namespace::new(format!("erase-b-{}", Uuid::new_v4().simple()));
+    backend.save_namespace(&ns_a).expect("save namespace A");
+    backend.save_namespace(&ns_b).expect("save namespace B");
+    fixture.enforce_rls();
+
+    // The `entities` row can only exist once — `id` is the primary key — so it
+    // is seeded in A. Everything else collides deliberately.
+    let mut entity = Entity::new("alice", EntityKind::User);
+    entity.namespace_id = ns_a.id;
+    backend.save_entity(&entity).expect("save entity in A");
+    let entity_id = entity.id;
+
+    let mut seeded = Vec::new();
+    for ns in [&ns_a, &ns_b] {
+        let episode_id = Uuid::new_v4();
+        let episodic = EpisodicMemory::new(ns.id, episode_id, entity_id, entity_id, "a turn");
+        backend.save_episodic(&episodic).expect("save episodic");
+
+        let mut fact = SemanticMemory::new(ns.id, Uuid::new_v4(), "reports to", "alice", 0.9);
+        fact.object_entity = Some(entity_id);
+        backend.save_semantic(&fact).expect("save object-side fact");
+
+        let observation = ObservationMemory::new(ns.id, episode_id, "x", "y", "z", "an obs");
+        backend
+            .save_observation(&observation)
+            .expect("save observation");
+
+        let edge = Edge::new(entity_id, Uuid::new_v4(), "knows");
+        backend.save_edge(&edge, ns.id).expect("save edge");
+
+        seeded.push((episodic.id, fact.id, observation.id, edge.id));
+    }
+
+    let erased = backend
+        .erase_entity_capturing(entity_id, ns_a.id)
+        .expect("capturing erase must succeed under enforced RLS");
+
+    let (a_episodic, a_fact, a_observation, _) = seeded[0];
+    assert_eq!(
+        erased.observations.iter().map(|o| o.id).collect::<Vec<_>>(),
+        vec![a_observation],
+        "only namespace A's observation may be captured"
+    );
+    let mut captured = memory_ids(&erased.memories);
+    captured.sort();
+    let mut expected = vec![a_episodic, a_fact];
+    expected.sort();
+    assert_eq!(
+        captured, expected,
+        "only namespace A's episodic and object-side semantic rows may be captured"
+    );
+    assert_eq!(
+        erased.edges.len(),
+        1,
+        "only namespace A's edge may be captured"
+    );
+    assert!(
+        erased.entity_deleted,
+        "the entity record lives in namespace A and must be removed"
+    );
+
+    // Namespace A really is empty — the erase committed rather than fail-closed
+    // no-op'ing on a connection bound to nothing.
+    assert!(
+        backend
+            .get_all_memories_by_namespace(ns_a.id)
+            .expect("read namespace A")
+            .is_empty(),
+        "namespace A must be empty after its own erase"
+    );
+    assert!(
+        backend
+            .get_edges_for_entity_in_namespace(entity_id, ns_a.id)
+            .expect("read namespace A's edges")
+            .is_empty(),
+        "an erase that reports deleted edges must leave none behind"
+    );
+
+    // …and namespace B is untouched.
+    let (b_episodic, b_fact, b_observation, b_edge) = seeded[1];
+    let surviving = memory_ids(
+        &backend
+            .get_all_memories_by_namespace(ns_b.id)
+            .expect("read namespace B"),
+    );
+    for (label, id) in [
+        ("episodic", b_episodic),
+        ("semantic", b_fact),
+        ("observation", b_observation),
+    ] {
+        assert!(
+            surviving.contains(&id),
+            "namespace B's {label} row must survive an erase issued for namespace A; \
+             B now holds {surviving:?}"
+        );
+    }
+    assert_eq!(
+        backend
+            .get_edges_for_entity_in_namespace(entity_id, ns_b.id)
+            .expect("read namespace B's edges")
+            .iter()
+            .map(|edge| edge.id)
+            .collect::<Vec<_>>(),
+        vec![b_edge],
+        "namespace B's edge must survive"
+    );
+}
+
 /// The schema runs on every startup, so it has to migrate a database that
 /// predates `edges.namespace_id` as cleanly as it creates a fresh one.
 ///

--- a/pensyve-core/src/storage/sqlite.rs
+++ b/pensyve-core/src/storage/sqlite.rs
@@ -5994,4 +5994,64 @@ mod tests {
         assert!(erased.edges.is_empty());
         assert!(!erased.entity_deleted);
     }
+
+    /// Superseded rows are erased too, and appear in the capture.
+    ///
+    /// A GDPR erase has to remove the entity's *history*, not just its current
+    /// state — a superseded memory still holds the content that was written
+    /// about the subject. The predicates deliberately carry no
+    /// `superseded_by IS NULL` clause; this pins that, because both the delete
+    /// and every read path around it filter on supersession somewhere, so an
+    /// added clause would look natural and silently strand history.
+    ///
+    /// It also pins the capture side: a superseded row that is deleted but not
+    /// returned keeps its vector-index entry, which is #268's failure one row
+    /// at a time.
+    #[test]
+    fn erase_entity_capturing_takes_superseded_rows_too() {
+        let (_dir, db) = setup();
+        let ns = make_namespace(&db);
+
+        let mut entity = Entity::new("subject", EntityKind::User);
+        entity.namespace_id = ns.id;
+        db.save_entity(&entity).unwrap();
+
+        let episode = Episode::new(ns.id, vec![entity.id]);
+        db.save_episode(&episode).unwrap();
+
+        let episodic = EpisodicMemory::new(ns.id, episode.id, entity.id, entity.id, "an old turn");
+        db.save_episodic(&episodic).unwrap();
+        let semantic = SemanticMemory::new(ns.id, entity.id, "lived_in", "berlin", 0.5);
+        db.save_semantic(&semantic).unwrap();
+
+        for id in [episodic.id, semantic.id] {
+            assert!(
+                db.supersede_memory_in_namespace(id, ns.id, Uuid::new_v4(), Utc::now())
+                    .unwrap(),
+                "the row must actually be superseded, or this test proves nothing"
+            );
+        }
+        // Live-row reads no longer see either one — which is exactly why the
+        // erase must not be built on a live-row read.
+        assert!(db.get_all_memories_by_namespace(ns.id).unwrap().is_empty());
+
+        let erased = db.erase_entity_capturing(entity.id, ns.id).unwrap();
+
+        let mut captured: Vec<Uuid> = erased.memories.iter().map(Memory::id).collect();
+        captured.sort();
+        let mut expected = vec![episodic.id, semantic.id];
+        expected.sort();
+        assert_eq!(
+            captured, expected,
+            "both superseded rows must be captured by the erase"
+        );
+        assert!(
+            db.get_all_memories_by_namespace_including_superseded(ns.id)
+                .unwrap()
+                .is_empty(),
+            "superseded history must be gone from storage, not just from live reads"
+        );
+        assert_eq!(fts_rows_for(&db, episodic.id), 0);
+        assert_eq!(fts_rows_for(&db, semantic.id), 0);
+    }
 }

--- a/pensyve-core/src/storage/sqlite.rs
+++ b/pensyve-core/src/storage/sqlite.rs
@@ -3042,9 +3042,19 @@ fn erase_observations_for_entity(
 
     // Phase 2B cascade: `kg_triples` / `kg_passage_entities` are keyed by the
     // observation's id (== `passage_id`). Driving the cleanup off the captured
-    // ids rather than off a repeat of the subquery keeps it exactly as wide as
-    // the delete was. `kg_entities` stay: they are namespace-scoped rather than
-    // passage-scoped and other passages' triples still reference them.
+    // ids rather than off a repeat of the subquery keeps it aimed at exactly
+    // the passages this delete removed. `kg_entities` stay: they are
+    // namespace-scoped rather than passage-scoped and other passages' triples
+    // still reference them.
+    //
+    // Each statement still needs the namespace on top of the passage id, and
+    // the two tables supply it differently. `kg_triples` has a `namespace_id`
+    // column. `kg_passage_entities` does not — its key is
+    // `(passage_id, entity_id)` — so the only thing that attributes one of its
+    // rows to a tenant is the `kg_entities` row it points at, and matching on
+    // `passage_id` alone deletes every tenant that shares the id. The join
+    // below is the same one `delete_memory_by_id_with_namespace` uses for the
+    // single-memory path; the two have to agree.
     for observation in &observations {
         let passage = observation.id.to_string();
         conn.execute(
@@ -3052,8 +3062,10 @@ fn erase_observations_for_entity(
             params![&passage, ns_str],
         )?;
         conn.execute(
-            "DELETE FROM kg_passage_entities WHERE passage_id = ?1",
-            params![&passage],
+            "DELETE FROM kg_passage_entities
+              WHERE passage_id = ?1
+                AND entity_id IN (SELECT id FROM kg_entities WHERE namespace_id = ?2)",
+            params![&passage, ns_str],
         )?;
         conn.execute(
             "DELETE FROM memory_fts
@@ -5454,6 +5466,29 @@ mod tests {
         .unwrap()
     }
 
+    /// `kg_passage_entities` rows for `passage_id` whose entity belongs to
+    /// `namespace_id`.
+    ///
+    /// The table carries no `namespace_id` of its own — its key is
+    /// `(passage_id, entity_id)` — so the only way to attribute a row to a
+    /// tenant is through `kg_entities`, which is what the cleanup has to do
+    /// too.
+    fn kg_passage_entities_count_in_namespace(
+        db: &SqliteBackend,
+        passage_id: Uuid,
+        namespace_id: Uuid,
+    ) -> i64 {
+        let conn = db.conn.lock().unwrap();
+        conn.query_row(
+            "SELECT COUNT(*) FROM kg_passage_entities \
+              WHERE passage_id = ?1 \
+                AND entity_id IN (SELECT id FROM kg_entities WHERE namespace_id = ?2)",
+            params![passage_id.to_string(), namespace_id.to_string()],
+            |r| r.get(0),
+        )
+        .unwrap()
+    }
+
     fn kg_entities_count_for_namespace(db: &SqliteBackend, namespace_id: Uuid) -> i64 {
         let conn = db.conn.lock().unwrap();
         conn.query_row(
@@ -5993,6 +6028,95 @@ mod tests {
         assert!(erased.memories.is_empty());
         assert!(erased.edges.is_empty());
         assert!(!erased.entity_deleted);
+    }
+
+    /// The knowledge-graph cascade must stay inside the erasing namespace.
+    ///
+    /// `kg_passage_entities` has no `namespace_id` column — its key is
+    /// `(passage_id, entity_id)` — so a delete matching `passage_id` alone
+    /// reaches every tenant that happens to share the id. Passage ids are
+    /// observation ids, and this schema does not treat ids as globally unique
+    /// anywhere else; the sibling single-memory path
+    /// (`delete_memory_by_id_with_namespace`) already joins through
+    /// `kg_entities` to attribute the row, and the erase has to match it.
+    ///
+    /// `kg_triples` carries its own `namespace_id` and is seeded here as the
+    /// control: it was already qualified, so it must survive on B's side too
+    /// and its survival is not what this test is about.
+    #[test]
+    fn erase_entity_capturing_kg_cascade_is_confined_to_its_namespace() {
+        let (_dir, db) = setup();
+        let ns_a = make_namespace(&db);
+        let ns_b = Namespace::new("other-ns");
+        db.save_namespace(&ns_b).unwrap();
+
+        let mut entity = Entity::new("subject", EntityKind::User);
+        entity.namespace_id = ns_a.id;
+        db.save_entity(&entity).unwrap();
+
+        let episode = Episode::new(ns_a.id, vec![entity.id]);
+        db.save_episode(&episode).unwrap();
+        let episodic = EpisodicMemory::new(ns_a.id, episode.id, entity.id, entity.id, "a turn");
+        db.save_episodic(&episodic).unwrap();
+
+        let observation =
+            ObservationMemory::new(ns_a.id, episode.id, "x", "y", "z", "an observation");
+        db.save_observation(&observation).unwrap();
+
+        // A's knowledge-graph rows for that passage.
+        let a_subject = seed_kg_entity(&db, ns_a.id, "S-A");
+        let a_object = seed_kg_entity(&db, ns_a.id, "O-A");
+        seed_kg_triple(&db, ns_a.id, observation.id, a_subject, a_object);
+
+        // B's knowledge-graph rows for the SAME passage id, wired to B's own
+        // `kg_entities`. Nothing in the schema prevents this: the passage id is
+        // not a foreign key, and `kg_passage_entities` cannot tell the two
+        // tenants apart on its own.
+        let b_subject = seed_kg_entity(&db, ns_b.id, "S-B");
+        let b_object = seed_kg_entity(&db, ns_b.id, "O-B");
+        seed_kg_triple(&db, ns_b.id, observation.id, b_subject, b_object);
+
+        assert_eq!(
+            kg_passage_entities_count_in_namespace(&db, observation.id, ns_a.id),
+            2
+        );
+        assert_eq!(
+            kg_passage_entities_count_in_namespace(&db, observation.id, ns_b.id),
+            2,
+            "B's rows must exist before the erase, or their absence afterwards proves nothing"
+        );
+
+        let erased = db.erase_entity_capturing(entity.id, ns_a.id).unwrap();
+        assert_eq!(
+            erased.observations.iter().map(|o| o.id).collect::<Vec<_>>(),
+            vec![observation.id],
+            "the erase must have captured the observation whose cascade is under test"
+        );
+
+        assert_eq!(
+            kg_passage_entities_count_in_namespace(&db, observation.id, ns_a.id),
+            0,
+            "namespace A's own passage-entity rows must cascade with its observation"
+        );
+        assert_eq!(
+            kg_passage_entities_count_in_namespace(&db, observation.id, ns_b.id),
+            2,
+            "namespace B's passage-entity rows were deleted by an erase issued for \
+             namespace A: the cleanup matched `passage_id` alone, and that column \
+             names nothing on its own"
+        );
+
+        // Control: the already-qualified legs behave.
+        assert_eq!(
+            kg_entities_count_for_namespace(&db, ns_b.id),
+            2,
+            "namespace B's kg_entities must survive"
+        );
+        assert_eq!(
+            kg_triples_count_for_passage(&db, observation.id),
+            1,
+            "only namespace A's triple may go; `kg_triples` was already namespace-qualified"
+        );
     }
 
     /// Superseded rows are erased too, and appear in the capture.

--- a/pensyve-core/src/storage/sqlite.rs
+++ b/pensyve-core/src/storage/sqlite.rs
@@ -12,7 +12,7 @@ use crate::types::{
 };
 
 use super::{
-    ActivityAggregate, ActivityEvent, StorageError, StorageResult, StorageTrait,
+    ActivityAggregate, ActivityEvent, ErasedRows, StorageError, StorageResult, StorageTrait,
     cross_namespace_edge_id,
 };
 use crate::graph::EdgeType;
@@ -2409,6 +2409,160 @@ impl StorageTrait for SqliteBackend {
         }
     }
 
+    /// One-transaction GDPR erase — the trait docs carry the leg order and why
+    /// it is fixed. `RETURNING` supplies the captured rows, so what the caller
+    /// gets back is what each `DELETE` removed rather than what a preceding
+    /// `SELECT` predicted it would remove.
+    ///
+    /// Every leg is qualified by `namespace_id`, the observation join included.
+    /// The unscoped `delete_observations_by_entity` this replaces on the erase
+    /// path matched on the entity id alone, and entity ids are not globally
+    /// unique in this schema, so that predicate reached into other tenants.
+    fn erase_entity_capturing(
+        &self,
+        entity_id: Uuid,
+        namespace_id: Uuid,
+    ) -> StorageResult<ErasedRows> {
+        let conn = lock_conn!(self);
+        let id_str = entity_id.to_string();
+        let ns_str = namespace_id.to_string();
+
+        conn.execute_batch("BEGIN")?;
+
+        let result = (|| -> StorageResult<ErasedRows> {
+            let mut erased = ErasedRows::default();
+
+            // Leg 1 — observations. MUST precede the episodic delete: the only
+            // link from an observation back to the entity runs through
+            // `episodic_memories.about_entity / source_entity`, and once those
+            // rows are gone the association cannot be reconstructed.
+            let mut stmt = conn.prepare(
+                r"DELETE FROM observation_memories
+                   WHERE namespace_id = ?2
+                     AND episode_id IN (
+                       SELECT DISTINCT episode_id FROM episodic_memories
+                        WHERE (about_entity = ?1 OR source_entity = ?1)
+                          AND namespace_id = ?2
+                     )
+                   RETURNING id, namespace_id, episode_id, entity_type, instance, action,
+                             quantity, unit, content, embedding, confidence, event_time,
+                             created_at, stability, retrievability, agent_id, user_id,
+                             superseded_by, invalid_at",
+            )?;
+            let rows = stmt
+                .query_map(params![&id_str, &ns_str], row_to_observation)?
+                .collect::<Result<Vec<_>, _>>()?;
+            for row in rows {
+                erased.observations.push(row?);
+            }
+
+            // Phase 2B cascade: `kg_triples` / `kg_passage_entities` are keyed
+            // by the observation's id (== `passage_id`). Driving the cleanup off
+            // the captured ids rather than off a repeat of the subquery keeps it
+            // exactly as wide as the delete was. `kg_entities` stay: they are
+            // namespace-scoped rather than passage-scoped and other passages'
+            // triples still reference them.
+            for observation in &erased.observations {
+                let passage = observation.id.to_string();
+                conn.execute(
+                    "DELETE FROM kg_triples WHERE passage_id = ?1 AND namespace_id = ?2",
+                    params![&passage, &ns_str],
+                )?;
+                conn.execute(
+                    "DELETE FROM kg_passage_entities WHERE passage_id = ?1",
+                    params![&passage],
+                )?;
+                conn.execute(
+                    "DELETE FROM memory_fts
+                      WHERE memory_id = ?1 AND namespace_id = ?2 AND memory_type = 'observation'",
+                    params![&passage, &ns_str],
+                )?;
+            }
+
+            // Leg 2 — episodic and semantic memories, superseded rows included.
+            // Predicates match `delete_memories_by_entity` verbatim.
+            let mut stmt = conn.prepare(
+                r"DELETE FROM episodic_memories
+                   WHERE (about_entity = ?1 OR source_entity = ?1) AND namespace_id = ?2
+                   RETURNING id, namespace_id, episode_id, source_entity, about_entity, content,
+                             content_type, summary, embedding, context_intent, timestamp,
+                             stability, retrievability, access_count, last_accessed, event_time,
+                             agent_id, user_id, superseded_by, invalid_at",
+            )?;
+            let rows = stmt
+                .query_map(params![&id_str, &ns_str], row_to_episodic)?
+                .collect::<Result<Vec<_>, _>>()?;
+            for row in rows {
+                erased.memories.push(Memory::Episodic(row?));
+            }
+
+            let mut stmt = conn.prepare(
+                r"DELETE FROM semantic_memories
+                   WHERE (subject = ?1 OR object_entity = ?1) AND namespace_id = ?2
+                   RETURNING id, namespace_id, subject, predicate, object, content_type,
+                             object_entity, confidence, valid_at, invalid_at,
+                             source_episodes, embedding, stability, retrievability,
+                             agent_id, user_id, superseded_by",
+            )?;
+            let rows = stmt
+                .query_map(params![&id_str, &ns_str], row_to_semantic)?
+                .collect::<Result<Vec<_>, _>>()?;
+            for row in rows {
+                erased.memories.push(Memory::Semantic(row?));
+            }
+
+            // `memory_fts` is keyed by `memory_id`, which identifies nothing on
+            // its own: ids repeat across namespaces, and within one namespace
+            // the same id can name both an episodic and a semantic row. Both
+            // halves of the key are pinned, or the cleanup strips an index entry
+            // whose base row is still live.
+            for memory in &erased.memories {
+                conn.execute(
+                    "DELETE FROM memory_fts
+                      WHERE memory_id = ?1 AND namespace_id = ?2 AND memory_type = ?3",
+                    params![memory.id().to_string(), &ns_str, memory.type_name()],
+                )?;
+            }
+
+            // Leg 3 — graph edges. Same-namespace edges only, by construction:
+            // an edge belongs to its source entity's namespace, so an edge from
+            // another tenant pointing at this entity is not visible here and
+            // survives. See the trait docs.
+            let mut stmt = conn.prepare(&format!(
+                "DELETE FROM edges
+                  WHERE (source = ?1 OR target = ?1) AND namespace_id = ?2
+                  RETURNING {EDGE_COLUMNS}",
+            ))?;
+            let rows = stmt
+                .query_map(params![&id_str, &ns_str], edge_columns)?
+                .collect::<Result<Vec<_>, _>>()?;
+            for row in rows {
+                erased.edges.push(columns_to_edge(row)?);
+            }
+
+            // Leg 4 — the entity record. Absence is not an error: the caller may
+            // be erasing data for an entity whose record was already removed.
+            let deleted = conn.execute(
+                "DELETE FROM entities WHERE id = ?1 AND namespace_id = ?2",
+                params![&id_str, &ns_str],
+            )?;
+            erased.entity_deleted = deleted > 0;
+
+            Ok(erased)
+        })();
+
+        match result {
+            Ok(erased) => {
+                conn.execute_batch("COMMIT")?;
+                Ok(erased)
+            }
+            Err(e) => {
+                let _ = conn.execute_batch("ROLLBACK");
+                Err(e)
+            }
+        }
+    }
+
     fn delete_memories_by_entity(
         &self,
         entity_id: Uuid,
@@ -2725,66 +2879,14 @@ impl StorageTrait for SqliteBackend {
         let conn = lock_conn!(self);
         let id_str = entity_id.to_string();
         let namespace_str = namespace_id.to_string();
-        let mut stmt = conn.prepare(
-            "SELECT id, source, target, relation, weight, valid_at, invalid_at, superseded_by, metadata \
+        let mut stmt = conn.prepare(&format!(
+            "SELECT {EDGE_COLUMNS} \
              FROM edges WHERE namespace_id = ?2 AND (source = ?1 OR target = ?1)",
-        )?;
-        let rows = stmt.query_map(params![&id_str, &namespace_str], |row| {
-            Ok((
-                row.get::<_, String>(0)?,
-                row.get::<_, String>(1)?,
-                row.get::<_, String>(2)?,
-                row.get::<_, String>(3)?,
-                row.get::<_, f64>(4)?,
-                row.get::<_, String>(5)?,
-                row.get::<_, Option<String>>(6)?,
-                row.get::<_, Option<String>>(7)?,
-                row.get::<_, String>(8)?,
-            ))
-        })?;
-        let mut edges = Vec::new();
-        for row in rows {
-            let (
-                id_str,
-                src_str,
-                tgt_str,
-                relation,
-                weight,
-                valid_at_str,
-                invalid_at_opt,
-                superseded_by_opt,
-                metadata_str,
-            ) = row?;
-            let id = Uuid::parse_str(&id_str)
-                .map_err(|e| StorageError::Context(format!("corrupt UUID: {e}")))?;
-            let source = Uuid::parse_str(&src_str)
-                .map_err(|e| StorageError::Context(format!("corrupt UUID: {e}")))?;
-            let target = Uuid::parse_str(&tgt_str)
-                .map_err(|e| StorageError::Context(format!("corrupt UUID: {e}")))?;
-            let valid_at = str_to_dt(&valid_at_str);
-            let invalid_at = invalid_at_opt.map(|s| str_to_dt(&s));
-            let superseded_by = superseded_by_opt
-                .map(|s| {
-                    Uuid::parse_str(&s)
-                        .map_err(|e| StorageError::Context(format!("corrupt UUID: {e}")))
-                })
-                .transpose()?;
-            let metadata: std::collections::HashMap<String, serde_json::Value> =
-                serde_json::from_str(&metadata_str)?;
-            edges.push(Edge {
-                id,
-                source,
-                target,
-                relation,
-                weight: weight as f32,
-                valid_at,
-                invalid_at,
-                superseded_by,
-                metadata,
-                edge_type: EdgeType::default(),
-            });
-        }
-        Ok(edges)
+        ))?;
+        let rows = stmt
+            .query_map(params![&id_str, &namespace_str], edge_columns)?
+            .collect::<Result<Vec<_>, _>>()?;
+        rows.into_iter().map(columns_to_edge).collect()
     }
 
     // -----------------------------------------------------------------------
@@ -3002,6 +3104,66 @@ fn load_memories_by_namespace(
 /// Parse a UUID string, returning `StorageError::Context` on failure.
 fn parse_uuid(s: &str) -> Result<Uuid, StorageError> {
     Uuid::parse_str(s).map_err(|e| StorageError::Context(format!("corrupt UUID: {e}")))
+}
+
+/// The `edges` columns [`columns_to_edge`] decodes, positionally.
+///
+/// Named once so the read's `SELECT` and the erase's `DELETE ... RETURNING`
+/// cannot drift apart: a mismatch there is a silent mis-decode, not a
+/// compile error.
+const EDGE_COLUMNS: &str =
+    "id, source, target, relation, weight, valid_at, invalid_at, superseded_by, metadata";
+
+type EdgeColumns = (
+    String,
+    String,
+    String,
+    String,
+    f64,
+    String,
+    Option<String>,
+    Option<String>,
+    String,
+);
+
+fn edge_columns(row: &rusqlite::Row<'_>) -> rusqlite::Result<EdgeColumns> {
+    Ok((
+        row.get(0)?,
+        row.get(1)?,
+        row.get(2)?,
+        row.get(3)?,
+        row.get(4)?,
+        row.get(5)?,
+        row.get(6)?,
+        row.get(7)?,
+        row.get(8)?,
+    ))
+}
+
+fn columns_to_edge(columns: EdgeColumns) -> StorageResult<Edge> {
+    let (
+        id_str,
+        src_str,
+        tgt_str,
+        relation,
+        weight,
+        valid_at_str,
+        invalid_at_opt,
+        superseded_by_opt,
+        metadata_str,
+    ) = columns;
+    Ok(Edge {
+        id: parse_uuid(&id_str)?,
+        source: parse_uuid(&src_str)?,
+        target: parse_uuid(&tgt_str)?,
+        relation,
+        weight: weight as f32,
+        valid_at: str_to_dt(&valid_at_str),
+        invalid_at: invalid_at_opt.map(|s| str_to_dt(&s)),
+        superseded_by: superseded_by_opt.as_deref().map(parse_uuid).transpose()?,
+        metadata: serde_json::from_str(&metadata_str)?,
+        edge_type: EdgeType::default(),
+    })
 }
 
 fn row_to_episodic(
@@ -5617,5 +5779,181 @@ mod tests {
         let current_hits = db.search_fts("currenttoken", ns.id, 10).unwrap();
         assert_eq!(current_hits.len(), 1);
         assert_eq!(current_hits[0].id(), new.id);
+    }
+
+    // -----------------------------------------------------------------------
+    // Capturing GDPR erase (#264, #268)
+    // -----------------------------------------------------------------------
+
+    /// One transaction, four legs, and the captured set is what the legs
+    /// removed.
+    ///
+    /// The observation leg is the ordering proof: an observation is only
+    /// reachable from the entity by joining through
+    /// `episodic_memories.about_entity / source_entity`, so if the episodic
+    /// delete ran first the captured observation list would be empty and the
+    /// rows would be orphaned in the table.
+    #[test]
+    fn erase_entity_capturing_removes_every_leg_and_returns_what_it_removed() {
+        let (_dir, db) = setup();
+        let ns = make_namespace(&db);
+
+        let mut subject = Entity::new("subject", EntityKind::User);
+        subject.namespace_id = ns.id;
+        db.save_entity(&subject).unwrap();
+
+        let mut peer = Entity::new("peer", EntityKind::User);
+        peer.namespace_id = ns.id;
+        db.save_entity(&peer).unwrap();
+
+        let episode = Episode::new(ns.id, vec![subject.id]);
+        db.save_episode(&episode).unwrap();
+
+        // Source-side episodic: the subject spoke, the row is about the peer.
+        let episodic = EpisodicMemory::new(ns.id, episode.id, subject.id, peer.id, "a turn");
+        db.save_episodic(&episodic).unwrap();
+
+        // Object-side semantic: the subject is the object of the peer's fact.
+        let mut semantic = SemanticMemory::new(ns.id, peer.id, "manages", "subject", 0.9);
+        semantic.object_entity = Some(subject.id);
+        db.save_semantic(&semantic).unwrap();
+
+        let observation =
+            ObservationMemory::new(ns.id, episode.id, "x", "y", "z", "an observation");
+        db.save_observation(&observation).unwrap();
+        let kg_subject = seed_kg_entity(&db, ns.id, "S");
+        let kg_object = seed_kg_entity(&db, ns.id, "O");
+        seed_kg_triple(&db, ns.id, observation.id, kg_subject, kg_object);
+
+        let outgoing = Edge::new(subject.id, peer.id, "knows");
+        db.save_edge(&outgoing, ns.id).unwrap();
+        let incoming = Edge::new(peer.id, subject.id, "manages");
+        db.save_edge(&incoming, ns.id).unwrap();
+
+        let erased = db.erase_entity_capturing(subject.id, ns.id).unwrap();
+
+        assert_eq!(
+            erased.observations.iter().map(|o| o.id).collect::<Vec<_>>(),
+            vec![observation.id],
+            "observations must be captured before the episodic rows they join through"
+        );
+        let memory_ids: Vec<Uuid> = erased.memories.iter().map(Memory::id).collect();
+        assert!(memory_ids.contains(&episodic.id) && memory_ids.contains(&semantic.id));
+        assert_eq!(memory_ids.len(), 2);
+        let mut edge_ids: Vec<Uuid> = erased.edges.iter().map(|e| e.id).collect();
+        edge_ids.sort();
+        let mut expected_edges = vec![outgoing.id, incoming.id];
+        expected_edges.sort();
+        assert_eq!(edge_ids, expected_edges, "both edge legs must be captured");
+        assert!(erased.entity_deleted);
+
+        // …and the table agrees with the capture.
+        assert!(
+            db.get_all_memories_by_namespace_including_superseded(ns.id)
+                .unwrap()
+                .is_empty()
+        );
+        assert!(
+            db.get_edges_for_entity_in_namespace(subject.id, ns.id)
+                .unwrap()
+                .is_empty()
+        );
+        assert!(db.get_entity(subject.id).unwrap().is_none());
+        assert_eq!(fts_rows_for(&db, episodic.id), 0);
+        assert_eq!(fts_rows_for(&db, semantic.id), 0);
+        assert_eq!(fts_rows_for(&db, observation.id), 0);
+        assert_eq!(kg_triples_count_for_passage(&db, observation.id), 0);
+        assert_eq!(
+            kg_passage_entities_count_for_passage(&db, observation.id),
+            0
+        );
+        assert_eq!(
+            kg_entities_count_for_namespace(&db, ns.id),
+            2,
+            "kg_entities are namespace-scoped and must not cascade with an entity erase"
+        );
+    }
+
+    /// Every leg carries `namespace_id`. Entity ids are not globally unique in
+    /// this schema, so an erase in one namespace must not reach the identically
+    /// keyed rows of another — including the observation and entity-record legs,
+    /// which the pre-#264 erase path matched on the entity id alone.
+    #[test]
+    fn erase_entity_capturing_is_confined_to_its_namespace() {
+        let (_dir, db) = setup();
+        let ns_a = make_namespace(&db);
+        let ns_b = Namespace::new("other-ns");
+        db.save_namespace(&ns_b).unwrap();
+
+        // The same entity id in both namespaces — the collision the memory,
+        // observation and edge predicates have to disambiguate. The `entities`
+        // row itself can only exist once (`id` is the primary key), so it is
+        // seeded in A alone.
+        let mut entity = Entity::new("subject", EntityKind::User);
+        entity.namespace_id = ns_a.id;
+        db.save_entity(&entity).unwrap();
+        let entity_id = entity.id;
+
+        let mut seeded = Vec::new();
+        for ns in [&ns_a, &ns_b] {
+            let episode = Episode::new(ns.id, vec![entity_id]);
+            db.save_episode(&episode).unwrap();
+            let episodic = EpisodicMemory::new(ns.id, episode.id, entity_id, entity_id, "a turn");
+            db.save_episodic(&episodic).unwrap();
+            let observation =
+                ObservationMemory::new(ns.id, episode.id, "x", "y", "z", "an observation");
+            db.save_observation(&observation).unwrap();
+            let edge = Edge::new(entity_id, Uuid::new_v4(), "knows");
+            db.save_edge(&edge, ns.id).unwrap();
+            seeded.push((episodic.id, observation.id, edge.id));
+        }
+
+        let erased = db.erase_entity_capturing(entity_id, ns_a.id).unwrap();
+        assert_eq!(erased.memories.len(), 1);
+        assert_eq!(erased.observations.len(), 1);
+        assert_eq!(erased.edges.len(), 1);
+        assert!(erased.entity_deleted);
+
+        let (b_episodic, b_observation, b_edge) = seeded[1];
+        let surviving: Vec<Uuid> = db
+            .get_all_memories_by_namespace_including_superseded(ns_b.id)
+            .unwrap()
+            .iter()
+            .map(Memory::id)
+            .collect();
+        assert!(
+            surviving.contains(&b_episodic) && surviving.contains(&b_observation),
+            "namespace B's rows must survive an erase issued for namespace A; B holds {surviving:?}"
+        );
+        assert_eq!(
+            db.get_edges_for_entity_in_namespace(entity_id, ns_b.id)
+                .unwrap()
+                .iter()
+                .map(|e| e.id)
+                .collect::<Vec<_>>(),
+            vec![b_edge],
+            "namespace B's edge must survive"
+        );
+        assert!(
+            db.get_all_memories_by_namespace_including_superseded(ns_a.id)
+                .unwrap()
+                .is_empty(),
+            "namespace A must be empty after its own erase"
+        );
+    }
+
+    /// An entity with nothing attached is not an error, and reports nothing
+    /// deleted rather than a bare `entity_deleted`.
+    #[test]
+    fn erase_entity_capturing_on_an_absent_entity_captures_nothing() {
+        let (_dir, db) = setup();
+        let ns = make_namespace(&db);
+
+        let erased = db.erase_entity_capturing(Uuid::new_v4(), ns.id).unwrap();
+
+        assert!(erased.observations.is_empty());
+        assert!(erased.memories.is_empty());
+        assert!(erased.edges.is_empty());
+        assert!(!erased.entity_deleted);
     }
 }

--- a/pensyve-core/src/storage/sqlite.rs
+++ b/pensyve-core/src/storage/sqlite.rs
@@ -2430,125 +2430,28 @@ impl StorageTrait for SqliteBackend {
         conn.execute_batch("BEGIN")?;
 
         let result = (|| -> StorageResult<ErasedRows> {
-            let mut erased = ErasedRows::default();
-
             // Leg 1 — observations. MUST precede the episodic delete: the only
             // link from an observation back to the entity runs through
             // `episodic_memories.about_entity / source_entity`, and once those
             // rows are gone the association cannot be reconstructed.
-            let mut stmt = conn.prepare(
-                r"DELETE FROM observation_memories
-                   WHERE namespace_id = ?2
-                     AND episode_id IN (
-                       SELECT DISTINCT episode_id FROM episodic_memories
-                        WHERE (about_entity = ?1 OR source_entity = ?1)
-                          AND namespace_id = ?2
-                     )
-                   RETURNING id, namespace_id, episode_id, entity_type, instance, action,
-                             quantity, unit, content, embedding, confidence, event_time,
-                             created_at, stability, retrievability, agent_id, user_id,
-                             superseded_by, invalid_at",
-            )?;
-            let rows = stmt
-                .query_map(params![&id_str, &ns_str], row_to_observation)?
-                .collect::<Result<Vec<_>, _>>()?;
-            for row in rows {
-                erased.observations.push(row?);
-            }
-
-            // Phase 2B cascade: `kg_triples` / `kg_passage_entities` are keyed
-            // by the observation's id (== `passage_id`). Driving the cleanup off
-            // the captured ids rather than off a repeat of the subquery keeps it
-            // exactly as wide as the delete was. `kg_entities` stay: they are
-            // namespace-scoped rather than passage-scoped and other passages'
-            // triples still reference them.
-            for observation in &erased.observations {
-                let passage = observation.id.to_string();
-                conn.execute(
-                    "DELETE FROM kg_triples WHERE passage_id = ?1 AND namespace_id = ?2",
-                    params![&passage, &ns_str],
-                )?;
-                conn.execute(
-                    "DELETE FROM kg_passage_entities WHERE passage_id = ?1",
-                    params![&passage],
-                )?;
-                conn.execute(
-                    "DELETE FROM memory_fts
-                      WHERE memory_id = ?1 AND namespace_id = ?2 AND memory_type = 'observation'",
-                    params![&passage, &ns_str],
-                )?;
-            }
-
+            let observations = erase_observations_for_entity(&conn, &id_str, &ns_str)?;
             // Leg 2 — episodic and semantic memories, superseded rows included.
-            // Predicates match `delete_memories_by_entity` verbatim.
-            let mut stmt = conn.prepare(
-                r"DELETE FROM episodic_memories
-                   WHERE (about_entity = ?1 OR source_entity = ?1) AND namespace_id = ?2
-                   RETURNING id, namespace_id, episode_id, source_entity, about_entity, content,
-                             content_type, summary, embedding, context_intent, timestamp,
-                             stability, retrievability, access_count, last_accessed, event_time,
-                             agent_id, user_id, superseded_by, invalid_at",
-            )?;
-            let rows = stmt
-                .query_map(params![&id_str, &ns_str], row_to_episodic)?
-                .collect::<Result<Vec<_>, _>>()?;
-            for row in rows {
-                erased.memories.push(Memory::Episodic(row?));
-            }
-
-            let mut stmt = conn.prepare(
-                r"DELETE FROM semantic_memories
-                   WHERE (subject = ?1 OR object_entity = ?1) AND namespace_id = ?2
-                   RETURNING id, namespace_id, subject, predicate, object, content_type,
-                             object_entity, confidence, valid_at, invalid_at,
-                             source_episodes, embedding, stability, retrievability,
-                             agent_id, user_id, superseded_by",
-            )?;
-            let rows = stmt
-                .query_map(params![&id_str, &ns_str], row_to_semantic)?
-                .collect::<Result<Vec<_>, _>>()?;
-            for row in rows {
-                erased.memories.push(Memory::Semantic(row?));
-            }
-
-            // `memory_fts` is keyed by `memory_id`, which identifies nothing on
-            // its own: ids repeat across namespaces, and within one namespace
-            // the same id can name both an episodic and a semantic row. Both
-            // halves of the key are pinned, or the cleanup strips an index entry
-            // whose base row is still live.
-            for memory in &erased.memories {
-                conn.execute(
-                    "DELETE FROM memory_fts
-                      WHERE memory_id = ?1 AND namespace_id = ?2 AND memory_type = ?3",
-                    params![memory.id().to_string(), &ns_str, memory.type_name()],
-                )?;
-            }
-
-            // Leg 3 — graph edges. Same-namespace edges only, by construction:
-            // an edge belongs to its source entity's namespace, so an edge from
-            // another tenant pointing at this entity is not visible here and
-            // survives. See the trait docs.
-            let mut stmt = conn.prepare(&format!(
-                "DELETE FROM edges
-                  WHERE (source = ?1 OR target = ?1) AND namespace_id = ?2
-                  RETURNING {EDGE_COLUMNS}",
-            ))?;
-            let rows = stmt
-                .query_map(params![&id_str, &ns_str], edge_columns)?
-                .collect::<Result<Vec<_>, _>>()?;
-            for row in rows {
-                erased.edges.push(columns_to_edge(row)?);
-            }
-
+            let memories = erase_memories_for_entity(&conn, &id_str, &ns_str)?;
+            // Leg 3 — graph edges.
+            let edges = erase_edges_for_entity(&conn, &id_str, &ns_str)?;
             // Leg 4 — the entity record. Absence is not an error: the caller may
             // be erasing data for an entity whose record was already removed.
             let deleted = conn.execute(
                 "DELETE FROM entities WHERE id = ?1 AND namespace_id = ?2",
                 params![&id_str, &ns_str],
             )?;
-            erased.entity_deleted = deleted > 0;
 
-            Ok(erased)
+            Ok(ErasedRows {
+                observations,
+                memories,
+                edges,
+                entity_deleted: deleted > 0,
+            })
         })();
 
         match result {
@@ -3104,6 +3007,141 @@ fn load_memories_by_namespace(
 /// Parse a UUID string, returning `StorageError::Context` on failure.
 fn parse_uuid(s: &str) -> Result<Uuid, StorageError> {
     Uuid::parse_str(s).map_err(|e| StorageError::Context(format!("corrupt UUID: {e}")))
+}
+
+/// Leg 1 of [`SqliteBackend::erase_entity_capturing`]: capture and delete the
+/// observations derived from episodes the entity took part in, and cascade the
+/// rows keyed by each observation's id.
+///
+/// Must run before the episodic delete — the join that finds these observations
+/// goes through `episodic_memories.about_entity / source_entity`.
+fn erase_observations_for_entity(
+    conn: &Connection,
+    id_str: &str,
+    ns_str: &str,
+) -> StorageResult<Vec<ObservationMemory>> {
+    let mut stmt = conn.prepare(
+        r"DELETE FROM observation_memories
+           WHERE namespace_id = ?2
+             AND episode_id IN (
+               SELECT DISTINCT episode_id FROM episodic_memories
+                WHERE (about_entity = ?1 OR source_entity = ?1)
+                  AND namespace_id = ?2
+             )
+           RETURNING id, namespace_id, episode_id, entity_type, instance, action,
+                     quantity, unit, content, embedding, confidence, event_time,
+                     created_at, stability, retrievability, agent_id, user_id,
+                     superseded_by, invalid_at",
+    )?;
+    let rows = stmt
+        .query_map(params![id_str, ns_str], row_to_observation)?
+        .collect::<Result<Vec<_>, _>>()?;
+    let observations = rows
+        .into_iter()
+        .collect::<Result<Vec<ObservationMemory>, _>>()?;
+
+    // Phase 2B cascade: `kg_triples` / `kg_passage_entities` are keyed by the
+    // observation's id (== `passage_id`). Driving the cleanup off the captured
+    // ids rather than off a repeat of the subquery keeps it exactly as wide as
+    // the delete was. `kg_entities` stay: they are namespace-scoped rather than
+    // passage-scoped and other passages' triples still reference them.
+    for observation in &observations {
+        let passage = observation.id.to_string();
+        conn.execute(
+            "DELETE FROM kg_triples WHERE passage_id = ?1 AND namespace_id = ?2",
+            params![&passage, ns_str],
+        )?;
+        conn.execute(
+            "DELETE FROM kg_passage_entities WHERE passage_id = ?1",
+            params![&passage],
+        )?;
+        conn.execute(
+            "DELETE FROM memory_fts
+              WHERE memory_id = ?1 AND namespace_id = ?2 AND memory_type = 'observation'",
+            params![&passage, ns_str],
+        )?;
+    }
+
+    Ok(observations)
+}
+
+/// Leg 2 of [`SqliteBackend::erase_entity_capturing`]: capture and delete the
+/// entity's episodic and semantic rows, superseded ones included, and strip
+/// their search-index entries.
+///
+/// Predicates match [`SqliteBackend::delete_memories_by_entity`] verbatim.
+fn erase_memories_for_entity(
+    conn: &Connection,
+    id_str: &str,
+    ns_str: &str,
+) -> StorageResult<Vec<Memory>> {
+    let mut memories = Vec::new();
+
+    let mut stmt = conn.prepare(
+        r"DELETE FROM episodic_memories
+           WHERE (about_entity = ?1 OR source_entity = ?1) AND namespace_id = ?2
+           RETURNING id, namespace_id, episode_id, source_entity, about_entity, content,
+                     content_type, summary, embedding, context_intent, timestamp,
+                     stability, retrievability, access_count, last_accessed, event_time,
+                     agent_id, user_id, superseded_by, invalid_at",
+    )?;
+    let rows = stmt
+        .query_map(params![id_str, ns_str], row_to_episodic)?
+        .collect::<Result<Vec<_>, _>>()?;
+    for row in rows {
+        memories.push(Memory::Episodic(row?));
+    }
+
+    let mut stmt = conn.prepare(
+        r"DELETE FROM semantic_memories
+           WHERE (subject = ?1 OR object_entity = ?1) AND namespace_id = ?2
+           RETURNING id, namespace_id, subject, predicate, object, content_type,
+                     object_entity, confidence, valid_at, invalid_at,
+                     source_episodes, embedding, stability, retrievability,
+                     agent_id, user_id, superseded_by",
+    )?;
+    let rows = stmt
+        .query_map(params![id_str, ns_str], row_to_semantic)?
+        .collect::<Result<Vec<_>, _>>()?;
+    for row in rows {
+        memories.push(Memory::Semantic(row?));
+    }
+
+    // `memory_fts` is keyed by `memory_id`, which identifies nothing on its own:
+    // ids repeat across namespaces, and within one namespace the same id can
+    // name both an episodic and a semantic row. Both halves of the key are
+    // pinned, or the cleanup strips an index entry whose base row is still live.
+    for memory in &memories {
+        conn.execute(
+            "DELETE FROM memory_fts
+              WHERE memory_id = ?1 AND namespace_id = ?2 AND memory_type = ?3",
+            params![memory.id().to_string(), ns_str, memory.type_name()],
+        )?;
+    }
+
+    Ok(memories)
+}
+
+/// Leg 3 of [`SqliteBackend::erase_entity_capturing`]: capture and delete the
+/// entity's graph edges.
+///
+/// Same-namespace edges only, by construction: an edge belongs to its source
+/// entity's namespace, so an edge from another tenant pointing at this entity is
+/// not visible here and survives. See the trait docs.
+fn erase_edges_for_entity(
+    conn: &Connection,
+    id_str: &str,
+    ns_str: &str,
+) -> StorageResult<Vec<Edge>> {
+    let mut stmt = conn.prepare(&format!(
+        "DELETE FROM edges
+          WHERE (source = ?1 OR target = ?1) AND namespace_id = ?2
+          RETURNING {EDGE_COLUMNS}",
+    ))?;
+    let rows = stmt
+        .query_map(params![id_str, ns_str], edge_columns)?
+        .collect::<Result<Vec<_>, _>>()?;
+    rows.into_iter().map(columns_to_edge).collect()
 }
 
 /// The `edges` columns [`columns_to_edge`] decodes, positionally.

--- a/pensyve-core/tests/test_namespace_scoping.rs
+++ b/pensyve-core/tests/test_namespace_scoping.rs
@@ -305,7 +305,8 @@ fn get_edges_for_entity_in_namespace_partitions_a_shared_entity_id() {
 /// `target` leg, where B would otherwise expect to find it. B erasing the
 /// target entity therefore does not see, and cannot delete, A's edge pointing
 /// at it. That is deliberate (an edge is A's data, and B cannot be handed a
-/// read into A), and handling the erase-side consequence is #264.
+/// read into A), and it is the one residue a GDPR erase leaves behind — see
+/// `StorageTrait::erase_entity_capturing`.
 #[test]
 fn an_edge_belongs_to_its_source_entitys_namespace_only() {
     let dir = tempfile::tempdir().expect("tempdir");
@@ -337,8 +338,8 @@ fn an_edge_belongs_to_its_source_entitys_namespace_only() {
         "the target leg still resolves inside the owning namespace"
     );
 
-    // B does not, even though the target is B's entity. This is the
-    // consequence #264 has to reckon with, not an accident.
+    // B does not, even though the target is B's entity. This is the accepted
+    // consequence of source-namespace ownership, not an accident.
     assert!(
         t.db.get_edges_for_entity_in_namespace(target_in_b, t.ns_b)
             .expect("edge lookup")

--- a/pensyve-mcp-gateway/src/rest.rs
+++ b/pensyve-mcp-gateway/src/rest.rs
@@ -2320,31 +2320,25 @@ async fn gdpr_erase(
         }
     };
 
-    // Collect memory IDs before deletion so we can remove them from vector
-    // index. The accessor mirrors the erasure's own delete predicates
-    // (`about_entity OR source_entity`, `subject OR object_entity`, superseded
-    // rows included) — the per-type `list_*_by_entity` calls that used to stand
-    // in here saw only the about-side, the subject-side and live rows, so every
-    // other deleted row kept its index entry (#261).
-    let memory_ids: Vec<Uuid> = ps
-        .storage
-        .list_memories_by_entity_including_superseded(entity.id, ps.namespace.id)
-        .map(|mems| mems.iter().map(pensyve_core::types::Memory::id).collect())
-        .unwrap_or_default();
-
-    let result = pensyve_core::gdpr::erase_entity(ps.storage.as_ref(), entity.id, ps.namespace.id)
-        .map_err(|e| {
-            RestError(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("GDPR erasure error: {e}"),
-            )
-        })?;
+    // The erasure hands back the rows it deleted, and the index cleanup is
+    // driven from those. Listing the ids first — which this handler used to do —
+    // leaves a window in which a concurrent writer inserts a matching row: the
+    // erase deletes it, the pre-list never saw it, and its index entry survives
+    // the request that was supposed to destroy its content (#268).
+    let (result, erased) =
+        pensyve_core::gdpr::erase_entity_captured(ps.storage.as_ref(), entity.id, ps.namespace.id)
+            .map_err(|e| {
+                RestError(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("GDPR erasure error: {e}"),
+                )
+            })?;
 
     // Clean vector index.
-    if result.memories_deleted > 0 {
+    if !erased.memories.is_empty() {
         let mut vi = ps.vector_index.write().await;
-        for id in &memory_ids {
-            let _ = vi.remove(*id);
+        for memory in &erased.memories {
+            let _ = vi.remove(memory.id());
         }
     }
 

--- a/pensyve-mcp-gateway/src/rest.rs
+++ b/pensyve-mcp-gateway/src/rest.rs
@@ -2297,6 +2297,36 @@ async fn feedback(
 // GDPR handler
 // ---------------------------------------------------------------------------
 
+/// Run the capturing GDPR erase on the blocking pool.
+///
+/// The call is synchronous the whole way down — a rusqlite transaction behind a
+/// mutex on `SQLite`, a `block_on` of an sqlx transaction on Postgres — so it
+/// goes to the blocking pool rather than parking a runtime worker for its
+/// duration. Same reasoning as [`forget_entity_blocking`] for the sibling
+/// entity-wide delete (#251).
+///
+/// The `Err` is the caller-facing message.
+async fn erase_entity_blocking(
+    ps: &PensyveState,
+    entity_id: Uuid,
+) -> Result<
+    (
+        pensyve_core::gdpr::ErasureResult,
+        pensyve_core::storage::ErasedRows,
+    ),
+    String,
+> {
+    let storage = ps.storage.clone();
+    let namespace_id = ps.namespace.id;
+
+    tokio::task::spawn_blocking(move || {
+        pensyve_core::gdpr::erase_entity_captured(storage.as_ref(), entity_id, namespace_id)
+    })
+    .await
+    .map_err(|err| format!("GDPR erasure task failed: {err}"))
+    .and_then(|outcome| outcome.map_err(|err| format!("GDPR erasure error: {err}")))
+}
+
 async fn gdpr_erase(
     State(state): State<Arc<AppState>>,
     axum::Extension(auth_ctx): axum::Extension<AuthContext>,
@@ -2320,27 +2350,48 @@ async fn gdpr_erase(
         }
     };
 
-    // The erasure hands back the rows it deleted, and the index cleanup is
-    // driven from those. Listing the ids first — which this handler used to do —
-    // leaves a window in which a concurrent writer inserts a matching row: the
-    // erase deletes it, the pre-list never saw it, and its index entry survives
-    // the request that was supposed to destroy its content (#268).
-    let (result, erased) =
-        pensyve_core::gdpr::erase_entity_captured(ps.storage.as_ref(), entity.id, ps.namespace.id)
-            .map_err(|e| {
-                RestError(
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("GDPR erasure error: {e}"),
-                )
-            })?;
+    // The erase and its vector-index cleanup run on a spawned task the handler
+    // only observes. axum drops handler futures when the client disconnects,
+    // and the cleanup waits on the index write lock *after* the transaction has
+    // committed — a drop in that window leaves index entries pointing at rows
+    // the erase destroyed. That is #268's failure mode with the concurrent
+    // writer replaced by a hang-up, and it needs no writer at all. A spawned
+    // task is detached from the request, so once the erase starts its
+    // bookkeeping runs to completion. Same reasoning and same shape as
+    // `forget_entity` above.
+    let ps_task = ps.clone();
+    let entity_id = entity.id;
+    let task = tokio::spawn(async move {
+        let (result, erased) = erase_entity_blocking(&ps_task, entity_id).await?;
 
-    // Clean vector index.
-    if !erased.memories.is_empty() {
-        let mut vi = ps.vector_index.write().await;
-        for memory in &erased.memories {
-            let _ = vi.remove(memory.id());
+        // The captured rows are exactly what the transaction removed, so they
+        // are also the authoritative list for index cleanup. Listing the ids
+        // beforehand — which this handler used to do — leaves a window in which
+        // a concurrent writer inserts a matching row: the erase deletes it, the
+        // pre-list never saw it, and its index entry survives the request that
+        // was supposed to destroy its content (#268).
+        if !erased.memories.is_empty() {
+            let mut vi = ps_task.vector_index.write().await;
+            for memory in &erased.memories {
+                let _ = vi.remove(memory.id());
+            }
         }
-    }
+
+        Ok::<_, String>(result)
+    });
+
+    // A panicked task cannot claim "nothing was erased" — the transaction may
+    // have committed before the bookkeeping panicked — so the message stays
+    // neutral, matching `forget_entity`.
+    let result = task
+        .await
+        .map_err(|err| {
+            RestError(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("GDPR erasure task failed: {err}"),
+            )
+        })?
+        .map_err(|err| RestError(StatusCode::INTERNAL_SERVER_ERROR, err))?;
 
     Ok(Json(json!({
         "entity": name,

--- a/pensyve-mcp-gateway/tests/test_rest_gdpr_erase_race.rs
+++ b/pensyve-mcp-gateway/tests/test_rest_gdpr_erase_race.rs
@@ -1,0 +1,609 @@
+//! The GDPR erase handler must strip the vector index of the rows the erase
+//! actually deleted, not of a set it listed beforehand (#268).
+//!
+//! The handler used to call `list_memories_by_entity_including_superseded`,
+//! then run the erase, then remove the listed ids from the index. Anything a
+//! concurrent writer inserted between those two calls was deleted by the erase
+//! and left in the index: an entry pointing at content that no longer exists,
+//! surviving a request whose whole purpose was to make that content go away.
+//!
+//! `RacingStorage` puts a writer in exactly that window. It delegates every
+//! `StorageTrait` method to a real `SqliteBackend`, except that
+//! `erase_entity_capturing` saves one extra matching memory before delegating —
+//! a row that exists by the time the delete runs and did not exist when a
+//! pre-list would have been taken. Cleanup driven from the captured rows sees
+//! it; cleanup driven from a pre-list cannot.
+
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use axum::Extension;
+use chrono::{DateTime, Utc};
+use pensyve_core::config::RetrievalConfig;
+use pensyve_core::embedding::OnnxEmbedder;
+use pensyve_core::storage::sqlite::SqliteBackend;
+use pensyve_core::storage::{
+    ActivityAggregate, ActivityEvent, ErasedRows, StorageResult, StorageTrait,
+};
+use pensyve_core::types::{
+    Edge, Entity, EntityKind, Episode, EpisodicMemory, Memory, Namespace, ObservationMemory,
+    ProceduralMemory, SemanticMemory,
+};
+use pensyve_core::vector::VectorIndex;
+use pensyve_mcp_gateway::AppState;
+use pensyve_mcp_gateway::auth::{AuthContext, AuthValidator};
+use pensyve_mcp_gateway::config::GatewayConfig;
+use pensyve_mcp_gateway::rate_limit::RateLimiter;
+use pensyve_mcp_gateway::rest;
+use pensyve_mcp_gateway::tenant::TenantStateManager;
+use pensyve_mcp_gateway::usage::UsageReporter;
+use pensyve_mcp_gateway::usage_counter::UsageCounter;
+use tempfile::TempDir;
+use tokio_util::sync::CancellationToken;
+use uuid::Uuid;
+
+const TEST_TENANT: &str = "test-gdpr-erase-race-tenant";
+const DIMENSIONS: usize = 768;
+
+// ---------------------------------------------------------------------------
+// The fake
+// ---------------------------------------------------------------------------
+
+/// A `SqliteBackend` with one concurrent writer wedged into the erase.
+///
+/// Everything is delegated; the only behaviour of its own is in
+/// `erase_entity_capturing`, which saves `racer` (once) before running the real
+/// erase. That is the row a pre-list taken by the handler would have missed.
+struct RacingStorage {
+    inner: Arc<SqliteBackend>,
+    racer: Mutex<Option<EpisodicMemory>>,
+}
+
+impl RacingStorage {
+    fn new(inner: Arc<SqliteBackend>) -> Self {
+        Self {
+            inner,
+            racer: Mutex::new(None),
+        }
+    }
+
+    /// Load the row the writer will land mid-erase. Called after the tenant's
+    /// namespace exists, which is what the row has to be keyed on.
+    fn arm(&self, racer: EpisodicMemory) {
+        *self.racer.lock().expect("racer lock") = Some(racer);
+    }
+}
+
+impl StorageTrait for RacingStorage {
+    fn erase_entity_capturing(
+        &self,
+        entity_id: Uuid,
+        namespace_id: Uuid,
+    ) -> StorageResult<ErasedRows> {
+        if let Some(racer) = self.racer.lock().expect("racer lock").take() {
+            self.inner.save_episodic(&racer)?;
+        }
+        self.inner.erase_entity_capturing(entity_id, namespace_id)
+    }
+
+    // --- pure delegation from here down -------------------------------------
+
+    fn db_path(&self) -> Option<&std::path::Path> {
+        self.inner.db_path()
+    }
+    fn save_namespace(&self, ns: &Namespace) -> StorageResult<()> {
+        self.inner.save_namespace(ns)
+    }
+    fn get_namespace(&self, id: Uuid) -> StorageResult<Option<Namespace>> {
+        self.inner.get_namespace(id)
+    }
+    fn get_namespace_by_name(&self, name: &str) -> StorageResult<Option<Namespace>> {
+        self.inner.get_namespace_by_name(name)
+    }
+    fn save_entity(&self, entity: &Entity) -> StorageResult<()> {
+        self.inner.save_entity(entity)
+    }
+    fn get_entity(&self, id: Uuid) -> StorageResult<Option<Entity>> {
+        self.inner.get_entity(id)
+    }
+    fn get_entity_by_name(&self, name: &str, namespace_id: Uuid) -> StorageResult<Option<Entity>> {
+        self.inner.get_entity_by_name(name, namespace_id)
+    }
+    fn save_episode(&self, episode: &Episode) -> StorageResult<()> {
+        self.inner.save_episode(episode)
+    }
+    fn get_episode_in_namespace(
+        &self,
+        id: Uuid,
+        namespace_id: Uuid,
+    ) -> StorageResult<Option<Episode>> {
+        self.inner.get_episode_in_namespace(id, namespace_id)
+    }
+    fn update_episode(&self, episode: &Episode) -> StorageResult<()> {
+        self.inner.update_episode(episode)
+    }
+    fn save_episodic(&self, mem: &EpisodicMemory) -> StorageResult<()> {
+        self.inner.save_episodic(mem)
+    }
+    fn get_episodic_in_namespace(
+        &self,
+        id: Uuid,
+        namespace_id: Uuid,
+    ) -> StorageResult<Option<EpisodicMemory>> {
+        self.inner.get_episodic_in_namespace(id, namespace_id)
+    }
+    fn list_episodic_by_entity(
+        &self,
+        about_entity: Uuid,
+        limit: usize,
+    ) -> StorageResult<Vec<EpisodicMemory>> {
+        self.inner.list_episodic_by_entity(about_entity, limit)
+    }
+    fn list_episodic_by_episode(
+        &self,
+        namespace_id: Uuid,
+        episode_id: Uuid,
+    ) -> StorageResult<Vec<EpisodicMemory>> {
+        self.inner
+            .list_episodic_by_episode(namespace_id, episode_id)
+    }
+    fn update_episodic_access(
+        &self,
+        id: Uuid,
+        stability: f32,
+        retrievability: f32,
+    ) -> StorageResult<()> {
+        self.inner
+            .update_episodic_access(id, stability, retrievability)
+    }
+    fn save_semantic(&self, mem: &SemanticMemory) -> StorageResult<()> {
+        self.inner.save_semantic(mem)
+    }
+    fn get_semantic_in_namespace(
+        &self,
+        id: Uuid,
+        namespace_id: Uuid,
+    ) -> StorageResult<Option<SemanticMemory>> {
+        self.inner.get_semantic_in_namespace(id, namespace_id)
+    }
+    fn list_semantic_by_entity(
+        &self,
+        subject: Uuid,
+        limit: usize,
+    ) -> StorageResult<Vec<SemanticMemory>> {
+        self.inner.list_semantic_by_entity(subject, limit)
+    }
+    fn invalidate_semantic(&self, id: Uuid) -> StorageResult<()> {
+        self.inner.invalidate_semantic(id)
+    }
+    fn save_procedural(&self, mem: &ProceduralMemory) -> StorageResult<()> {
+        self.inner.save_procedural(mem)
+    }
+    fn get_procedural_in_namespace(
+        &self,
+        id: Uuid,
+        namespace_id: Uuid,
+    ) -> StorageResult<Option<ProceduralMemory>> {
+        self.inner.get_procedural_in_namespace(id, namespace_id)
+    }
+    fn update_procedural_reliability(
+        &self,
+        id: Uuid,
+        reliability: f32,
+        trial_count: u32,
+        success_count: u32,
+    ) -> StorageResult<()> {
+        self.inner
+            .update_procedural_reliability(id, reliability, trial_count, success_count)
+    }
+    fn save_observation(&self, mem: &ObservationMemory) -> StorageResult<()> {
+        self.inner.save_observation(mem)
+    }
+    fn get_observation_in_namespace(
+        &self,
+        id: Uuid,
+        namespace_id: Uuid,
+    ) -> StorageResult<Option<ObservationMemory>> {
+        self.inner.get_observation_in_namespace(id, namespace_id)
+    }
+    fn list_observations_by_entity_instance(
+        &self,
+        namespace_id: Uuid,
+        instance: &str,
+        limit: usize,
+    ) -> StorageResult<Vec<ObservationMemory>> {
+        self.inner
+            .list_observations_by_entity_instance(namespace_id, instance, limit)
+    }
+    fn list_observations_by_episode_ids(
+        &self,
+        namespace_id: Uuid,
+        episode_ids: &[Uuid],
+        limit: usize,
+    ) -> StorageResult<Vec<ObservationMemory>> {
+        self.inner
+            .list_observations_by_episode_ids(namespace_id, episode_ids, limit)
+    }
+    fn delete_observations_by_episode(
+        &self,
+        namespace_id: Uuid,
+        episode_id: Uuid,
+    ) -> StorageResult<usize> {
+        self.inner
+            .delete_observations_by_episode(namespace_id, episode_id)
+    }
+    fn delete_observations_by_entity(&self, entity_id: Uuid) -> StorageResult<usize> {
+        self.inner.delete_observations_by_entity(entity_id)
+    }
+    fn search_fts(
+        &self,
+        query: &str,
+        namespace_id: Uuid,
+        limit: usize,
+    ) -> StorageResult<Vec<Memory>> {
+        self.inner.search_fts(query, namespace_id, limit)
+    }
+    fn search_fts_scoped_by_pair(
+        &self,
+        query: &str,
+        namespace_id: Uuid,
+        agent_id: Option<Uuid>,
+        user_id: Option<Uuid>,
+        agent_only: Option<Uuid>,
+        limit: usize,
+    ) -> StorageResult<Vec<Memory>> {
+        self.inner.search_fts_scoped_by_pair(
+            query,
+            namespace_id,
+            agent_id,
+            user_id,
+            agent_only,
+            limit,
+        )
+    }
+    fn get_all_memories_by_namespace_scoped_pair(
+        &self,
+        namespace_id: Uuid,
+        agent_id: Option<Uuid>,
+        user_id: Option<Uuid>,
+        agent_only: Option<Uuid>,
+    ) -> StorageResult<Vec<Memory>> {
+        self.inner.get_all_memories_by_namespace_scoped_pair(
+            namespace_id,
+            agent_id,
+            user_id,
+            agent_only,
+        )
+    }
+    fn search_fts_scoped(
+        &self,
+        query: &str,
+        namespace_id: Uuid,
+        entity_id: Uuid,
+        limit: usize,
+    ) -> StorageResult<Vec<Memory>> {
+        self.inner
+            .search_fts_scoped(query, namespace_id, entity_id, limit)
+    }
+    fn get_all_memories_by_namespace(&self, namespace_id: Uuid) -> StorageResult<Vec<Memory>> {
+        self.inner.get_all_memories_by_namespace(namespace_id)
+    }
+    fn get_all_memories_by_namespace_including_superseded(
+        &self,
+        namespace_id: Uuid,
+    ) -> StorageResult<Vec<Memory>> {
+        self.inner
+            .get_all_memories_by_namespace_including_superseded(namespace_id)
+    }
+    fn list_memories_by_entity_including_superseded(
+        &self,
+        entity_id: Uuid,
+        namespace_id: Uuid,
+    ) -> StorageResult<Vec<Memory>> {
+        self.inner
+            .list_memories_by_entity_including_superseded(entity_id, namespace_id)
+    }
+    fn supersede_memory_in_namespace(
+        &self,
+        id: Uuid,
+        namespace_id: Uuid,
+        superseded_by: Uuid,
+        invalid_at: DateTime<Utc>,
+    ) -> StorageResult<bool> {
+        self.inner
+            .supersede_memory_in_namespace(id, namespace_id, superseded_by, invalid_at)
+    }
+    fn delete_memories_by_entity(
+        &self,
+        entity_id: Uuid,
+        namespace_id: Uuid,
+    ) -> StorageResult<usize> {
+        self.inner
+            .delete_memories_by_entity(entity_id, namespace_id)
+    }
+    fn delete_memories_by_entity_capturing(
+        &self,
+        entity_id: Uuid,
+        namespace_id: Uuid,
+        persist: &mut dyn FnMut(&[Memory]) -> StorageResult<()>,
+    ) -> StorageResult<Vec<Memory>> {
+        self.inner
+            .delete_memories_by_entity_capturing(entity_id, namespace_id, persist)
+    }
+    fn delete_memory_by_id_in_namespace(
+        &self,
+        id: Uuid,
+        namespace_id: Uuid,
+    ) -> StorageResult<bool> {
+        self.inner
+            .delete_memory_by_id_in_namespace(id, namespace_id)
+    }
+    fn purge_namespace(&self, namespace_id: Uuid) -> StorageResult<usize> {
+        self.inner.purge_namespace(namespace_id)
+    }
+    fn update_semantic_content(
+        &self,
+        id: Uuid,
+        predicate: &str,
+        object: &str,
+        confidence: Option<f32>,
+    ) -> StorageResult<()> {
+        self.inner
+            .update_semantic_content(id, predicate, object, confidence)
+    }
+    fn delete_entity(&self, id: Uuid) -> StorageResult<bool> {
+        self.inner.delete_entity(id)
+    }
+    fn list_entities_by_namespace(&self, namespace_id: Uuid) -> StorageResult<Vec<Entity>> {
+        self.inner.list_entities_by_namespace(namespace_id)
+    }
+    fn save_edge(&self, edge: &Edge, namespace_id: Uuid) -> StorageResult<()> {
+        self.inner.save_edge(edge, namespace_id)
+    }
+    fn get_edges_for_entity_in_namespace(
+        &self,
+        entity_id: Uuid,
+        namespace_id: Uuid,
+    ) -> StorageResult<Vec<Edge>> {
+        self.inner
+            .get_edges_for_entity_in_namespace(entity_id, namespace_id)
+    }
+    fn count_memories_by_namespace(
+        &self,
+        namespace_id: Uuid,
+    ) -> StorageResult<(usize, usize, usize)> {
+        self.inner.count_memories_by_namespace(namespace_id)
+    }
+    fn count_entities_by_namespace(&self, namespace_id: Uuid) -> StorageResult<usize> {
+        self.inner.count_entities_by_namespace(namespace_id)
+    }
+    fn log_activity(
+        &self,
+        namespace_id: Uuid,
+        event_type: &str,
+        detail: &serde_json::Value,
+    ) -> StorageResult<()> {
+        self.inner.log_activity(namespace_id, event_type, detail)
+    }
+    fn get_activity_aggregates(
+        &self,
+        namespace_id: Uuid,
+        days: u32,
+    ) -> StorageResult<Vec<ActivityAggregate>> {
+        self.inner.get_activity_aggregates(namespace_id, days)
+    }
+    fn get_recent_activity(
+        &self,
+        namespace_id: Uuid,
+        limit: usize,
+    ) -> StorageResult<Vec<ActivityEvent>> {
+        self.inner.get_recent_activity(namespace_id, limit)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Fixture
+// ---------------------------------------------------------------------------
+
+fn retrieval_config() -> RetrievalConfig {
+    RetrievalConfig {
+        default_limit: 5,
+        max_candidates: 100,
+        weights: [0.30, 0.15, 0.20, 0.10, 0.10, 0.05, 0.05, 0.05],
+        recall_timeout_secs: 5,
+        rrf_k: 60,
+        rrf_weights: [1.0, 0.8, 1.0, 0.8, 0.5, 0.5, 1.2, 1.0],
+        beam_width: 10,
+        max_depth: 4,
+    }
+}
+
+fn gateway_config(dir: &TempDir) -> GatewayConfig {
+    GatewayConfig {
+        host: "127.0.0.1".to_string(),
+        port: 0,
+        storage_path: dir.path().to_path_buf(),
+        namespace: "default".to_string(),
+        api_keys: vec![],
+        rate_limit_per_minute: 300,
+        stripe_api_key: None,
+        admin_key: None,
+        key_user_map: vec![],
+        allowed_hosts: vec![],
+    }
+}
+
+fn auth_context() -> AuthContext {
+    AuthContext {
+        key_id: TEST_TENANT.to_string(),
+        tenant_id: None,
+        user_id: None,
+        scope: "mcp".to_string(),
+        stripe_customer_id: None,
+        plan: "free".to_string(),
+    }
+}
+
+fn embedding(seed: f32) -> Vec<f32> {
+    (0..DIMENSIONS).map(|i| seed + (i as f32) * 0.001).collect()
+}
+
+async fn start_test_server(state: Arc<AppState>) -> (String, CancellationToken) {
+    let app = rest::router()
+        .layer(Extension(auth_context()))
+        .with_state(state);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test server");
+    let addr = listener.local_addr().expect("test server address");
+    let cancellation = CancellationToken::new();
+    let shutdown = cancellation.clone();
+
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app)
+            .with_graceful_shutdown(shutdown.cancelled_owned())
+            .await;
+    });
+
+    (format!("http://{addr}"), cancellation)
+}
+
+/// What the erase must clear from the index: the row that was there all along,
+/// and the row the racing writer landed inside the pre-list window.
+struct Seeded {
+    entity_name: String,
+    settled: Uuid,
+    racer: Uuid,
+}
+
+async fn app_state(dir: &TempDir, snapshot_root: PathBuf) -> (Arc<AppState>, Seeded) {
+    let inner = Arc::new(SqliteBackend::open(dir.path()).expect("open storage"));
+    let default_namespace = Namespace::new("default");
+    inner
+        .save_namespace(&default_namespace)
+        .expect("save default namespace");
+
+    let racing = Arc::new(RacingStorage::new(inner));
+    let tenant_mgr = TenantStateManager::new(
+        racing.clone() as Arc<dyn StorageTrait>,
+        Arc::new(OnnxEmbedder::new_mock(DIMENSIONS)),
+        retrieval_config(),
+        default_namespace,
+        VectorIndex::new(DIMENSIONS, 1024),
+        snapshot_root,
+    );
+    let config = gateway_config(dir);
+
+    let state = Arc::new(AppState {
+        auth: AuthValidator::new(&config),
+        rate_limiter: RateLimiter::new(None),
+        usage_reporter: UsageReporter::new(None),
+        usage_counter: UsageCounter::new(),
+        tenant_mgr,
+        auth_required: false,
+        admin_key: None,
+        ct: CancellationToken::new(),
+        redis: None,
+        extractor: None,
+    });
+
+    // The handler resolves the tenant's own namespace, not the default one, so
+    // everything is seeded through the state the request will see.
+    let ps = state
+        .tenant_mgr
+        .get_tenant_state(TEST_TENANT)
+        .expect("tenant state");
+    let namespace_id = ps.namespace.id;
+
+    let mut entity = Entity::new("alice", EntityKind::User);
+    entity.namespace_id = namespace_id;
+    ps.storage.save_entity(&entity).expect("save entity");
+
+    let episode = Episode::new(namespace_id, vec![entity.id]);
+    ps.storage.save_episode(&episode).expect("save episode");
+
+    // Already committed when the request arrives — a pre-list would see it.
+    let mut settled = EpisodicMemory::new(
+        namespace_id,
+        episode.id,
+        entity.id,
+        entity.id,
+        "a turn that predates the request",
+    );
+    settled.embedding = embedding(0.1);
+    ps.storage
+        .save_episodic(&settled)
+        .expect("save settled memory");
+
+    // Not written yet. `RacingStorage` writes it once the erase starts, which is
+    // after the point a pre-list would have been taken.
+    let mut racer = EpisodicMemory::new(
+        namespace_id,
+        episode.id,
+        entity.id,
+        entity.id,
+        "a turn that lands mid-erase",
+    );
+    racer.embedding = embedding(0.2);
+    racing.arm(racer.clone());
+
+    // The concurrent writer indexes its row as it writes it, so both entries are
+    // present by the time the erase's cleanup runs. They are seeded together
+    // here because a synchronous `StorageTrait` method cannot reach the index.
+    {
+        let mut index = ps.vector_index.write().await;
+        index
+            .add_with_entity(settled.id, &settled.embedding, entity.id)
+            .expect("index settled memory");
+        index
+            .add_with_entity(racer.id, &racer.embedding, entity.id)
+            .expect("index racing memory");
+    }
+
+    let seeded = Seeded {
+        entity_name: entity.name.clone(),
+        settled: settled.id,
+        racer: racer.id,
+    };
+
+    (state, seeded)
+}
+
+#[tokio::test]
+async fn gdpr_erase_strips_the_index_of_a_row_written_after_a_pre_list_would_have_run() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let (state, seeded) = app_state(&dir, dir.path().join("snapshots")).await;
+
+    let (url, cancellation) = start_test_server(state.clone()).await;
+    let client = reqwest::Client::new();
+    let response = client
+        .delete(format!("{url}/v1/gdpr/erase/{}", seeded.entity_name))
+        .send()
+        .await
+        .expect("gdpr erase request");
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    let body: serde_json::Value = response.json().await.expect("gdpr erase response JSON");
+    assert_eq!(
+        body["memories_deleted"], 2,
+        "the erase deleted the settled row and the racing one; it must report both"
+    );
+
+    let ps = state
+        .tenant_mgr
+        .get_tenant_state(TEST_TENANT)
+        .expect("tenant state");
+    let index = ps.vector_index.read().await;
+    assert!(
+        index.get(seeded.settled).is_none(),
+        "the settled row's index entry must go with its row"
+    );
+    assert!(
+        index.get(seeded.racer).is_none(),
+        "the row written after a pre-list would have been taken was deleted by the \
+         erase, so its index entry must go too — cleanup driven from a pre-list \
+         leaves it behind, pointing at content the request destroyed (#268)"
+    );
+
+    cancellation.cancel();
+}

--- a/pensyve-mcp-gateway/tests/test_rest_gdpr_erase_race.rs
+++ b/pensyve-mcp-gateway/tests/test_rest_gdpr_erase_race.rs
@@ -13,9 +13,17 @@
 //! a row that exists by the time the delete runs and did not exist when a
 //! pre-list would have been taken. Cleanup driven from the captured rows sees
 //! it; cleanup driven from a pre-list cannot.
+//!
+//! The same fake also signals the moment the erase transaction **commits**,
+//! which is what the second test needs: the identical orphaned entry is
+//! reachable with no concurrent writer at all, by disconnecting the client
+//! between the commit and the cleanup. Driving cleanup from the captured rows
+//! fixes the first; running the erase and its bookkeeping on a detached task
+//! fixes the second. Both are needed, and each has its own test below.
 
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
 use axum::Extension;
 use chrono::{DateTime, Utc};
@@ -39,6 +47,7 @@ use pensyve_mcp_gateway::tenant::TenantStateManager;
 use pensyve_mcp_gateway::usage::UsageReporter;
 use pensyve_mcp_gateway::usage_counter::UsageCounter;
 use tempfile::TempDir;
+use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
@@ -57,6 +66,7 @@ const DIMENSIONS: usize = 768;
 struct RacingStorage {
     inner: Arc<SqliteBackend>,
     racer: Mutex<Option<EpisodicMemory>>,
+    committed: Mutex<Option<mpsc::UnboundedSender<()>>>,
 }
 
 impl RacingStorage {
@@ -64,6 +74,7 @@ impl RacingStorage {
         Self {
             inner,
             racer: Mutex::new(None),
+            committed: Mutex::new(None),
         }
     }
 
@@ -71,6 +82,15 @@ impl RacingStorage {
     /// namespace exists, which is what the row has to be keyed on.
     fn arm(&self, racer: EpisodicMemory) {
         *self.racer.lock().expect("racer lock") = Some(racer);
+    }
+
+    /// A receiver that fires once the erase transaction has **committed** and
+    /// before the caller has done any of its post-commit bookkeeping. That is
+    /// the window a dropped handler future strands.
+    fn signal_on_commit(&self) -> mpsc::UnboundedReceiver<()> {
+        let (tx, rx) = mpsc::unbounded_channel();
+        *self.committed.lock().expect("commit-signal lock") = Some(tx);
+        rx
     }
 }
 
@@ -83,7 +103,11 @@ impl StorageTrait for RacingStorage {
         if let Some(racer) = self.racer.lock().expect("racer lock").take() {
             self.inner.save_episodic(&racer)?;
         }
-        self.inner.erase_entity_capturing(entity_id, namespace_id)
+        let erased = self.inner.erase_entity_capturing(entity_id, namespace_id)?;
+        if let Some(tx) = self.committed.lock().expect("commit-signal lock").take() {
+            let _ = tx.send(());
+        }
+        Ok(erased)
     }
 
     // --- pure delegation from here down -------------------------------------
@@ -477,7 +501,10 @@ struct Seeded {
     racer: Uuid,
 }
 
-async fn app_state(dir: &TempDir, snapshot_root: PathBuf) -> (Arc<AppState>, Seeded) {
+async fn app_state(
+    dir: &TempDir,
+    snapshot_root: PathBuf,
+) -> (Arc<AppState>, Seeded, Arc<RacingStorage>) {
     let inner = Arc::new(SqliteBackend::open(dir.path()).expect("open storage"));
     let default_namespace = Namespace::new("default");
     inner
@@ -567,13 +594,13 @@ async fn app_state(dir: &TempDir, snapshot_root: PathBuf) -> (Arc<AppState>, See
         racer: racer.id,
     };
 
-    (state, seeded)
+    (state, seeded, racing)
 }
 
 #[tokio::test]
 async fn gdpr_erase_strips_the_index_of_a_row_written_after_a_pre_list_would_have_run() {
     let dir = tempfile::tempdir().expect("tempdir");
-    let (state, seeded) = app_state(&dir, dir.path().join("snapshots")).await;
+    let (state, seeded, _racing) = app_state(&dir, dir.path().join("snapshots")).await;
 
     let (url, cancellation) = start_test_server(state.clone()).await;
     let client = reqwest::Client::new();
@@ -603,6 +630,93 @@ async fn gdpr_erase_strips_the_index_of_a_row_written_after_a_pre_list_would_hav
         "the row written after a pre-list would have been taken was deleted by the \
          erase, so its index entry must go too — cleanup driven from a pre-list \
          leaves it behind, pointing at content the request destroyed (#268)"
+    );
+
+    cancellation.cancel();
+}
+
+/// The same orphaned index entry, reached by a different door: the client goes
+/// away after the erase has committed but before the cleanup has run.
+///
+/// No concurrent writer is needed for this one. `gdpr_erase` awaits the vector
+/// index's write lock *after* the transaction commits, and axum drops a handler
+/// future when the client disconnects — so a disconnect while that lock is
+/// contended abandons the cleanup with the rows already gone from storage. The
+/// entries left behind point at content the request destroyed, which is #268's
+/// failure mode with the race replaced by a hang-up.
+///
+/// The fix is the one the sibling `forget_entity` handler already uses: run the
+/// erase and its bookkeeping on a `tokio::spawn`ed task the handler only
+/// observes, so once the erase starts it finishes regardless of the request.
+///
+/// The window is forced rather than raced: the test holds the index write lock,
+/// waits for `RacingStorage` to signal that the transaction committed, aborts
+/// the request, and only then releases the lock.
+#[tokio::test]
+async fn gdpr_erase_finishes_its_index_cleanup_after_the_client_disconnects() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let (state, seeded, racing) = app_state(&dir, dir.path().join("snapshots")).await;
+    let mut committed = racing.signal_on_commit();
+
+    let ps = state
+        .tenant_mgr
+        .get_tenant_state(TEST_TENANT)
+        .expect("tenant state");
+
+    // Park the cleanup: whoever owns it will block here until this is dropped.
+    let index_guard = ps.vector_index.write().await;
+
+    let (url, cancellation) = start_test_server(state.clone()).await;
+    let request_url = format!("{url}/v1/gdpr/erase/{}", seeded.entity_name);
+    let request = tokio::spawn(async move {
+        let _ = reqwest::Client::new().delete(request_url).send().await;
+    });
+
+    // The transaction has committed; the rows are gone from storage.
+    tokio::time::timeout(Duration::from_secs(30), committed.recv())
+        .await
+        .expect("the erase must reach its commit point")
+        .expect("commit signal");
+
+    // The client hangs up, then the lock frees.
+    request.abort();
+    let _ = request.await;
+    drop(index_guard);
+
+    // The cleanup must still happen. Polled rather than asserted once: it now
+    // runs on a task nothing awaits, so "eventually" is the only honest
+    // contract — but it is bounded, and a handler that abandoned the cleanup
+    // never gets there at all.
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        let stranded: Vec<Uuid> = {
+            let index = ps.vector_index.read().await;
+            [seeded.settled, seeded.racer]
+                .into_iter()
+                .filter(|id| index.get(*id).is_some())
+                .collect()
+        };
+        if stranded.is_empty() {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "the erase committed and the client disconnected, and these index entries \
+             were never cleaned up: {stranded:?}. They now point at content the request \
+             destroyed. Run the erase and its bookkeeping on a spawned task, the way \
+             `forget_entity` does."
+        );
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+
+    // …and storage really is empty, so the assertion above is about cleanup
+    // rather than about an erase that never ran.
+    assert!(
+        ps.storage
+            .get_all_memories_by_namespace_including_superseded(ps.namespace.id)
+            .expect("read storage")
+            .is_empty(),
+        "the erase must have committed for this test to mean anything"
     );
 
     cancellation.cancel();


### PR DESCRIPTION
Closes #268, closes #264.

`gdpr::erase_entity` was four independent storage calls with partial-success warnings: its vector-index cleanup was driven by a pre-list racing the delete (#268), and `edges_deleted` reported the count of a SELECT while every edge stayed in the table (#264). It is now one capturing transaction per backend — `erase_entity_capturing` deletes observations (before the memory rows their join needs), memories (superseded included, FTS inside the transaction), edges (`(source OR target) AND namespace_id`, via `DELETE … RETURNING`), and the entity record, on the namespace-scoped connection, all-or-nothing. The gateway drives index cleanup from the captured rows; the pre-list is gone with no production caller left.

**Behaviour change: GDPR erase is now all-or-nothing, and `edges_deleted` is real.** Partial-success semantics are gone from the storage layer: every leg commits or every leg rolls back and the call returns `Err`. `ErasureResult.warnings` survives only for post-commit cleanup the erasure does not own (the gateway's vector index), and `complete` is `true` on every `Ok` unless such a warning was appended. `erase_entity`'s signature is unchanged, so the CLI and `erase_namespace` are unaffected.

**Operational shape:** the erase runs on the blocking pool and, together with its index cleanup, on a task detached from request cancellation, matching `forget_entity` — a client disconnect after commit no longer strands index entries pointing at destroyed content. A task-level failure returns `500 GDPR erasure task failed`, worded neutrally because a panic after commit cannot claim nothing was erased.

**Deliberate residue** (documented in `docs/SECURITY.md` and on `erase_entity_captured`): an edge belongs to its **source** entity's namespace, so an edge whose source lives in tenant A and whose target is being erased in tenant B is stored in A, invisible from B, and survives B's erase — deleting it would require B to read into A.

Tests (TDD): edges-really-deleted regression that fails pre-fix; a handler-level race harness with a commit signal proving index cleanup is driven by the captured set and completes after a mid-request client disconnect; superseded-row capture coverage with an anti-vacuity sabotage check; live-Postgres enforced-RLS confinement test (`capturing_erase_is_confined_to_its_namespace_under_enforced_rls`) asserting A erased and B intact — verified load-bearing by reproducing the #253 empty-namespace failure against a sabotaged connection acquire. 945 + 735 live-PG tests green, 30/30 live_rls running, clippy clean both feature sets.

Follow-up filed: #278 (`purge_namespace` leaves edges and entity records behind; doc pointers retargeted there).