### PR TITLE
fix(codex): update plugin metadata for current schema

### DIFF
--- a/integrations/codex-plugin/.codex-plugin/plugin.json
+++ b/integrations/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pensyve",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Persistent working memory for Codex with Pensyve recall, capture, hooks, skills, commands, and MCP tools",
   "author": {
     "name": "Major7 Apps",
@@ -26,8 +26,7 @@
     "defaultPrompt": [
       "Use Pensyve to recall relevant project memory before we continue.",
       "$pensyve what do you remember about this project?",
-      "/pensyve status",
-      "$pensyve review my memory health and suggest cleanup."
+      "/pensyve status"
     ]
   }
 }

--- a/integrations/codex-plugin/CHANGELOG.md
+++ b/integrations/codex-plugin/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the Pensyve Codex CLI adapter are documented in this file
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). The Codex CLI adapter versions independently of the Claude Code plugin.
 
+## [1.4.3] - 2026-08-27
+
+### Fixed
+
+- Replaced scalar Pensyve tool names in `skills/pensyve/agents/openai.yaml` with Codex's structured MCP dependency metadata so current Codex releases load the skill instead of rejecting its sidecar.
+- Reduced the plugin manifest's default prompts to Codex's supported maximum of three.
+- Added static release checks for the structured Pensyve MCP dependency and default-prompt limit.
+
 ## [1.4.2] - 2026-05-24
 
 ### Fixed

--- a/integrations/codex-plugin/scripts/lint-mcp-refs.sh
+++ b/integrations/codex-plugin/scripts/lint-mcp-refs.sh
@@ -171,6 +171,11 @@ in_dependencies = False
 in_tools = False
 current = None
 
+# This is intentionally a canonical-format validator, not a general YAML parser.
+# The plugin owns this small file and requires dependencies.tools to use block
+# mappings, two-space indentation, quoted scalars, and no inline comments. Keeping
+# that surface exact avoids adding a YAML runtime dependency to the release job.
+
 for number, raw_line in enumerate(lines, start=1):
     if not raw_line.strip() or raw_line.lstrip().startswith("#"):
         continue
@@ -200,7 +205,9 @@ for number, raw_line in enumerate(lines, start=1):
     if match and current is not None:
         current[match.group(1)] = match.group(2)
         continue
-    raise SystemExit(f"unsupported dependencies.tools syntax at {path}:{number}: {raw_line}")
+    raise SystemExit(
+        f"non-canonical dependencies.tools syntax at {path}:{number}: {raw_line}"
+    )
 
 def scalar(value):
     if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
@@ -221,7 +228,7 @@ PY
 then
   echo "  PASS"
 else
-  echo "  FAIL: dependencies.tools must contain exactly one complete Pensyve MCP object"
+  echo "  FAIL: dependencies.tools must use the canonical one-object Pensyve MCP block"
   EXIT_CODE=1
 fi
 echo ""
@@ -235,18 +242,25 @@ import sys
 
 path = pathlib.Path(sys.argv[1])
 manifest = json.loads(path.read_text(encoding="utf-8"))
-prompts = manifest.get("interface", {}).get("defaultPrompt")
-if not isinstance(prompts, list):
-    raise SystemExit("interface.defaultPrompt must be an array")
-if not 1 <= len(prompts) <= 3:
-    raise SystemExit(f"interface.defaultPrompt must contain 1-3 entries, found {len(prompts)}")
+value = manifest.get("interface", {}).get("defaultPrompt")
+if isinstance(value, str):
+    prompts = [value]
+elif isinstance(value, list):
+    prompts = value
+else:
+    raise SystemExit("interface.defaultPrompt must be a string or an array of strings")
+if len(prompts) > 3:
+    raise SystemExit(f"interface.defaultPrompt supports at most 3 entries, found {len(prompts)}")
 for index, prompt in enumerate(prompts):
     if not isinstance(prompt, str):
         raise SystemExit(f"defaultPrompt[{index}] must be a string")
-    if not prompt.strip():
+    normalized = " ".join(prompt.split())
+    if not normalized:
         raise SystemExit(f"defaultPrompt[{index}] must not be empty")
