### PR TITLE
fix(storage): scope the remaining namespace-less methods; split schema apply from serving

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -261,10 +261,32 @@ The digest covers the whole schema file, so any edit invalidates it and the
 batch runs again. The idempotent re-apply is preserved where it matters, a
 changed file, and skipped only where it was already a guaranteed no-op.
 
-The operational consequence is one extra step on upgrades that change the
-schema: run the new build once as the owner (or run
-`pensyve-core/src/storage/postgres_schema.sql` by hand as the owner), then
-start the serving role. A build whose schema is unchanged needs nothing.
+##### Upgrading a deployment that serves as `pensyve_app`
+
+A build whose schema text is unchanged needs nothing: the digest still matches,
+the DDL is skipped, and the serving role starts as it always did. A build that
+changes the schema needs this sequence, in this order:
+
+1. **Apply the new schema text**, however you prefer. Starting the new build on
+   an owner connection does it; so does
+   `psql -f pensyve-core/src/storage/postgres_schema.sql` as the owner. Either
+   is fine, and this step is where the owner-only DDL actually happens.
+2. **Start the new build once on an owner connection.** This step is required
+   even if step 1 already applied the file by hand, and it is not optional
+   ceremony: `postgres_schema.sql` cannot record its own digest, so a
+   hand-applied schema leaves `pensyve_schema_state` present but empty. Only a
+   startup stamps it. The startup verifies the schema, re-applies it —
+   idempotently, so doing step 1 by hand first costs nothing — and writes the
+   digest. It logs `schema marker present but unstamped` when it finds the
+   hand-applied state.
+3. **Flip serving back to `pensyve_app`.** With the digest stamped, the probe
+   reads "current", the DDL batch is skipped, and the unprivileged role starts.
+
+Step 2 is the one worth not skipping. Without it the marker is never stamped,
+every later startup reads "not current", and `pensyve_app` fails on owner-only
+DDL indefinitely — the database is fine and the application will not start.
+Running the new build as the owner for step 1 collapses steps 1 and 2 into one
+action, which is the simplest way to do this.
 
 `NOBYPASSRLS` is required because a role with `BYPASSRLS`, and any superuser,
 ignores every policy — the startup self-check above will warn if you get this
@@ -312,13 +334,19 @@ count) is what settles it either way.
 
 **Startup fails with `must be owner of table entities`.** The serving role has
 been asked to apply the schema, which is owner-only DDL. It is only asked to
-when the schema is not already at this build's version, so this means the
-database is behind: apply the new build's schema once as the owning role — start
-the new build as the owner, or run
-`pensyve-core/src/storage/postgres_schema.sql` by hand as the owner — and then
-start the serving role again. A build whose schema text is unchanged skips the
-DDL entirely and needs none of this. The error the application raises says the
-same thing; the bare Postgres message is not what you will see.
+when the digest in `pensyve_schema_state` is not this build's, so the fix is
+always the same: **start the new build once on an owner connection**, then start
+the serving role again. See the upgrade sequence above. A build whose schema
+text is unchanged skips the DDL entirely and never reaches this. The error the
+application raises says the same thing; the bare Postgres message is not what
+you will see.
+
+Note that applying `postgres_schema.sql` by hand does *not* on its own clear
+this. The file creates `pensyve_schema_state` but cannot record its own digest,
+so a hand-applied schema leaves the marker empty and the serving role still
+fails here. The owner-connected startup is what stamps it — look for
+`schema marker present but unstamped` in that startup's log to confirm it found
+and fixed exactly this state.
 
 **Startup fails with `permission denied for table pensyve_schema_state`.** The
 serving role cannot read the applied-schema marker, so it cannot establish that

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -71,12 +71,14 @@ result. The internal uses are limited to DDL, which RLS does not apply to, and
 to `namespaces` and `activity_events`, neither of which carries a policy.
 
 Layer 2 is not active by default. Postgres exempts a table's owner from its own
-policies, and the application connects as the role that owns the schema, so the
-policies do not apply to it. Removing that exemption requires
-`FORCE ROW LEVEL SECURITY`, which ships as a separate file that an operator
-applies (`postgres_rls_enforce.sql`, also reachable as
-`PostgresBackend::enforce_rls`) rather than as part of the schema that runs on
-every startup.
+policies, and a deployment that applies the schema on startup connects as the
+role that owns it, so the policies do not apply to that connection. Removing
+the exemption requires `FORCE ROW LEVEL SECURITY`, which ships as a separate
+file that an operator applies (`postgres_rls_enforce.sql`, also reachable as
+`PostgresBackend::enforce_rls`) rather than as part of the schema. Every
+storage path now carries a namespace, so enforcement is safe to apply; making
+it the default is the remaining step, and it is a schema change rather than a
+code one.
 
 #### Before enabling enforcement
 
@@ -86,30 +88,42 @@ deletes nothing while still returning `Ok`. The hazard is that the call
 succeeds at all, so a caller that only checks for an error treats a no-op as a
 completed erase.
 
-The memory read, supersede and delete-by-id paths no longer have that problem.
-Recall candidate hydration, memory supersession and delete-by-id took no
-`namespace_id` until #254, which replaced each with an `_in_namespace` variant;
-entity forget left the same list in #256. `live_rls.rs` now gates each of them
-under enforcement directly, in
+No `StorageTrait` method has that problem any more. Every method that reaches
+a table carrying a `namespace_isolation_*` policy now takes a `namespace_id`
+and puts it in the SQL. The list used to be enumerated here and is now empty.
+
+Getting there took three rounds. #254 replaced recall candidate hydration,
+memory supersession and delete-by-id with `_in_namespace` variants; #256 did
+the same for entity forget; #264 folded the GDPR erase's four independent
+calls into one transaction whose every leg — observations and the entity record
+included — carries a `namespace_id` predicate and runs on a namespace-bound
+connection. The last round replaced the remaining nine. Five became scoped
+variants — `get_entity_in_namespace`,
+`list_episodic_by_entity_in_namespace`, `list_semantic_by_entity_in_namespace`,
+`update_episodic_access_in_namespace` and
+`update_procedural_reliability_in_namespace`. The other four —
+`delete_entity`, `invalidate_semantic`, `update_semantic_content` and
+`delete_observations_by_entity` — had no caller left once the capturing erase
+absorbed their work, and were removed rather than scoped, so there is no
+unscoped path left to call by accident.
+
+The highest-traffic one is worth naming: `update_episodic_access_in_namespace`
+writes the retrieval reinforcement stamp, once per episodic result of every
+recall. Unscoped, that `UPDATE` matched no row under enforcement and returned
+success, so spaced-repetition decay would have quietly stopped tracking access
+on every enforced deployment.
+
+`live_rls.rs` gates each replacement under enforcement directly, in
 `scoped_memory_reads_still_work_under_enforced_rls`,
 `supersede_still_works_under_enforced_rls`,
