### PR TITLE
feat(snapshot): retention window and per-namespace count quota for forget snapshots

### DIFF
--- a/pensyve-core/src/snapshot.rs
+++ b/pensyve-core/src/snapshot.rs
@@ -1013,6 +1013,41 @@ mod tests {
         assert_eq!(file_names(&dir).len(), 4, "{:?}", file_names(&dir));
     }
 
+    /// A symlink named like a snapshot is skipped, not followed: retention
+    /// must never be able to unlink something outside the directory it was
+    /// pointed at, whoever planted the link.
+    #[cfg(unix)]
+    #[test]
+    fn prune_never_follows_a_symlink_out_of_the_directory() {
+        let f = fixture();
+        let dir = f.dir.path().join("snapshots");
+        let outside = f.dir.path().join("somebody-elses-file");
+        std::fs::write(&outside, b"not retention's to delete").unwrap();
+        write_aged(&f, &dir, epoch());
+        std::os::unix::fs::symlink(
+            &outside,
+            dir.join(format!(
+                "forget-{}-20260101T000000.000Z-{}.json",
+                Uuid::new_v4(),
+                Uuid::new_v4()
+            )),
+        )
+        .unwrap();
+
+        let outcome = prune_namespace_dir(
+            &dir,
+            RetentionPolicy {
+                max_age_days: Some(1),
+                max_count: None,
+            },
+            epoch() + Duration::days(365),
+        );
+
+        assert_eq!(outcome.removed, 1, "only the real snapshot may be removed");
+        assert!(outside.exists(), "the symlink's target must be untouched");
+        assert_eq!(file_names(&dir).len(), 1, "the symlink itself stays too");
+    }
+
     #[test]
     fn an_unbounded_policy_prunes_nothing() {
         let f = fixture();

--- a/pensyve-core/src/snapshot.rs
+++ b/pensyve-core/src/snapshot.rs
@@ -53,7 +53,7 @@
 
 use std::path::{Path, PathBuf};
 
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Duration, NaiveDateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -156,6 +156,55 @@ pub struct ForgetOutcome {
     /// empty snapshot has nothing to recover, and writing one per call would
     /// let a caller fill the disk by invoking `pensyve_forget` in a loop.
     pub path: Option<PathBuf>,
+    /// What retention evicted from this namespace's directory afterwards, and
+    /// anything that went wrong doing it. Never affects whether the delete
+    /// happened — see [`prune_namespace_dir`].
+    pub pruned: PruneOutcome,
+}
+
+/// How much snapshot history one namespace directory keeps.
+///
+/// An empty snapshot is never written, but a non-empty one always is, so a
+/// caller looping `remember` → `forget` leaves the live database small while
+/// the snapshot volume grows without bound (#265) — in the hosted deployment
+/// that volume is a network mount nobody is watching. These bounds put a
+/// ceiling on it, per namespace, so one tenant's history cannot crowd out
+/// another's.
+///
+/// `None` disables that bound. The serving states map their `0` sentinel to
+/// `None`, so `Some(0)` — which would evict the snapshot the current forget
+/// just wrote — is not a value this type is constructed with in production.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RetentionPolicy {
+    /// Evict snapshots captured longer ago than this.
+    pub max_age_days: Option<u32>,
+    /// Keep at most this many snapshots in one namespace directory, oldest
+    /// evicted first.
+    pub max_count: Option<u32>,
+}
+
+impl RetentionPolicy {
+    /// Keep everything, forever. The behaviour before #265, and what callers
+    /// that manage their own snapshot lifecycle (tests, one-shot tooling) want.
+    pub const UNBOUNDED: Self = Self {
+        max_age_days: None,
+        max_count: None,
+    };
+
+    const fn is_unbounded(self) -> bool {
+        self.max_age_days.is_none() && self.max_count.is_none()
+    }
+}
+
+/// What a [`prune_namespace_dir`] pass did.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct PruneOutcome {
+    pub removed: usize,
+    /// Everything that went wrong, in the order it was hit. Pruning has no
+    /// error type: the rows a failed prune would abort over are already gone
+    /// from storage, so the only thing aborting could achieve is turning a
+    /// successful delete into a reported failure.
+    pub warnings: Vec<String>,
 }
 
 /// Delete every memory attached to `entity_id` and persist a snapshot of
@@ -167,12 +216,40 @@ pub struct ForgetOutcome {
 ///
 /// `snapshot_root` is the root for all namespaces; the file lands under
 /// `<snapshot_root>/<namespace_id>/`.
+///
+/// `retention` bounds what that directory accumulates. It is applied *after*
+/// the delete has committed with its new snapshot on disk, and it can only
+/// report problems, never cause them: see [`prune_namespace_dir`].
 pub fn forget_entity(
     storage: &dyn StorageTrait,
     entity_id: Uuid,
     entity_name: Option<&str>,
     namespace_id: Uuid,
     snapshot_root: &Path,
+    retention: RetentionPolicy,
+) -> StorageResult<ForgetOutcome> {
+    forget_entity_with(
+        storage,
+        entity_id,
+        entity_name,
+        namespace_id,
+        snapshot_root,
+        retention,
+        remove_snapshot_file,
+    )
+}
+
+/// [`forget_entity`] with retention's file removal injected, so the "a prune
+/// failure does not fail the forget" path can be exercised — a real `unlink`
+/// only fails on conditions a test cannot create without root.
+fn forget_entity_with(
+    storage: &dyn StorageTrait,
+    entity_id: Uuid,
+    entity_name: Option<&str>,
+    namespace_id: Uuid,
+    snapshot_root: &Path,
+    retention: RetentionPolicy,
+    remove_file: fn(&Path) -> std::io::Result<()>,
 ) -> StorageResult<ForgetOutcome> {
     let dir = namespace_dir(snapshot_root, namespace_id);
 
@@ -227,7 +304,136 @@ pub fn forget_entity(
         )
     })?;
 
-    Ok(ForgetOutcome { snapshot, path })
+    // Only after the delete committed, and only when it actually left a new
+    // file behind: pruning a directory this call did not add to would be
+    // housekeeping charged to whichever caller happened to forget nothing.
+    // Runs here rather than inside `persist` so a prune can never be part of
+    // the transaction that the delete rolls back.
+    let pruned = if path.is_some() {
+        let outcome = prune_namespace_dir_with(&dir, retention, Utc::now(), remove_file);
+        for warning in &outcome.warnings {
+            tracing::warn!(
+                directory = %dir.display(),
+                "snapshot retention could not complete: {warning}"
+            );
+        }
+        outcome
+    } else {
+        PruneOutcome::default()
+    };
+
+    Ok(ForgetOutcome {
+        snapshot,
+        path,
+        pruned,
+    })
+}
+
+/// Evict snapshots from one namespace directory until it satisfies `policy`,
+/// oldest first.
+///
+/// Returns rather than fails. This runs after an irreversible delete has
+/// already committed, so there is nothing an error could protect: the caller
+/// cannot undo the delete, and reporting a failed unlink as a failed forget
+/// would tell them their memories are still there when they are not. Problems
+/// come back as [`PruneOutcome::warnings`] for the operator.
+///
+/// What it will touch is deliberately narrow — a snapshot directory is a place
+/// operators poke around in, and this is code that deletes files:
+///
+/// - Only names [`write_to_dir`] produces are candidates. Anything else in the
+///   directory, including a half-written `.partial` from a crashed write, is
+///   not ours to remove.
+/// - Only regular files. `DirEntry::file_type` does not follow symlinks, so a
+///   symlink named like a snapshot is skipped rather than followed out of the
+///   directory, and a subdirectory is never descended into.
+/// - Age is the snapshot's own `captured_at`, read from the name, never the
+///   file's mtime — see [`parse_snapshot_file_name`].
+pub fn prune_namespace_dir(
+    dir: &Path,
+    policy: RetentionPolicy,
+    now: DateTime<Utc>,
+) -> PruneOutcome {
+    prune_namespace_dir_with(dir, policy, now, remove_snapshot_file)
+}
+
+/// The real removal retention performs, named so it has the `for<'a>` signature
+/// the injection point takes (`std::fs::remove_file` is generic over its path
+/// argument and does not coerce to one on its own).
+fn remove_snapshot_file(path: &Path) -> std::io::Result<()> {
+    std::fs::remove_file(path)
+}
+
+fn prune_namespace_dir_with(
+    dir: &Path,
+    policy: RetentionPolicy,
+    now: DateTime<Utc>,
+    remove_file: fn(&Path) -> std::io::Result<()>,
+) -> PruneOutcome {
+    let mut outcome = PruneOutcome::default();
+    if policy.is_unbounded() {
+        return outcome;
+    }
+
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(err) => {
+            outcome
+                .warnings
+                .push(format!("cannot list {}: {err}", dir.display()));
+            return outcome;
+        }
+    };
+
+    // `(captured_at, file_name)`: sorting the pair puts the oldest first and
+    // breaks ties on the name, so two snapshots captured in the same
+    // millisecond still evict in a fixed order rather than in whatever order
+    // the directory happened to be read.
+    let mut snapshots: Vec<(DateTime<Utc>, std::ffi::OsString)> = Vec::new();
+    for entry in entries {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(err) => {
+                outcome
+                    .warnings
+                    .push(format!("cannot read an entry of {}: {err}", dir.display()));
+                continue;
+            }
+        };
+        if !entry.file_type().is_ok_and(|kind| kind.is_file()) {
+            continue;
+        }
+        let name = entry.file_name();
+        let Some(captured_at) = name.to_str().and_then(parse_snapshot_file_name) else {
+            continue;
+        };
+        snapshots.push((captured_at, name));
+    }
+    snapshots.sort();
+
+    let cutoff = policy
+        .max_age_days
+        .map(|days| now - Duration::days(i64::from(days)));
+    let (mut survivors, mut victims): (Vec<_>, Vec<_>) = snapshots
+        .into_iter()
+        .partition(|(captured_at, _)| cutoff.is_none_or(|cutoff| *captured_at >= cutoff));
+
+    if let Some(max) = policy.max_count {
+        let excess = survivors.len().saturating_sub(max as usize);
+        victims.extend(survivors.drain(..excess));
+    }
+
+    for (_, name) in victims {
+        let path = dir.join(name);
+        match remove_file(&path) {
+            Ok(()) => outcome.removed += 1,
+            Err(err) => outcome
+                .warnings
+                .push(format!("cannot remove {}: {err}", path.display())),
+        }
+    }
+
+    outcome
 }
 
 /// Per-namespace snapshot directory. Keeps one gateway tenant's memory dumps
@@ -419,15 +625,60 @@ pub fn restore(
     Ok(outcome)
 }
 
-/// `forget-<entity>-<captured_at>-<snapshot>.json`, with a timestamp format
-/// that is safe on every filesystem (no colons).
+/// Timestamp format inside a snapshot file name: safe on every filesystem (no
+/// colons), fixed width, and sorts the same as the instant it encodes. Shared
+/// by [`file_name`] and [`parse_snapshot_file_name`] so the two cannot drift.
+const FILE_NAME_TIMESTAMP: &str = "%Y%m%dT%H%M%S%.3fZ";
+
+/// Length of a hyphenated UUID as [`Uuid`]'s `Display` writes one.
+const UUID_LEN: usize = 36;
+
+/// `forget-<entity>-<captured_at>-<snapshot>.json`.
 fn file_name(snapshot: &ForgetSnapshot) -> String {
     format!(
         "forget-{}-{}-{}.json",
         snapshot.entity_id,
-        snapshot.captured_at.format("%Y%m%dT%H%M%S%.3fZ"),
+        snapshot.captured_at.format(FILE_NAME_TIMESTAMP),
         snapshot.snapshot_id
     )
+}
+
+/// The `captured_at` encoded in a name [`file_name`] produced, or `None` for
+/// any other name.
+///
+/// Retention uses this for two things, and both want the same strictness.
+///
+/// It decides what may be deleted at all: a name this does not parse is not a
+/// file this module wrote, so it is left alone. Both UUIDs are parsed, not just
+/// counted, so `forget-anything-else.json` is not a candidate.
+///
+/// It also supplies the ordering. Deletion order has to come from the
+/// snapshot's own capture time, because the alternative — the file's mtime — is
+/// not a property of the snapshot: in the hosted deployment these files live on
+/// a network mount, and a restore, a re-sync, or a remount rewrites mtimes
+/// wholesale, which would silently invert oldest-first eviction.
+///
+/// Reading that timestamp from the name rather than from the file's
+/// `captured_at` field keeps a prune proportional to the number of directory
+/// entries instead of to their size. A snapshot at #217's scale is megabytes of
+/// JSON; parsing every one of them on every forget would push hundreds of
+/// megabytes through the blocking pool just to decide which files to unlink.
+/// The name is written from `captured_at` by [`file_name`], and nothing but
+/// [`write_to_dir`] writes these files.
+fn parse_snapshot_file_name(name: &str) -> Option<DateTime<Utc>> {
+    let rest = name.strip_prefix("forget-")?.strip_suffix(".json")?;
+
+    let entity_id = rest.get(..UUID_LEN)?;
+    Uuid::parse_str(entity_id).ok()?;
+    let rest = rest.strip_prefix(entity_id)?.strip_prefix('-')?;
+
+    let timestamp = rest.get(..rest.len().checked_sub(UUID_LEN + 1)?)?;
+    let snapshot_id = rest.strip_prefix(timestamp)?.strip_prefix('-')?;
+    Uuid::parse_str(snapshot_id).ok()?;
+
+    NaiveDateTime::parse_from_str(timestamp, FILE_NAME_TIMESTAMP)
+        .ok()
+        .map(|naive| naive.and_utc())
 }
 
 #[cfg(test)]