-    if len(prompt) > 128:
-        raise SystemExit(f"defaultPrompt[{index}] exceeds 128 characters ({len(prompt)})")
+    if len(normalized) > 128:
+        raise SystemExit(
+            f"defaultPrompt[{index}] exceeds 128 normalized characters ({len(normalized)})"
+        )
 print(f"validated {len(prompts)} prompts")
 PY
 then

--- a/integrations/codex-plugin/scripts/lint-mcp-refs.sh
+++ b/integrations/codex-plugin/scripts/lint-mcp-refs.sh
@@ -159,27 +159,101 @@ echo ""
 
 # Check 7: current Codex requires structured DependencyTool objects, not scalar tool names.
 echo "Check 7: openai.yaml declares the Pensyve MCP as a structured dependency"
-if grep -Eq '^[[:space:]]*-[[:space:]]+pensyve_[a-z_]+[[:space:]]*$' "$OPENAI_METADATA"; then
-  echo "  FAIL: dependencies.tools contains legacy scalar tool names"
-  EXIT_CODE=1
-elif ! grep -Eq '^[[:space:]]*-[[:space:]]+type:[[:space:]]+"?mcp"?[[:space:]]*$' "$OPENAI_METADATA" \
-  || ! grep -Eq '^[[:space:]]+value:[[:space:]]+"?pensyve"?[[:space:]]*$' "$OPENAI_METADATA" \
-  || ! grep -Eq '^[[:space:]]+url:[[:space:]]+"?https://mcp\.pensyve\.com/mcp"?[[:space:]]*$' "$OPENAI_METADATA"; then
-  echo "  FAIL: structured Pensyve MCP dependency is incomplete"
-  EXIT_CODE=1
-else
+if python3 - "$OPENAI_METADATA" <<'PY'
+import pathlib
+import re
+import sys
+
+path = pathlib.Path(sys.argv[1])
+lines = path.read_text(encoding="utf-8").splitlines()
+items = []
+in_dependencies = False
+in_tools = False
+current = None
+
+for number, raw_line in enumerate(lines, start=1):
+    if not raw_line.strip() or raw_line.lstrip().startswith("#"):
+        continue
+    indent = len(raw_line) - len(raw_line.lstrip(" "))
+    text = raw_line.strip()
+
+    if indent == 0:
+        in_dependencies = text == "dependencies:"
+        in_tools = False
+        current = None
+        continue
+    if not in_dependencies:
+        continue
+    if indent == 2:
+        in_tools = text == "tools:"
+        current = None
+        continue
+    if not in_tools:
+        continue
+
+    match = re.fullmatch(r"- ([a-z_]+):\s*(.+)", text) if indent == 4 else None
+    if match:
+        current = {match.group(1): match.group(2)}
+        items.append(current)
+        continue
+    match = re.fullmatch(r"([a-z_]+):\s*(.+)", text) if indent == 6 else None
+    if match and current is not None:
+        current[match.group(1)] = match.group(2)
+        continue
+    raise SystemExit(f"unsupported dependencies.tools syntax at {path}:{number}: {raw_line}")
+
+def scalar(value):
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
+        return value[1:-1]
+    return value
+
+parsed = [{key: scalar(value) for key, value in item.items()} for item in items]
+expected = [{
+    "type": "mcp",
+    "value": "pensyve",
+    "description": "Pensyve persistent-memory MCP server",
+    "transport": "streamable_http",
+    "url": "https://mcp.pensyve.com/mcp",
+}]
+if parsed != expected:
+    raise SystemExit(f"expected exactly one Pensyve MCP dependency, found: {parsed!r}")
+PY
+then
   echo "  PASS"
+else
+  echo "  FAIL: dependencies.tools must contain exactly one complete Pensyve MCP object"
+  EXIT_CODE=1
 fi
 echo ""
 