-`namespace_scoping_end_to_end_under_enforced_rls` and
-`entity_delete_still_works_under_enforced_rls`, so the old
-`enforced_rls_fails_closed_for_unscoped_methods` checklist is empty and gone.
-
-The rest of the storage surface still runs unscoped and would fail closed the
-same way. Every `StorageTrait` method that reaches a policied table without a
-`namespace_id` is: `get_entity`, `delete_entity`, `list_episodic_by_entity`,
-`list_semantic_by_entity`, `update_episodic_access`, `invalidate_semantic`,
-`update_semantic_content`, `update_procedural_reliability` and
-`delete_observations_by_entity`. One of those is still on the recall path:
-`update_episodic_access` writes the reinforcement stamp. GDPR erase no longer
-reaches any of them: `erase_entity_capturing` replaced the four independent
-calls with one transaction whose every leg — observations and the entity record
-included — carries a `namespace_id` predicate and runs on a namespace-bound
-connection (#264). The rest is tracked by #254.
-
-Do not apply enforcement to a deployment until those paths carry a namespace.
+`namespace_scoping_end_to_end_under_enforced_rls`,
+`entity_delete_still_works_under_enforced_rls`,
+`entity_lookup_by_id_still_works_under_enforced_rls`,
+`entity_scoped_memory_listings_still_work_under_enforced_rls`,
+`reinforcement_stamp_still_lands_under_enforced_rls` and
+`procedural_reliability_update_still_lands_under_enforced_rls`. The old
+`enforced_rls_fails_closed_for_unscoped_methods` checklist is empty and gone;
+the per-method tests are the standing gate in its place.
 
 Edges are the newest addition to layer 2. They gained a `namespace_id` — an
 edge belongs to the namespace of its source entity — plus a
@@ -149,20 +163,37 @@ clear the refusal, apply the schema once as a role the policies do not apply
 to, or `ALTER TABLE entities NO FORCE ROW LEVEL SECURITY` for the duration of
 the upgrade and restore it afterward.
 
-#### Applying enforcement
+#### The startup self-check
 
-First check that the application's role is not a superuser. Postgres exempts
-superusers from row-level security unconditionally, and `FORCE` does not change
-that, so enforcement applied to a superuser connection silently does nothing.
-The enforce script will still report success, which makes this easy to get
-wrong. Check with the query below, and expect `f`:
+The backend runs this check itself, on every Postgres startup:
 
 ```sql
-SELECT rolsuper FROM pg_roles WHERE rolname = current_user;
+SELECT rolsuper, rolbypassrls FROM pg_roles WHERE rolname = current_user;
 ```
 
-If it returns `t`, enforcement cannot work on that connection. Move the
-application to an ordinary role that owns the tables before going further.
+If either column is true it logs a `WARN` naming the role and both flags.
+Both exemptions survive `FORCE ROW LEVEL SECURITY`, so a deployment running as
+such a role has enforced nothing, and there is no other symptom — queries keep
+returning rows, the catalog keeps reporting the tables as forced. Making it
+observable from the application is the point; it is not a runbook step anyone
+has to remember.
+
+It is a warning, not a refusal. A local or single-tenant deployment
+legitimately connects as the owner or as `postgres`, and enforcement there is
+an operator choice rather than a precondition for starting. If you see this
+warning on a multi-tenant deployment, treat it as enforcement being off no
+matter what the enforce script reported.
+
+`PostgresBackend::role_rls_exemptions` exposes the same answer to callers that
+want to assert on it.
+
+#### Applying enforcement
+
+First check that the application's role is not a superuser and does not hold
+`BYPASSRLS` — the startup self-check above will already have told you, and the
+query it runs is the one to re-run by hand. Expect `f` in both columns. If
+either is `t`, enforcement cannot work on that connection; move the application
+to an ordinary role before going further.
 
 Then apply `pensyve-core/src/storage/postgres_rls_enforce.sql`, or call
 `PostgresBackend::enforce_rls`. Both run the same statements. The connecting
@@ -200,29 +231,43 @@ To roll back, run `ALTER TABLE <table> NO FORCE ROW LEVEL SECURITY;` for each
 table. Rollback takes effect immediately and touches neither the policies nor
 the data.
 
-#### The dedicated application role, and why it is not available yet
+#### The dedicated application role
 
 A role that does not own the tables is subject to their policies regardless of
-whether `FORCE` is set, so running the application as a non-owner role would be
-the more durable control. It is not possible today. Do not follow the SQL below
-as deployment instructions, because an application pointed at such a role will
-not start. Issue #254 tracks the change that makes it usable.
+whether `FORCE` is set, so running the application as a non-owner role is the
+more durable control. It is supported.
 
-`PostgresBackend::new` applies the schema on every startup, and the schema
-contains statements only a table's owner may run, including
-`ALTER TABLE ... ADD COLUMN`, `CREATE INDEX`, `ALTER TABLE ... ENABLE ROW LEVEL
-SECURITY`, and `CREATE POLICY`. A non-owner role fails at startup with
-`must be owner of table entities`, even when it holds every table privilege and
-`CREATE` on the schema. Pointing `DATABASE_URL` at a non-owner role today stops
-the application from starting.
+It used not to be. `PostgresBackend::new` applied the schema unconditionally on
+every startup, and the schema contains statements only a table's owner may run
+— `ALTER TABLE ... ADD COLUMN`, `CREATE INDEX`, `ALTER TABLE ... ENABLE ROW
+LEVEL SECURITY`, `CREATE POLICY`. A non-owner failed at startup with
+`must be owner of table entities`, even holding every table privilege and
+`CREATE` on the schema.
 
-Supporting a non-owner role needs a code change first, so that applying the
-schema is separate from serving traffic. Once that exists, the role should look
-like the target state below. `NOBYPASSRLS` is required because a role with
-`BYPASSRLS`, and any superuser, ignores every policy.
+Startup now separates applying the schema from serving traffic. It first reads
+`pensyve_schema_state`, a one-row table holding a digest of the schema text
+that was last applied. When that digest is the one this build ships, the whole
+DDL batch is skipped and a role with only DML grants starts normally. When it
+is not — a fresh database, or an upgrade carrying a schema change — the batch
+runs, which still requires ownership, and a non-owner is told so:
+
+> pensyve: the database schema is not at the version this build applies, and
+> the connected role may not apply it. Schema application is owner-only DDL …
+
+The digest covers the whole schema file, so any edit invalidates it and the
+batch runs again. The idempotent re-apply is preserved where it matters, a
+changed file, and skipped only where it was already a guaranteed no-op.
+
+The operational consequence is one extra step on upgrades that change the
+schema: run the new build once as the owner (or run
+`pensyve-core/src/storage/postgres_schema.sql` by hand as the owner), then
+start the serving role. A build whose schema is unchanged needs nothing.
+
+`NOBYPASSRLS` is required because a role with `BYPASSRLS`, and any superuser,
+ignores every policy — the startup self-check above will warn if you get this
+wrong.
 
 ```sql
--- Target state. Not usable until issue #254 lands.
 CREATE ROLE pensyve_app LOGIN PASSWORD '...' NOSUPERUSER NOBYPASSRLS;
 GRANT USAGE ON SCHEMA public TO pensyve_app;
 GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO pensyve_app;
@@ -237,7 +282,10 @@ ALTER DEFAULT PRIVILEGES FOR ROLE pensyve_owner IN SCHEMA public
 
 `ALTER DEFAULT PRIVILEGES` never applies to tables that already exist, so the
 `GRANT ... ON ALL TABLES` above is what covers the current schema. Both
-statements are needed.
+statements are needed. The `GRANT ... ON ALL TABLES` also covers
+`pensyve_schema_state`; without `SELECT` on it the serving role cannot read the
+applied digest and startup fails with `permission denied for table
+pensyve_schema_state` rather than skipping the DDL.
 
 #### What goes wrong
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -196,9 +196,12 @@ either is `t`, enforcement cannot work on that connection; move the application
 to an ordinary role before going further.
 
 Then apply `pensyve-core/src/storage/postgres_rls_enforce.sql`, or call
-`PostgresBackend::enforce_rls`. Both run the same statements. The connecting
-role must own the tables, and the application already connects as the owner, so
-no new role is needed.
+`PostgresBackend::enforce_rls`. Both run the same statements, and both are
+`ALTER TABLE ... FORCE ROW LEVEL SECURITY`, so **the connecting role must own
+the tables**. Run this step as the owning role — the same one that applies the
+schema. It is not the role that has to serve traffic afterwards: enforcement is
+a one-off migration, and the point of forcing the policies is that an
+unprivileged `pensyve_app` can then serve under them. See the role setup below.
 
 Then verify enforcement actually took effect, because a successful run does not
 prove it. Every row below should report `t`:

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -289,18 +289,39 @@ pensyve_schema_state` rather than skipping the DDL.
 
 #### What goes wrong
 
-Enforcement applied while query paths are still unscoped produces empty reads
-and writes that do nothing, rather than a visible failure. Check the
-unscoped-method list first, and roll back with `NO FORCE` if reads start coming
-back empty.
+**Reads come back empty after applying enforcement.** Enforcement fails closed
+without raising, so an unscoped query path returns nothing and an unscoped
+delete deletes nothing while still returning `Ok`. Every `StorageTrait` method
+carries a namespace now, so the usual cause is not the application: check the
+connection. A path that reached the database without going through a storage
+method — the `PostgresBackend::pool` accessor, or a tool holding its own
+connection — has to bind `pensyve.namespace_id` itself. Roll back with
+`NO FORCE` while you find it; rollback is immediate and touches neither the
+policies nor the data.
 
-Pointing `DATABASE_URL` at a role that does not own the tables stops the
-application from starting, and adding privileges does not fix it. The blocker
-is ownership, not grants: the schema runs owner-restricted statements on every
-startup, and a non-owner role fails with `must be owner of table entities` even
-holding every table privilege and `CREATE` on the schema. The fix is to connect
-as the owning role until issue #254 separates schema application from serving
-traffic.
+**Enforcement appears to do nothing: rows from every namespace still come
+back.** Look at the startup log. The backend warns on every start when
+`current_user` holds `rolsuper` or `rolbypassrls`, because both survive
+`FORCE` — the catalog will report the tables as forced and the policies will
+still not apply. Move the application to a `NOSUPERUSER NOBYPASSRLS` role. The
+behavioural check above (`set_config` to a namespace that owns no rows, then
+count) is what settles it either way.
+
+**Startup fails with `must be owner of table entities`.** The serving role has
+been asked to apply the schema, which is owner-only DDL. It is only asked to
+when the schema is not already at this build's version, so this means the
+database is behind: apply the new build's schema once as the owning role — start
+the new build as the owner, or run
+`pensyve-core/src/storage/postgres_schema.sql` by hand as the owner — and then
+start the serving role again. A build whose schema text is unchanged skips the
+DDL entirely and needs none of this. The error the application raises says the
+same thing; the bare Postgres message is not what you will see.
+
+**Startup fails with `permission denied for table pensyve_schema_state`.** The
+serving role cannot read the applied-schema marker, so it cannot establish that
+the DDL is safe to skip. Grant it `SELECT` — the
+`GRANT ... ON ALL TABLES IN SCHEMA public` in the role setup above covers it, so
+this usually means that grant was run before the table existed. Re-run it.
 
 ## Network Policy
 

--- a/pensyve-cli/src/main.rs
+++ b/pensyve-cli/src/main.rs
@@ -560,7 +560,7 @@ fn cmd_inspect(
     let mut memories: Vec<serde_json::Value> = Vec::new();
 
     if want_episodic {
-        let episodic = storage.list_episodic_by_entity(entity.id, 100)?;
+        let episodic = storage.list_episodic_by_entity_in_namespace(entity.id, ns.id, 100)?;
         for m in episodic {
             memories.push(serde_json::json!({
                 "id": m.id.to_string(),
@@ -575,7 +575,7 @@ fn cmd_inspect(
     }
 
     if want_semantic {
-        let semantic = storage.list_semantic_by_entity(entity.id, 100)?;
+        let semantic = storage.list_semantic_by_entity_in_namespace(entity.id, ns.id, 100)?;
         for m in semantic {
             memories.push(serde_json::json!({
                 "id": m.id.to_string(),

--- a/pensyve-core/src/consolidation/mod.rs
+++ b/pensyve-core/src/consolidation/mod.rs
@@ -683,7 +683,8 @@ impl ConsolidationEngine {
                     if retrievability < threshold {
                         // Mark as archived by setting retrievability to near-zero and
                         // generating a summary stub if none exists. We store the updated
-                        // stability/retrievability back via update_episodic_access.
+                        // stability/retrievability back via
+                        // `update_episodic_access_in_namespace`.
                         storage.update_episodic_access_in_namespace(
                             em.id,
                             namespace_id,

--- a/pensyve-core/src/consolidation/mod.rs
+++ b/pensyve-core/src/consolidation/mod.rs
@@ -664,7 +664,8 @@ impl ConsolidationEngine {
                 break;
             }
             // Per-row cancel check — sits between the previous row's
-            // `update_episodic_access` / `update_procedural_reliability`
+            // `update_episodic_access_in_namespace` /
+            // `update_procedural_reliability_in_namespace`
             // (each a single-statement SQLite transaction) and the next
             // row. Per pre-reg §5.5 (I5), partial-write corruption is
             // prevented by checking BETWEEN transactions, not within.
@@ -683,15 +684,21 @@ impl ConsolidationEngine {
                         // Mark as archived by setting retrievability to near-zero and
                         // generating a summary stub if none exists. We store the updated
                         // stability/retrievability back via update_episodic_access.
-                        storage.update_episodic_access(
+                        storage.update_episodic_access_in_namespace(
                             em.id,
+                            namespace_id,
                             em.stability * 0.5,
                             retrievability,
                         )?;
                         archived += 1;
                     } else {
                         // Just record updated retrievability.
-                        storage.update_episodic_access(em.id, em.stability, retrievability)?;
+                        storage.update_episodic_access_in_namespace(
+                            em.id,
+                            namespace_id,
+                            em.stability,
+                            retrievability,
+                        )?;
                     }
                     decayed += 1;
                 }
@@ -703,8 +710,8 @@ impl ConsolidationEngine {
                     if retrievability < threshold {
                         // Semantic memories: flag for review by invalidating (not deleting).
                         // We don't archive semantic memories — just note the retrievability.
-                        // For now we track archived count but do not call invalidate_semantic,
-                        // as that would permanently mark the fact as invalid. Instead we
+                        // For now we track archived count but do not invalidate the
+                        // fact, as that would permanently mark it invalid. Instead we
                         // simply note it in stats.
                         archived += 1;
                     }
@@ -720,8 +727,9 @@ impl ConsolidationEngine {
                     if retrievability < threshold && pm.reliability < 0.1 {
                         // Archive: reduce reliability and increment archived count.
                         let new_reliability = pm.reliability * 0.5;
-                        storage.update_procedural_reliability(
+                        storage.update_procedural_reliability_in_namespace(
                             pm.id,
+                            namespace_id,
                             new_reliability,
                             pm.trial_count,
                             pm.success_count,
@@ -1507,7 +1515,9 @@ mod tests {
         );
 
         // Verify a semantic memory was actually saved for this entity.
-        let semantics = storage.list_semantic_by_entity(entity_id, 10).unwrap();
+        let semantics = storage
+            .list_semantic_by_entity_in_namespace(entity_id, ns.id, 10)
+            .unwrap();
         assert!(
             !semantics.is_empty(),
             "Expected at least one semantic memory for entity"

--- a/pensyve-core/src/graph.rs
+++ b/pensyve-core/src/graph.rs
@@ -227,7 +227,9 @@ impl MemoryGraph {
             graph.add_node(entity.id);
 
             // Entity → memory edges for episodic memories.
-            if let Ok(memories) = storage.list_episodic_by_entity(entity.id, usize::MAX) {
+            if let Ok(memories) =
+                storage.list_episodic_by_entity_in_namespace(entity.id, namespace_id, usize::MAX)
+            {
                 for mem in memories {
                     graph.add_edge(entity.id, mem.id, 1.0);
                 }
@@ -243,7 +245,9 @@ impl MemoryGraph {
 
         // Also pull semantic memories: subject → memory node.
         for entity in &entities {
-            if let Ok(sem_mems) = storage.list_semantic_by_entity(entity.id, usize::MAX) {
+            if let Ok(sem_mems) =
+                storage.list_semantic_by_entity_in_namespace(entity.id, namespace_id, usize::MAX)
+            {
                 for mem in sem_mems {
                     graph.add_edge(entity.id, mem.id, mem.confidence);
                 }

--- a/pensyve-core/src/retrieval/engine.rs
+++ b/pensyve-core/src/retrieval/engine.rs
@@ -1130,7 +1130,7 @@ impl<'a> RecallEngine<'a> {
         scored.truncate(limit);
 
         // Step 9: Retrieval-induced reinforcement.
-        self.apply_reinforcement(&scored);
+        self.apply_reinforcement(&scored, namespace_id);
 
         info!(
             event = "recall_decision",
@@ -1360,14 +1360,23 @@ impl<'a> RecallEngine<'a> {
     }
 
     /// Apply retrieval-induced reinforcement to all returned episodic memories.
-    fn apply_reinforcement(&self, scored: &[ScoredCandidate]) {
+    ///
+    /// `namespace_id` is the namespace the recall ran in, threaded through
+    /// rather than read off each candidate row: the stamp must land in the
+    /// namespace the caller asked about, not in whatever namespace a row
+    /// claims to belong to. It is also what keeps this working under enforced
+    /// row-level security — an unscoped `UPDATE` there matches no row and
+    /// returns success, so reinforcement stops happening with nothing to
+    /// notice (#254).
+    fn apply_reinforcement(&self, scored: &[ScoredCandidate], namespace_id: Uuid) {
         for candidate in scored {
             if let Memory::Episodic(e) = &candidate.memory {
                 let new_stability = decay::reinforce(e.stability, candidate.recency_score, 5);
                 let new_retrievability = decay::retrievability(new_stability, 0.0);
                 // Best-effort; ignore errors during reinforcement.
-                let _ = self.storage.update_episodic_access(
+                let _ = self.storage.update_episodic_access_in_namespace(
                     candidate.memory_id,
+                    namespace_id,
                     new_stability,
                     new_retrievability,
                 );

--- a/pensyve-core/src/storage/mod.rs
+++ b/pensyve-core/src/storage/mod.rs
@@ -119,7 +119,25 @@ pub trait StorageTrait: Send + Sync {
 
     // Entities
     fn save_entity(&self, entity: &Entity) -> StorageResult<()>;
-    fn get_entity(&self, id: Uuid) -> StorageResult<Option<Entity>>;
+    /// Fetch an entity only when it belongs to `namespace_id`.
+    ///
+    /// There is deliberately no unscoped `get_entity`. Entity ids are not
+    /// globally unique in this schema, so a lookup keyed on `id` alone resolves
+    /// whichever tenant's row carries the id — and under enforced row-level
+    /// security it resolves nothing at all, because a connection carrying no
+    /// namespace matches no row (#254). Requiring the namespace here is what
+    /// makes the REST identifier resolver behave the same in both
+    /// configurations, instead of reading the foreign row and then comparing
+    /// `entity.namespace_id` after the fact.
+    ///
+    /// Backends must implement this as a single `id AND namespace_id` query.
+    /// Callers should treat `Ok(None)` as "not found" without distinguishing
+    /// "owned by someone else", so the result is not an existence oracle.
+    fn get_entity_in_namespace(
+        &self,
+        id: Uuid,
+        namespace_id: Uuid,
+    ) -> StorageResult<Option<Entity>>;
     fn get_entity_by_name(&self, name: &str, namespace_id: Uuid) -> StorageResult<Option<Entity>>;
 
     // Episodes
@@ -167,9 +185,19 @@ pub trait StorageTrait: Send + Sync {
         namespace_id: Uuid,
     ) -> StorageResult<Option<EpisodicMemory>>;
 
-    fn list_episodic_by_entity(
+    /// List the live episodic memories about `about_entity` *within
+    /// `namespace_id`*, most recent first, bounded by `limit`.
+    ///
+    /// `namespace_id` is required rather than inferred, for the same reason it
+    /// is on [`StorageTrait::delete_memories_by_entity`]: entity ids repeat
+    /// across namespaces, so an entity-only predicate reads another tenant's
+    /// turns — and under enforced row-level security it reads nothing at all
+    /// while still reporting `Ok(vec![])`, which a caller cannot tell from an
+    /// entity that simply has no memories (#254).
+    fn list_episodic_by_entity_in_namespace(
         &self,
         about_entity: Uuid,
+        namespace_id: Uuid,
         limit: usize,
     ) -> StorageResult<Vec<EpisodicMemory>>;
 
@@ -197,9 +225,23 @@ pub trait StorageTrait: Send + Sync {
         Ok(out)
     }
 
-    fn update_episodic_access(
+    /// Stamp retrieval-induced reinforcement onto an episodic memory, but only
+    /// when it belongs to `namespace_id`.
+    ///
+    /// This is the highest-traffic write in the system: the retrieval engine
+    /// calls it for every episodic result of every recall. Unscoped it was also
+    /// the most dangerous one under enforced row-level security — the `UPDATE`
+    /// matched no row, affected nothing, and returned `Ok(())`, so recall
+    /// silently stopped reinforcing anything at all with no error anywhere to
+    /// notice (#254).
+    ///
+    /// Backends must put both predicates in the SQL. A no-match is not an
+    /// error: the row may have been superseded or forgotten between the read
+    /// and the stamp, and reinforcement is best-effort by design.
+    fn update_episodic_access_in_namespace(
         &self,
         id: Uuid,
+        namespace_id: Uuid,
         stability: f32,
         retrievability: f32,
     ) -> StorageResult<()>;
@@ -216,12 +258,16 @@ pub trait StorageTrait: Send + Sync {
         namespace_id: Uuid,
     ) -> StorageResult<Option<SemanticMemory>>;
 
-    fn list_semantic_by_entity(
+    /// List the live semantic memories whose subject is `subject` *within
+    /// `namespace_id`*, newest first, bounded by `limit`. Same contract — and
+    /// the same reason for the namespace parameter — as
+    /// [`StorageTrait::list_episodic_by_entity_in_namespace`].
+    fn list_semantic_by_entity_in_namespace(
         &self,
         subject: Uuid,
+        namespace_id: Uuid,
         limit: usize,
     ) -> StorageResult<Vec<SemanticMemory>>;
-    fn invalidate_semantic(&self, id: Uuid) -> StorageResult<()>;
 
     // Procedural Memory
     fn save_procedural(&self, mem: &ProceduralMemory) -> StorageResult<()>;
@@ -235,9 +281,14 @@ pub trait StorageTrait: Send + Sync {
         namespace_id: Uuid,
     ) -> StorageResult<Option<ProceduralMemory>>;
 
-    fn update_procedural_reliability(
+    /// Record a procedural memory's updated reliability and trial counts, but
+    /// only when it belongs to `namespace_id`. Same contract — and the same
+    /// silent-no-op failure mode when unscoped — as
+    /// [`StorageTrait::update_episodic_access_in_namespace`].
+    fn update_procedural_reliability_in_namespace(
         &self,
         id: Uuid,
+        namespace_id: Uuid,
         reliability: f32,
         trial_count: u32,
         success_count: u32,
@@ -307,15 +358,13 @@ pub trait StorageTrait: Send + Sync {
         Ok(0)
     }
 
-    /// Delete every observation whose source episode is associated with the
-    /// given entity (either as `source_entity` or `about_entity` on an
-    /// episodic memory). Used by GDPR cascade-delete paths — called BEFORE
-    /// `delete_memories_by_entity` so the episodic→entity join still exists.
-    ///
-    /// Returns the row count of deleted observations.
-    fn delete_observations_by_entity(&self, _entity_id: Uuid) -> StorageResult<usize> {
-        Ok(0)
-    }
+    // There is deliberately no `delete_observations_by_entity`. It was the
+    // observation leg of the old multi-call GDPR erase, took no `namespace_id`,
+    // and lost its last caller when [`StorageTrait::erase_entity_capturing`]
+    // absorbed that leg into one scoped transaction (#264). Rather than scope a
+    // method nothing calls, it was removed: an entity-wide observation delete
+    // only ever makes sense inside the erase transaction, where the ordering
+    // against the episodic delete is load-bearing.
 
     // Full-text search (BM25)
     fn search_fts(
@@ -421,11 +470,21 @@ pub trait StorageTrait: Send + Sync {
     /// take their ids from what the delete returned —
     /// [`StorageTrait::delete_memories_by_entity_capturing`] for forget and
     /// [`StorageTrait::erase_entity_capturing`] for GDPR erase (#268).
-    /// `list_episodic_by_entity` and
-    /// `list_semantic_by_entity` are not a substitute: they look at
+    /// `list_episodic_by_entity_in_namespace` and
+    /// `list_semantic_by_entity_in_namespace` are not a substitute: they look at
     /// `about_entity` and `subject` alone and skip superseded rows, so every
     /// source-side episodic, object-side semantic and superseded row kept its
     /// index entry after its base row was gone.
+    ///
+    /// With both cleanup paths now driven by what their `DELETE` returned, this
+    /// accessor has no production caller left. It is kept rather than removed
+    /// because it is the cross-backend oracle that pins the delete's predicate
+    /// set: `entity_scoped_listing_matches_the_delete_scope` (live Postgres) and
+    /// its `SQLite` twin assert that this listing and
+    /// [`StorageTrait::delete_memories_by_entity`] agree row for row. Deleting
+    /// it would mean re-spelling those predicates in test-local SQL per backend,
+    /// which is the thing the oracle exists to catch. It already carries a
+    /// `namespace_id`, so it is not one of the paths blocking enforcement.
     ///
     /// Implementations must mirror the delete's predicates verbatim — the
     /// namespace one included. Entity ids are not globally unique in this
@@ -605,17 +664,16 @@ pub trait StorageTrait: Send + Sync {
         Ok(count)
     }
 
-    /// Update a semantic memory's content and/or confidence.
-    fn update_semantic_content(
-        &self,
-        id: Uuid,
-        predicate: &str,
-        object: &str,
-        confidence: Option<f32>,
-    ) -> StorageResult<()>;
-
-    /// Delete an entity record by its UUID. Returns true if the entity was found and deleted.
-    fn delete_entity(&self, id: Uuid) -> StorageResult<bool>;
+    // There is deliberately no `update_semantic_content`, no
+    // `invalidate_semantic` and no `delete_entity`. All three keyed on a memory
+    // or entity id alone, all three reached a policied table, and none of them
+    // had a production caller left: supersession replaced in-place semantic
+    // edits, and the entity record is deleted by leg 4 of
+    // [`StorageTrait::erase_entity_capturing`], inside the same transaction as
+    // the rows that reference it. Scoping a method nothing calls would add SQL
+    // no path exercises and tests that gate nothing, so they were removed
+    // instead (#254). Reintroducing any of them means adding the `namespace_id`
+    // parameter and the predicate at the same time.
 
     // Entities (bulk)
     fn list_entities_by_namespace(&self, namespace_id: Uuid) -> StorageResult<Vec<Entity>>;

--- a/pensyve-core/src/storage/postgres.rs
+++ b/pensyve-core/src/storage/postgres.rs
@@ -21,7 +21,7 @@ use crate::types::{
 };
 
 use super::{
-    ActivityAggregate, ActivityEvent, ErasedRows, StorageResult, StorageTrait,
+    ActivityAggregate, ActivityEvent, ErasedRows, StorageError, StorageResult, StorageTrait,
     cross_namespace_edge_id,
 };
 use crate::graph::EdgeType;
@@ -173,13 +173,86 @@ mod scoped_pool;
 
 use scoped_pool::ScopedPool;
 
-/// The namespace GUC value used for connections that are not scoped to any
-/// namespace.
+/// The namespace GUC value bound on connections that carry no namespace.
 ///
 /// Namespaces are UUIDs, so the empty string matches no row: under enforced
 /// RLS such a connection reads nothing and writes nothing. It fails closed
 /// instead of falling back to whatever the previous checkout left set.
-const UNSCOPED_NAMESPACE: &str = "";
+///
+/// No `StorageTrait` method takes this path any more — every one of them now
+/// carries a `namespace_id` and goes through [`PostgresBackend::scoped_conn`]
+/// (#254). It survives as the value [`ScopedPool::unbound`] checkouts are
+/// pinned to, which is what keeps a schema-application or `namespaces` read
+/// from inheriting the previous tenant's namespace.
+pub(crate) const UNSCOPED_NAMESPACE: &str = "";
+
+/// What the connected role's own privileges do to row-level security.
+///
+/// Either flag makes the `namespace_isolation_*` policies inert for this
+/// connection regardless of `FORCE ROW LEVEL SECURITY`, so a deployment can
+/// believe it has enforced tenant isolation while enforcing nothing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RoleRlsExemptions {
+    /// `current_user`, as Postgres reports it.
+    pub role: String,
+    /// `pg_roles.rolsuper` — superusers are unconditionally exempt.
+    pub superuser: bool,
+    /// `pg_roles.rolbypassrls` — `BYPASSRLS` survives `FORCE`.
+    pub bypassrls: bool,
+}
+
+impl RoleRlsExemptions {
+    /// Whether row-level security is inert for this role.
+    ///
+    /// Note what this deliberately does *not* cover: a role that merely *owns*
+    /// the tables is also exempt, but only until `FORCE ROW LEVEL SECURITY` is
+    /// applied, which is the supported way to run. These two flags are the ones
+    /// `FORCE` cannot fix.
+    #[must_use]
+    pub fn exempt(&self) -> bool {
+        self.superuser || self.bypassrls
+    }
+}
+
+/// A 64-bit FNV-1a digest of the schema text this build ships, in hex.
+///
+/// Used only to answer "is the applied schema the one in this binary?" — see
+/// [`PostgresBackend::run_schema`]. Any edit to `postgres_schema.sql` changes
+/// it, which is the whole requirement.
+fn schema_digest() -> String {
+    const OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+    const PRIME: u64 = 0x0000_0100_0000_01b3;
+    let mut hash = OFFSET;
+    for byte in SCHEMA.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(PRIME);
+    }
+    format!("fnv1a64:{hash:016x}")
+}
+
+/// Turn a failure to apply the schema into an error that names the cause.
+///
+/// A non-owner reaching the DDL batch gets `must be owner of table entities`
+/// from Postgres, which says nothing about the deployment model that produced
+/// it. Startup is the one place that knows the schema was out of date *and*
+/// that applying it is owner-only, so it says so.
+fn schema_apply_error(error: &sqlx_core::error::Error) -> StorageError {
+    let insufficient_privilege = error
+        .as_database_error()
+        .and_then(sqlx_core::error::DatabaseError::code)
+        .is_some_and(|code| code == "42501");
+
+    if insufficient_privilege {
+        return StorageError::Context(format!(
+            "pensyve: the database schema is not at the version this build applies, and \
+             the connected role may not apply it. Schema application is owner-only DDL \
+             (CREATE TABLE / ALTER TABLE / CREATE POLICY). Run the schema once as the role \
+             that owns the tables, then start the application as the unprivileged serving \
+             role — see docs/SECURITY.md. Underlying error: {error}"
+        ));
+    }
+    io_err(error)
+}
 
 pub struct PostgresBackend {
     /// Wrapped so that the only ways to obtain a connection are
@@ -237,7 +310,7 @@ impl PostgresBackend {
             rt,
             default_namespace: None,
         };
-        backend.run_schema()?;
+        backend.start()?;
         Ok(backend)
     }
 
@@ -249,8 +322,17 @@ impl PostgresBackend {
             rt,
             default_namespace: None,
         };
-        backend.run_schema()?;
+        backend.start()?;
         Ok(backend)
+    }
+
+    /// Everything both constructors do once the pool exists: bring the schema
+    /// up to date (or establish that it already is), then report what the
+    /// connected role's own privileges mean for row-level security.
+    fn start(&self) -> StorageResult<()> {
+        self.run_schema()?;
+        self.warn_on_rls_exempt_role();
+        Ok(())
     }
 
     /// Set the default namespace used to scope RLS on get-by-id queries
@@ -261,15 +343,182 @@ impl PostgresBackend {
         self
     }
 
+    /// Bring the database schema up to the version this build ships, or
+    /// establish that it is already there and do nothing.
+    ///
+    /// # Why "already applied" is checked before anything is applied
+    ///
+    /// `postgres_schema.sql` is owner-only DDL: `CREATE TABLE`, `ALTER TABLE`,
+    /// `CREATE POLICY`. Unconditionally sending it on every startup means the
+    /// serving role must own every table — and a role that owns a table is
+    /// exempt from that table's policies unless `FORCE ROW LEVEL SECURITY` is
+    /// set, while a managed-Postgres owner typically also carries `BYPASSRLS`,
+    /// which no amount of `FORCE` removes. Separating "apply the schema" from
+    /// "serve traffic" is what lets a deployment run as an unprivileged
+    /// `pensyve_app` role that the policies genuinely apply to.
+    ///
+    /// So startup probes first. `pensyve_schema_state` records the digest of
+    /// the schema text that was last applied; when it matches this build's, the
+    /// DDL batch is skipped entirely and a non-owner starts normally. The probe
+    /// is two plain `SELECT`s on an unpolicied table, which any role with
+    /// `SELECT` can run.
+    ///
+    /// The digest is over the whole file, so *any* schema edit invalidates it
+    /// and the batch runs again — the idempotent re-apply is preserved where it
+    /// matters (a changed file) and only skipped where it was a guaranteed
+    /// no-op (an unchanged one). It is a drift marker, not a security control:
+    /// a 64-bit FNV-1a is ample for telling two revisions of a file in this
+    /// repository apart, and nothing trusts it for anything else.
+    ///
+    /// When the schema *is* out of date and the role cannot apply it, the
+    /// privilege error is re-raised with the owner requirement spelled out,
+    /// rather than surfacing as a bare `must be owner of table entities`.
     fn run_schema(&self) -> StorageResult<()> {
+        let digest = schema_digest();
+        if self.schema_state_matches(&digest)? {
+            tracing::debug!(
+                schema_digest = %digest,
+                "pensyve: database schema already at this build's version; skipping DDL"
+            );
+            return Ok(());
+        }
+
         self.block_on(async {
             self.pool
                 .unbound()
                 .execute(raw_sql(SCHEMA))
                 .await
-                .map_err(sqlx_to_io)?;
+                .map_err(|e| schema_apply_error(&e))?;
+            Ok::<(), StorageError>(())
+        })?;
+
+        self.record_schema_state(&digest)
+    }
+
+    /// Read `pensyve_schema_state` and report whether it names `digest`.
+    ///
+    /// Returns `false` — "not current, apply the schema" — for every reason the
+    /// answer is not an unambiguous yes: the table does not exist yet (a fresh
+    /// database, or one provisioned before this marker existed), it is empty,
+    /// or it names a different digest. Failing towards applying keeps this
+    /// probe unable to *skip* a migration that is genuinely needed; the worst
+    /// it can do is make an owner re-run a batch that is a no-op.
+    fn schema_state_matches(&self, digest: &str) -> StorageResult<bool> {
+        self.block_on(async {
+            let mut conn = self.conn_with_namespace(UNSCOPED_NAMESPACE).await?;
+
+            // `to_regclass` yields NULL instead of raising for an absent
+            // relation, so this cannot poison the connection on a fresh
+            // database.
+            let (present,): (Option<String>,) =
+                query_as::<Postgres, _>("SELECT to_regclass('public.pensyve_schema_state')::text")
+                    .fetch_one(&mut *conn)
+                    .await
+                    .map_err(sqlx_to_io)?;
+            if present.is_none() {
+                return Ok(false);
+            }
+
+            let applied: Option<(String,)> = query_as::<Postgres, _>(
+                "SELECT schema_digest FROM pensyve_schema_state WHERE id = 1",
+            )
+            .fetch_optional(&mut *conn)
+            .await
+            .map_err(sqlx_to_io)?;
+
+            Ok(applied.is_some_and(|(applied,)| applied == digest))
+        })
+    }
+
+    /// Stamp the digest of the schema text that was just applied.
+    ///
+    /// Deliberately issued from Rust rather than added to
+    /// `postgres_schema.sql`: the file cannot name its own digest, and its DML
+    /// is confined to the `SET row_security = off` window that
+    /// `schema_dml_on_policied_tables_cannot_be_silently_blinded` pins.
+    /// `pensyve_schema_state` carries no `namespace_isolation_*` policy, so
+    /// writing it from an unbound connection reads and writes exactly one row
+    /// regardless of what namespace the previous checkout left set.
+    fn record_schema_state(&self, digest: &str) -> StorageResult<()> {
+        self.block_on(async {
+            let mut conn = self.conn_with_namespace(UNSCOPED_NAMESPACE).await?;
+            query::<Postgres>(
+                "INSERT INTO pensyve_schema_state (id, schema_digest, applied_at)
+                      VALUES (1, $1, now())
+                 ON CONFLICT (id) DO UPDATE
+                        SET schema_digest = EXCLUDED.schema_digest,
+                            applied_at = EXCLUDED.applied_at",
+            )
+            .bind(digest)
+            .execute(&mut *conn)
+            .await
+            .map_err(|e| schema_apply_error(&e))?;
             Ok(())
         })
+    }
+
+    /// Report the row-level-security exemptions the connected role carries.
+    ///
+    /// `rolsuper` and `rolbypassrls` both make the policies inert for this
+    /// connection no matter what `FORCE ROW LEVEL SECURITY` says, so a
+    /// deployment that believes it has enforced isolation may have enforced
+    /// nothing at all. That is invisible from the outside — queries keep
+    /// returning rows — which is exactly why it is worth saying out loud at
+    /// startup.
+    pub fn role_rls_exemptions(&self) -> StorageResult<RoleRlsExemptions> {
+        self.block_on(async {
+            let mut conn = self.conn_with_namespace(UNSCOPED_NAMESPACE).await?;
+            let row: Option<(String, bool, bool)> = query_as::<Postgres, _>(
+                "SELECT rolname, rolsuper, rolbypassrls FROM pg_roles WHERE rolname = current_user",
+            )
+            .fetch_optional(&mut *conn)
+            .await
+            .map_err(sqlx_to_io)?;
+
+            let (role, superuser, bypassrls) = row.ok_or_else(|| {
+                StorageError::Context(
+                    "pg_roles has no row for current_user, so the connected role's \
+                     row-level-security exemptions cannot be determined"
+                        .to_string(),
+                )
+            })?;
+            Ok(RoleRlsExemptions {
+                role,
+                superuser,
+                bypassrls,
+            })
+        })
+    }
+
+    /// Log a prominent warning when the connected role is exempt from RLS.
+    ///
+    /// A warning rather than a refusal: a local or single-tenant deployment
+    /// legitimately connects as the owner or as `postgres`, and enforcement is
+    /// an operator step there, not a precondition for starting. Failing to
+    /// *read* the answer is likewise only worth a warning — an unreadable
+    /// `pg_roles` is not a reason to refuse traffic.
+    fn warn_on_rls_exempt_role(&self) {
+        match self.role_rls_exemptions() {
+            Ok(exemptions) if exemptions.exempt() => {
+                tracing::warn!(
+                    role = %exemptions.role,
+                    rolsuper = exemptions.superuser,
+                    rolbypassrls = exemptions.bypassrls,
+                    "pensyve: the database role is exempt from row-level security. The \
+                     namespace_isolation_* policies do not apply to this connection, so \
+                     FORCE ROW LEVEL SECURITY enforces nothing here and namespace \
+                     isolation rests entirely on the namespace_id predicates in the SQL. \
+                     Serve traffic as a NOSUPERUSER NOBYPASSRLS role that does not own \
+                     the tables. See docs/SECURITY.md."
+                );
+            }
+            Ok(_) => {}
+            Err(e) => tracing::warn!(
+                error = %e,
+                "pensyve: could not determine whether the database role is exempt from \
+                 row-level security"
+            ),
+        }
     }
 
     /// Subject the schema-owning role to its own row-level security policies.

--- a/pensyve-core/src/storage/postgres.rs
+++ b/pensyve-core/src/storage/postgres.rs
@@ -404,8 +404,17 @@ impl PostgresBackend {
             // `to_regclass` yields NULL instead of raising for an absent
             // relation, so this cannot poison the connection on a fresh
             // database.
+            //
+            // Deliberately unqualified. `CREATE TABLE pensyve_schema_state` in
+            // the schema file and the `SELECT` below both resolve through
+            // `search_path`, so the probe has to resolve the same way or it
+            // asks about a different relation than the one it gates. Qualified
+            // as `public.`, a deployment with a non-default `search_path` would
+            // create the marker elsewhere, read NULL here forever, and never
+            // stop re-applying the schema — which fails safe for an owner and
+            // makes a non-owner permanently unstartable.
             let (present,): (Option<String>,) =
-                query_as::<Postgres, _>("SELECT to_regclass('public.pensyve_schema_state')::text")
+                query_as::<Postgres, _>("SELECT to_regclass('pensyve_schema_state')::text")
                     .fetch_one(&mut *conn)
                     .await
                     .map_err(sqlx_to_io)?;

--- a/pensyve-core/src/storage/postgres.rs
+++ b/pensyve-core/src/storage/postgres.rs
@@ -263,9 +263,6 @@ pub struct PostgresBackend {
     /// `self.pool.begin()` check out an unbound connection.
     pool: ScopedPool,
     rt: Runtime,
-    /// Optional default namespace for RLS scoping on get-by-id methods
-    /// where the trait signature does not provide a `namespace_id`.
-    default_namespace: Option<Uuid>,
 }
 
 impl PostgresBackend {
@@ -308,7 +305,6 @@ impl PostgresBackend {
         let backend = Self {
             pool: ScopedPool::new(pool),
             rt,
-            default_namespace: None,
         };
         backend.start()?;
         Ok(backend)
@@ -320,7 +316,6 @@ impl PostgresBackend {
         let backend = Self {
             pool: ScopedPool::new(pool),
             rt,
-            default_namespace: None,
         };
         backend.start()?;
         Ok(backend)
@@ -335,13 +330,12 @@ impl PostgresBackend {
         Ok(())
     }
 
-    /// Set the default namespace used to scope RLS on get-by-id queries
-    /// where the `StorageTrait` signature does not provide a `namespace_id`.
-    #[must_use]
-    pub fn with_default_namespace(mut self, namespace_id: Uuid) -> Self {
-        self.default_namespace = Some(namespace_id);
-        self
-    }
+    // `with_default_namespace` is gone. It existed so the `StorageTrait`
+    // methods whose signatures carried no `namespace_id` could still bind
+    // *something* on their connection. Every one of those methods now takes the
+    // namespace explicitly (#254), so a backend-wide default would only be a
+    // way to make a query look scoped while reading a namespace the caller
+    // never asked for.
 
     /// Bring the database schema up to the version this build ships, or
     /// establish that it is already there and do nothing.
@@ -568,23 +562,6 @@ impl PostgresBackend {
         namespace_id: Uuid,
     ) -> StorageResult<sqlx_core::pool::PoolConnection<sqlx_postgres::Postgres>> {
         self.conn_with_namespace(&namespace_id.to_string()).await
-    }
-
-    /// Acquire a connection, scoping it to `default_namespace` if one has been
-    /// configured.  Used for `StorageTrait` methods whose signatures do not
-    /// include a `namespace_id` parameter.
-    ///
-    /// With no default namespace configured this still sets the GUC — to
-    /// [`UNSCOPED_NAMESPACE`], which no row can match.  Such a connection
-    /// therefore reads nothing and writes nothing once RLS is enforced, rather
-    /// than inheriting whatever namespace the previous checkout left behind.
-    async fn maybe_scoped_conn(
-        &self,
-    ) -> StorageResult<sqlx_core::pool::PoolConnection<sqlx_postgres::Postgres>> {
-        match self.default_namespace {
-            Some(ns) => self.scoped_conn(ns).await,
-            None => self.conn_with_namespace(UNSCOPED_NAMESPACE).await,
-        }
     }
 
     /// Acquire a pooled connection and bind the namespace GUC that the RLS
@@ -970,31 +947,38 @@ impl StorageTrait for PostgresBackend {
         })
     }
 
-    fn get_entity(&self, id: Uuid) -> StorageResult<Option<Entity>> {
+    fn get_entity_in_namespace(
+        &self,
+        id: Uuid,
+        namespace_id: Uuid,
+    ) -> StorageResult<Option<Entity>> {
         self.block_on(async {
-            // Trait provides only entity id; use default_namespace for RLS if set.
-            let mut conn = self.maybe_scoped_conn().await?;
+            let mut conn = self.scoped_conn(namespace_id).await?;
             let row: Option<(Uuid, Uuid, String, String, serde_json::Value, DateTime<Utc>)> =
                 query_as::<Postgres, _>(
-                    "SELECT id, namespace_id, name, kind, metadata, created_at FROM entities WHERE id = $1",
+                    "SELECT id, namespace_id, name, kind, metadata, created_at FROM entities \
+                      WHERE id = $1 AND namespace_id = $2",
                 )
                 .bind(id)
+                .bind(namespace_id)
                 .fetch_optional(&mut *conn)
                 .await
                 .map_err(sqlx_to_io)?;
 
-            Ok(row.map(|(id, namespace_id, name, kind_str, metadata, created_at)| {
-                let metadata: HashMap<String, serde_json::Value> =
-                    serde_json::from_value(metadata).unwrap_or_default();
-                Entity {
-                    id,
-                    namespace_id,
-                    name,
-                    kind: str_to_entity_kind(&kind_str),
-                    metadata,
-                    created_at,
-                }
-            }))
+            Ok(
+                row.map(|(id, namespace_id, name, kind_str, metadata, created_at)| {
+                    let metadata: HashMap<String, serde_json::Value> =
+                        serde_json::from_value(metadata).unwrap_or_default();
+                    Entity {
+                        id,
+                        namespace_id,
+                        name,
+                        kind: str_to_entity_kind(&kind_str),
+                        metadata,
+                        created_at,
+                    }
+                }),
+            )
         })
     }
 
@@ -1178,22 +1162,25 @@ impl StorageTrait for PostgresBackend {
         })
     }
 
-    fn list_episodic_by_entity(
+    fn list_episodic_by_entity_in_namespace(
         &self,
         about_entity: Uuid,
+        namespace_id: Uuid,
         limit: usize,
     ) -> StorageResult<Vec<EpisodicMemory>> {
         let limit_i64 = i64::try_from(limit).unwrap_or(i64::MAX);
         self.block_on(async {
-            let mut conn = self.maybe_scoped_conn().await?;
+            let mut conn = self.scoped_conn(namespace_id).await?;
             let rows: Vec<EpisodicRow> = query_as::<Postgres, _>(
                 r"SELECT id, namespace_id, episode_id, source_entity, about_entity, content,
                           summary, embedding::text AS embedding, context_intent, timestamp, stability, retrievability,
                           access_count, last_accessed, event_time, superseded_by, invalid_at
-                   FROM episodic_memories WHERE about_entity = $1 AND superseded_by IS NULL
-                   ORDER BY timestamp DESC LIMIT $2",
+                   FROM episodic_memories
+                   WHERE about_entity = $1 AND namespace_id = $2 AND superseded_by IS NULL
+                   ORDER BY timestamp DESC LIMIT $3",
             )
             .bind(about_entity)
+            .bind(namespace_id)
             .bind(limit_i64)
             .fetch_all(&mut *conn)
             .await
@@ -1230,26 +1217,28 @@ impl StorageTrait for PostgresBackend {
         })
     }
 
-    fn update_episodic_access(
+    fn update_episodic_access_in_namespace(
         &self,
         id: Uuid,
+        namespace_id: Uuid,
         stability: f32,
         retrievability: f32,
     ) -> StorageResult<()> {
         let now = Utc::now();
         self.block_on(async {
-            let mut conn = self.maybe_scoped_conn().await?;
+            let mut conn = self.scoped_conn(namespace_id).await?;
             query::<Postgres>(
                 r"UPDATE episodic_memories
                    SET stability = $1, retrievability = $2,
                        access_count = access_count + 1,
                        last_accessed = $3
-                   WHERE id = $4",
+                   WHERE id = $4 AND namespace_id = $5",
             )
             .bind(stability)
             .bind(retrievability)
             .bind(now)
             .bind(id)
+            .bind(namespace_id)
             .execute(&mut *conn)
             .await
             .map_err(sqlx_to_io)?;
@@ -1321,42 +1310,31 @@ impl StorageTrait for PostgresBackend {
         })
     }
 
-    fn list_semantic_by_entity(
+    fn list_semantic_by_entity_in_namespace(
         &self,
         subject: Uuid,
+        namespace_id: Uuid,
         limit: usize,
     ) -> StorageResult<Vec<SemanticMemory>> {
         let limit_i64 = i64::try_from(limit).unwrap_or(i64::MAX);
         self.block_on(async {
-            let mut conn = self.maybe_scoped_conn().await?;
+            let mut conn = self.scoped_conn(namespace_id).await?;
             let rows: Vec<SemanticRow> = query_as::<Postgres, _>(
                 r"SELECT id, namespace_id, subject, predicate, object, object_entity, confidence,
                           valid_at, invalid_at, source_episodes, embedding::text, stability,
                           retrievability, superseded_by
-                   FROM semantic_memories WHERE subject = $1 AND superseded_by IS NULL
-                   ORDER BY valid_at DESC LIMIT $2",
+                   FROM semantic_memories
+                   WHERE subject = $1 AND namespace_id = $2 AND superseded_by IS NULL
+                   ORDER BY valid_at DESC LIMIT $3",
             )
             .bind(subject)
+            .bind(namespace_id)
             .bind(limit_i64)
             .fetch_all(&mut *conn)
             .await
             .map_err(sqlx_to_io)?;
 
             Ok(rows.into_iter().map(row_to_semantic).collect())
-        })
-    }
-
-    fn invalidate_semantic(&self, id: Uuid) -> StorageResult<()> {
-        let now = Utc::now();
-        self.block_on(async {
-            let mut conn = self.maybe_scoped_conn().await?;
-            query::<Postgres>("UPDATE semantic_memories SET invalid_at = $1 WHERE id = $2")
-                .bind(now)
-                .bind(id)
-                .execute(&mut *conn)
-                .await
-                .map_err(sqlx_to_io)?;
-            Ok(())
         })
     }
 
@@ -1428,26 +1406,28 @@ impl StorageTrait for PostgresBackend {
         })
     }
 
-    fn update_procedural_reliability(
+    fn update_procedural_reliability_in_namespace(
         &self,
         id: Uuid,
+        namespace_id: Uuid,
         reliability: f32,
         trial_count: u32,
         success_count: u32,
     ) -> StorageResult<()> {
         let now = Utc::now();
         self.block_on(async {
-            let mut conn = self.maybe_scoped_conn().await?;
+            let mut conn = self.scoped_conn(namespace_id).await?;
             query::<Postgres>(
                 r"UPDATE procedural_memories
                    SET reliability = $1, trial_count = $2, success_count = $3, last_used = $4
-                   WHERE id = $5",
+                   WHERE id = $5 AND namespace_id = $6",
             )
             .bind(reliability)
             .bind(i32::try_from(trial_count).unwrap_or(i32::MAX))
             .bind(i32::try_from(success_count).unwrap_or(i32::MAX))
             .bind(now)
             .bind(id)
+            .bind(namespace_id)
             .execute(&mut *conn)
             .await
             .map_err(sqlx_to_io)?;
@@ -1590,24 +1570,6 @@ impl StorageTrait for PostgresBackend {
             )
             .bind(episode_id)
             .bind(namespace_id)
-            .execute(&mut *conn)
-            .await
-            .map_err(sqlx_to_io)?;
-            Ok(usize::try_from(result.rows_affected()).unwrap_or(0))
-        })
-    }
-
-    fn delete_observations_by_entity(&self, entity_id: Uuid) -> StorageResult<usize> {
-        self.block_on(async {
-            let mut conn = self.maybe_scoped_conn().await?;
-            let result = query::<Postgres>(
-                "DELETE FROM observation_memories \
-                 WHERE episode_id IN (\
-                   SELECT DISTINCT episode_id FROM episodic_memories \
-                    WHERE about_entity = $1 OR source_entity = $1\
-                 )",
-            )
-            .bind(entity_id)
             .execute(&mut *conn)
             .await
             .map_err(sqlx_to_io)?;
@@ -2276,43 +2238,6 @@ impl StorageTrait for PostgresBackend {
         })
     }
 
-    fn update_semantic_content(
-        &self,
-        id: Uuid,
-        predicate: &str,
-        object: &str,
-        confidence: Option<f32>,
-    ) -> StorageResult<()> {
-        self.block_on(async {
-            let mut conn = self.maybe_scoped_conn().await?;
-
-            if let Some(conf) = confidence {
-                query::<Postgres>(
-                    "UPDATE semantic_memories SET predicate = $1, object = $2, confidence = $3 WHERE id = $4",
-                )
-                .bind(predicate)
-                .bind(object)
-                .bind(conf)
-                .bind(id)
-                .execute(&mut *conn)
-                .await
-                .map_err(sqlx_to_io)?;
-            } else {
-                query::<Postgres>(
-                    "UPDATE semantic_memories SET predicate = $1, object = $2 WHERE id = $3",
-                )
-                .bind(predicate)
-                .bind(object)
-                .bind(id)
-                .execute(&mut *conn)
-                .await
-                .map_err(sqlx_to_io)?;
-            }
-
-            Ok(())
-        })
-    }
-
     // -----------------------------------------------------------------------
     // Entities (bulk)
     // -----------------------------------------------------------------------
@@ -2344,18 +2269,6 @@ impl StorageTrait for PostgresBackend {
                     }
                 })
                 .collect())
-        })
-    }
-
-    fn delete_entity(&self, id: Uuid) -> StorageResult<bool> {
-        self.block_on(async {
-            let mut conn = self.maybe_scoped_conn().await?;
-            let result = query::<Postgres>("DELETE FROM entities WHERE id = $1")
-                .bind(id)
-                .execute(&mut *conn)
-                .await
-                .map_err(sqlx_to_io)?;
-            Ok(result.rows_affected() > 0)
         })
     }
 

--- a/pensyve-core/src/storage/postgres.rs
+++ b/pensyve-core/src/storage/postgres.rs
@@ -230,6 +230,26 @@ fn schema_digest() -> String {
     format!("fnv1a64:{hash:016x}")
 }
 
+/// What `pensyve_schema_state` says about the schema this build ships.
+///
+/// Only [`SchemaState::Current`] authorises skipping the DDL batch. The other
+/// three are all "apply it", and are distinguished so the startup log can say
+/// which situation the operator is in — see [`PostgresBackend::schema_state`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SchemaState {
+    /// No marker table: a fresh database, or one provisioned before the marker
+    /// existed.
+    Absent,
+    /// Marker table exists but holds no row. The schema text was applied by
+    /// something that cannot record its own digest — a hand-run
+    /// `psql -f postgres_schema.sql`.
+    Unstamped,
+    /// Marker names a different digest: the database is at some other version.
+    Stale,
+    /// Marker names this build's digest.
+    Current,
+}
+
 /// Turn a failure to apply the schema into an error that names the cause.
 ///
 /// A non-owner reaching the DDL batch gets `must be owner of table entities`
@@ -369,12 +389,32 @@ impl PostgresBackend {
     /// rather than surfacing as a bare `must be owner of table entities`.
     fn run_schema(&self) -> StorageResult<()> {
         let digest = schema_digest();
-        if self.schema_state_matches(&digest)? {
-            tracing::debug!(
+        match self.schema_state(&digest)? {
+            SchemaState::Current => {
+                tracing::debug!(
+                    schema_digest = %digest,
+                    "pensyve: database schema already at this build's version; skipping DDL"
+                );
+                return Ok(());
+            }
+            SchemaState::Unstamped => tracing::info!(
                 schema_digest = %digest,
-                "pensyve: database schema already at this build's version; skipping DDL"
-            );
-            return Ok(());
+                "pensyve: schema marker present but unstamped — applying and stamping now. \
+                 This is the state a hand-applied `psql -f postgres_schema.sql` leaves \
+                 behind: the file creates pensyve_schema_state but cannot record its own \
+                 digest, so only a startup can. This startup must therefore be on an owner \
+                 connection; once it stamps, an unprivileged serving role starts normally. \
+                 See docs/SECURITY.md."
+            ),
+            SchemaState::Stale => tracing::info!(
+                schema_digest = %digest,
+                "pensyve: database schema is not at this build's version; applying it. \
+                 Requires an owner connection."
+            ),
+            SchemaState::Absent => tracing::info!(
+                schema_digest = %digest,
+                "pensyve: no schema marker; applying the schema. Requires an owner connection."
+            ),
         }
 
         self.block_on(async {
@@ -389,15 +429,20 @@ impl PostgresBackend {
         self.record_schema_state(&digest)
     }
 
-    /// Read `pensyve_schema_state` and report whether it names `digest`.
+    /// Read `pensyve_schema_state` and classify what it says about `digest`.
     ///
-    /// Returns `false` — "not current, apply the schema" — for every reason the
-    /// answer is not an unambiguous yes: the table does not exist yet (a fresh
-    /// database, or one provisioned before this marker existed), it is empty,
-    /// or it names a different digest. Failing towards applying keeps this
-    /// probe unable to *skip* a migration that is genuinely needed; the worst
-    /// it can do is make an owner re-run a batch that is a no-op.
-    fn schema_state_matches(&self, digest: &str) -> StorageResult<bool> {
+    /// Only [`SchemaState::Current`] authorises a skip; every other answer means
+    /// "apply the schema". Failing towards applying keeps this probe unable to
+    /// *skip* a migration that is genuinely needed; the worst it can do is make
+    /// an owner re-run a batch that is a no-op.
+    ///
+    /// The three not-current answers are distinguished for the log alone —
+    /// [`SchemaState::Unstamped`] in particular is the state a hand-applied
+    /// `psql -f postgres_schema.sql` leaves behind, and an operator who reaches
+    /// it is one owner-connected startup away from a working deployment rather
+    /// than looking at a broken one. Saying which of the three it is turns that
+    /// into a readable line instead of an inference.
+    fn schema_state(&self, digest: &str) -> StorageResult<SchemaState> {
         self.block_on(async {
             let mut conn = self.conn_with_namespace(UNSCOPED_NAMESPACE).await?;
 
@@ -419,7 +464,7 @@ impl PostgresBackend {
                     .await
                     .map_err(sqlx_to_io)?;
             if present.is_none() {
-                return Ok(false);
+                return Ok(SchemaState::Absent);
             }
 
             let applied: Option<(String,)> = query_as::<Postgres, _>(
@@ -429,7 +474,11 @@ impl PostgresBackend {
             .await
             .map_err(sqlx_to_io)?;
 
-            Ok(applied.is_some_and(|(applied,)| applied == digest))
+            Ok(match applied {
+                None => SchemaState::Unstamped,
+                Some((applied,)) if applied == digest => SchemaState::Current,
+                Some(_) => SchemaState::Stale,
+            })
         })
     }
 

--- a/pensyve-core/src/storage/postgres/live_rls.rs
+++ b/pensyve-core/src/storage/postgres/live_rls.rs
@@ -55,6 +55,16 @@
 //! [`namespace_scoping_end_to_end_under_enforced_rls`]. The checklist is empty
 //! and therefore gone; the per-method tests are the standing gate in its place.
 //!
+//! **Fixed — the whole storage surface now carries a namespace.** The last
+//! nine unscoped methods were replaced with `_in_namespace` variants or, where
+//! nothing called them any more, removed outright (#254). Each replacement has
+//! its own enforced-mode test here:
+//! [`entity_lookup_by_id_still_works_under_enforced_rls`],
+//! [`entity_scoped_memory_listings_still_work_under_enforced_rls`],
+//! [`reinforcement_stamp_still_lands_under_enforced_rls`] and
+//! [`procedural_reliability_update_still_lands_under_enforced_rls`].
+//! `docs/SECURITY.md` no longer enumerates anything.
+//!
 //! **Fixed — the role can now be an unprivileged one.**
 //! `PostgresBackend::new` used to apply the schema unconditionally on every
 //! startup, which is owner-only DDL, so the application had to connect as the
@@ -70,11 +80,10 @@
 //! [`startup_reports_whether_the_role_is_exempt_from_rls`] — because a
 //! `BYPASSRLS` role makes `FORCE` enforce nothing with no other symptom.
 //!
-//! **Still open — enforcement is not yet the default.** The rest of the
-//! storage surface still runs unscoped and fails closed the same way;
-//! `docs/SECURITY.md` enumerates it. Until that lands, `FORCE` stays in
-//! `postgres_rls_enforce.sql` as an explicit operator step — see
-//! `docs/SECURITY.md`.
+//! **Still open — enforcement is not yet the default.** What is left is the
+//! flip itself: moving `FORCE` out of `postgres_rls_enforce.sql` and into
+//! `postgres_schema.sql`. Until that lands it stays an explicit operator step
+//! — see `docs/SECURITY.md`.
 //!
 //! Tests therefore come in two flavours: [`Fixture::provision`] mirrors a
 //! current deployment (policies present, not enforced), and a test that wants
@@ -294,6 +303,7 @@ impl Fixture {
             .enforce_rls()
             .expect("force row level security");
     }
+
     /// Create — once — an unprivileged role that can read and write every
     /// table but owns none of them, and return its name.
     ///
@@ -750,11 +760,12 @@ fn scoped_namespace_does_not_leak_into_the_next_checkout() {
             };
 
             // The scoped connection is now back in the pool. Take it again
-            // through the *unscoped* path, which is what every `StorageTrait`
-            // method lacking a namespace parameter uses.
+            // through the *unscoped* path — the one schema application and the
+            // `namespaces` read use, and the one a checkout would inherit a
+            // stale namespace through if acquisition did not rebind the GUC.
             let mut conn = fixture
                 .backend
-                .maybe_scoped_conn()
+                .conn_with_namespace(super::UNSCOPED_NAMESPACE)
                 .await
                 .expect("acquire unscoped connection");
             let (second_pid,): (i32,) = query_as::<Postgres, _>("SELECT pg_backend_pid()")
@@ -2224,6 +2235,253 @@ fn supersede_still_works_under_enforced_rls() {
         Some(successor),
         "the stamp must be the one this namespace wrote"
     );
+}
+
+/// Resolving an entity by id keeps working with RLS enforced, and only inside
+/// its own namespace.
+///
+/// `get_entity` took no `namespace_id`, so the REST identifier resolver read
+/// whichever tenant's row carried the id and compared `entity.namespace_id`
+/// afterwards. Under enforcement the read returned nothing at all and the
+/// resolver reported "no such entity" for an entity the caller owns.
+#[test]
+fn entity_lookup_by_id_still_works_under_enforced_rls() {
+    let Some(admin_opts) = skip_notice("entity_lookup_by_id_still_works_under_enforced_rls") else {
+        return;
+    };
+    let fixture = Fixture::provision(&admin_opts);
+    let backend = &fixture.backend;
+
+    let ns_a = Namespace::new(format!("rls-a-{}", Uuid::new_v4().simple()));
+    let ns_b = Namespace::new(format!("rls-b-{}", Uuid::new_v4().simple()));
+    backend.save_namespace(&ns_a).expect("save namespace A");
+    backend.save_namespace(&ns_b).expect("save namespace B");
+
+    let mut entity = Entity::new("alice", EntityKind::User);
+    entity.namespace_id = ns_a.id;
+    backend.save_entity(&entity).expect("save A's entity");
+
+    fixture.enforce_rls();
+
+    assert_eq!(
+        backend
+            .get_entity_in_namespace(entity.id, ns_a.id)
+            .expect("read A's entity")
+            .map(|e| e.id),
+        Some(entity.id),
+        "the scoped lookup must still resolve its own namespace's entity"
+    );
+    assert!(
+        backend
+            .get_entity_in_namespace(entity.id, ns_b.id)
+            .expect("read A's entity through B")
+            .is_none(),
+        "a foreign namespace must not resolve another namespace's entity"
+    );
+}
+
+/// The entity-scoped memory listings behind `pensyve_inspect`, the REST
+/// inspect handler, the CLI and the graph build keep working with RLS
+/// enforced, and neither of them reaches across namespaces.
+///
+/// Both took an entity id and a limit and nothing else. Entity ids are not
+/// globally unique, so with RLS inert they enumerated every tenant's rows for
+/// that id, and with RLS enforced they enumerated none — `Ok(vec![])`, which a
+/// caller cannot tell from an entity that simply has no memories.
+#[test]
+fn entity_scoped_memory_listings_still_work_under_enforced_rls() {
+    let Some(admin_opts) =
+        skip_notice("entity_scoped_memory_listings_still_work_under_enforced_rls")
+    else {
+        return;
+    };
+    let fixture = Fixture::provision(&admin_opts);
+    let backend = &fixture.backend;
+
+    let ns_a = Namespace::new(format!("rls-a-{}", Uuid::new_v4().simple()));
+    let ns_b = Namespace::new(format!("rls-b-{}", Uuid::new_v4().simple()));
+    backend.save_namespace(&ns_a).expect("save namespace A");
+    backend.save_namespace(&ns_b).expect("save namespace B");
+
+    // The same entity id on both sides — the collision the predicate has to
+    // disambiguate.
+    let entity_id = Uuid::new_v4();
+    let mine = EpisodicMemory::new(
+        ns_a.id,
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+        entity_id,
+        "A's turn",
+    );
+    backend.save_episodic(&mine).expect("save A's memory");
+    let theirs = EpisodicMemory::new(
+        ns_b.id,
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+        entity_id,
+        "B's turn",
+    );
+    backend.save_episodic(&theirs).expect("save B's memory");
+
+    let my_fact = SemanticMemory::new(ns_a.id, entity_id, "likes", "rust", 0.9);
+    backend.save_semantic(&my_fact).expect("save A's fact");
+    let their_fact = SemanticMemory::new(ns_b.id, entity_id, "likes", "go", 0.9);
+    backend.save_semantic(&their_fact).expect("save B's fact");
+
+    fixture.enforce_rls();
+
+    assert_eq!(
+        backend
+            .list_episodic_by_entity_in_namespace(entity_id, ns_a.id, 10)
+            .expect("list A's episodic")
+            .iter()
+            .map(|m| m.id)
+            .collect::<Vec<_>>(),
+        vec![mine.id],
+        "the episodic listing must return its own namespace's row, and only that"
+    );
+    assert_eq!(
+        backend
+            .list_semantic_by_entity_in_namespace(entity_id, ns_a.id, 10)
+            .expect("list A's semantic")
+            .iter()
+            .map(|m| m.id)
+            .collect::<Vec<_>>(),
+        vec![my_fact.id],
+        "the semantic listing must return its own namespace's row, and only that"
+    );
+
+    // And B still sees exactly its own, which is what keeps the assertions
+    // above from passing on a query that simply never matches anything.
+    assert_eq!(
+        backend
+            .list_episodic_by_entity_in_namespace(entity_id, ns_b.id, 10)
+            .expect("list B's episodic")
+            .iter()
+            .map(|m| m.id)
+            .collect::<Vec<_>>(),
+        vec![theirs.id]
+    );
+    assert_eq!(
+        backend
+            .list_semantic_by_entity_in_namespace(entity_id, ns_b.id, 10)
+            .expect("list B's semantic")
+            .iter()
+            .map(|m| m.id)
+            .collect::<Vec<_>>(),
+        vec![their_fact.id]
+    );
+}
+
+/// The reinforcement stamp on the recall path keeps landing with RLS enforced,
+/// and only on its own namespace's row.
+///
+/// This is the highest-traffic write in the system — the retrieval engine
+/// calls it for every episodic result of every recall — and the one that fails
+/// most quietly. `update_episodic_access` took no `namespace_id`, so under
+/// enforcement the `UPDATE` matched nothing, affected nothing, and returned
+/// `Ok(())`: spaced-repetition decay would have silently stopped tracking
+/// access on every enforced deployment.
+#[test]
+fn reinforcement_stamp_still_lands_under_enforced_rls() {
+    let Some(admin_opts) = skip_notice("reinforcement_stamp_still_lands_under_enforced_rls") else {
+        return;
+    };
+    let fixture = Fixture::provision(&admin_opts);
+    let backend = &fixture.backend;
+    let ns_a = Namespace::new(format!("rls-a-{}", Uuid::new_v4().simple()));
+    let ns_b = Namespace::new(format!("rls-b-{}", Uuid::new_v4().simple()));
+    let memory = seed(&fixture, &ns_a, &ns_b);
+    fixture.enforce_rls();
+
+    backend
+        .update_episodic_access_in_namespace(memory.id, ns_b.id, 0.1, 0.1)
+        .expect("stamp through namespace B must not error");
+    assert_eq!(
+        backend
+            .get_episodic_in_namespace(memory.id, ns_a.id)
+            .expect("re-read the row")
+            .expect("the row is still there")
+            .access_count,
+        0,
+        "a foreign namespace must not stamp another namespace's row"
+    );
+
+    backend
+        .update_episodic_access_in_namespace(memory.id, ns_a.id, 0.8, 0.7)
+        .expect("stamp through namespace A");
+    let stamped = backend
+        .get_episodic_in_namespace(memory.id, ns_a.id)
+        .expect("re-read the stamped row")
+        .expect("the row is still there");
+    assert_eq!(
+        stamped.access_count, 1,
+        "the scoped stamp must still take effect in its own namespace"
+    );
+    assert!((stamped.stability - 0.8).abs() < 0.001);
+    assert!((stamped.retrievability - 0.7).abs() < 0.001);
+    assert!(stamped.last_accessed.is_some());
+}
+
+/// The consolidation engine's procedural-reliability write keeps landing with
+/// RLS enforced, and only on its own namespace's row. Same silent-no-op
+/// failure mode as [`reinforcement_stamp_still_lands_under_enforced_rls`].
+#[test]
+fn procedural_reliability_update_still_lands_under_enforced_rls() {
+    let Some(admin_opts) =
+        skip_notice("procedural_reliability_update_still_lands_under_enforced_rls")
+    else {
+        return;
+    };
+    let fixture = Fixture::provision(&admin_opts);
+    let backend = &fixture.backend;
+
+    let ns_a = Namespace::new(format!("rls-a-{}", Uuid::new_v4().simple()));
+    let ns_b = Namespace::new(format!("rls-b-{}", Uuid::new_v4().simple()));
+    backend.save_namespace(&ns_a).expect("save namespace A");
+    backend.save_namespace(&ns_b).expect("save namespace B");
+
+    let procedural = ProceduralMemory::new(
+        ns_a.id,
+        "on_error",
+        "log_and_retry",
+        Outcome::Failure,
+        HashMap::new(),
+    );
+    backend
+        .save_procedural(&procedural)
+        .expect("save A's procedural memory");
+
+    fixture.enforce_rls();
+
+    backend
+        .update_procedural_reliability_in_namespace(procedural.id, ns_b.id, 0.01, 99, 99)
+        .expect("update through namespace B must not error");
+    let untouched = backend
+        .get_procedural_in_namespace(procedural.id, ns_a.id)
+        .expect("re-read the row")
+        .expect("the row is still there");
+    assert_eq!(
+        (untouched.trial_count, untouched.success_count),
+        (procedural.trial_count, procedural.success_count),
+        "a foreign namespace must not rewrite another namespace's row"
+    );
+    assert!(
+        (untouched.reliability - procedural.reliability).abs() < 0.001,
+        "nor its reliability"
+    );
+
+    backend
+        .update_procedural_reliability_in_namespace(procedural.id, ns_a.id, 0.75, 4, 3)
+        .expect("update through namespace A");
+    let updated = backend
+        .get_procedural_in_namespace(procedural.id, ns_a.id)
+        .expect("re-read the updated row")
+        .expect("the row is still there");
+    assert_eq!(updated.trial_count, 4);
+    assert_eq!(updated.success_count, 3);
+    assert!((updated.reliability - 0.75).abs() < 0.001);
+    assert!(updated.last_used.is_some());
 }
 
 /// Startup must be able to say whether the connected role is exempt from RLS

--- a/pensyve-core/src/storage/postgres/live_rls.rs
+++ b/pensyve-core/src/storage/postgres/live_rls.rs
@@ -55,16 +55,26 @@
 //! [`namespace_scoping_end_to_end_under_enforced_rls`]. The checklist is empty
 //! and therefore gone; the per-method tests are the standing gate in its place.
 //!
-//! **Still open — enforcement is not yet the default.** Two things remain.
-//! The rest of the storage surface still runs unscoped and fails closed the
-//! same way; `docs/SECURITY.md` enumerates it. And the role matters:
-//! `PostgresBackend::new` applies the schema on every startup, which is
-//! owner-only DDL, so the application has to connect as the table owner — and
-//! a managed-Postgres owner role typically also carries `BYPASSRLS`, which
-//! exempts it from the policies whether or not `FORCE` is set. Separating
-//! schema application from serving traffic is the other #254 work item. Until
-//! both land, `FORCE` stays in `postgres_rls_enforce.sql` as an explicit
-//! operator step — see `docs/SECURITY.md`.
+//! **Fixed — the role can now be an unprivileged one.**
+//! `PostgresBackend::new` used to apply the schema unconditionally on every
+//! startup, which is owner-only DDL, so the application had to connect as the
+//! table owner — and an owner is exempt from its own policies until `FORCE`,
+//! while a managed-Postgres owner typically also carries `BYPASSRLS`, which
+//! `FORCE` cannot remove. Startup now reads `pensyve_schema_state` first and
+//! skips the DDL batch when the applied digest is this build's, so a serving
+//! role that only holds DML grants starts normally:
+//! [`a_non_owner_starts_against_an_already_migrated_database`],
+//! [`a_non_owner_that_must_apply_ddl_is_told_it_needs_the_owner`] and
+//! [`the_schema_skip_follows_the_schema_text`]. Startup also reports the
+//! role's own exemptions —
+//! [`startup_reports_whether_the_role_is_exempt_from_rls`] — because a
+//! `BYPASSRLS` role makes `FORCE` enforce nothing with no other symptom.
+//!
+//! **Still open — enforcement is not yet the default.** The rest of the
+//! storage surface still runs unscoped and fails closed the same way;
+//! `docs/SECURITY.md` enumerates it. Until that lands, `FORCE` stays in
+//! `postgres_rls_enforce.sql` as an explicit operator step — see
+//! `docs/SECURITY.md`.
 //!
 //! Tests therefore come in two flavours: [`Fixture::provision`] mirrors a
 //! current deployment (policies present, not enforced), and a test that wants
@@ -72,7 +82,7 @@
 
 use std::collections::HashMap;
 
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use sqlx_core::query::query;
 use sqlx_core::query_as::query_as;
 use sqlx_core::raw_sql::raw_sql;
@@ -187,6 +197,11 @@ struct Fixture {
     backend: PostgresBackend,
     database: String,
     role: String,
+    /// Extra roles this fixture created — see [`Fixture::serving_role`]. They
+    /// hold grants inside the throwaway database, so they can only be dropped
+    /// after it is, which is why [`Drop`] owns their teardown rather than the
+    /// tests that ask for them.
+    extra_roles: std::cell::RefCell<Vec<String>>,
 }
 
 impl Fixture {
@@ -261,6 +276,7 @@ impl Fixture {
             backend,
             database,
             role,
+            extra_roles: std::cell::RefCell::new(Vec::new()),
         }
     }
 
@@ -278,6 +294,77 @@ impl Fixture {
             .enforce_rls()
             .expect("force row level security");
     }
+    /// Create — once — an unprivileged role that can read and write every
+    /// table but owns none of them, and return its name.
+    ///
+    /// This is the `pensyve_app` role of the DDL/serving split: it holds the
+    /// DML grants a serving deployment needs and nothing that would let it run
+    /// `CREATE TABLE` or `ALTER TABLE`, which is exactly the shape that makes
+    /// `FORCE ROW LEVEL SECURITY` mean something.
+    fn serving_role(&self, admin_opts: &PgConnectOptions) -> String {
+        let role = format!("{}_serving", self.role);
+        self.rt.block_on(async {
+            exec(
+                &self.admin,
+                format!(
+                    "CREATE ROLE \"{role}\" LOGIN PASSWORD '{APP_ROLE_PASSWORD}' \
+                     NOSUPERUSER NOBYPASSRLS"
+                ),
+            )
+            .await;
+        });
+        self.grant_dml(admin_opts, &role);
+        self.extra_roles.borrow_mut().push(role.clone());
+        role
+    }
+
+    /// Give `role` everything a serving deployment needs and nothing more:
+    /// `USAGE` on the schema and DML on every table, but no ownership, so it
+    /// cannot run the schema's DDL.
+    fn grant_dml(&self, admin_opts: &PgConnectOptions, role: &str) {
+        {
+            let mut extra = self.extra_roles.borrow_mut();
+            if !extra.iter().any(|existing| existing == role) {
+                extra.push(role.to_string());
+            }
+        }
+        with_admin_pool(&self.rt, admin_opts, &self.database, |rt, pool| {
+            rt.block_on(async {
+                for statement in [
+                    format!("GRANT USAGE ON SCHEMA public TO \"{role}\""),
+                    format!(
+                        "GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public \
+                         TO \"{role}\""
+                    ),
+                ] {
+                    exec(pool, statement).await;
+                }
+            });
+        });
+    }
+
+    /// A single-connection pool against this fixture's database as `role`.
+    fn pool_for(&self, admin_opts: &PgConnectOptions, role: &str) -> PgPool {
+        self.rt.block_on(async {
+            PgPoolOptions::new()
+                .max_connections(1)
+                .connect_with(
+                    admin_opts
+                        .clone()
+                        .username(role)
+                        .password(APP_ROLE_PASSWORD)
+                        .database(&self.database),
+                )
+                .await
+                .unwrap_or_else(|e| panic!("connect to the fixture database as {role}: {e}"))
+        })
+    }
+
+    /// A second backend against this fixture's database, connected as `role`.
+    fn backend_as(&self, admin_opts: &PgConnectOptions, role: &str) -> PostgresBackend {
+        PostgresBackend::from_pool(self.pool_for(admin_opts, role))
+            .unwrap_or_else(|e| panic!("build a backend as {role}: {e}"))
+    }
 }
 
 impl Drop for Fixture {
@@ -286,16 +373,21 @@ impl Drop for Fixture {
         // that panics mid-run leaks its database; CI throws the container away.
         let admin = self.admin.clone();
         let database = self.database.clone();
-        let role = self.role.clone();
+        let mut roles = self.extra_roles.borrow().clone();
+        roles.push(self.role.clone());
         self.rt.block_on(async {
             let _ = raw_sql(AssertSqlSafe(format!(
                 "DROP DATABASE IF EXISTS \"{database}\" WITH (FORCE)"
             )))
             .execute(&admin)
             .await;
-            let _ = raw_sql(AssertSqlSafe(format!("DROP ROLE IF EXISTS \"{role}\"")))
-                .execute(&admin)
-                .await;
+            // Roles only after the database: a grant inside it is a dependency
+            // that would otherwise refuse the drop.
+            for role in &roles {
+                let _ = raw_sql(AssertSqlSafe(format!("DROP ROLE IF EXISTS \"{role}\"")))
+                    .execute(&admin)
+                    .await;
+            }
         });
     }
 }
@@ -2131,6 +2223,192 @@ fn supersede_still_works_under_enforced_rls() {
             .and_then(|m| m.superseded_by),
         Some(successor),
         "the stamp must be the one this namespace wrote"
+    );
+}
+
+/// Startup must be able to say whether the connected role is exempt from RLS
+/// at all, because a role that is exempt makes `FORCE ROW LEVEL SECURITY`
+/// enforce nothing and there is no other symptom.
+///
+/// Both sides are checked: the fixture's `NOSUPERUSER NOBYPASSRLS` application
+/// role must report clean, and a `BYPASSRLS` role must report exempt. Only the
+/// second half is the interesting one, but without the first the probe could
+/// be reporting `true` unconditionally.
+#[test]
+fn startup_reports_whether_the_role_is_exempt_from_rls() {
+    let Some(admin_opts) = skip_notice("startup_reports_whether_the_role_is_exempt_from_rls")
+    else {
+        return;
+    };
+    let fixture = Fixture::provision(&admin_opts);
+
+    let serving = fixture
+        .backend
+        .role_rls_exemptions()
+        .expect("read the serving role's exemptions");
+    assert_eq!(serving.role, fixture.role);
+    assert!(
+        !serving.exempt(),
+        "the fixture's application role is NOSUPERUSER NOBYPASSRLS, so it must not report \
+         exempt; if it does, the probe is not reading what it claims to"
+    );
+
+    let bypass_role = format!("{}_bypass", fixture.role);
+    fixture.rt.block_on(async {
+        exec(
+            &fixture.admin,
+            format!(
+                "CREATE ROLE \"{bypass_role}\" LOGIN PASSWORD '{APP_ROLE_PASSWORD}' \
+                 NOSUPERUSER BYPASSRLS"
+            ),
+        )
+        .await;
+    });
+    fixture.grant_dml(&admin_opts, &bypass_role);
+
+    let exempt = fixture
+        .backend_as(&admin_opts, &bypass_role)
+        .role_rls_exemptions()
+        .expect("read the BYPASSRLS role's exemptions");
+    assert_eq!(exempt.role, bypass_role);
+    assert!(
+        exempt.bypassrls && exempt.exempt(),
+        "a BYPASSRLS role must be reported as exempt: FORCE ROW LEVEL SECURITY does not \
+         remove that exemption, so a deployment running as one enforces nothing"
+    );
+}
+
+/// A role that does not own the tables must be able to start against an
+/// already-migrated database.
+///
+/// This is the serving half of the DDL/serving split. `PostgresBackend::new`
+/// applies the schema on every startup, which is owner-only DDL, so before the
+/// applied-state probe a non-owner could not get past construction at all —
+/// which is why every deployment connects as the owner, and why the policies
+/// are inert for it. Startup now reads `pensyve_schema_state` first and skips
+/// the batch when it names this build's digest.
+#[test]
+fn a_non_owner_starts_against_an_already_migrated_database() {
+    let Some(admin_opts) = skip_notice("a_non_owner_starts_against_an_already_migrated_database")
+    else {
+        return;
+    };
+    let fixture = Fixture::provision(&admin_opts);
+
+    // The owner's startup has already applied the schema and stamped the
+    // marker; that is the state a serving role is expected to find.
+    let serving = fixture.serving_role(&admin_opts);
+    let backend = PostgresBackend::from_pool(fixture.pool_for(&admin_opts, &serving))
+        .expect("a non-owner must start against an already-migrated database");
+
+    // And it can actually serve: the skip must not have left the backend in a
+    // state where ordinary reads fail.
+    let ns = Namespace::new(format!("non-owner-{}", Uuid::new_v4().simple()));
+    backend
+        .save_namespace(&ns)
+        .expect("write as the serving role");
+    assert_eq!(
+        backend
+            .get_namespace(ns.id)
+            .expect("read as the serving role")
+            .map(|n| n.id),
+        Some(ns.id)
+    );
+}
+
+/// …and when the schema is *not* current, the non-owner is told why rather
+/// than being handed `must be owner of table entities`.
+///
+/// The failure has to name the deployment model, because the operator's next
+/// action — run the migration as the owner, then restart the serving role — is
+/// not deducible from the Postgres error alone.
+#[test]
+fn a_non_owner_that_must_apply_ddl_is_told_it_needs_the_owner() {
+    let Some(admin_opts) =
+        skip_notice("a_non_owner_that_must_apply_ddl_is_told_it_needs_the_owner")
+    else {
+        return;
+    };
+    let fixture = Fixture::provision(&admin_opts);
+    let serving = fixture.serving_role(&admin_opts);
+
+    // Stale marker: the database is at *some* version, but not this build's,
+    // so the probe correctly refuses to skip.
+    fixture.rt.block_on(async {
+        exec(
+            fixture.backend.pool(),
+            "UPDATE pensyve_schema_state SET schema_digest = 'fnv1a64:0000000000000000' \
+              WHERE id = 1",
+        )
+        .await;
+    });
+
+    let error = PostgresBackend::from_pool(fixture.pool_for(&admin_opts, &serving))
+        .err()
+        .expect("a non-owner must not silently start against an out-of-date schema");
+    let message = error.to_string();
+    assert!(
+        message.contains("owner-only DDL") && message.contains("docs/SECURITY.md"),
+        "the failure must name the owner requirement and where the deployment model is \
+         documented, not just Postgres's `must be owner of table ...`; got: {message}"
+    );
+}
+
+/// Re-applying the same schema is skipped, and editing it un-skips it.
+///
+/// The skip is what makes the split possible, but it must not be able to
+/// swallow a real migration: the marker records a digest of the schema text,
+/// so any edit invalidates it. Both directions are asserted, because a probe
+/// that always skips and a probe that never skips each pass one of them.
+#[test]
+fn the_schema_skip_follows_the_schema_text() {
+    let Some(admin_opts) = skip_notice("the_schema_skip_follows_the_schema_text") else {
+        return;
+    };
+    let fixture = Fixture::provision(&admin_opts);
+
+    let applied_at = |label: &str| -> DateTime<Utc> {
+        fixture.rt.block_on(async {
+            let (at,): (DateTime<Utc>,) =
+                query_as::<Postgres, _>("SELECT applied_at FROM pensyve_schema_state WHERE id = 1")
+                    .fetch_one(fixture.backend.pool())
+                    .await
+                    .unwrap_or_else(|e| panic!("read schema state ({label}): {e}"));
+            at
+        })
+    };
+
+    let first = applied_at("after provisioning");
+
+    // Re-running startup against an unchanged schema must not re-apply it.
+    let again = PostgresBackend::from_pool(fixture.pool_for(&admin_opts, &fixture.role.clone()))
+        .expect("restart as the owner");
+    drop(again);
+    assert_eq!(
+        applied_at("after an unchanged restart"),
+        first,
+        "an unchanged schema must be skipped, not re-applied — that skip is the only \
+         reason a non-owner can start at all"
+    );
+
+    // A changed schema must be re-applied. Standing in for an edit by rolling
+    // the marker back to a digest no build will ever produce.
+    fixture.rt.block_on(async {
+        exec(
+            fixture.backend.pool(),
+            "UPDATE pensyve_schema_state SET schema_digest = 'fnv1a64:ffffffffffffffff' \
+              WHERE id = 1",
+        )
+        .await;
+    });
+    let reapplied =
+        PostgresBackend::from_pool(fixture.pool_for(&admin_opts, &fixture.role.clone()))
+            .expect("restart as the owner over a changed schema");
+    drop(reapplied);
+    assert!(
+        applied_at("after a changed restart") > first,
+        "a schema whose text differs from what was applied must be applied again; \
+         otherwise a real migration would be skipped forever"
     );
 }
 

--- a/pensyve-core/src/storage/postgres/live_rls.rs
+++ b/pensyve-core/src/storage/postgres/live_rls.rs
@@ -2951,9 +2951,11 @@ fn only_bound_connections_reach_policied_tables() {
         "postgres.rs has {unbound} uses of `ScopedPool::unbound()`, expected \
          {ALLOWED_UNBOUND_USES}. An unbound connection carries the previous checkout's \
          namespace, so a query on a table with a namespace_isolation_* policy would read \
-         another namespace's rows once RLS is enforced. Use `scoped_conn` or \
-         `maybe_scoped_conn` unless the statement is DDL or targets an unpolicied table \
-         (namespaces, activity_events), and update this count if it is."
+         another namespace's rows once RLS is enforced. Use `scoped_conn`, or \
+         `conn_with_namespace(UNSCOPED_NAMESPACE)` for a statement that genuinely has no \
+         namespace, unless the statement is DDL or targets an unpolicied table \
+         (namespaces, activity_events, pensyve_schema_state), and update this count if \
+         it is."
     );
 
     // The wrapper is only worth having if the raw pool is genuinely out of
@@ -2962,8 +2964,8 @@ fn only_bound_connections_reach_policied_tables() {
         assert!(
             !source.contains(forbidden),
             "postgres.rs contains `{forbidden}`, which takes a connection without binding a \
-             namespace. Go through `scoped_conn`, `maybe_scoped_conn`, or an allowlisted \
-             `unbound()` call."
+             namespace. Go through `scoped_conn`, `conn_with_namespace`, or an \
+             allowlisted `unbound()` call."
         );
     }
 }

--- a/pensyve-core/src/storage/postgres/live_rls.rs
+++ b/pensyve-core/src/storage/postgres/live_rls.rs
@@ -2670,6 +2670,76 @@ fn the_schema_skip_follows_the_schema_text() {
     );
 }
 
+/// The documented manual-upgrade sequence has to actually complete.
+///
+/// `docs/SECURITY.md` tells an operator they may apply new schema text however
+/// they like — `psql -f postgres_schema.sql` included — and then start the
+/// application once on an owner connection before flipping serving back to the
+/// unprivileged role. That middle step is not optional and the docs used to
+/// present it as an alternative rather than a follow-on: the schema file
+/// creates `pensyve_schema_state` but cannot record its own digest, so a
+/// hand-applied schema leaves the marker table present and empty. Without the
+/// owner-connected startup the marker never gets stamped, every later startup
+/// reads "not current", and the serving role fails on owner-only DDL forever —
+/// the upgrade path as written could not finish.
+///
+/// This runs the sequence as documented. The empty-marker state is what stands
+/// in for the hand-applied schema, because that is precisely what `psql` leaves.
+#[test]
+fn the_documented_manual_upgrade_sequence_completes() {
+    let Some(admin_opts) = skip_notice("the_documented_manual_upgrade_sequence_completes") else {
+        return;
+    };
+    let fixture = Fixture::provision(&admin_opts);
+    let serving = fixture.serving_role(&admin_opts);
+    let owner = fixture.role.clone();
+
+    // Step 1 — the schema is applied by something that cannot stamp the digest.
+    // `psql -f postgres_schema.sql` creates the marker table and leaves it
+    // empty; nothing else about the database differs.
+    fixture.rt.block_on(async {
+        exec(fixture.backend.pool(), "DELETE FROM pensyve_schema_state").await;
+    });
+
+    // The serving role cannot get past this state on its own — it would be
+    // asked for owner-only DDL. This is the failure the docs must not lead an
+    // operator into.
+    let blocked = PostgresBackend::from_pool(fixture.pool_for(&admin_opts, &serving))
+        .err()
+        .expect("an unstamped marker must not let a non-owner start");
+    assert!(
+        blocked.to_string().contains("owner-only DDL"),
+        "and it must say why: {blocked}"
+    );
+
+    // Step 2 — start once on an owner connection. This is the step the docs
+    // now require rather than offer.
+    let stamping = PostgresBackend::from_pool(fixture.pool_for(&admin_opts, &owner))
+        .expect("an owner startup must complete over a hand-applied schema");
+    drop(stamping);
+
+    let stamped: i64 = fixture.rt.block_on(async {
+        let (count,): (i64,) =
+            query_as::<Postgres, _>("SELECT count(*) FROM pensyve_schema_state WHERE id = 1")
+                .fetch_one(fixture.backend.pool())
+                .await
+                .expect("read the marker after the owner startup");
+        count
+    });
+    assert_eq!(
+        stamped, 1,
+        "the owner startup must stamp the digest; without it the sequence cannot finish"
+    );
+
+    // Step 3 — flip serving back. This is what the whole sequence is for.
+    let serving_backend = PostgresBackend::from_pool(fixture.pool_for(&admin_opts, &serving))
+        .expect("the serving role must start once the owner startup has stamped the digest");
+    let ns = Namespace::new(format!("upgraded-{}", Uuid::new_v4().simple()));
+    serving_backend
+        .save_namespace(&ns)
+        .expect("and must be able to serve");
+}
+
 /// The applied-schema probe must resolve the marker the same way the
 /// statements it gates do.
 ///

--- a/pensyve-core/src/storage/postgres/live_rls.rs
+++ b/pensyve-core/src/storage/postgres/live_rls.rs
@@ -2670,6 +2670,91 @@ fn the_schema_skip_follows_the_schema_text() {
     );
 }
 
+/// The applied-schema probe must resolve the marker the same way the
+/// statements it gates do.
+///
+/// `CREATE TABLE pensyve_schema_state` in the schema file, the `SELECT` that
+/// reads the digest and the `INSERT` that stamps it all resolve through
+/// `search_path`. A probe qualified as `public.pensyve_schema_state` would
+/// therefore ask about a different relation than the one it gates on any
+/// deployment whose role carries a non-default `search_path`: the marker lands
+/// wherever `search_path` puts it, `to_regclass` returns NULL forever, and the
+/// DDL batch is re-applied on every startup — harmless for an owner, and
+/// permanently unstartable for the non-owner serving role this whole mechanism
+/// exists to support. Silently, with no error to notice.
+///
+/// So this stages exactly that: the marker moved out of `public`, and the role
+/// pointed at the schema holding it. Startup must still skip.
+#[test]
+fn the_schema_probe_resolves_the_marker_through_search_path() {
+    let Some(admin_opts) = skip_notice("the_schema_probe_resolves_the_marker_through_search_path")
+    else {
+        return;
+    };
+    let fixture = Fixture::provision(&admin_opts);
+    let alt = format!("alt_{}", Uuid::new_v4().simple());
+
+    // Move the marker out of `public` and point the role's `search_path` at
+    // where it now lives. `ALTER TABLE ... SET SCHEMA` needs ownership, which
+    // the fixture role has, but `CREATE SCHEMA` and `ALTER ROLE` need the
+    // admin.
+    let role = fixture.role.clone();
+    let database = fixture.database.clone();
+    with_admin_pool(&fixture.rt, &admin_opts, &database, |rt, pool| {
+        rt.block_on(async {
+            exec(
+                pool,
+                format!("CREATE SCHEMA \"{alt}\" AUTHORIZATION \"{role}\""),
+            )
+            .await;
+            exec(
+                pool,
+                format!(
+                    "ALTER ROLE \"{role}\" IN DATABASE \"{database}\" \
+                     SET search_path = \"{alt}\", public"
+                ),
+            )
+            .await;
+        });
+    });
+    fixture.rt.block_on(async {
+        exec(
+            fixture.backend.pool(),
+            format!("ALTER TABLE public.pensyve_schema_state SET SCHEMA \"{alt}\""),
+        )
+        .await;
+    });
+
+    let applied_at = |label: &str| -> DateTime<Utc> {
+        with_admin_pool(&fixture.rt, &admin_opts, &database, |rt, pool| {
+            rt.block_on(async {
+                // Identifier is a hex-only name generated in this module, so
+                // `AssertSqlSafe` is sound — same rule as `exec`.
+                let (at,): (DateTime<Utc>,) = query_as::<Postgres, _>(AssertSqlSafe(format!(
+                    "SELECT applied_at FROM \"{alt}\".pensyve_schema_state WHERE id = 1"
+                )))
+                .fetch_one(pool)
+                .await
+                .unwrap_or_else(|e| panic!("read relocated schema state ({label}): {e}"));
+                at
+            })
+        })
+    };
+    let before = applied_at("after relocating the marker");
+
+    let restarted = PostgresBackend::from_pool(fixture.pool_for(&admin_opts, &role))
+        .expect("restart against a marker outside `public`");
+    drop(restarted);
+
+    assert_eq!(
+        applied_at("after restarting"),
+        before,
+        "startup re-applied the schema even though the marker names this build's digest, \
+         so the probe resolved a different relation than the statements it gates. A \
+         non-owner serving role would never be able to start on this deployment."
+    );
+}
+
 /// Every table in [`RLS_POLICIES`] must carry exactly one policy, named as
 /// expected and qualified by the namespace GUC, as Postgres actually
 /// registered it.

--- a/pensyve-core/src/storage/postgres_schema.sql
+++ b/pensyve-core/src/storage/postgres_schema.sql
@@ -4,6 +4,27 @@
 CREATE EXTENSION IF NOT EXISTS vector;
 
 -- ---------------------------------------------------------------------------
+-- Schema state
+--
+-- One row, holding the digest of the schema text that was last applied.
+-- `PostgresBackend::run_schema` reads it before doing anything: when it names
+-- this build's digest the whole file is skipped, which is what lets a
+-- deployment serve traffic as a role that does not own these tables and
+-- therefore cannot run the DDL below. The row is written from Rust, after the
+-- batch commits — the file cannot name its own digest, and DML belongs in this
+-- file only inside the `row_security = off` window further down.
+--
+-- Carries no namespace and therefore no RLS policy: it describes the database,
+-- not a tenant's data.
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS pensyve_schema_state (
+    id             SMALLINT PRIMARY KEY,
+    schema_digest  TEXT NOT NULL,
+    applied_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- ---------------------------------------------------------------------------
 -- Namespaces
 -- ---------------------------------------------------------------------------
 

--- a/pensyve-core/src/storage/sqlite.rs
+++ b/pensyve-core/src/storage/sqlite.rs
@@ -942,12 +942,17 @@ impl StorageTrait for SqliteBackend {
         Ok(())
     }
 
-    fn get_entity(&self, id: Uuid) -> StorageResult<Option<Entity>> {
+    fn get_entity_in_namespace(
+        &self,
+        id: Uuid,
+        namespace_id: Uuid,
+    ) -> StorageResult<Option<Entity>> {
         let conn = lock_conn!(self);
         let result = conn
             .query_row(
-                "SELECT id, namespace_id, name, kind, metadata, created_at FROM entities WHERE id = ?1",
-                params![id.to_string()],
+                "SELECT id, namespace_id, name, kind, metadata, created_at FROM entities \
+                  WHERE id = ?1 AND namespace_id = ?2",
+                params![id.to_string(), namespace_id.to_string()],
                 |row| {
                     Ok((
                         row.get::<_, String>(0)?,
@@ -1170,9 +1175,10 @@ impl StorageTrait for SqliteBackend {
         result.transpose()
     }
 
-    fn list_episodic_by_entity(
+    fn list_episodic_by_entity_in_namespace(
         &self,
         about_entity: Uuid,
+        namespace_id: Uuid,
         limit: usize,
     ) -> StorageResult<Vec<EpisodicMemory>> {
         let conn = lock_conn!(self);
@@ -1181,12 +1187,14 @@ impl StorageTrait for SqliteBackend {
                       content_type, summary, embedding, context_intent, timestamp,
                       stability, retrievability, access_count, last_accessed, event_time,
                       agent_id, user_id, superseded_by, invalid_at
-               FROM episodic_memories WHERE about_entity = ?1 AND superseded_by IS NULL
-               ORDER BY timestamp DESC LIMIT ?2",
+               FROM episodic_memories
+               WHERE about_entity = ?1 AND namespace_id = ?2 AND superseded_by IS NULL
+               ORDER BY timestamp DESC LIMIT ?3",
         )?;
         let rows = stmt.query_map(
             params![
                 about_entity.to_string(),
+                namespace_id.to_string(),
                 i64::try_from(limit).unwrap_or(i64::MAX)
             ],
             row_to_episodic,
@@ -1198,9 +1206,10 @@ impl StorageTrait for SqliteBackend {
         Ok(out)
     }
 
-    fn update_episodic_access(
+    fn update_episodic_access_in_namespace(
         &self,
         id: Uuid,
+        namespace_id: Uuid,
         stability: f32,
         retrievability: f32,
     ) -> StorageResult<()> {
@@ -1210,12 +1219,13 @@ impl StorageTrait for SqliteBackend {
                SET stability = ?1, retrievability = ?2,
                    access_count = access_count + 1,
                    last_accessed = ?3
-               WHERE id = ?4",
+               WHERE id = ?4 AND namespace_id = ?5",
             params![
                 f64::from(stability),
                 f64::from(retrievability),
                 Utc::now().to_rfc3339(),
                 id.to_string(),
+                namespace_id.to_string(),
             ],
         )?;
         Ok(())
@@ -1313,9 +1323,10 @@ impl StorageTrait for SqliteBackend {
         result.transpose()
     }
 
-    fn list_semantic_by_entity(
+    fn list_semantic_by_entity_in_namespace(
         &self,
         subject: Uuid,
+        namespace_id: Uuid,
         limit: usize,
     ) -> StorageResult<Vec<SemanticMemory>> {
         let conn = lock_conn!(self);
@@ -1324,12 +1335,14 @@ impl StorageTrait for SqliteBackend {
                       object_entity, confidence, valid_at, invalid_at,
                       source_episodes, embedding, stability, retrievability,
                       agent_id, user_id, superseded_by
-               FROM semantic_memories WHERE subject = ?1 AND superseded_by IS NULL
-               ORDER BY valid_at DESC LIMIT ?2",
+               FROM semantic_memories
+               WHERE subject = ?1 AND namespace_id = ?2 AND superseded_by IS NULL
+               ORDER BY valid_at DESC LIMIT ?3",
         )?;
         let rows = stmt.query_map(
             params![
                 subject.to_string(),
+                namespace_id.to_string(),
                 i64::try_from(limit).unwrap_or(i64::MAX)
             ],
             row_to_semantic,
@@ -1365,15 +1378,6 @@ impl StorageTrait for SqliteBackend {
             out.push(row??);
         }
         Ok(out)
-    }
-
-    fn invalidate_semantic(&self, id: Uuid) -> StorageResult<()> {
-        let conn = lock_conn!(self);
-        conn.execute(
-            "UPDATE semantic_memories SET invalid_at = ?1 WHERE id = ?2",
-            params![Utc::now().to_rfc3339(), id.to_string()],
-        )?;
-        Ok(())
     }
 
     // -----------------------------------------------------------------------
@@ -1453,9 +1457,10 @@ impl StorageTrait for SqliteBackend {
         result.transpose()
     }
 
-    fn update_procedural_reliability(
+    fn update_procedural_reliability_in_namespace(
         &self,
         id: Uuid,
+        namespace_id: Uuid,
         reliability: f32,
         trial_count: u32,
         success_count: u32,
@@ -1465,13 +1470,14 @@ impl StorageTrait for SqliteBackend {
             r"UPDATE procedural_memories
                SET reliability = ?1, trial_count = ?2, success_count = ?3,
                    last_used = ?4
-               WHERE id = ?5",
+               WHERE id = ?5 AND namespace_id = ?6",
             params![
                 f64::from(reliability),
                 trial_count,
                 success_count,
                 Utc::now().to_rfc3339(),
                 id.to_string(),
+                namespace_id.to_string(),
             ],
         )?;
         Ok(())
@@ -1634,78 +1640,6 @@ impl StorageTrait for SqliteBackend {
             out.push(row??);
         }
         Ok(out)
-    }
-
-    fn delete_observations_by_entity(&self, entity_id: Uuid) -> StorageResult<usize> {
-        let conn = lock_conn!(self);
-        let id_str = entity_id.to_string();
-        conn.execute_batch("BEGIN")?;
-        let result = (|| -> StorageResult<usize> {
-            // Phase 2B cascade (CodeRabbit PR #115 round 2): the
-            // observations slated for delete may have populated
-            // `kg_triples` / `kg_passage_entities` rows keyed by their
-            // `id` (== `passage_id`). Remove those BEFORE deleting the
-            // owning observation rows so the cleanup matches the
-            // observation set being deleted; `kg_entities` are kept
-            // (they're namespace-scoped, not passage-scoped, and may
-            // be referenced by other observations' triples — they
-            // only get purged in `purge_namespace`).
-            conn.execute(
-                "DELETE FROM kg_triples \
-                 WHERE passage_id IN (\
-                   SELECT id FROM observation_memories \
-                    WHERE episode_id IN (\
-                      SELECT DISTINCT episode_id FROM episodic_memories \
-                       WHERE about_entity = ?1 OR source_entity = ?1\
-                    )\
-                 )",
-                params![&id_str],
-            )?;
-            conn.execute(
-                "DELETE FROM kg_passage_entities \
-                 WHERE passage_id IN (\
-                   SELECT id FROM observation_memories \
-                    WHERE episode_id IN (\
-                      SELECT DISTINCT episode_id FROM episodic_memories \
-                       WHERE about_entity = ?1 OR source_entity = ?1\
-                    )\
-                 )",
-                params![&id_str],
-            )?;
-            // Strip FTS entries first — we need the observation IDs before
-            // the rows are gone.
-            conn.execute(
-                "DELETE FROM memory_fts \
-                 WHERE memory_type = 'observation' \
-                   AND memory_id IN (\
-                     SELECT id FROM observation_memories \
-                      WHERE episode_id IN (\
-                        SELECT DISTINCT episode_id FROM episodic_memories \
-                         WHERE about_entity = ?1 OR source_entity = ?1\
-                      )\
-                   )",
-                params![&id_str],
-            )?;
-            let deleted = conn.execute(
-                "DELETE FROM observation_memories \
-                 WHERE episode_id IN (\
-                   SELECT DISTINCT episode_id FROM episodic_memories \
-                    WHERE about_entity = ?1 OR source_entity = ?1\
-                 )",
-                params![&id_str],
-            )?;
-            Ok(deleted)
-        })();
-        match result {
-            Ok(n) => {
-                conn.execute_batch("COMMIT")?;
-                Ok(n)
-            }
-            Err(e) => {
-                let _ = conn.execute_batch("ROLLBACK");
-                Err(e)
-            }
-        }
     }
 
     fn delete_observations_by_episode(
@@ -2415,9 +2349,11 @@ impl StorageTrait for SqliteBackend {
     /// `SELECT` predicted it would remove.
     ///
     /// Every leg is qualified by `namespace_id`, the observation join included.
-    /// The unscoped `delete_observations_by_entity` this replaces on the erase
+    /// The unscoped `delete_observations_by_entity` this replaced on the erase
     /// path matched on the entity id alone, and entity ids are not globally
-    /// unique in this schema, so that predicate reached into other tenants.
+    /// unique in this schema, so that predicate reached into other tenants. It
+    /// had no caller left afterwards and was removed rather than scoped (#254),
+    /// so this leg is now the only entity-wide observation delete there is.
     fn erase_entity_capturing(
         &self,
         entity_id: Uuid,
@@ -2635,38 +2571,6 @@ impl StorageTrait for SqliteBackend {
         }
     }
 
-    fn update_semantic_content(
-        &self,
-        id: Uuid,
-        predicate: &str,
-        object: &str,
-        confidence: Option<f32>,
-    ) -> StorageResult<()> {
-        let conn = lock_conn!(self);
-        let id_str = id.to_string();
-
-        if let Some(conf) = confidence {
-            conn.execute(
-                "UPDATE semantic_memories SET predicate = ?1, object = ?2, confidence = ?3 WHERE id = ?4",
-                params![predicate, object, conf, &id_str],
-            )?;
-        } else {
-            conn.execute(
-                "UPDATE semantic_memories SET predicate = ?1, object = ?2 WHERE id = ?3",
-                params![predicate, object, &id_str],
-            )?;
-        }
-
-        // Update FTS index content.
-        let content = format!("{predicate} {object}");
-        conn.execute(
-            "UPDATE memory_fts SET content = ?1 WHERE memory_id = ?2",
-            params![&content, &id_str],
-        )?;
-
-        Ok(())
-    }
-
     // -----------------------------------------------------------------------
     // Entities (bulk)
     // -----------------------------------------------------------------------
@@ -2713,13 +2617,6 @@ impl StorageTrait for SqliteBackend {
             });
         }
         Ok(entities)
-    }
-
-    fn delete_entity(&self, id: Uuid) -> StorageResult<bool> {
-        let conn = lock_conn!(self);
-        let id_str = id.to_string();
-        let rows = conn.execute("DELETE FROM entities WHERE id = ?1", params![&id_str])?;
-        Ok(rows > 0)
     }
 
     // -----------------------------------------------------------------------
@@ -3614,11 +3511,25 @@ mod tests {
         entity.namespace_id = ns.id;
         db.save_entity(&entity).unwrap();
 
-        let fetched = db.get_entity(entity.id).unwrap().unwrap();
+        let fetched = db
+            .get_entity_in_namespace(entity.id, ns.id)
+            .unwrap()
+            .unwrap();
         assert_eq!(fetched.id, entity.id);
         assert_eq!(fetched.name, "alice");
         assert!(matches!(fetched.kind, EntityKind::User));
         assert_eq!(fetched.namespace_id, ns.id);
+
+        // Entity ids are not globally unique, so the lookup has to be a
+        // namespace-qualified query rather than a read followed by a check.
+        let foreign = Namespace::new("foreign-entity-read");
+        db.save_namespace(&foreign).unwrap();
+        assert!(
+            db.get_entity_in_namespace(entity.id, foreign.id)
+                .unwrap()
+                .is_none(),
+            "another namespace must not resolve this entity"
+        );
     }
 
     #[test]
@@ -3726,11 +3637,37 @@ mod tests {
         );
         db.save_episodic(&other).unwrap();
 
-        let results = db.list_episodic_by_entity(about, 10).unwrap();
+        // The same entity id in a second namespace — the collision the
+        // namespace predicate has to disambiguate.
+        let foreign_ns = Namespace::new("foreign-episodic-listing");
+        db.save_namespace(&foreign_ns).unwrap();
+        let foreign = EpisodicMemory::new(
+            foreign_ns.id,
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            about,
+            "another tenant's turn",
+        );
+        db.save_episodic(&foreign).unwrap();
+
+        let results = db
+            .list_episodic_by_entity_in_namespace(about, ns.id, 10)
+            .unwrap();
         assert_eq!(results.len(), 2);
         let contents: Vec<&str> = results.iter().map(|m| m.content.as_str()).collect();
         assert!(contents.contains(&"first event"));
         assert!(contents.contains(&"second event"));
+        assert!(
+            !contents.contains(&"another tenant's turn"),
+            "the listing must not reach into another namespace's rows"
+        );
+        assert_eq!(
+            db.list_episodic_by_entity_in_namespace(about, foreign_ns.id, 10)
+                .unwrap()
+                .len(),
+            1,
+            "and each namespace must still see its own"
+        );
     }
 
     #[test]
@@ -3747,7 +3684,22 @@ mod tests {
         );
         db.save_episodic(&mem).unwrap();
 
-        db.update_episodic_access(mem.id, 0.8, 0.7).unwrap();
+        // A foreign namespace must not be able to stamp this row.
+        let foreign = Namespace::new("foreign-reinforcement");
+        db.save_namespace(&foreign).unwrap();
+        db.update_episodic_access_in_namespace(mem.id, foreign.id, 0.1, 0.1)
+            .unwrap();
+        let untouched = db
+            .get_episodic_in_namespace(mem.id, ns.id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            untouched.access_count, 0,
+            "a cross-namespace reinforcement stamp must land on nothing"
+        );
+
+        db.update_episodic_access_in_namespace(mem.id, ns.id, 0.8, 0.7)
+            .unwrap();
 
         let fetched = db
             .get_episodic_in_namespace(mem.id, ns.id)
@@ -3849,12 +3801,14 @@ mod tests {
         mem.event_time = Some(when);
         db.save_episodic(&mem).unwrap();
 
-        let results = db.list_episodic_by_entity(about, 10).unwrap();
+        let results = db
+            .list_episodic_by_entity_in_namespace(about, ns.id, 10)
+            .unwrap();
         assert_eq!(results.len(), 1);
         assert_eq!(
             results[0].event_time,
             Some(when),
-            "list_episodic_by_entity must read event_time from the DB"
+            "list_episodic_by_entity_in_namespace must read event_time from the DB"
         );
     }
 
@@ -3897,32 +3851,26 @@ mod tests {
         let other = SemanticMemory::new(ns.id, Uuid::new_v4(), "likes", "coffee", 0.7);
         db.save_semantic(&other).unwrap();
 
-        let results = db.list_semantic_by_entity(subject, 10).unwrap();
+        // The same subject id in a second namespace.
+        let foreign_ns = Namespace::new("foreign-semantic-listing");
+        db.save_namespace(&foreign_ns).unwrap();
+        let foreign = SemanticMemory::new(foreign_ns.id, subject, "knows", "Go", 0.8);
+        db.save_semantic(&foreign).unwrap();
+
+        let results = db
+            .list_semantic_by_entity_in_namespace(subject, ns.id, 10)
+            .unwrap();
         assert_eq!(results.len(), 2);
-    }
-
-    #[test]
-    fn test_invalidate_semantic() {
-        let (_dir, db) = setup();
-        let ns = make_namespace(&db);
-
-        let mem = SemanticMemory::new(ns.id, Uuid::new_v4(), "works_at", "OldCo", 0.9);
-        db.save_semantic(&mem).unwrap();
-
         assert!(
-            db.get_semantic_in_namespace(mem.id, ns.id)
-                .unwrap()
-                .unwrap()
-                .invalid_at
-                .is_none()
+            !results.iter().any(|m| m.id == foreign.id),
+            "the listing must not reach into another namespace's rows"
         );
-        db.invalidate_semantic(mem.id).unwrap();
-        assert!(
-            db.get_semantic_in_namespace(mem.id, ns.id)
+        assert_eq!(
+            db.list_semantic_by_entity_in_namespace(subject, foreign_ns.id, 10)
                 .unwrap()
-                .unwrap()
-                .invalid_at
-                .is_some()
+                .len(),
+            1,
+            "and each namespace must still see its own"
         );
     }
 
@@ -3970,7 +3918,22 @@ mod tests {
         );
         db.save_procedural(&mem).unwrap();
 
-        db.update_procedural_reliability(mem.id, 0.75, 4, 3)
+        // A foreign namespace must not be able to rewrite this row.
+        let foreign = Namespace::new("foreign-procedural-update");
+        db.save_namespace(&foreign).unwrap();
+        db.update_procedural_reliability_in_namespace(mem.id, foreign.id, 0.01, 99, 99)
+            .unwrap();
+        let untouched = db
+            .get_procedural_in_namespace(mem.id, ns.id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            (untouched.trial_count, untouched.success_count),
+            (mem.trial_count, mem.success_count),
+            "a cross-namespace reliability update must land on nothing"
+        );
+
+        db.update_procedural_reliability_in_namespace(mem.id, ns.id, 0.75, 4, 3)
             .unwrap();
 
         let fetched = db
@@ -5395,7 +5358,9 @@ mod tests {
     // assertions stay independent of the dep-parse hook's extraction
     // contract. The cascade paths we exercise are:
     //   - delete_observations_by_episode
-    //   - delete_observations_by_entity
+    //   - erase_entity_capturing's observation leg (the entity-wide case;
+    //     covered by `erase_entity_capturing_removes_every_leg_and_returns_
+    //     what_it_removed` alongside the rest of the erase)
     //   - delete_memory_by_id_in_namespace (observation case)
     //   - purge_namespace
     // -----------------------------------------------------------------------
@@ -5534,54 +5499,6 @@ mod tests {
             kg_entities_count_for_namespace(&db, ns.id),
             2,
             "kg_entities are namespace-scoped and must NOT cascade with an episode delete"
-        );
-    }
-
-    #[test]
-    fn delete_observations_by_entity_cascades_kg_rows() {
-        let (_dir, db) = setup();
-        let ns = make_namespace(&db);
-
-        // To exercise the cascade we need an episodic memory that
-        // references the entity to delete, plus an observation tied
-        // to that episode. The episodic.about_entity / source_entity
-        // columns drive the cascade JOIN.
-        let about = Uuid::new_v4();
-        let ep = Uuid::new_v4();
-        let episode = Episode::new(ns.id, vec![about]);
-        let ep_id = episode.id;
-        db.save_episode(&episode).unwrap();
-
-        let mut episodic = EpisodicMemory::new(ns.id, ep_id, about, Uuid::new_v4(), "msg");
-        episodic.episode_id = ep;
-        db.save_episodic(&episodic).unwrap();
-
-        let obs = ObservationMemory::new(ns.id, ep, "x", "y", "z", "c");
-        db.save_observation(&obs).unwrap();
-
-        let s = seed_kg_entity(&db, ns.id, "S");
-        let o = seed_kg_entity(&db, ns.id, "O");
-        seed_kg_triple(&db, ns.id, obs.id, s, o);
-
-        assert_eq!(kg_triples_count_for_passage(&db, obs.id), 1);
-        assert_eq!(kg_passage_entities_count_for_passage(&db, obs.id), 2);
-
-        db.delete_observations_by_entity(about).unwrap();
-
-        assert_eq!(
-            kg_triples_count_for_passage(&db, obs.id),
-            0,
-            "kg_triples must cascade with delete_observations_by_entity"
-        );
-        assert_eq!(
-            kg_passage_entities_count_for_passage(&db, obs.id),
-            0,
-            "kg_passage_entities must cascade with delete_observations_by_entity"
-        );
-        assert_eq!(
-            kg_entities_count_for_namespace(&db, ns.id),
-            2,
-            "kg_entities are namespace-scoped and must NOT cascade with entity-scoped observation delete"
         );
     }
 
@@ -5931,7 +5848,11 @@ mod tests {
                 .unwrap()
                 .is_empty()
         );
-        assert!(db.get_entity(subject.id).unwrap().is_none());
+        assert!(
+            db.get_entity_in_namespace(subject.id, ns.id)
+                .unwrap()
+                .is_none()
+        );
         assert_eq!(fts_rows_for(&db, episodic.id), 0);
         assert_eq!(fts_rows_for(&db, semantic.id), 0);
         assert_eq!(fts_rows_for(&db, observation.id), 0);

--- a/pensyve-core/src/storage/sqlite.rs
+++ b/pensyve-core/src/storage/sqlite.rs
@@ -3782,8 +3782,8 @@ mod tests {
 
     #[test]
     fn test_list_episodic_by_entity_preserves_event_time() {
-        // list_episodic_by_entity has its own SELECT statement separate
-        // from get_episodic_in_namespace — must also read event_time.
+        // list_episodic_by_entity_in_namespace has its own SELECT statement
+        // separate from get_episodic_in_namespace — must also read event_time.
         let (_dir, db) = setup();
         let ns = make_namespace(&db);
         let about = Uuid::new_v4();

--- a/pensyve-core/tests/test_consolidation_policy_and_cancel.rs
+++ b/pensyve-core/tests/test_consolidation_policy_and_cancel.rs
@@ -184,7 +184,8 @@ fn i5_pre_cancelled_token_returns_cancelled_immediately() {
 /// Test design (per the brief's option (b)): inject a synthetic large
 /// input — 5 000 episodic memories under one entity — and rely on the
 /// per-row work in both passes (cosine-similarity loop + per-row
-/// `update_episodic_access` `SQLite` writes) to provide enough wall-clock
+/// `update_episodic_access_in_namespace` `SQLite` writes) to provide
+/// enough wall-clock
 /// for the cancel signal to interpose between iteration boundaries.
 ///
 /// The cancel checks land BETWEEN `SQLite` transactions, so the integrity
@@ -292,8 +293,8 @@ async fn i5_long_running_consolidation_cancels_within_budget() {
     // I5 integrity guarantee: no partial-write corruption. The only writes
     // either pass performs are (a) `save_semantic` in promotion (a brand-new
     // row — never observable as "partial" since SQLite commits atomically)
-    // and (b) `update_episodic_access` in decay (an UPDATE on an existing
-    // row, atomic per statement). Either pass's in-flight transaction at
+    // and (b) `update_episodic_access_in_namespace` in decay (an UPDATE on an
+    // existing row, atomic per statement). Either pass's in-flight transaction at
     // cancel time committed or rolled back atomically; no row count change
     // beyond legitimate full-transaction effects is possible. We assert the
     // weaker, easier-to-state property: the original 5 000 episodic rows

--- a/pensyve-mcp-gateway/src/rest.rs
+++ b/pensyve-mcp-gateway/src/rest.rs
@@ -335,9 +335,8 @@ fn resolve_entity_identifier(
         return Ok(None);
     };
 
-    match storage.get_entity(entity_id) {
-        Ok(Some(entity)) if entity.namespace_id == namespace_id => Ok(Some(entity)),
-        Ok(_) => Ok(None),
+    match storage.get_entity_in_namespace(entity_id, namespace_id) {
+        Ok(entity) => Ok(entity),
         Err(err) => Err(RestError(
             StatusCode::INTERNAL_SERVER_ERROR,
             format!("Error looking up entity '{identifier}': {err}"),
@@ -1540,7 +1539,10 @@ async fn inspect(
     }
 
     let mut episodic = Vec::new();
-    if let Ok(mems) = ps.storage.list_episodic_by_entity(entity.id, limit) {
+    if let Ok(mems) =
+        ps.storage
+            .list_episodic_by_entity_in_namespace(entity.id, ps.namespace.id, limit)
+    {
         for mem in mems {
             let mut val = serde_json::to_value(&mem).unwrap_or_default();
             strip_embedding(&mut val);
@@ -1551,7 +1553,9 @@ async fn inspect(
     let remaining = limit.saturating_sub(episodic.len());
     let mut semantic = Vec::new();
     if remaining > 0
-        && let Ok(mems) = ps.storage.list_semantic_by_entity(entity.id, remaining)
+        && let Ok(mems) =
+            ps.storage
+                .list_semantic_by_entity_in_namespace(entity.id, ps.namespace.id, remaining)
     {
         for mem in mems {
             let mut val = serde_json::to_value(&mem).unwrap_or_default();

--- a/pensyve-mcp-gateway/tests/test_rest_gdpr_erase_race.rs
+++ b/pensyve-mcp-gateway/tests/test_rest_gdpr_erase_race.rs
@@ -127,8 +127,12 @@ impl StorageTrait for RacingStorage {
     fn save_entity(&self, entity: &Entity) -> StorageResult<()> {
         self.inner.save_entity(entity)
     }
-    fn get_entity(&self, id: Uuid) -> StorageResult<Option<Entity>> {
-        self.inner.get_entity(id)
+    fn get_entity_in_namespace(
+        &self,
+        id: Uuid,
+        namespace_id: Uuid,
+    ) -> StorageResult<Option<Entity>> {
+        self.inner.get_entity_in_namespace(id, namespace_id)
     }
     fn get_entity_by_name(&self, name: &str, namespace_id: Uuid) -> StorageResult<Option<Entity>> {
         self.inner.get_entity_by_name(name, namespace_id)
@@ -156,12 +160,14 @@ impl StorageTrait for RacingStorage {
     ) -> StorageResult<Option<EpisodicMemory>> {
         self.inner.get_episodic_in_namespace(id, namespace_id)
     }
-    fn list_episodic_by_entity(
+    fn list_episodic_by_entity_in_namespace(
         &self,
         about_entity: Uuid,
+        namespace_id: Uuid,
         limit: usize,
     ) -> StorageResult<Vec<EpisodicMemory>> {
-        self.inner.list_episodic_by_entity(about_entity, limit)
+        self.inner
+            .list_episodic_by_entity_in_namespace(about_entity, namespace_id, limit)
     }
     fn list_episodic_by_episode(
         &self,
@@ -171,14 +177,15 @@ impl StorageTrait for RacingStorage {
         self.inner
             .list_episodic_by_episode(namespace_id, episode_id)
     }
-    fn update_episodic_access(
+    fn update_episodic_access_in_namespace(
         &self,
         id: Uuid,
+        namespace_id: Uuid,
         stability: f32,
         retrievability: f32,
     ) -> StorageResult<()> {
         self.inner
-            .update_episodic_access(id, stability, retrievability)
+            .update_episodic_access_in_namespace(id, namespace_id, stability, retrievability)
     }
     fn save_semantic(&self, mem: &SemanticMemory) -> StorageResult<()> {
         self.inner.save_semantic(mem)
@@ -190,15 +197,14 @@ impl StorageTrait for RacingStorage {
     ) -> StorageResult<Option<SemanticMemory>> {
         self.inner.get_semantic_in_namespace(id, namespace_id)
     }
-    fn list_semantic_by_entity(
+    fn list_semantic_by_entity_in_namespace(
         &self,
         subject: Uuid,
+        namespace_id: Uuid,
         limit: usize,
     ) -> StorageResult<Vec<SemanticMemory>> {
-        self.inner.list_semantic_by_entity(subject, limit)
-    }
-    fn invalidate_semantic(&self, id: Uuid) -> StorageResult<()> {
-        self.inner.invalidate_semantic(id)
+        self.inner
+            .list_semantic_by_entity_in_namespace(subject, namespace_id, limit)
     }
     fn save_procedural(&self, mem: &ProceduralMemory) -> StorageResult<()> {
         self.inner.save_procedural(mem)
@@ -210,15 +216,21 @@ impl StorageTrait for RacingStorage {
     ) -> StorageResult<Option<ProceduralMemory>> {
         self.inner.get_procedural_in_namespace(id, namespace_id)
     }
-    fn update_procedural_reliability(
+    fn update_procedural_reliability_in_namespace(
         &self,
         id: Uuid,
+        namespace_id: Uuid,
         reliability: f32,
         trial_count: u32,
         success_count: u32,
     ) -> StorageResult<()> {
-        self.inner
-            .update_procedural_reliability(id, reliability, trial_count, success_count)
+        self.inner.update_procedural_reliability_in_namespace(
+            id,
+            namespace_id,
+            reliability,
+            trial_count,
+            success_count,
+        )
     }
     fn save_observation(&self, mem: &ObservationMemory) -> StorageResult<()> {
         self.inner.save_observation(mem)
@@ -255,9 +267,6 @@ impl StorageTrait for RacingStorage {
     ) -> StorageResult<usize> {
         self.inner
             .delete_observations_by_episode(namespace_id, episode_id)
-    }
-    fn delete_observations_by_entity(&self, entity_id: Uuid) -> StorageResult<usize> {
-        self.inner.delete_observations_by_entity(entity_id)
     }
     fn search_fts(
         &self,
@@ -364,19 +373,6 @@ impl StorageTrait for RacingStorage {
     }
     fn purge_namespace(&self, namespace_id: Uuid) -> StorageResult<usize> {
         self.inner.purge_namespace(namespace_id)
-    }
-    fn update_semantic_content(
-        &self,
-        id: Uuid,
-        predicate: &str,
-        object: &str,
-        confidence: Option<f32>,
-    ) -> StorageResult<()> {
-        self.inner
-            .update_semantic_content(id, predicate, object, confidence)
-    }
-    fn delete_entity(&self, id: Uuid) -> StorageResult<bool> {
-        self.inner.delete_entity(id)
     }
     fn list_entities_by_namespace(&self, namespace_id: Uuid) -> StorageResult<Vec<Entity>> {
         self.inner.list_entities_by_namespace(namespace_id)

--- a/pensyve-mcp-tools/src/server.rs
+++ b/pensyve-mcp-tools/src/server.rs
@@ -845,7 +845,11 @@ impl PensyveMcpServer {
         let mut remaining = limit;
 
         if remaining > 0 && (type_filter.is_none() || type_filter == Some("episodic")) {
-            match state.storage.list_episodic_by_entity(entity.id, remaining) {
+            match state.storage.list_episodic_by_entity_in_namespace(
+                entity.id,
+                state.namespace.id,
+                remaining,
+            ) {
                 Ok(episodics) => {
                     for mem in episodics {
                         let mut val = serde_json::to_value(&mem).unwrap_or_default();
@@ -862,7 +866,11 @@ impl PensyveMcpServer {
         }
 
         if remaining > 0 && (type_filter.is_none() || type_filter == Some("semantic")) {
-            match state.storage.list_semantic_by_entity(entity.id, remaining) {
+            match state.storage.list_semantic_by_entity_in_namespace(
+                entity.id,
+                state.namespace.id,
+                remaining,
+            ) {
                 Ok(semantics) => {
                     for mem in semantics {
                         let mut val = serde_json::to_value(&mem).unwrap_or_default();
@@ -926,10 +934,18 @@ impl PensyveMcpServer {
             // Stats for a specific entity
             if let Ok(Some(entity)) = state.storage.get_entity_by_name(entity_name, ns.id) {
                 entity_count = 1;
-                if let Ok(mems) = state.storage.list_semantic_by_entity(entity.id, usize::MAX) {
+                if let Ok(mems) =
+                    state
+                        .storage
+                        .list_semantic_by_entity_in_namespace(entity.id, ns.id, usize::MAX)
+                {
                     semantic_count = mems.len();
                 }
-                if let Ok(mems) = state.storage.list_episodic_by_entity(entity.id, usize::MAX) {
+                if let Ok(mems) =
+                    state
+                        .storage
+                        .list_episodic_by_entity_in_namespace(entity.id, ns.id, usize::MAX)
+                {
                     episodic_count = mems.len();
                 }
             }

--- a/pensyve-mcp/tests/integration_test.rs
+++ b/pensyve-mcp/tests/integration_test.rs
@@ -128,7 +128,7 @@ async fn test_remember_creates_semantic_memory() {
     // Verify retrieval.
     let stored = state
         .storage
-        .list_semantic_by_entity(entity.id, 10)
+        .list_semantic_by_entity_in_namespace(entity.id, state.namespace.id, 10)
         .expect("list semantic");
 
     assert_eq!(stored.len(), 1, "should have exactly one semantic memory");
@@ -235,7 +235,7 @@ async fn test_forget_removes_all_memories_for_entity() {
     // Confirm they're there.
     let before = state
         .storage
-        .list_semantic_by_entity(entity.id, 10)
+        .list_semantic_by_entity_in_namespace(entity.id, state.namespace.id, 10)
         .expect("list semantic");
     assert_eq!(before.len(), 2);
 
@@ -249,7 +249,7 @@ async fn test_forget_removes_all_memories_for_entity() {
     // Confirm they're gone.
     let after = state
         .storage
-        .list_semantic_by_entity(entity.id, 10)
+        .list_semantic_by_entity_in_namespace(entity.id, state.namespace.id, 10)
         .expect("list semantic after delete");
     assert!(after.is_empty(), "no memories should remain after forget");
 }
@@ -295,7 +295,7 @@ async fn test_inspect_lists_semantic_memories_for_entity() {
     let limit = 20_usize;
     let semantics = state
         .storage
-        .list_semantic_by_entity(entity.id, limit)
+        .list_semantic_by_entity_in_namespace(entity.id, state.namespace.id, limit)
         .expect("list semantic");
 
     assert_eq!(semantics.len(), 2);


### PR DESCRIPTION
Refs #254 — completes the code half. The ops half (create the `pensyve_app` NOBYPASSRLS role, apply enforcement, flip the connection string) is the runbook in #254's comments; this PR removes every code blocker in its way.

**The nine remaining namespace-less `StorageTrait` methods** (enumerated in `docs/SECURITY.md` until now) are gone as a class:

- **Scoped** (`_in_namespace` variants, predicate in the SQL on both backends, all callers threaded with the namespace they already hold): `get_entity`, `list_episodic_by_entity`, `list_semantic_by_entity`, `update_episodic_access` (the recall path's reinforcement stamp — highest-traffic silent failure under FORCE), `update_procedural_reliability`. Each carries an enforced-mode live-RLS test (write in A; A-scoped call succeeds; B-scoped is a no-op/None/0), with cross-namespace decoy rows so scoping is distinguished from a no-op.
- **Deleted as caller-less** (per the no-corpse rule; verified zero production callers): `delete_entity`, `delete_observations_by_entity`, `invalidate_semantic`, `update_semantic_content` — the atomic capturing erase subsumed the first two; nothing ever called the others. `PostgresBackend::with_default_namespace` is also removed (it existed only to feed the now-deleted `maybe_scoped_conn`; zero references in this workspace and the three sibling repos). This widens the declared major-version API break.

**Schema apply split from serving** so a non-owner role can run the gateway: startup probes a `pensyve_schema_state` digest marker and skips the owner-only DDL batch when the schema text is unchanged; a genuine schema change on a non-owner connection fails loudly with an error naming the owner requirement (never serves against a stale schema). The probe resolves through search_path exactly like the statements it gates — pinned by a live test that relocates the marker and asserts the skip still holds. The migration-safety `row_security` guard window is untouched (guardrail tests intact).

**Startup role self-check:** the backend queries `rolsuper`/`rolbypassrls` for `current_user` at startup and logs a prominent warning when either is true — the flags that make FORCE silently inert are now observable from the app, not just a runbook line.

**`docs/SECURITY.md`:** the unscoped-method list is empty and removed, the "do not apply enforcement" warning is gone, the troubleshooting section is rewritten around the self-check and the digest marker, and the enforce step is documented as owner-run while serving may use `pensyve_app`. FORCE itself stays the operator step until the runbook completes (that flip closes #254).

**Recall-path safety:** paraphrase eval re-run after scoping `update_episodic_access` — corpus-wide top-3 **0.903** (= baseline exactly), MRR 0.883, per-kind parity.

Tests: 39/39 live-RLS running (not skipping) against a real Postgres 17 container, full workspace suites green both feature sets, clippy pedantic clean.