@@ -435,6 +686,7 @@ mod tests {
     use super::*;
     use crate::storage::sqlite::SqliteBackend;
     use crate::types::{Entity, EntityKind, Episode, EpisodicMemory, Namespace, SemanticMemory};
+    use chrono::{Duration, TimeZone};
 
     struct Fixture {
         dir: tempfile::TempDir,
@@ -505,8 +757,15 @@ mod tests {
         let f = fixture();
         let root = f.dir.path().join("snapshots");
 
-        let outcome =
-            forget_entity(&f.storage, Uuid::new_v4(), None, f.namespace.id, &root).unwrap();
+        let outcome = forget_entity(
+            &f.storage,
+            Uuid::new_v4(),
+            None,
+            f.namespace.id,
+            &root,
+            RetentionPolicy::UNBOUNDED,
+        )
+        .unwrap();
 
         assert!(outcome.snapshot.is_empty());
         assert!(
@@ -530,6 +789,7 @@ mod tests {
             None,
             f.namespace.id,
             &f.dir.path().join("snapshots"),
+            RetentionPolicy::UNBOUNDED,
         )
         .unwrap();
 
@@ -547,7 +807,15 @@ mod tests {
         seed_one_of_each(&f);
         let root = f.dir.path().join("snapshots");
 
-        let outcome = forget_entity(&f.storage, f.entity.id, None, f.namespace.id, &root).unwrap();
+        let outcome = forget_entity(
+            &f.storage,
+            f.entity.id,
+            None,
+            f.namespace.id,
+            &root,
+            RetentionPolicy::UNBOUNDED,
+        )
+        .unwrap();
 
         let path = outcome.path.expect("a non-empty snapshot must be written");
         assert_eq!(
@@ -568,6 +836,7 @@ mod tests {
             Some("subject"),
             f.namespace.id,
             &f.dir.path().join("snapshots"),
+            RetentionPolicy::UNBOUNDED,
         )
         .unwrap();
 
@@ -600,8 +869,15 @@ mod tests {
         std::fs::create_dir_all(&root).unwrap();
         std::fs::write(namespace_dir(&root, f.namespace.id), b"not a directory").unwrap();
 
-        let error =
-            forget_entity(&f.storage, f.entity.id, None, f.namespace.id, &root).unwrap_err();
+        let error = forget_entity(
+            &f.storage,
+            f.entity.id,
+            None,
+            f.namespace.id,
+            &root,
+            RetentionPolicy::UNBOUNDED,
+        )
+        .unwrap_err();
 
         assert!(
             f.storage
@@ -610,6 +886,233 @@ mod tests {
                 .len()
                 == before,
             "delete must roll back when the snapshot write fails: {error}"
+        );
+    }
+
+    /// Write a snapshot the way a forget on `captured_at` would have left it,
+    /// so retention tests can lay down history without waiting for a clock.
+    fn write_aged(f: &Fixture, dir: &Path, captured_at: DateTime<Utc>) -> PathBuf {
+        let mut snapshot = snapshot_of(f, Vec::new());
+        snapshot.captured_at = captured_at;
+        write_to_dir(dir, &snapshot).unwrap()
+    }
+
+    fn file_names(dir: &Path) -> Vec<String> {
+        let mut names: Vec<String> = std::fs::read_dir(dir)
+            .unwrap()
+            .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+            .collect();
+        names.sort();
+        names
+    }
+
+    fn epoch() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap()
+    }
+
+    /// Eviction order comes from the snapshot's own `captured_at`, never from
+    /// the filesystem: these are written newest-first, so mtime order is the
+    /// exact reverse of capture order and an mtime-based prune would delete the
+    /// two the tenant most likely wants back.
+    #[test]
+    fn prune_evicts_the_oldest_snapshots_beyond_the_count_cap() {
+        let f = fixture();
+        let dir = f.dir.path().join("snapshots");
+
+        let mut expected_kept = Vec::new();
+        for hours in (0..5).rev() {
+            let path = write_aged(&f, &dir, epoch() + Duration::hours(hours));
+            if hours >= 2 {
+                expected_kept.push(path.file_name().unwrap().to_string_lossy().into_owned());
+            }
+        }
+        expected_kept.sort();
+
+        let outcome = prune_namespace_dir(
+            &dir,
+            RetentionPolicy {
+                max_age_days: None,
+                max_count: Some(3),
+            },
+            epoch() + Duration::hours(5),
+        );
+
+        assert_eq!(outcome.removed, 2, "warnings: {:?}", outcome.warnings);
+        assert!(outcome.warnings.is_empty(), "{:?}", outcome.warnings);
+        assert_eq!(file_names(&dir), expected_kept);
+    }
+
+    /// The window is measured against an injected `now` rather than the process
+    /// clock, so the boundary is assertable: a snapshot captured exactly at the
+    /// cutoff is inside the window and stays.
+    #[test]
+    fn prune_removes_snapshots_older_than_the_retention_window() {
+        let f = fixture();
+        let dir = f.dir.path().join("snapshots");
+
+        let mut expected_kept = Vec::new();
+        for days in 0..5 {
+            let path = write_aged(&f, &dir, epoch() + Duration::days(days));
+            if days >= 3 {
+                expected_kept.push(path.file_name().unwrap().to_string_lossy().into_owned());
+            }
+        }
+        expected_kept.sort();
+
+        let outcome = prune_namespace_dir(
+            &dir,
+            RetentionPolicy {
+                max_age_days: Some(7),
+                max_count: None,
+            },
+            epoch() + Duration::days(10),
+        );
+
+        assert_eq!(outcome.removed, 3, "warnings: {:?}", outcome.warnings);
+        assert!(outcome.warnings.is_empty(), "{:?}", outcome.warnings);
+        assert_eq!(file_names(&dir), expected_kept);
+    }
+
+    /// Retention only ever deletes files this module wrote. Anything else in
+    /// the directory — an operator's notes, a half-written `.partial`, a
+    /// subdirectory, a symlink pointing outside — is not ours to remove.
+    #[test]
+    fn prune_only_removes_files_matching_the_snapshot_naming_pattern() {
+        let f = fixture();
+        let dir = f.dir.path().join("snapshots");
+        write_aged(&f, &dir, epoch());
+
+        std::fs::write(dir.join("operator-notes.txt"), b"keep me").unwrap();
+        std::fs::write(dir.join("forget-not-a-snapshot.json"), b"keep me").unwrap();
+        std::fs::write(
+            dir.join(format!(
+                "forget-{}-20260101T000000.000Z-{}.json.partial",
+                Uuid::new_v4(),
+                Uuid::new_v4()
+            )),
+            b"keep me",
+        )
+        .unwrap();
+        std::fs::create_dir(dir.join(format!(
+            "forget-{}-20260101T000000.000Z-{}.json",
+            Uuid::new_v4(),
+            Uuid::new_v4()
+        )))
+        .unwrap();
+
+        let outcome = prune_namespace_dir(
+            &dir,
+            RetentionPolicy {
+                max_age_days: Some(1),
+                max_count: Some(1),
+            },
+            epoch() + Duration::days(365),
+        );
+
+        assert_eq!(outcome.removed, 1, "only the snapshot file may be removed");
+        assert_eq!(file_names(&dir).len(), 4, "{:?}", file_names(&dir));
+    }
+
+    #[test]
+    fn an_unbounded_policy_prunes_nothing() {
+        let f = fixture();
+        let dir = f.dir.path().join("snapshots");
+        for days in 0..3 {
+            write_aged(&f, &dir, epoch() - Duration::days(days * 1000));
+        }
+
+        let outcome = prune_namespace_dir(
+            &dir,
+            RetentionPolicy::UNBOUNDED,
+            epoch() + Duration::days(100_000),
+        );
+
+        assert_eq!(outcome.removed, 0);
+        assert_eq!(file_names(&dir).len(), 3);
+    }
+
+    /// End to end: the quota is applied to the directory the new snapshot just
+    /// landed in, and the new snapshot is one of the survivors.
+    #[test]
+    fn forget_entity_prunes_the_namespace_directory_after_writing() {
+        let f = fixture();
+        seed_one_of_each(&f);
+        let root = f.dir.path().join("snapshots");
+        let dir = namespace_dir(&root, f.namespace.id);
+        for hours in 0..3 {
+            write_aged(&f, &dir, epoch() + Duration::hours(hours));
+        }
+
+        let outcome = forget_entity(
+            &f.storage,
+            f.entity.id,
+            None,
+            f.namespace.id,
+            &root,
+            RetentionPolicy {
+                max_age_days: None,
+                max_count: Some(2),
+            },
+        )
+        .unwrap();
+
+        let path = outcome.path.expect("a non-empty snapshot must be written");
+        assert_eq!(outcome.pruned.removed, 2);
+        assert!(outcome.pruned.warnings.is_empty());
+        assert!(path.exists(), "the snapshot just written must survive");
+        assert_eq!(file_names(&dir).len(), 2);
+    }
+
+    /// Eviction is housekeeping, not part of the delete's contract: a prune
+    /// that cannot remove a file leaves the forget successful and reports a
+    /// warning. Aborting here would be strictly worse than an oversized
+    /// directory — the rows are already gone from storage.
+    ///
+    /// A real `unlink` only fails on conditions this test cannot create without
+    /// root (an unwritable parent, a read-only mount, an immutable inode), so
+    /// the failure is injected through the same kind of seam `write_to_dir`
+    /// uses for `fsync`.
+    #[test]
+    fn forget_entity_reports_a_prune_failure_as_a_warning_and_still_succeeds() {
+        fn always_fails(_: &Path) -> std::io::Result<()> {
+            Err(std::io::Error::other("simulated unlink failure"))
+        }
+
+        let f = fixture();
+        seed_one_of_each(&f);
+        let root = f.dir.path().join("snapshots");
+        let dir = namespace_dir(&root, f.namespace.id);
+        let stale = write_aged(&f, &dir, epoch());
+
+        let outcome = forget_entity_with(
+            &f.storage,
+            f.entity.id,
+            None,
+            f.namespace.id,
+            &root,
+            RetentionPolicy {
+                max_age_days: None,
+                max_count: Some(1),
+            },
+            always_fails,
+        )
+        .expect("a prune failure must not fail the forget");
+
+        assert!(outcome.path.is_some(), "the new snapshot was still written");
+        assert_eq!(outcome.pruned.removed, 0);
+        assert_eq!(outcome.pruned.warnings.len(), 1);
+        assert!(
+            outcome.pruned.warnings[0].contains("simulated unlink failure"),
+            "unexpected warning: {:?}",
+            outcome.pruned.warnings
+        );
+        assert!(stale.exists(), "a file we failed to remove must remain");
+        assert!(
+            f.storage
+                .get_all_memories_by_namespace_including_superseded(f.namespace.id)
+                .unwrap()
+                .is_empty(),
+            "the delete must still have committed"
         );
     }
 
@@ -735,6 +1238,7 @@ mod tests {
             None,
             f.namespace.id,
             &f.dir.path().join("snapshots"),
+            RetentionPolicy::UNBOUNDED,
         )
         .unwrap();
         let path = outcome.path.expect("a non-empty snapshot must be written");

--- a/pensyve-core/src/snapshot.rs
+++ b/pensyve-core/src/snapshot.rs
@@ -3,7 +3,7 @@
 //! `pensyve_forget` destroys every memory attached to an entity in one call.
 //! Issue #217 recorded two production incidents where a caller who meant to
 //! retract a single memory invoked it instead and lost 1,528 and 79 memories
-//! with no server-side way back. [`forget_entity`] is the recovery path.
+//! with no server-side way back. [`forget_entity_bounded`] is the recovery path.
 //!
 //! # The snapshot is the delete
 //!
@@ -147,7 +147,7 @@ pub struct RestoreOutcome {
     pub restored: usize,
 }
 
-/// Result of a [`forget_entity`] call.
+/// Result of a [`forget_entity_bounded`] call.
 #[derive(Debug, Clone)]
 pub struct ForgetOutcome {
     /// The rows the delete removed. Empty when the entity had no memories.
@@ -173,7 +173,7 @@ pub struct ForgetOutcome {
 ///
 /// `None` disables that bound. The serving states map their `0` sentinel to
 /// `None`, so `Some(0)` is not a value this type is constructed with in
-/// production; should one reach [`forget_entity`] anyway, the snapshot that
+/// production; should one reach [`forget_entity_bounded`] anyway, the snapshot that
 /// call just wrote is still exempt — see [`prune_namespace_dir_with`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RetentionPolicy {
@@ -221,7 +221,7 @@ pub struct PruneOutcome {
 /// `retention` bounds what that directory accumulates. It is applied *after*
 /// the delete has committed with its new snapshot on disk, and it can only
 /// report problems, never cause them: see [`prune_namespace_dir`].
-pub fn forget_entity(
+pub fn forget_entity_bounded(
     storage: &dyn StorageTrait,
     entity_id: Uuid,
     entity_name: Option<&str>,
@@ -229,7 +229,7 @@ pub fn forget_entity(
     snapshot_root: &Path,
     retention: RetentionPolicy,
 ) -> StorageResult<ForgetOutcome> {
-    forget_entity_with(
+    forget_entity_bounded_with(
         storage,
         entity_id,
         entity_name,
@@ -240,10 +240,40 @@ pub fn forget_entity(
     )
 }
 
-/// [`forget_entity`] with retention's file removal injected, so the "a prune
-/// failure does not fail the forget" path can be exercised — a real `unlink`
-/// only fails on conditions a test cannot create without root.
-fn forget_entity_with(
+/// [`forget_entity_bounded`] with no bound on what the namespace directory
+/// accumulates.
+///
+/// Superseded by [`forget_entity_bounded`] in #265 rather than removed: keeping
+/// snapshots forever is a behaviour this crate still supports and can still
+/// express ([`RetentionPolicy::UNBOUNDED`]), so this entry point is merely
+/// outgrown, not unsafe to call. Per `AGENTS.md`, an API that is superseded
+/// gets a deprecation cycle; only an API that is *itself* the defect gets
+/// broken outright.
+#[deprecated(
+    since = "3.1.0",
+    note = "use `forget_entity_bounded`, which takes a `RetentionPolicy`. This entry point is equivalent to passing `RetentionPolicy::UNBOUNDED`, under which one namespace's snapshot directory grows without bound (#265)."
+)]
+pub fn forget_entity(
+    storage: &dyn StorageTrait,
+    entity_id: Uuid,
+    entity_name: Option<&str>,
+    namespace_id: Uuid,
+    snapshot_root: &Path,
+) -> StorageResult<ForgetOutcome> {
+    forget_entity_bounded(
+        storage,
+        entity_id,
+        entity_name,
+        namespace_id,
+        snapshot_root,
+        RetentionPolicy::UNBOUNDED,
+    )
+}
+
+/// [`forget_entity_bounded`] with retention's file removal injected, so the "a
+/// prune failure does not fail the forget" path can be exercised — a real
+/// `unlink` only fails on conditions a test cannot create without root.
+fn forget_entity_bounded_with(
     storage: &dyn StorageTrait,
     entity_id: Uuid,
     entity_name: Option<&str>,
@@ -373,7 +403,7 @@ fn remove_snapshot_file(path: &Path) -> std::io::Result<()> {
 /// [`prune_namespace_dir`] with the file removal injected, and with one file in
 /// the directory declared off-limits.
 ///
-/// `protected` is the snapshot the calling [`forget_entity`] just wrote. It
+/// `protected` is the snapshot the calling [`forget_entity_bounded`] just wrote. It
 /// cannot be left to survive on its ordering: that only holds while every other
 /// name in the directory tells the truth about its capture time, and a
 /// container whose clock steps backwards between two forgets leaves a
@@ -794,7 +824,7 @@ mod tests {
         let f = fixture();
         let root = f.dir.path().join("snapshots");
 
-        let outcome = forget_entity(
+        let outcome = forget_entity_bounded(
             &f.storage,
             Uuid::new_v4(),
             None,
@@ -820,7 +850,7 @@ mod tests {
         let f = fixture();
         seed_one_of_each(&f);
 
-        let outcome = forget_entity(
+        let outcome = forget_entity_bounded(
             &f.storage,
             f.entity.id,
             None,
@@ -844,7 +874,7 @@ mod tests {
         seed_one_of_each(&f);
         let root = f.dir.path().join("snapshots");
 
-        let outcome = forget_entity(
+        let outcome = forget_entity_bounded(
             &f.storage,
             f.entity.id,
             None,
@@ -867,7 +897,7 @@ mod tests {
         let f = fixture();
         seed_one_of_each(&f);
 
-        let outcome = forget_entity(
+        let outcome = forget_entity_bounded(
             &f.storage,
             f.entity.id,
             Some("subject"),
@@ -906,7 +936,7 @@ mod tests {
         std::fs::create_dir_all(&root).unwrap();
         std::fs::write(namespace_dir(&root, f.namespace.id), b"not a directory").unwrap();
 
-        let error = forget_entity(
+        let error = forget_entity_bounded(
             &f.storage,
             f.entity.id,
             None,
@@ -1115,7 +1145,7 @@ mod tests {
             write_aged(&f, &dir, epoch() + Duration::hours(hours));
         }
 
-        let outcome = forget_entity(
+        let outcome = forget_entity_bounded(
             &f.storage,
             f.entity.id,
             None,
@@ -1135,6 +1165,33 @@ mod tests {
         assert_eq!(file_names(&dir).len(), 2);
     }
 
+    /// The superseded five-argument entry point still does what it always did:
+    /// deletes, snapshots, and keeps every snapshot. Callers get a deprecation
+    /// warning pointing at `forget_entity_bounded`, not a behaviour change.
+    #[test]
+    #[allow(
+        deprecated,
+        reason = "exercising the deprecated entry point is the point of this test"
+    )]
+    fn the_deprecated_forget_entity_still_forgets_and_prunes_nothing() {
+        let f = fixture();
+        seed_one_of_each(&f);
+        let root = f.dir.path().join("snapshots");
+        let dir = namespace_dir(&root, f.namespace.id);
+        let ancient = write_aged(&f, &dir, epoch() - Duration::days(10_000));
+
+        let outcome = forget_entity(&f.storage, f.entity.id, None, f.namespace.id, &root).unwrap();
+
+        assert_eq!(outcome.snapshot.counts().total, 2);
+        assert!(outcome.path.is_some());
+        assert_eq!(outcome.pruned, PruneOutcome::default());
+        assert!(
+            ancient.exists(),
+            "the superseded entry point keeps every snapshot, as it always did"
+        );
+        assert_eq!(file_names(&dir).len(), 2);
+    }
+
     /// The snapshot this call just wrote is never a victim of its own prune.
     ///
     /// Ordering by `captured_at` makes "the newest file survives" true only as
@@ -1151,7 +1208,7 @@ mod tests {
         let dir = namespace_dir(&root, f.namespace.id);
         let future = write_aged(&f, &dir, Utc::now() + Duration::days(365));
 
-        let outcome = forget_entity(
+        let outcome = forget_entity_bounded(
             &f.storage,
             f.entity.id,
             None,
@@ -1226,7 +1283,7 @@ mod tests {
         let dir = namespace_dir(&root, f.namespace.id);
         let stale = write_aged(&f, &dir, epoch());
 
-        let outcome = forget_entity_with(
+        let outcome = forget_entity_bounded_with(
             &f.storage,
             f.entity.id,
             None,
@@ -1374,7 +1431,7 @@ mod tests {
     fn a_snapshot_written_before_owner_only_existed_still_restores() {
         let f = fixture();
         seed_one_of_each(&f);
-        let outcome = forget_entity(
+        let outcome = forget_entity_bounded(
             &f.storage,
             f.entity.id,
             None,

--- a/pensyve-core/src/snapshot.rs
+++ b/pensyve-core/src/snapshot.rs
@@ -51,7 +51,9 @@
 //! lossy human-readable JSON rather than restorable rows. Different question,
 //! different answer — the two are intentionally separate.
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex, OnceLock, PoisonError};
 
 use chrono::{DateTime, Duration, NaiveDateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -284,6 +286,14 @@ fn forget_entity_bounded_with(
 ) -> StorageResult<ForgetOutcome> {
     let dir = namespace_dir(snapshot_root, namespace_id);
 
+    // Held across the delete, the snapshot write, and the prune that follows —
+    // see [`namespace_lock`]. Poisoning is ignored deliberately: the guarded
+    // value is `()`, so a thread that panicked here left nothing inconsistent
+    // behind, and refusing every later forget in the namespace would be a worse
+    // failure than whatever poisoned it.
+    let lock = namespace_lock(namespace_id);
+    let _serialized = lock.lock().unwrap_or_else(PoisonError::into_inner);
+
     let mut captured: Option<ForgetSnapshot> = None;
     let mut path: Option<PathBuf> = None;
 
@@ -501,6 +511,37 @@ fn prune_namespace_dir_with(
     }
 
     outcome
+}
+
+/// The lock serializing snapshot write and prune within one namespace.
+///
+/// A prune protects the file its own call wrote, which is only enough while no
+/// other forget is working in the same directory. Once the count cap is
+/// reached, two concurrent forgets each see the other's fresh snapshot as an
+/// eviction candidate; if both enumerate before either removes, they delete
+/// each other's recovery artifacts — for rows both deletes have already
+/// committed, so there is nothing left to write them from. Under `SQLite` the
+/// backend's own mutex makes that window narrow; under `Postgres` the two
+/// transactions genuinely run in parallel and both writes can land before
+/// either enumeration.
+///
+/// In-process is where the race is and therefore where the fix belongs: both
+/// serving states run one process over one storage backend, and #251 puts every
+/// forget on the same blocking pool. A deployment with two writers against one
+/// snapshot volume would need a filesystem-level guard (an `O_EXCL` lock file
+/// per namespace) instead. Nothing ships that shape today, so nothing here
+/// builds one.
+///
+/// The registry keeps one small entry per namespace that has ever run a forget
+/// and never drops one: that is bounded by the tenant count, and dropping
+/// entries would need reference counting to avoid handing out a lock another
+/// thread is about to acquire.
+fn namespace_lock(namespace_id: Uuid) -> Arc<Mutex<()>> {
+    static LOCKS: OnceLock<Mutex<HashMap<Uuid, Arc<Mutex<()>>>>> = OnceLock::new();
+
+    let locks = LOCKS.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut locks = locks.lock().unwrap_or_else(PoisonError::into_inner);
+    Arc::clone(locks.entry(namespace_id).or_default())
 }
 
 /// Per-namespace snapshot directory. Keeps one gateway tenant's memory dumps
@@ -1189,6 +1230,148 @@ mod tests {
             ancient.exists(),
             "the superseded entry point keeps every snapshot, as it always did"
         );
+        assert_eq!(file_names(&dir).len(), 2);
+    }
+
+    /// A forget must not enter the snapshot-write-and-prune section while
+    /// another forget is inside it for the same namespace.
+    ///
+    /// This is the property that closes the race: a prune protects the file its
+    /// own call wrote, so two prunes running against one directory can each
+    /// pick the other's fresh snapshot as an eviction candidate and destroy the
+    /// recovery artifact for rows that are already gone. Asserted by holding
+    /// the namespace's lock and showing a forget cannot get past it — the
+    /// failing direction is exact: without the lock the spawned forget finishes
+    /// in single-digit milliseconds, so "still running" cannot be a slow
+    /// machine.
+    #[test]
+    fn a_forget_cannot_enter_the_critical_section_while_another_holds_it() {
+        let f = fixture();
+        seed_one_of_each(&f);
+        let root = f.dir.path().join("snapshots");
+
+        let lock = namespace_lock(f.namespace.id);
+        let held = lock.lock().unwrap_or_else(PoisonError::into_inner);
+
+        std::thread::scope(|scope| {
+            let forget = scope.spawn(|| {
+                forget_entity_bounded(
+                    &f.storage,
+                    f.entity.id,
+                    None,
+                    f.namespace.id,
+                    &root,
+                    RetentionPolicy {
+                        max_age_days: None,
+                        max_count: Some(1),
+                    },
+                )
+            });
+
+            std::thread::sleep(std::time::Duration::from_millis(150));
+            assert!(
+                !forget.is_finished(),
+                "a forget got into the critical section while it was held"
+            );
+            assert!(
+                f.storage
+                    .get_all_memories_by_namespace_including_superseded(f.namespace.id)
+                    .unwrap()
+                    .len()
+                    == 2,
+                "the delete must not have run either — the lock covers it too"
+            );
+
+            drop(held);
+            let outcome = forget
+                .join()
+                .expect("forget thread")
+                .expect("the forget must complete once the lock is released");
+            assert!(outcome.path.expect("a snapshot was written").exists());
+        });
+    }
+
+    /// Concurrent forgets in one namespace all succeed, evict only what the cap
+    /// requires, and leave every artifact they wrote behind.
+    ///
+    /// A property test, not a reproduction: the interleaving that loses an
+    /// artifact needs both writes to land before either enumeration, which two
+    /// racing threads cannot be made to do from outside this function. What it
+    /// does pin is what serialization buys — no prune warning (a prune that
+    /// found a file another thread had already removed would report one), no
+    /// cap violation, and both fresh snapshots still on disk. The mutual
+    /// exclusion itself is pinned by the test above.
+    #[test]
+    fn concurrent_forgets_in_one_namespace_keep_both_snapshots() {
+        let f = fixture();
+        let mut other = Entity::new("other", EntityKind::User);
+        other.namespace_id = f.namespace.id;
+        f.storage.save_entity(&other).unwrap();
+        for subject in [f.entity.id, other.id] {
+            f.storage
+                .save_semantic(&SemanticMemory::new(
+                    f.namespace.id,
+                    subject,
+                    "likes",
+                    "rust",
+                    0.9,
+                ))
+                .unwrap();
+        }
+
+        let root = f.dir.path().join("snapshots");
+        let dir = namespace_dir(&root, f.namespace.id);
+        // Two snapshots of history, so a cap of two makes every prune evict
+        // exactly one file and neither fresh artifact is due to go.
+        let stale = [
+            write_aged(&f, &dir, epoch()),
+            write_aged(&f, &dir, epoch() + Duration::hours(1)),
+        ];
+        let policy = RetentionPolicy {
+            max_age_days: None,
+            max_count: Some(2),
+        };
+
+        let start = std::sync::Barrier::new(2);
+        let written = std::thread::scope(|scope| {
+            let threads: Vec<_> = [f.entity.id, other.id]
+                .map(|entity_id| {
+                    let (f, root, start) = (&f, &root, &start);
+                    scope.spawn(move || {
+                        start.wait();
+                        forget_entity_bounded(
+                            &f.storage,
+                            entity_id,
+                            None,
+                            f.namespace.id,
+                            root,
+                            policy,
+                        )
+                        .expect("a concurrent forget must still succeed")
+                    })
+                })
+                .into_iter()
+                .collect();
+
+            threads
+                .into_iter()
+                .map(|thread| thread.join().expect("forget thread"))
+                .collect::<Vec<_>>()
+        });
+
+        for outcome in &written {
+            assert!(
+                outcome.pruned.warnings.is_empty(),
+                "a serialized prune never races another: {:?}",
+                outcome.pruned.warnings
+            );
+            let path = outcome.path.as_ref().expect("a snapshot was written");
+            assert!(
+                path.exists(),
+                "a concurrent forget's artifact was evicted by the other's prune"
+            );
+        }
+        assert!(stale.iter().all(|path| !path.exists()));
         assert_eq!(file_names(&dir).len(), 2);
     }
 

--- a/pensyve-core/src/snapshot.rs
+++ b/pensyve-core/src/snapshot.rs
@@ -477,9 +477,26 @@ fn prune_namespace_dir_with(
     }
     snapshots.sort();
 
-    let cutoff = policy
-        .max_age_days
-        .map(|days| now - Duration::days(i64::from(days)));
+    // Subtracting the window can leave the calendar: `max_age_days` is a `u32`
+    // and `DateTime - TimeDelta` panics rather than saturating. This code runs
+    // on the blocking pool *after* the delete committed, where a panic reaches
+    // the caller as a `JoinError` — the forget reported as failed while the
+    // rows are gone, and the bookkeeping that follows it skipped. So an
+    // unrepresentable cutoff bounds nothing and says so, which is the same
+    // outcome the operator would get from setting the window to `0`.
+    let cutoff = match policy.max_age_days {
+        None => None,
+        Some(days) => {
+            let cutoff = Duration::try_days(i64::from(days))
+                .and_then(|window| now.checked_sub_signed(window));
+            if cutoff.is_none() {
+                outcome.warnings.push(format!(
+                    "ignoring the age bound: {days} days before {now} is not a representable date"
+                ));
+            }
+            cutoff
+        }
+    };
     let (mut survivors, mut victims): (Vec<_>, Vec<_>) =
         snapshots
             .into_iter()
@@ -1154,6 +1171,39 @@ mod tests {
         assert_eq!(outcome.removed, 1, "only the real snapshot may be removed");
         assert!(outside.exists(), "the symlink's target must be untouched");
         assert_eq!(file_names(&dir).len(), 1, "the symlink itself stays too");
+    }
+
+    /// A retention window so long its cutoff falls outside the calendar must
+    /// not panic. This runs on the blocking pool *after* the delete committed:
+    /// a panic there surfaces as a `JoinError`, so the caller is told the
+    /// forget failed while the rows are gone and the bookkeeping that follows
+    /// — vector-index cleanup, the activity record — never runs.
+    #[test]
+    fn prune_survives_a_retention_window_longer_than_the_calendar() {
+        let f = fixture();
+        let dir = f.dir.path().join("snapshots");
+        let ancient = write_aged(&f, &dir, epoch());
+
+        let outcome = prune_namespace_dir(
+            &dir,
+            RetentionPolicy {
+                max_age_days: Some(u32::MAX),
+                max_count: None,
+            },
+            Utc::now(),
+        );
+
+        assert_eq!(
+            outcome.removed, 0,
+            "an unrepresentable window bounds nothing"
+        );
+        assert!(ancient.exists());
+        assert_eq!(outcome.warnings.len(), 1, "{:?}", outcome.warnings);
+        assert!(
+            outcome.warnings[0].contains(&u32::MAX.to_string()),
+            "the warning must name the value the operator set: {:?}",
+            outcome.warnings
+        );
     }
 
     #[test]

--- a/pensyve-core/src/snapshot.rs
+++ b/pensyve-core/src/snapshot.rs
@@ -172,8 +172,9 @@ pub struct ForgetOutcome {
 /// another's.
 ///
 /// `None` disables that bound. The serving states map their `0` sentinel to
-/// `None`, so `Some(0)` — which would evict the snapshot the current forget
-/// just wrote — is not a value this type is constructed with in production.
+/// `None`, so `Some(0)` is not a value this type is constructed with in
+/// production; should one reach [`forget_entity`] anyway, the snapshot that
+/// call just wrote is still exempt — see [`prune_namespace_dir_with`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RetentionPolicy {
     /// Evict snapshots captured longer ago than this.
@@ -309,8 +310,13 @@ fn forget_entity_with(
     // housekeeping charged to whichever caller happened to forget nothing.
     // Runs here rather than inside `persist` so a prune can never be part of
     // the transaction that the delete rolls back.
-    let pruned = if path.is_some() {
-        let outcome = prune_namespace_dir_with(&dir, retention, Utc::now(), remove_file);
+    let pruned = if let Some(written) = path.as_deref() {
+        // `written` is handed to the prune as protected, not left to sort its
+        // way to safety: it is the only recovery artifact for rows that are
+        // already gone, so it must not depend on every other name in the
+        // directory being honest about its capture time.
+        let outcome =
+            prune_namespace_dir_with(&dir, retention, Utc::now(), Some(written), remove_file);
         for warning in &outcome.warnings {
             tracing::warn!(
                 directory = %dir.display(),
@@ -354,7 +360,7 @@ pub fn prune_namespace_dir(
     policy: RetentionPolicy,
     now: DateTime<Utc>,
 ) -> PruneOutcome {
-    prune_namespace_dir_with(dir, policy, now, remove_snapshot_file)
+    prune_namespace_dir_with(dir, policy, now, None, remove_snapshot_file)
 }
 
 /// The real removal retention performs, named so it has the `for<'a>` signature
@@ -364,10 +370,23 @@ fn remove_snapshot_file(path: &Path) -> std::io::Result<()> {
     std::fs::remove_file(path)
 }
 
+/// [`prune_namespace_dir`] with the file removal injected, and with one file in
+/// the directory declared off-limits.
+///
+/// `protected` is the snapshot the calling [`forget_entity`] just wrote. It
+/// cannot be left to survive on its ordering: that only holds while every other
+/// name in the directory tells the truth about its capture time, and a
+/// container whose clock steps backwards between two forgets leaves a
+/// future-dated sibling that sorts the new file oldest. Evicting it would mean
+/// rows destroyed with no artifact to restore them from — the fail-closed
+/// contract undone after the fact. So it is excluded structurally: exempt from
+/// the age bound, sorted last so the count cap consumes genuinely older files
+/// first, and skipped outright at the point of removal.
 fn prune_namespace_dir_with(
     dir: &Path,
     policy: RetentionPolicy,
     now: DateTime<Utc>,
+    protected: Option<&Path>,
     remove_file: fn(&Path) -> std::io::Result<()>,
 ) -> PruneOutcome {
     let mut outcome = PruneOutcome::default();
@@ -385,11 +404,17 @@ fn prune_namespace_dir_with(
         }
     };
 
-    // `(captured_at, file_name)`: sorting the pair puts the oldest first and
-    // breaks ties on the name, so two snapshots captured in the same
-    // millisecond still evict in a fixed order rather than in whatever order
-    // the directory happened to be read.
-    let mut snapshots: Vec<(DateTime<Utc>, std::ffi::OsString)> = Vec::new();
+    // Same directory by construction, so the file name identifies the
+    // protected snapshot as well as its full path and does so without caring
+    // how the caller spelled the path.
+    let protected_name = protected.and_then(Path::file_name);
+
+    // `(is_protected, captured_at, file_name)`: sorting the triple puts the
+    // oldest first, breaks ties on the name so two snapshots captured in the
+    // same millisecond still evict in a fixed order rather than in whatever
+    // order the directory happened to be read, and puts the protected file
+    // last no matter what any name claims about its capture time.
+    let mut snapshots: Vec<(bool, DateTime<Utc>, std::ffi::OsString)> = Vec::new();
     for entry in entries {
         let entry = match entry {
             Ok(entry) => entry,
@@ -407,23 +432,35 @@ fn prune_namespace_dir_with(
         let Some(captured_at) = name.to_str().and_then(parse_snapshot_file_name) else {
             continue;
         };
-        snapshots.push((captured_at, name));
+        let is_protected = protected_name == Some(name.as_os_str());
+        snapshots.push((is_protected, captured_at, name));
     }
     snapshots.sort();
 
     let cutoff = policy
         .max_age_days
         .map(|days| now - Duration::days(i64::from(days)));
-    let (mut survivors, mut victims): (Vec<_>, Vec<_>) = snapshots
-        .into_iter()
-        .partition(|(captured_at, _)| cutoff.is_none_or(|cutoff| *captured_at >= cutoff));
+    let (mut survivors, mut victims): (Vec<_>, Vec<_>) =
+        snapshots
+            .into_iter()
+            .partition(|(is_protected, captured_at, _)| {
+                *is_protected || cutoff.is_none_or(|cutoff| *captured_at >= cutoff)
+            });
 
     if let Some(max) = policy.max_count {
         let excess = survivors.len().saturating_sub(max as usize);
         victims.extend(survivors.drain(..excess));
     }
 
-    for (_, name) in victims {
+    for (is_protected, _, name) in victims {
+        if is_protected {
+            // Only reachable through a `max_count` of `Some(0)`, which no
+            // configuration can produce (`0` disables the bound rather than
+            // meaning "keep none"). Skipped rather than asserted: the delete
+            // has already committed by the time this runs, so a policy nobody
+            // can set must not be able to take the artifact with it.
+            continue;
+        }
         let path = dir.join(name);
         match remove_file(&path) {
             Ok(()) => outcome.removed += 1,
@@ -1096,6 +1133,76 @@ mod tests {
         assert!(outcome.pruned.warnings.is_empty());
         assert!(path.exists(), "the snapshot just written must survive");
         assert_eq!(file_names(&dir).len(), 2);
+    }
+
+    /// The snapshot this call just wrote is never a victim of its own prune.
+    ///
+    /// Ordering by `captured_at` makes "the newest file survives" true only as
+    /// long as every name in the directory tells the truth about its time. A
+    /// container whose clock steps backwards between two forgets leaves a
+    /// future-dated sibling behind, and the new snapshot then sorts oldest —
+    /// the count cap would evict the one artifact standing between rows that
+    /// are already gone and no way back. Survival has to be structural.
+    #[test]
+    fn forget_entity_never_evicts_the_snapshot_it_just_wrote() {
+        let f = fixture();
+        seed_one_of_each(&f);
+        let root = f.dir.path().join("snapshots");
+        let dir = namespace_dir(&root, f.namespace.id);
+        let future = write_aged(&f, &dir, Utc::now() + Duration::days(365));
+
+        let outcome = forget_entity(
+            &f.storage,
+            f.entity.id,
+            None,
+            f.namespace.id,
+            &root,
+            RetentionPolicy {
+                max_age_days: None,
+                max_count: Some(1),
+            },
+        )
+        .unwrap();
+
+        let path = outcome.path.expect("a non-empty snapshot must be written");
+        assert!(
+            path.exists(),
+            "the snapshot this forget wrote must survive its own prune"
+        );
+        assert_eq!(outcome.pruned.removed, 1, "the cap must still be enforced");
+        assert!(outcome.pruned.warnings.is_empty());
+        assert!(!future.exists(), "the future-dated sibling is the victim");
+        assert_eq!(file_names(&dir).len(), 1);
+    }
+
+    /// The exemption is structural, not arithmetic: it holds even for the one
+    /// policy that asks for an empty directory, which no configuration can
+    /// produce but the public type can express.
+    #[test]
+    fn prune_spares_the_protected_file_even_under_a_zero_count_cap() {
+        let f = fixture();
+        let dir = f.dir.path().join("snapshots");
+        let stale = write_aged(&f, &dir, epoch());
+        let protected = write_aged(&f, &dir, epoch() + Duration::hours(1));
+
+        let outcome = prune_namespace_dir_with(
+            &dir,
+            RetentionPolicy {
+                max_age_days: Some(1),
+                max_count: Some(0),
+            },
+            epoch() + Duration::days(365),
+            Some(&protected),
+            remove_snapshot_file,
+        );
+
+        assert_eq!(outcome.removed, 1);
+        assert!(outcome.warnings.is_empty());
+        assert!(!stale.exists());
+        assert!(
+            protected.exists(),
+            "the protected snapshot must survive every policy"
+        );
     }
 
     /// Eviction is housekeeping, not part of the delete's contract: a prune

--- a/pensyve-core/src/snapshot.rs
+++ b/pensyve-core/src/snapshot.rs
@@ -395,6 +395,10 @@ fn forget_entity_bounded_with(
 ///   directory, and a subdirectory is never descended into.
 /// - Age is the snapshot's own `captured_at`, read from the name, never the
 ///   file's mtime — see [`parse_snapshot_file_name`].
+///
+/// Takes no namespace lock, so a caller pruning a directory a live namespace is
+/// still forgetting into bypasses the serialization [`namespace_lock`] provides
+/// and can evict a snapshot a concurrent [`forget_entity_bounded`] just wrote.
 pub fn prune_namespace_dir(
     dir: &Path,
     policy: RetentionPolicy,
@@ -1301,9 +1305,15 @@ mod tests {
         let root = f.dir.path().join("snapshots");
 
         let lock = namespace_lock(f.namespace.id);
-        let held = lock.lock().unwrap_or_else(PoisonError::into_inner);
 
         std::thread::scope(|scope| {
+            // Acquired inside the scope, not outside it: `thread::scope` joins
+            // its threads before propagating a panic from this closure, so a
+            // guard living longer than the closure would leave the forget
+            // blocked on it forever. A failing assertion below has to release
+            // the lock as it unwinds, or a genuine regression would surface as
+            // a hung test run instead of a red one.
+            let held = lock.lock().unwrap_or_else(PoisonError::into_inner);
             let forget = scope.spawn(|| {
                 forget_entity_bounded(
                     &f.storage,

--- a/pensyve-core/src/storage/postgres/live_rls.rs
+++ b/pensyve-core/src/storage/postgres/live_rls.rs
@@ -889,7 +889,7 @@ fn capturing_delete_still_works_under_enforced_rls() {
     fixture.enforce_rls();
 
     let snapshot_root = tempfile::tempdir().expect("snapshot tempdir");
-    let outcome = crate::snapshot::forget_entity(
+    let outcome = crate::snapshot::forget_entity_bounded(
         backend,
         entity_id,
         Some("shared-entity"),
@@ -2327,7 +2327,7 @@ fn capturing_delete_is_confined_to_its_namespace() {
     backend.save_semantic(&their_fact).expect("save B's fact");
 
     let snapshot_root = tempfile::tempdir().expect("snapshot tempdir");
-    let outcome = crate::snapshot::forget_entity(
+    let outcome = crate::snapshot::forget_entity_bounded(
         backend,
         entity_id,
         Some("shared-entity"),

--- a/pensyve-core/src/storage/postgres/live_rls.rs
+++ b/pensyve-core/src/storage/postgres/live_rls.rs
@@ -895,6 +895,7 @@ fn capturing_delete_still_works_under_enforced_rls() {
         Some("shared-entity"),
         ns_a.id,
         snapshot_root.path(),
+        crate::snapshot::RetentionPolicy::UNBOUNDED,
     )
     .expect("forget in namespace A must still succeed under enforced RLS");
 
@@ -2332,6 +2333,7 @@ fn capturing_delete_is_confined_to_its_namespace() {
         Some("shared-entity"),
         ns_a.id,
         snapshot_root.path(),
+        crate::snapshot::RetentionPolicy::UNBOUNDED,
     )
     .expect("forget in namespace A");
 

--- a/pensyve-core/tests/forget_snapshot_scope.rs
+++ b/pensyve-core/tests/forget_snapshot_scope.rs
@@ -208,6 +208,7 @@ fn snapshot_scope_equals_delete_scope() {
         None,
         fixture.namespace.id,
         &fixture.snapshot_root(),
+        snapshot::RetentionPolicy::UNBOUNDED,
     )
     .unwrap();
     let snapshot_ids: HashSet<Uuid> = outcome.snapshot.memory_ids().into_iter().collect();
@@ -337,6 +338,7 @@ fn snapshot_round_trips_the_deleted_memories_back_into_storage() {
         Some(fixture.target.name.as_str()),
         fixture.namespace.id,
         &fixture.snapshot_root(),
+        snapshot::RetentionPolicy::UNBOUNDED,
     )
     .unwrap();
 
@@ -400,6 +402,7 @@ fn restore_is_idempotent() {
         None,
         fixture.namespace.id,
         &fixture.snapshot_root(),
+        snapshot::RetentionPolicy::UNBOUNDED,
     )
     .unwrap();
 

--- a/pensyve-core/tests/forget_snapshot_scope.rs
+++ b/pensyve-core/tests/forget_snapshot_scope.rs
@@ -202,7 +202,7 @@ fn snapshot_scope_equals_delete_scope() {
 
     let before = live_ids(storage, fixture.namespace.id);
 
-    let outcome = snapshot::forget_entity(
+    let outcome = snapshot::forget_entity_bounded(
         storage,
         fixture.target.id,
         None,
@@ -332,7 +332,7 @@ fn snapshot_round_trips_the_deleted_memories_back_into_storage() {
     let storage = &fixture.storage;
 
     let before = live_ids(storage, fixture.namespace.id);
-    let outcome = snapshot::forget_entity(
+    let outcome = snapshot::forget_entity_bounded(
         storage,
         fixture.target.id,
         Some(fixture.target.name.as_str()),
@@ -396,7 +396,7 @@ fn restore_is_idempotent() {
     let storage = &fixture.storage;
 
     let before = live_ids(storage, fixture.namespace.id);
-    let outcome = snapshot::forget_entity(
+    let outcome = snapshot::forget_entity_bounded(
         storage,
         fixture.target.id,
         None,

--- a/pensyve-mcp-gateway/src/main.rs
+++ b/pensyve-mcp-gateway/src/main.rs
@@ -216,6 +216,10 @@ async fn async_main(config: GatewayConfig, res: InitResources) -> Result<()> {
         // recovery artifacts belong inside the directory that backups and
         // volume mounts already cover.
         PensyveState::snapshot_root_for(&config.storage_path),
+        // Bounds what that directory accumulates: every non-empty forget
+        // writes a full copy of what it destroyed, so an unbounded snapshot
+        // volume is one `remember`/`forget` loop away from filling (#265).
+        PensyveState::snapshot_retention_from_env(),
     );
 
     let ct = CancellationToken::new();

--- a/pensyve-mcp-gateway/src/rest.rs
+++ b/pensyve-mcp-gateway/src/rest.rs
@@ -1187,6 +1187,7 @@ async fn forget_entity_blocking(
             Some(entity_name.as_str()),
             namespace_id,
             &snapshot_root,
+            pensyve_core::snapshot::RetentionPolicy::UNBOUNDED,
         )
     })
     .await

--- a/pensyve-mcp-gateway/src/rest.rs
+++ b/pensyve-mcp-gateway/src/rest.rs
@@ -1182,7 +1182,7 @@ async fn forget_entity_blocking(
     let namespace_id = ps.namespace.id;
 
     tokio::task::spawn_blocking(move || {
-        pensyve_core::snapshot::forget_entity(
+        pensyve_core::snapshot::forget_entity_bounded(
             storage.as_ref(),
             entity_id,
             Some(entity_name.as_str()),

--- a/pensyve-mcp-gateway/src/rest.rs
+++ b/pensyve-mcp-gateway/src/rest.rs
@@ -1178,6 +1178,7 @@ async fn forget_entity_blocking(
 ) -> Result<pensyve_core::snapshot::ForgetOutcome, String> {
     let storage = ps.storage.clone();
     let snapshot_root = ps.snapshot_root.clone();
+    let retention = ps.snapshot_retention;
     let namespace_id = ps.namespace.id;
 
     tokio::task::spawn_blocking(move || {
@@ -1187,7 +1188,7 @@ async fn forget_entity_blocking(
             Some(entity_name.as_str()),
             namespace_id,
             &snapshot_root,
-            pensyve_core::snapshot::RetentionPolicy::UNBOUNDED,
+            retention,
         )
     })
     .await

--- a/pensyve-mcp-gateway/src/tenant.rs
+++ b/pensyve-mcp-gateway/src/tenant.rs
@@ -9,6 +9,7 @@ use uuid::Uuid;
 use pensyve_core::config::RetrievalConfig;
 use pensyve_core::embedding::OnnxEmbedder;
 use pensyve_core::reranker::Reranker;
+use pensyve_core::snapshot::RetentionPolicy;
 use pensyve_core::storage::StorageTrait;
 use pensyve_core::types::Namespace;
 use pensyve_core::vector::VectorIndex;
@@ -38,6 +39,11 @@ pub struct TenantStateManager {
     /// tenants. Derived from the gateway's own storage path so recovery
     /// artifacts sit inside the directory operators actually back up.
     snapshot_root: PathBuf,
+    /// How much snapshot history each tenant's directory keeps (#265). One
+    /// policy for every tenant: the bound exists so no single tenant can grow
+    /// the shared volume without limit, which only works if it applies to all
+    /// of them.
+    snapshot_retention: RetentionPolicy,
 }
 
 impl TenantStateManager {
@@ -48,6 +54,7 @@ impl TenantStateManager {
         default_namespace: Namespace,
         default_vector_index: VectorIndex,
         snapshot_root: PathBuf,
+        snapshot_retention: RetentionPolicy,
     ) -> Self {
         let dimensions = default_vector_index.dimensions();
         let reranker_cell = Arc::new(OnceLock::new());
@@ -61,6 +68,7 @@ impl TenantStateManager {
             is_remote: true,
             reranker_cell: reranker_cell.clone(),
             snapshot_root: snapshot_root.clone(),
+            snapshot_retention,
         });
 
         Self {
@@ -72,6 +80,7 @@ impl TenantStateManager {
             tenants: DashMap::new(),
             reranker_cell,
             snapshot_root,
+            snapshot_retention,
         }
     }
 
@@ -178,6 +187,7 @@ impl TenantStateManager {
             is_remote: true,
             reranker_cell: self.reranker_cell.clone(),
             snapshot_root: self.snapshot_root.clone(),
+            snapshot_retention: self.snapshot_retention,
         }))
     }
 }
@@ -210,6 +220,7 @@ mod tests {
             ns,
             index,
             dir.path().join("snapshots"),
+            RetentionPolicy::UNBOUNDED,
         )
     }
 

--- a/pensyve-mcp-gateway/tests/integration_test.rs
+++ b/pensyve-mcp-gateway/tests/integration_test.rs
@@ -53,6 +53,7 @@ fn create_test_state_with_reranker(
         is_remote: false,
         reranker_cell: Arc::new(OnceLock::from(reranker)),
         snapshot_root: dir.path().join("snapshots"),
+        snapshot_retention: pensyve_core::snapshot::RetentionPolicy::UNBOUNDED,
     })
 }
 

--- a/pensyve-mcp-gateway/tests/test_cross_tenant_isolation.rs
+++ b/pensyve-mcp-gateway/tests/test_cross_tenant_isolation.rs
@@ -90,6 +90,7 @@ fn app_state(dir: &TempDir) -> Arc<AppState> {
         namespace,
         VectorIndex::new(768, 1024),
         dir.path().join("snapshots"),
+        pensyve_core::snapshot::RetentionPolicy::UNBOUNDED,
     );
 
     // Resolve the shared reranker cell up front with a mock, so nothing in

--- a/pensyve-mcp-gateway/tests/test_multi_tenant_propagation.rs
+++ b/pensyve-mcp-gateway/tests/test_multi_tenant_propagation.rs
@@ -85,6 +85,7 @@ fn make_mgr(dir: &tempfile::TempDir) -> Arc<TenantStateManager> {
         ns,
         idx,
         dir.path().join("snapshots"),
+        pensyve_core::snapshot::RetentionPolicy::UNBOUNDED,
     ));
 
     // Resolve the shared reranker cell up front with a mock, so nothing in

--- a/pensyve-mcp-gateway/tests/test_rest_consolidate_coalesced.rs
+++ b/pensyve-mcp-gateway/tests/test_rest_consolidate_coalesced.rs
@@ -84,6 +84,7 @@ fn app_state(dir: &TempDir) -> Arc<AppState> {
         namespace,
         VectorIndex::new(EMBEDDING_DIMS, 1024),
         dir.path().join("snapshots"),
+        pensyve_core::snapshot::RetentionPolicy::UNBOUNDED,
     );
     let config = gateway_config(dir);
 

--- a/pensyve-mcp-gateway/tests/test_rest_forget_index_cleanup.rs
+++ b/pensyve-mcp-gateway/tests/test_rest_forget_index_cleanup.rs
@@ -86,6 +86,7 @@ fn app_state(dir: &TempDir, snapshot_root: PathBuf) -> Arc<AppState> {
         namespace,
         VectorIndex::new(DIMENSIONS, 1024),
         snapshot_root,
+        pensyve_core::snapshot::RetentionPolicy::UNBOUNDED,
     );
     let config = gateway_config(dir);
 

--- a/pensyve-mcp-gateway/tests/test_rest_forget_inspect.rs
+++ b/pensyve-mcp-gateway/tests/test_rest_forget_inspect.rs
@@ -69,6 +69,7 @@ fn app_state(dir: &TempDir) -> Arc<AppState> {
         namespace,
         VectorIndex::new(768, 1024),
         dir.path().join("snapshots"),
+        pensyve_core::snapshot::RetentionPolicy::UNBOUNDED,
     );
     let config = gateway_config(dir);
 

--- a/pensyve-mcp-gateway/tests/test_rest_forget_snapshot.rs
+++ b/pensyve-mcp-gateway/tests/test_rest_forget_snapshot.rs
@@ -13,6 +13,7 @@ use std::sync::Arc;
 use axum::Extension;
 use pensyve_core::config::RetrievalConfig;
 use pensyve_core::embedding::OnnxEmbedder;
+use pensyve_core::snapshot::RetentionPolicy;
 use pensyve_core::storage::StorageTrait;
 use pensyve_core::storage::sqlite::SqliteBackend;
 use pensyve_core::types::Namespace;
@@ -65,6 +66,16 @@ fn gateway_config(dir: &TempDir) -> GatewayConfig {
 /// from the environment, so each test owns its own directory without mutating
 /// process-wide state (#250).
 fn app_state(dir: &TempDir, snapshot_root: PathBuf) -> Arc<AppState> {
+    app_state_with_retention(dir, snapshot_root, RetentionPolicy::UNBOUNDED)
+}
+
+/// Retention is injected the same way the snapshot root is, so a test can pin
+/// a policy without touching the environment the whole binary shares (#250).
+fn app_state_with_retention(
+    dir: &TempDir,
+    snapshot_root: PathBuf,
+    snapshot_retention: RetentionPolicy,
+) -> Arc<AppState> {
     let storage =
         Arc::new(SqliteBackend::open(dir.path()).expect("open storage")) as Arc<dyn StorageTrait>;
     let namespace = Namespace::new("default");
@@ -79,6 +90,7 @@ fn app_state(dir: &TempDir, snapshot_root: PathBuf) -> Arc<AppState> {
         namespace,
         VectorIndex::new(768, 1024),
         snapshot_root,
+        snapshot_retention,
     );
     let config = gateway_config(dir);
 
@@ -482,5 +494,59 @@ async fn a2a_forget_on_an_unknown_entity_reports_zero_and_writes_no_snapshot() {
     assert!(body["output"].get("snapshot").is_none());
     assert!(!snapshot_root.exists());
     assert_eq!(stored_memory_count(&state), 1);
+    cancellation.cancel();
+}
+
+/// The gateway must hand its configured retention policy down to the snapshot
+/// layer (#265). Without it a tenant looping `remember` → `forget` leaves the
+/// live database small while the shared snapshot volume — a network mount in
+/// the hosted deployment — grows without bound.
+#[tokio::test]
+async fn rest_forget_evicts_snapshots_beyond_the_per_namespace_quota() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let snapshot_root = dir.path().join("snapshots");
+    let state = app_state_with_retention(
+        &dir,
+        snapshot_root.clone(),
+        RetentionPolicy {
+            max_age_days: None,
+            max_count: Some(2),
+        },
+    );
+    let namespace_id = tenant_namespace_id(&state);
+    let (url, cancellation) = start_test_server(state.clone()).await;
+    let client = reqwest::Client::new();
+
+    for round in 0..4 {
+        remember(&client, &url, "alice", &format!("fact number {round}")).await;
+        let response = forget(&client, &url, "alice").await;
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+    }
+
+    let namespace_dir = pensyve_core::snapshot::namespace_dir(&snapshot_root, namespace_id);
+    let remaining: Vec<PathBuf> = std::fs::read_dir(&namespace_dir)
+        .expect("namespace snapshot dir exists")
+        .map(|entry| entry.expect("dir entry").path())
+        .collect();
+    assert_eq!(
+        remaining.len(),
+        2,
+        "four forgets under a cap of two must leave two snapshots: {remaining:?}"
+    );
+
+    // Eviction is oldest-first, so what survives is the recent history — the
+    // part a caller who just realised their mistake would ask for.
+    let mut captured: Vec<String> = remaining
+        .iter()
+        .map(|path| {
+            pensyve_core::snapshot::read_file(path)
+                .expect("surviving snapshots stay readable")
+                .captured_at
+                .to_rfc3339()
+        })
+        .collect();
+    captured.sort();
+    assert_eq!(captured.len(), 2);
+
     cancellation.cancel();
 }

--- a/pensyve-mcp-gateway/tests/test_rest_gdpr_erase_race.rs
+++ b/pensyve-mcp-gateway/tests/test_rest_gdpr_erase_race.rs
@@ -519,6 +519,7 @@ async fn app_state(
         default_namespace,
         VectorIndex::new(DIMENSIONS, 1024),
         snapshot_root,
+        pensyve_core::snapshot::RetentionPolicy::UNBOUNDED,
     );
     let config = gateway_config(dir);
 

--- a/pensyve-mcp-gateway/tests/test_rest_recall_contradictions.rs
+++ b/pensyve-mcp-gateway/tests/test_rest_recall_contradictions.rs
@@ -66,6 +66,7 @@ fn app_state(dir: &TempDir) -> Arc<AppState> {
         namespace,
         VectorIndex::new(768, 1024),
         dir.path().join("snapshots"),
+        pensyve_core::snapshot::RetentionPolicy::UNBOUNDED,
     );
 
     // Resolve the shared reranker cell up front with a mock, so nothing in

--- a/pensyve-mcp-tools/src/server.rs
+++ b/pensyve-mcp-tools/src/server.rs
@@ -639,7 +639,7 @@ impl PensyveMcpServer {
             let namespace_id = task_state.namespace.id;
             let blocking_name = entity_name.clone();
             let outcome = tokio::task::spawn_blocking(move || {
-                pensyve_core::snapshot::forget_entity(
+                pensyve_core::snapshot::forget_entity_bounded(
                     storage.as_ref(),
                     entity_id,
                     Some(blocking_name.as_str()),

--- a/pensyve-mcp-tools/src/server.rs
+++ b/pensyve-mcp-tools/src/server.rs
@@ -644,6 +644,7 @@ impl PensyveMcpServer {
                     Some(blocking_name.as_str()),
                     namespace_id,
                     &snapshot_root,
+                    pensyve_core::snapshot::RetentionPolicy::UNBOUNDED,
                 )
             })
             .await

--- a/pensyve-mcp-tools/src/server.rs
+++ b/pensyve-mcp-tools/src/server.rs
@@ -635,6 +635,7 @@ impl PensyveMcpServer {
         let task = tokio::spawn(async move {
             let storage = task_state.storage.clone();
             let snapshot_root = task_state.snapshot_root.clone();
+            let retention = task_state.snapshot_retention;
             let namespace_id = task_state.namespace.id;
             let blocking_name = entity_name.clone();
             let outcome = tokio::task::spawn_blocking(move || {
@@ -644,7 +645,7 @@ impl PensyveMcpServer {
                     Some(blocking_name.as_str()),
                     namespace_id,
                     &snapshot_root,
-                    pensyve_core::snapshot::RetentionPolicy::UNBOUNDED,
+                    retention,
                 )
             })
             .await
@@ -1029,6 +1030,14 @@ mod tests {
     }
 
     fn forget_fixture(snapshot_root: PathBuf, is_remote: bool) -> ForgetFixture {
+        forget_fixture_with_retention(snapshot_root, is_remote, RetentionPolicy::UNBOUNDED)
+    }
+
+    fn forget_fixture_with_retention(
+        snapshot_root: PathBuf,
+        is_remote: bool,
+        snapshot_retention: RetentionPolicy,
+    ) -> ForgetFixture {
         let dir = tempfile::tempdir().unwrap();
         let storage = SqliteBackend::open(dir.path()).unwrap();
 
@@ -1072,6 +1081,7 @@ mod tests {
             is_remote,
             reranker_cell: Arc::new(OnceLock::new()),
             snapshot_root,
+            snapshot_retention,
         });
 
         ForgetFixture {
@@ -1243,6 +1253,61 @@ mod tests {
         );
     }
 
+    /// The tool must hand its state's retention policy to the snapshot layer.
+    /// Without it a tenant looping `remember` → `forget` grows the snapshot
+    /// volume without bound while the live database stays small (#265).
+    #[tokio::test]
+    async fn forget_enforces_the_states_snapshot_retention_policy() {
+        let snapshot_root = tempfile::tempdir().unwrap();
+        let snapshot_dir = snapshot_root.path().join("snapshots");
+        let fixture = forget_fixture_with_retention(
+            snapshot_dir.clone(),
+            false,
+            RetentionPolicy {
+                max_age_days: None,
+                max_count: Some(2),
+            },
+        );
+        let namespace_dir =
+            pensyve_core::snapshot::namespace_dir(&snapshot_dir, fixture.server.state.namespace.id);
+
+        // Three snapshots a previous forget loop left behind.
+        std::fs::create_dir_all(&namespace_dir).unwrap();
+        for hour in 0..3 {
+            std::fs::write(
+                namespace_dir.join(format!(
+                    "forget-{}-2026010{}T0{hour}0000.000Z-{}.json",
+                    Uuid::new_v4(),
+                    hour + 1,
+                    Uuid::new_v4()
+                )),
+                b"{}",
+            )
+            .unwrap();
+        }
+
+        let raw = fixture
+            .server
+            .forget(Parameters(ForgetParams {
+                entity: "subject".to_string(),
+            }))
+            .await
+            .expect("forget should succeed");
+        let response: serde_json::Value = serde_json::from_str(&raw).unwrap();
+
+        assert_eq!(response["forgotten_count"], 2);
+        let path = PathBuf::from(response["snapshot"]["path"].as_str().unwrap());
+        assert!(
+            path.is_file(),
+            "the new snapshot must survive its own prune"
+        );
+        assert_eq!(
+            std::fs::read_dir(&namespace_dir).unwrap().count(),
+            2,
+            "retention must cap the directory at max_count"
+        );
+    }
+
     #[tokio::test]
     async fn forget_on_an_unknown_entity_writes_no_snapshot_and_deletes_nothing() {
         let snapshot_root = tempfile::tempdir().unwrap();
@@ -1356,6 +1421,7 @@ mod tests {
     use pensyve_core::config::RetrievalConfig;
     use pensyve_core::embedding::OnnxEmbedder;
     use pensyve_core::reranker::Reranker;
+    use pensyve_core::snapshot::RetentionPolicy;
     use pensyve_core::storage::sqlite::SqliteBackend;
     use pensyve_core::types::{Episode, Namespace};
     use pensyve_core::vector::VectorIndex;
@@ -1408,6 +1474,7 @@ mod tests {
                 is_remote: true,
                 reranker_cell: reranker_cell.clone(),
                 snapshot_root: dir.path().join("snapshots"),
+                snapshot_retention: RetentionPolicy::UNBOUNDED,
             })));
         }
         let victim = servers.pop().expect("victim server");

--- a/pensyve-mcp-tools/src/state.rs
+++ b/pensyve-mcp-tools/src/state.rs
@@ -6,6 +6,7 @@ use tokio::sync::RwLock;
 use pensyve_core::config::RetrievalConfig;
 use pensyve_core::embedding::OnnxEmbedder;
 use pensyve_core::reranker::Reranker;
+use pensyve_core::snapshot::RetentionPolicy;
 use pensyve_core::storage::StorageTrait;
 use pensyve_core::types::Namespace;
 use pensyve_core::vector::VectorIndex;
@@ -13,6 +14,37 @@ use pensyve_core::vector::VectorIndex;
 /// Model name used for the lazily-resolved cross-encoder reranker. Matches
 /// the default in `pensyve-python`'s `Pensyve(reranker="BGERerankerBase")`.
 const RERANKER_MODEL: &str = "BGERerankerBase";
+
+/// Default snapshot retention window. Long enough that a forget noticed a
+/// fortnight later is still recoverable, short enough to bound the volume.
+const DEFAULT_SNAPSHOT_RETENTION_DAYS: u32 = 30;
+
+/// Default per-namespace snapshot count cap. A tenant deleting entities at a
+/// normal rate never reaches it; one looping `remember` → `forget` stops here.
+const DEFAULT_SNAPSHOT_MAX_PER_NAMESPACE: u32 = 50;
+
+/// One retention bound, from its raw environment value.
+///
+/// Takes the value rather than reading the variable so it is testable without
+/// mutating process-global state (#273). `0` disables the bound; anything
+/// unparseable keeps the default and says so — silently disabling a bound
+/// because someone wrote `30d` would be the one outcome nobody asked for.
+fn retention_bound(var: &str, raw: Option<&str>, default: u32) -> Option<u32> {
+    let value = match raw {
+        None => default,
+        Some(raw) => match raw.trim().parse::<u32>() {
+            Ok(parsed) => parsed,
+            Err(err) => {
+                tracing::warn!(
+                    "{var}={raw:?} is not a whole number ({err}); using the default of {default}"
+                );
+                default
+            }
+        },
+    };
+
+    (value > 0).then_some(value)
+}
 
 /// Shared state for the Pensyve MCP server.
 ///
@@ -44,6 +76,12 @@ pub struct PensyveState {
     /// snapshot for, so this must point somewhere writable and durable — see
     /// [`PensyveState::snapshot_root_for`].
     pub snapshot_root: PathBuf,
+    /// How much snapshot history each namespace directory keeps (#265). Every
+    /// non-empty forget writes a full copy of what it destroyed, so without a
+    /// bound a caller looping `remember` → `forget` grows the snapshot volume
+    /// without bound while the live database stays small. See
+    /// [`PensyveState::snapshot_retention_from_env`].
+    pub snapshot_retention: RetentionPolicy,
 }
 
 impl PensyveState {
@@ -59,6 +97,33 @@ impl PensyveState {
     pub fn snapshot_root_for(storage_root: &Path) -> PathBuf {
         std::env::var("PENSYVE_SNAPSHOT_DIR")
             .map_or_else(|_| storage_root.join("snapshots"), PathBuf::from)
+    }
+
+    /// Snapshot retention bounds from the environment:
+    /// `PENSYVE_SNAPSHOT_RETENTION_DAYS` (default 30) and
+    /// `PENSYVE_SNAPSHOT_MAX_PER_NAMESPACE` (default 50). `0` disables that
+    /// bound; both at `0` restores the unbounded behaviour from before #265.
+    ///
+    /// Read here rather than inside `pensyve-core`: the core takes its
+    /// configuration as arguments, the same way `snapshot_root` is threaded in
+    /// rather than resolved from `PENSYVE_SNAPSHOT_DIR` down there.
+    pub fn snapshot_retention_from_env() -> RetentionPolicy {
+        RetentionPolicy {
+            max_age_days: retention_bound(
+                "PENSYVE_SNAPSHOT_RETENTION_DAYS",
+                std::env::var("PENSYVE_SNAPSHOT_RETENTION_DAYS")
+                    .ok()
+                    .as_deref(),
+                DEFAULT_SNAPSHOT_RETENTION_DAYS,
+            ),
+            max_count: retention_bound(
+                "PENSYVE_SNAPSHOT_MAX_PER_NAMESPACE",
+                std::env::var("PENSYVE_SNAPSHOT_MAX_PER_NAMESPACE")
+                    .ok()
+                    .as_deref(),
+                DEFAULT_SNAPSHOT_MAX_PER_NAMESPACE,
+            ),
+        }
     }
 
     /// Resolve the reranker lazily (first call wins) and return a clone of
@@ -130,6 +195,45 @@ mod tests {
             // reader observes the environment — no data race.
             unsafe { std::env::set_var("PENSYVE_RERANKER", "0") };
         });
+    }
+
+    #[test]
+    fn retention_bound_falls_back_to_the_default_when_unset() {
+        assert_eq!(retention_bound("VAR", None, 30), Some(30));
+    }
+
+    #[test]
+    fn retention_bound_reads_an_explicit_value() {
+        assert_eq!(retention_bound("VAR", Some("7"), 30), Some(7));
+        assert_eq!(retention_bound("VAR", Some(" 7 "), 30), Some(7));
+    }
+
+    /// The documented way to turn a bound off — and the only value that may
+    /// produce `None`, since a policy of "keep zero snapshots" would evict the
+    /// one the current forget just wrote.
+    #[test]
+    fn retention_bound_treats_zero_as_disabled() {
+        assert_eq!(retention_bound("VAR", Some("0"), 30), None);
+    }
+
+    /// A typo must not silently disable the bound it was trying to set.
+    #[test]
+    fn retention_bound_keeps_the_default_for_an_unparseable_value() {
+        assert_eq!(retention_bound("VAR", Some("30d"), 30), Some(30));
+        assert_eq!(retention_bound("VAR", Some("-1"), 30), Some(30));
+        assert_eq!(retention_bound("VAR", Some(""), 30), Some(30));
+    }
+
+    #[test]
+    fn the_shipped_defaults_bound_both_dimensions() {
+        assert_eq!(
+            retention_bound("VAR", None, DEFAULT_SNAPSHOT_RETENTION_DAYS),
+            Some(30)
+        );
+        assert_eq!(
+            retention_bound("VAR", None, DEFAULT_SNAPSHOT_MAX_PER_NAMESPACE),
+            Some(50)
+        );
     }
 
     #[test]

--- a/pensyve-mcp-tools/src/state.rs
+++ b/pensyve-mcp-tools/src/state.rs
@@ -219,7 +219,7 @@ mod tests {
         });
     }
 
-    const TEST_MAX: u32 = 36_500;
+    const TEST_MAX: u32 = MAX_SNAPSHOT_RETENTION_DAYS;
 
     #[test]
     fn retention_bound_falls_back_to_the_default_when_unset() {

--- a/pensyve-mcp-tools/src/state.rs
+++ b/pensyve-mcp-tools/src/state.rs
@@ -35,18 +35,34 @@ const MAX_SNAPSHOT_RETENTION_DAYS: u32 = 36_500;
 /// cost more than the bound saves.
 const MAX_SNAPSHOT_MAX_PER_NAMESPACE: u32 = 1_000_000;
 
-/// One retention bound, from its raw environment value.
+/// One retention bound, from its raw environment lookup.
 ///
-/// Takes the value rather than reading the variable so it is testable without
-/// mutating process-global state (#273). `0` disables the bound; anything
-/// unparseable — or larger than `max` — keeps the default and says so.
-/// Silently disabling a bound because someone wrote `30d`, or accepting a
-/// window so long the bound is inert, would each be the one outcome nobody
-/// asked for.
-fn retention_bound(var: &str, raw: Option<&str>, default: u32, max: u32) -> Option<u32> {
+/// Takes the lookup's `Result` rather than reading the variable itself, so
+/// every arm — including the one that needs a value no `String` can hold — is
+/// testable without mutating process-global state (#273).
+///
+/// `0` disables the bound. Every other input the bound cannot be built from
+/// keeps the default and says which value was rejected and why: silently
+/// disabling a bound because someone wrote `30d`, accepting a window so long
+/// the bound is inert, or ignoring a value the environment could not even hand
+/// over as text would each be the one outcome nobody asked for. Only an unset
+/// variable is silent, because only an unset variable is a choice nobody made.
+fn retention_bound(
+    var: &str,
+    raw: Result<String, std::env::VarError>,
+    default: u32,
+    max: u32,
+) -> Option<u32> {
     let value = match raw {
-        None => default,
-        Some(raw) => match raw.trim().parse::<u32>() {
+        Err(std::env::VarError::NotPresent) => default,
+        // Distinguishable from unset: `.ok()` would fold this into `None` and
+        // apply the default in silence, which is exactly the report an operator
+        // whose value did not survive the environment needs to see.
+        Err(std::env::VarError::NotUnicode(raw)) => {
+            tracing::warn!("{var}={raw:?} is not valid Unicode; using the default of {default}");
+            default
+        }
+        Ok(raw) => match raw.trim().parse::<u32>() {
             Ok(parsed) if parsed > max => {
                 tracing::warn!(
                     "{var}={raw:?} exceeds the maximum of {max}; using the default of {default}"
@@ -131,17 +147,13 @@ impl PensyveState {
         RetentionPolicy {
             max_age_days: retention_bound(
                 "PENSYVE_SNAPSHOT_RETENTION_DAYS",
-                std::env::var("PENSYVE_SNAPSHOT_RETENTION_DAYS")
-                    .ok()
-                    .as_deref(),
+                std::env::var("PENSYVE_SNAPSHOT_RETENTION_DAYS"),
                 DEFAULT_SNAPSHOT_RETENTION_DAYS,
                 MAX_SNAPSHOT_RETENTION_DAYS,
             ),
             max_count: retention_bound(
                 "PENSYVE_SNAPSHOT_MAX_PER_NAMESPACE",
-                std::env::var("PENSYVE_SNAPSHOT_MAX_PER_NAMESPACE")
-                    .ok()
-                    .as_deref(),
+                std::env::var("PENSYVE_SNAPSHOT_MAX_PER_NAMESPACE"),
                 DEFAULT_SNAPSHOT_MAX_PER_NAMESPACE,
                 MAX_SNAPSHOT_MAX_PER_NAMESPACE,
             ),
@@ -221,15 +233,40 @@ mod tests {
 
     const TEST_MAX: u32 = MAX_SNAPSHOT_RETENTION_DAYS;
 
+    /// The two failing lookup outcomes `std::env::var` can return, spelled out
+    /// so the bound's arms are exercised the way the environment would deliver
+    /// them — and without any test mutating the environment (#273). A value
+    /// that did arrive is just `Ok(..)`.
+    fn unset() -> Result<String, std::env::VarError> {
+        Err(std::env::VarError::NotPresent)
+    }
+
+    #[cfg(unix)]
+    fn not_unicode() -> Result<String, std::env::VarError> {
+        use std::os::unix::ffi::OsStringExt;
+
+        // A lone continuation byte: a value the environment will hand over and
+        // `String` cannot hold.
+        Err(std::env::VarError::NotUnicode(
+            std::ffi::OsString::from_vec(vec![b'3', b'0', 0x80]),
+        ))
+    }
+
     #[test]
     fn retention_bound_falls_back_to_the_default_when_unset() {
-        assert_eq!(retention_bound("VAR", None, 30, TEST_MAX), Some(30));
+        assert_eq!(retention_bound("VAR", unset(), 30, TEST_MAX), Some(30));
     }
 
     #[test]
     fn retention_bound_reads_an_explicit_value() {
-        assert_eq!(retention_bound("VAR", Some("7"), 30, TEST_MAX), Some(7));
-        assert_eq!(retention_bound("VAR", Some(" 7 "), 30, TEST_MAX), Some(7));
+        assert_eq!(
+            retention_bound("VAR", Ok("7".to_string()), 30, TEST_MAX),
+            Some(7)
+        );
+        assert_eq!(
+            retention_bound("VAR", Ok(" 7 ".to_string()), 30, TEST_MAX),
+            Some(7)
+        );
     }
 
     /// The documented way to turn a bound off — and the only value that may
@@ -237,15 +274,27 @@ mod tests {
     /// one the current forget just wrote.
     #[test]
     fn retention_bound_treats_zero_as_disabled() {
-        assert_eq!(retention_bound("VAR", Some("0"), 30, TEST_MAX), None);
+        assert_eq!(
+            retention_bound("VAR", Ok("0".to_string()), 30, TEST_MAX),
+            None
+        );
     }
 
     /// A typo must not silently disable the bound it was trying to set.
     #[test]
     fn retention_bound_keeps_the_default_for_an_unparseable_value() {
-        assert_eq!(retention_bound("VAR", Some("30d"), 30, TEST_MAX), Some(30));
-        assert_eq!(retention_bound("VAR", Some("-1"), 30, TEST_MAX), Some(30));
-        assert_eq!(retention_bound("VAR", Some(""), 30, TEST_MAX), Some(30));
+        assert_eq!(
+            retention_bound("VAR", Ok("30d".to_string()), 30, TEST_MAX),
+            Some(30)
+        );
+        assert_eq!(
+            retention_bound("VAR", Ok("-1".to_string()), 30, TEST_MAX),
+            Some(30)
+        );
+        assert_eq!(
+            retention_bound("VAR", Ok(String::new()), 30, TEST_MAX),
+            Some(30)
+        );
     }
 
     /// A window whose cutoff falls off the end of the calendar makes the bound
@@ -254,17 +303,42 @@ mod tests {
     #[test]
     fn retention_bound_keeps_the_default_for_a_value_past_the_maximum() {
         assert_eq!(
-            retention_bound("VAR", Some(&u32::MAX.to_string()), 30, TEST_MAX),
+            retention_bound("VAR", Ok(u32::MAX.to_string()), 30, TEST_MAX),
             Some(30)
         );
         assert_eq!(
-            retention_bound("VAR", Some("20260818"), 30, TEST_MAX),
+            retention_bound("VAR", Ok("20260818".to_string()), 30, TEST_MAX),
             Some(30)
         );
         assert_eq!(
-            retention_bound("VAR", Some(&TEST_MAX.to_string()), 30, TEST_MAX),
+            retention_bound("VAR", Ok(TEST_MAX.to_string()), 30, TEST_MAX),
             Some(TEST_MAX),
             "the maximum itself is accepted"
+        );
+    }
+
+    /// A value that never made it through the environment as text is not the
+    /// same as no value at all: `.ok()` folded both into `None`, so the one
+    /// input an operator most needs told about took the default in silence.
+    ///
+    /// What this pins is that the arm exists, is reachable, and lands on the
+    /// default rather than on a disabled bound — and, by construction, that the
+    /// lookup keeps its `Result`: `not_unicode()` does not typecheck against an
+    /// `Option<&str>` parameter, so a return to `.ok()` fails to compile rather
+    /// than failing silently again. It does not assert the warning text. This
+    /// crate has no log-capture harness and no `tracing-subscriber` dependency,
+    /// and pulling one in for a single line is a bigger change than the fix.
+    #[cfg(unix)]
+    #[test]
+    fn retention_bound_keeps_the_default_for_a_non_unicode_value() {
+        assert_eq!(
+            retention_bound("VAR", not_unicode(), 30, TEST_MAX),
+            Some(30)
+        );
+        assert_eq!(
+            retention_bound("VAR", unset(), 30, TEST_MAX),
+            Some(30),
+            "unset lands on the same default — the difference is the warning"
         );
     }
 
@@ -273,7 +347,7 @@ mod tests {
         assert_eq!(
             retention_bound(
                 "VAR",
-                None,
+                unset(),
                 DEFAULT_SNAPSHOT_RETENTION_DAYS,
                 MAX_SNAPSHOT_RETENTION_DAYS
             ),
@@ -282,7 +356,7 @@ mod tests {
         assert_eq!(
             retention_bound(
                 "VAR",
-                None,
+                unset(),
                 DEFAULT_SNAPSHOT_MAX_PER_NAMESPACE,
                 MAX_SNAPSHOT_MAX_PER_NAMESPACE
             ),

--- a/pensyve-mcp-tools/src/state.rs
+++ b/pensyve-mcp-tools/src/state.rs
@@ -23,16 +23,36 @@ const DEFAULT_SNAPSHOT_RETENTION_DAYS: u32 = 30;
 /// normal rate never reaches it; one looping `remember` → `forget` stops here.
 const DEFAULT_SNAPSHOT_MAX_PER_NAMESPACE: u32 = 50;
 
+/// Longest accepted retention window: a century. Past this the value is not a
+/// retention policy, it is a typo (`20260818` as a date, say) — and a window
+/// long enough to push the cutoff off the end of the calendar makes the bound
+/// inert anyway, which is not what someone typing a very large number meant.
+/// `0` remains the way to say "keep everything".
+const MAX_SNAPSHOT_RETENTION_DAYS: u32 = 36_500;
+
+/// Largest accepted per-namespace count cap. Same reasoning: a directory this
+/// deep is not a policy anyone chose, and enumerating it on every forget would
+/// cost more than the bound saves.
+const MAX_SNAPSHOT_MAX_PER_NAMESPACE: u32 = 1_000_000;
+
 /// One retention bound, from its raw environment value.
 ///
 /// Takes the value rather than reading the variable so it is testable without
 /// mutating process-global state (#273). `0` disables the bound; anything
-/// unparseable keeps the default and says so — silently disabling a bound
-/// because someone wrote `30d` would be the one outcome nobody asked for.
-fn retention_bound(var: &str, raw: Option<&str>, default: u32) -> Option<u32> {
+/// unparseable — or larger than `max` — keeps the default and says so.
+/// Silently disabling a bound because someone wrote `30d`, or accepting a
+/// window so long the bound is inert, would each be the one outcome nobody
+/// asked for.
+fn retention_bound(var: &str, raw: Option<&str>, default: u32, max: u32) -> Option<u32> {
     let value = match raw {
         None => default,
         Some(raw) => match raw.trim().parse::<u32>() {
+            Ok(parsed) if parsed > max => {
+                tracing::warn!(
+                    "{var}={raw:?} exceeds the maximum of {max}; using the default of {default}"
+                );
+                default
+            }
             Ok(parsed) => parsed,
             Err(err) => {
                 tracing::warn!(
@@ -115,6 +135,7 @@ impl PensyveState {
                     .ok()
                     .as_deref(),
                 DEFAULT_SNAPSHOT_RETENTION_DAYS,
+                MAX_SNAPSHOT_RETENTION_DAYS,
             ),
             max_count: retention_bound(
                 "PENSYVE_SNAPSHOT_MAX_PER_NAMESPACE",
@@ -122,6 +143,7 @@ impl PensyveState {
                     .ok()
                     .as_deref(),
                 DEFAULT_SNAPSHOT_MAX_PER_NAMESPACE,
+                MAX_SNAPSHOT_MAX_PER_NAMESPACE,
             ),
         }
     }
@@ -197,15 +219,17 @@ mod tests {
         });
     }
 
+    const TEST_MAX: u32 = 36_500;
+
     #[test]
     fn retention_bound_falls_back_to_the_default_when_unset() {
-        assert_eq!(retention_bound("VAR", None, 30), Some(30));
+        assert_eq!(retention_bound("VAR", None, 30, TEST_MAX), Some(30));
     }
 
     #[test]
     fn retention_bound_reads_an_explicit_value() {
-        assert_eq!(retention_bound("VAR", Some("7"), 30), Some(7));
-        assert_eq!(retention_bound("VAR", Some(" 7 "), 30), Some(7));
+        assert_eq!(retention_bound("VAR", Some("7"), 30, TEST_MAX), Some(7));
+        assert_eq!(retention_bound("VAR", Some(" 7 "), 30, TEST_MAX), Some(7));
     }
 
     /// The documented way to turn a bound off — and the only value that may
@@ -213,25 +237,55 @@ mod tests {
     /// one the current forget just wrote.
     #[test]
     fn retention_bound_treats_zero_as_disabled() {
-        assert_eq!(retention_bound("VAR", Some("0"), 30), None);
+        assert_eq!(retention_bound("VAR", Some("0"), 30, TEST_MAX), None);
     }
 
     /// A typo must not silently disable the bound it was trying to set.
     #[test]
     fn retention_bound_keeps_the_default_for_an_unparseable_value() {
-        assert_eq!(retention_bound("VAR", Some("30d"), 30), Some(30));
-        assert_eq!(retention_bound("VAR", Some("-1"), 30), Some(30));
-        assert_eq!(retention_bound("VAR", Some(""), 30), Some(30));
+        assert_eq!(retention_bound("VAR", Some("30d"), 30, TEST_MAX), Some(30));
+        assert_eq!(retention_bound("VAR", Some("-1"), 30, TEST_MAX), Some(30));
+        assert_eq!(retention_bound("VAR", Some(""), 30, TEST_MAX), Some(30));
+    }
+
+    /// A window whose cutoff falls off the end of the calendar makes the bound
+    /// inert, which is never what a very large number was meant to express.
+    /// `pensyve-core` refuses to panic on one; this stops it reaching there.
+    #[test]
+    fn retention_bound_keeps_the_default_for_a_value_past_the_maximum() {
+        assert_eq!(
+            retention_bound("VAR", Some(&u32::MAX.to_string()), 30, TEST_MAX),
+            Some(30)
+        );
+        assert_eq!(
+            retention_bound("VAR", Some("20260818"), 30, TEST_MAX),
+            Some(30)
+        );
+        assert_eq!(
+            retention_bound("VAR", Some(&TEST_MAX.to_string()), 30, TEST_MAX),
+            Some(TEST_MAX),
+            "the maximum itself is accepted"
+        );
     }
 
     #[test]
     fn the_shipped_defaults_bound_both_dimensions() {
         assert_eq!(
-            retention_bound("VAR", None, DEFAULT_SNAPSHOT_RETENTION_DAYS),
+            retention_bound(
+                "VAR",
+                None,
+                DEFAULT_SNAPSHOT_RETENTION_DAYS,
+                MAX_SNAPSHOT_RETENTION_DAYS
+            ),
             Some(30)
         );
         assert_eq!(
-            retention_bound("VAR", None, DEFAULT_SNAPSHOT_MAX_PER_NAMESPACE),
+            retention_bound(
+                "VAR",
+                None,
+                DEFAULT_SNAPSHOT_MAX_PER_NAMESPACE,
+                MAX_SNAPSHOT_MAX_PER_NAMESPACE
+            ),
             Some(50)
         );
     }

--- a/pensyve-mcp/src/main.rs
+++ b/pensyve-mcp/src/main.rs
@@ -319,6 +319,7 @@ async fn main() -> Result<()> {
         // unreranked) — see `pensyve_mcp_tools::state::PensyveState::reranker`.
         reranker_cell: Arc::new(OnceLock::new()),
         snapshot_root: PensyveState::snapshot_root_for(&storage_path),
+        snapshot_retention: PensyveState::snapshot_retention_from_env(),
     });
 
     let server = PensyveMcpServer::new(state);


### PR DESCRIPTION
Closes #265.

Every nonempty entity-wide forget writes a full-fidelity pre-delete snapshot, and nothing expired or bounded them — a remember→forget loop could grow the EFS volume without bound while the live database stayed small. This bounds the snapshot directory per namespace:

- **Retention window:** `PENSYVE_SNAPSHOT_RETENTION_DAYS` (default **30**; `0` disables) — snapshots older than the window are pruned.
- **Count quota:** `PENSYVE_SNAPSHOT_MAX_PER_NAMESPACE` (default **50**; `0` disables) — oldest-first eviction beyond the cap.

Mechanics: pruning runs only after a successful new-snapshot write, synchronously inside the same blocking-pool task (#251's placement). Ordering is by the snapshot's own `captured_at` — parsed from the filename `write_to_dir` derives from it, never filesystem mtime (EFS/restores skew mtimes), with filename tiebreak. Only files matching the snapshot naming pattern are candidates; symlinks and subdirectories are skipped; the `.json.partial` temp from a crashed write is excluded by construction. The snapshot a forget just wrote is **structurally exempt** from its own prune (exempt from the age bound, sorted last, skipped at removal), so even a backward clock step that leaves future-dated siblings cannot evict the artifact protecting the rows this call deleted.

**Fail-closed contract untouched:** a failed new-snapshot write still aborts the delete; a prune failure never aborts or blocks a forget — it is a logged warning (`PruneOutcome` has no error type). Eviction never blocks a new write. Config is read in the serving states (REST/A2A gateway and MCP tools both thread it); pensyve-core stays env-free. Unparseable env values keep the default and warn — never silently unbound the volume.

Non-default values in production would go beside `PENSYVE_SNAPSHOT_DIR` in pensyve-infra (`infra/modules/compute/main.tf:412`); defaults need no infra change.

Tests (TDD, RED evidence four ways): count eviction oldest-first with deliberately inverted mtimes; age expiry with injected now; prune-failure-is-a-warning via a private injection seam (production path hardcodes `std::fs::remove_file`); write-failure-still-aborts; symlink/pattern filters; just-written-survival under a future-dated sibling and under a zero cap. 953 tests across three crates green; clippy clean both feature sets.