-# Check 8: Codex currently accepts at most three plugin default prompts.
-echo "Check 8: plugin manifest has at most three default prompts"
-DEFAULT_PROMPT_COUNT="$(python3 -c 'import json, sys; print(len(json.load(open(sys.argv[1]))["interface"]["defaultPrompt"]))' "$PLUGIN_MANIFEST")"
-if [ "$DEFAULT_PROMPT_COUNT" -gt 3 ]; then
-  echo "  FAIL: found $DEFAULT_PROMPT_COUNT default prompts; Codex supports at most 3"
-  EXIT_CODE=1
+# Check 8: Codex accepts up to three non-empty string prompts, each at most 128 characters.
+echo "Check 8: plugin manifest default prompts satisfy Codex constraints"
+if python3 - "$PLUGIN_MANIFEST" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+manifest = json.loads(path.read_text(encoding="utf-8"))
+prompts = manifest.get("interface", {}).get("defaultPrompt")
+if not isinstance(prompts, list):
+    raise SystemExit("interface.defaultPrompt must be an array")
+if not 1 <= len(prompts) <= 3:
+    raise SystemExit(f"interface.defaultPrompt must contain 1-3 entries, found {len(prompts)}")
+for index, prompt in enumerate(prompts):
+    if not isinstance(prompt, str):
+        raise SystemExit(f"defaultPrompt[{index}] must be a string")
+    if not prompt.strip():
+        raise SystemExit(f"defaultPrompt[{index}] must not be empty")
+    if len(prompt) > 128:
+        raise SystemExit(f"defaultPrompt[{index}] exceeds 128 characters ({len(prompt)})")
+print(f"validated {len(prompts)} prompts")
+PY
+then
+  echo "  PASS"
 else
-  echo "  PASS: $DEFAULT_PROMPT_COUNT default prompts"
+  echo "  FAIL: invalid interface.defaultPrompt"
+  EXIT_CODE=1
 fi
 echo ""
 

--- a/integrations/codex-plugin/scripts/lint-mcp-refs.sh
+++ b/integrations/codex-plugin/scripts/lint-mcp-refs.sh
@@ -203,7 +203,10 @@ for number, raw_line in enumerate(lines, start=1):
         continue
     match = re.fullmatch(r"([a-z_]+):\s*(.+)", text) if indent == 6 else None
     if match and current is not None:
-        current[match.group(1)] = match.group(2)
+        key = match.group(1)
+        if key in current:
+            raise SystemExit(f"duplicate dependencies.tools key at {path}:{number}: {key}")
+        current[key] = match.group(2)
         continue
     raise SystemExit(
         f"non-canonical dependencies.tools syntax at {path}:{number}: {raw_line}"

--- a/integrations/codex-plugin/scripts/lint-mcp-refs.sh
+++ b/integrations/codex-plugin/scripts/lint-mcp-refs.sh
@@ -22,6 +22,8 @@ MENTION_DOC_FILES=(
   "$PLUGIN_ROOT/commands/pensyve.md"
   "$PLUGIN_ROOT/docs/ARCHITECTURE.md"
 )
+OPENAI_METADATA="$PLUGIN_ROOT/skills/pensyve/agents/openai.yaml"
+PLUGIN_MANIFEST="$PLUGIN_ROOT/.codex-plugin/plugin.json"
 
 EXIT_CODE=0
 
@@ -152,6 +154,32 @@ done
 if [ "$MISSING_MENTION_DOC" != "0" ]; then
   echo "  FAIL: mention workflow must document that true @-mention dispatch is not currently exposed in every mention surface"
   EXIT_CODE=1
+fi
+echo ""
+
+# Check 7: current Codex requires structured DependencyTool objects, not scalar tool names.
+echo "Check 7: openai.yaml declares the Pensyve MCP as a structured dependency"
+if grep -Eq '^[[:space:]]*-[[:space:]]+pensyve_[a-z_]+[[:space:]]*$' "$OPENAI_METADATA"; then
+  echo "  FAIL: dependencies.tools contains legacy scalar tool names"
+  EXIT_CODE=1
+elif ! grep -Eq '^[[:space:]]*-[[:space:]]+type:[[:space:]]+"?mcp"?[[:space:]]*$' "$OPENAI_METADATA" \
+  || ! grep -Eq '^[[:space:]]+value:[[:space:]]+"?pensyve"?[[:space:]]*$' "$OPENAI_METADATA" \
+  || ! grep -Eq '^[[:space:]]+url:[[:space:]]+"?https://mcp\.pensyve\.com/mcp"?[[:space:]]*$' "$OPENAI_METADATA"; then
+  echo "  FAIL: structured Pensyve MCP dependency is incomplete"
+  EXIT_CODE=1
+else
+  echo "  PASS"
+fi
+echo ""
+
+# Check 8: Codex currently accepts at most three plugin default prompts.
+echo "Check 8: plugin manifest has at most three default prompts"
+DEFAULT_PROMPT_COUNT="$(python3 -c 'import json, sys; print(len(json.load(open(sys.argv[1]))["interface"]["defaultPrompt"]))' "$PLUGIN_MANIFEST")"
+if [ "$DEFAULT_PROMPT_COUNT" -gt 3 ]; then
+  echo "  FAIL: found $DEFAULT_PROMPT_COUNT default prompts; Codex supports at most 3"
+  EXIT_CODE=1
+else
+  echo "  PASS: $DEFAULT_PROMPT_COUNT default prompts"
 fi
 echo ""
 

--- a/integrations/codex-plugin/scripts/lint-mcp-refs.sh
+++ b/integrations/codex-plugin/scripts/lint-mcp-refs.sh
@@ -212,7 +212,7 @@ for number, raw_line in enumerate(lines, start=1):
 def scalar(value):
     if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
         return value[1:-1]
-    return value
+    raise SystemExit(f"canonical dependencies.tools scalars must be quoted: {value!r}")
 
 parsed = [{key: scalar(value) for key, value in item.items()} for item in items]
 expected = [{

--- a/integrations/codex-plugin/skills/pensyve/agents/openai.yaml
+++ b/integrations/codex-plugin/skills/pensyve/agents/openai.yaml
@@ -7,9 +7,8 @@ policy:
   allow_implicit_invocation: true
 dependencies:
   tools:
-    - pensyve_recall
-    - pensyve_remember
-    - pensyve_observe
-    - pensyve_inspect
-    - pensyve_status
-    - pensyve_forget
+    - type: "mcp"
+      value: "pensyve"
+      description: "Pensyve persistent-memory MCP server"
+      transport: "streamable_http"
+      url: "https://mcp.pensyve.com/mcp"


### PR DESCRIPTION
Installing the Codex adapter can currently leave users in a misleading half-working state: the Pensyve MCP transport initializes, but `$pensyve` and implicit memory routing are unavailable because Codex rejects the skill metadata.

Codex 0.149.1 expects each `dependencies.tools` entry in `agents/openai.yaml` to be a structured dependency object. Adapter 1.4.2 instead lists individual tool names as scalar strings, producing `invalid type: string ... expected struct DependencyTool`. Its manifest also declares four default prompts where current Codex accepts at most three.

This changes the skill metadata to declare the Pensyve streamable-HTTP MCP server once as a structured dependency, reduces the default prompts to three, bumps the adapter to 1.4.3, and adds release checks for both constraints.

The Pensyve MCP endpoint, tool contracts, authentication, stored memories, and runtime behavior are deliberately unchanged. This is a Codex adapter compatibility repair.

Verification at commit `8b4d1d4`:

- `bash integrations/codex-plugin/scripts/lint-mcp-refs.sh` — all eight checks passed
- split dependency fields across two YAML objects are rejected
- non-canonical dependency syntax is rejected by the documented canonical-format gate
- scalar and empty-list default-prompt forms accepted by Codex are accepted
- a non-string default prompt is rejected
- installed the resulting adapter locally as 1.4.3
- explicit `$pensyve` status returned healthy
- a fresh setup question that did not name Pensyve automatically invoked `pensyve_recall`

Follow-up after merge is publishing the 1.4.3 Codex adapter so marketplace refreshes receive the repaired metadata.

Authored with OpenAI Codex.

Fixes #301