### PR TITLE
chore(deps): upgrade fastembed to 6.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1267,11 +1267,10 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastembed"
-version = "5.17.4"
+version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4539f4a2c4472269adc227587b935c0a973e6b5fc4a03e14bbe62608e06c2298"
+checksum = "86e4df99af9b19c94ef9d5c3fec8732816595e31101847fe0d05326a040ef720"
 dependencies = [
- "anyhow",
  "hf-hub",
  "image",
  "ndarray",
@@ -1279,6 +1278,7 @@ dependencies = [
  "safetensors",
  "serde",
  "serde_json",
+ "thiserror 2.0.20",
  "tokenizers",
 ]
 
@@ -4272,7 +4272,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4272,7 +4272,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/pensyve-core/Cargo.toml
+++ b/pensyve-core/Cargo.toml
@@ -46,7 +46,7 @@ regex = "1"
 # requirement now that CI runs `test_no_network_invariants` against a
 # seeded cache on every PR (see `.github/workflows/ci.yml`) and will fail
 # the build if cached-model resolution ever regresses again.
-fastembed = "5.17.3"
+fastembed = "=6.0.1"
 petgraph = "0.8"
 # Phase 2B: compile-time predicate-verb lexicon for the shallow dependency
 # parser (`extraction::dep_parse`). `phf::Map` keys are interned at build

--- a/pensyve-core/Cargo.toml
+++ b/pensyve-core/Cargo.toml
@@ -42,10 +42,10 @@ regex = "1"
 # the latent test race documented in
 # `tests/test_no_network_invariants.rs`) rather than a real fastembed
 # regression -- PR #190's own body already concluded no transitive
-# dependency change could explain it. Unpinned back to a normal caret
-# requirement now that CI runs `test_no_network_invariants` against a
-# seeded cache on every PR (see `.github/workflows/ci.yml`) and will fail
-# the build if cached-model resolution ever regresses again.
+# dependency change could explain it. Pinned to exact 6.0.1 for this reviewed
+# migration because a normal caret requirement now admits unreviewed 6.0.2.
+# Revisit the pin separately; CI runs `test_no_network_invariants` against a
+# seeded cache on every PR (see `.github/workflows/ci.yml`).
 fastembed = "=6.0.1"
 petgraph = "0.8"
 # Phase 2B: compile-time predicate-verb lexicon for the shallow dependency


### PR DESCRIPTION
## Summary

- upgrade `fastembed` from locked 5.17.4 to exactly 6.0.1
- retain the existing embedding/reranker adapters because the typed fastembed 6 error enum already compiles through their `.to_string()` mappings
- refresh only the root Cargo lock resolution; no Rust source, test, benchmark, baseline, workflow, or release changes

This integrates the update tracked by Dependabot PR #307. It intentionally uses
`=6.0.1`: the ordinary Cargo requirement `"6.0.1"` now admits the newly
published 6.0.2, while this reviewed task is scoped to 6.0.1.

Upstream evidence:

- [5.17.4...6.0.1](https://github.com/Anush008/fastembed-rs/compare/v5.17.4...v6.0.1)
- [6.0.0...6.0.1](https://github.com/Anush008/fastembed-rs/compare/v6.0.0...v6.0.1)
- fastembed 6.0.0 replaces the `anyhow::Error` alias with a typed error enum
- fastembed 6.0.1 exposes ORT placement controls for user-defined text models

## Compiler and lock evidence

The plan expected a compiler RED after the manifest/lock-only update, but
`cargo check -p pensyve-core` passed before any source edit. Existing
`.to_string()` adapters accept the new enum, so no failure or source migration
was fabricated. The final `cargo check -p pensyve-core --locked` also passes,
and `cargo tree -p pensyve-core --locked` resolves `fastembed v6.0.1`.

The final lock diff changes only fastembed's package entry: it removes
fastembed's `anyhow` edge and adds the already-integrated `thiserror 2.0.20`
edge. The initial commit also contained unrelated resolver churn changing
`tempfile 3.27.0` from `getrandom 0.3.4` to the already-present 0.4.2.

Independent spec review challenged the evidence for that line. A disposable
copy changed only tempfile's edge back to 0.3.4 and passed `cargo check -p
pensyve-core --locked` without rewriting the lock. The earlier contrary result
came from a contextless experiment that had actually changed `rand 0.10.2`'s
required 0.4.2 edge. A normal-pushed cleanup commit restores tempfile's base
edge and corrects the adjacent manifest comment to explain the exact 6.0.1
pin. No force push was used.

## Real-model and no-egress proof

A fresh isolated cache was seeded in one online Rust process with only:

- `Qdrant/all-MiniLM-L6-v2-onnx`
- `BAAI/bge-reranker-base`

Both models loaded and ran inference. No GTE or Jina model was seeded, and no
cache artifact is committed.

The prebuilt no-network invariant suite then ran in a privileged container with
`--network none`, read-only root, all capabilities dropped,
`no-new-privileges`, and HTTP/HTTPS/SOCKS proxy guards at `127.0.0.1:9`:

- no-network invariants: 6/6 passed
- MiniLM and BGE loaded and inferred without an egress attempt or proxy error

A separate hardened no-network CLI lifecycle used the exact `fd1530b` release
binary, the same read-only isolated cache, and fresh state; it exited 0 at
`2026-08-28T17:22:39Z`:

- `status` started namespace `task9-fastembed6-fd1530b`
- `remember` stored a synthetic fact
- `recall "offline fastembed migration"` returned it with vector score
  `0.6256477833` and total score `4.9153709412`
- no mock-embedder or reranker-unavailable warning appeared

## Paraphrase and binary-size gates

The committed reranked paraphrase baseline gate passed without rewriting the
baseline: overall top-3 `0.903`, MRR `0.882`, paraphrase top-3 `0.885`, against
baseline top-3 `0.903` with allowed margin `0.030`.

| Shipped binary | 5.17.4 bytes | 6.0.1 bytes | Delta |
| --- | ---: | ---: | ---: |
| CLI `pensyve` | 41,719,488 | 41,640,840 | -78,648 |
| MCP `pensyve-mcp` | 45,756,112 | 45,620,424 | -135,688 |
| Gateway | 66,546,640 | 66,422,856 | -123,784 |

The exact-head isolated release build completed at `2026-08-28T17:21:03Z`.
All three remain below the 300,000,000-byte ceiling. Exact-head SHA-256:

- CLI: `6e79f1e1c658bff5ffd4cb6ce16bde507fe4aba7d8fe2e8f0c3d82e5e0f2f4c1`
- MCP: `2b5236e4a357d0e9f3c62278fa7a7cd72332df909751f504c62f45545d6889a4`
- gateway: `9d016b461ac2d9039ed693a230dff068f0f160cbf07e9e753636f37cca97fb2b`

## Validation

- [x] `cargo check -p pensyve-core --locked`
- [x] embedding tests: 13 passed, 7 ignored
- [x] reranker tests: 6 passed, 1 ignored
- [x] isolated real MiniLM+BGE inference
- [x] privileged no-network suite: 6 passed
- [x] reranked committed paraphrase baseline gate
- [x] `cargo test --workspace`
- [x] live PostgreSQL core suite: 610 passed, 8 ignored, plus integration/doc tests
- [x] gateway/tools focused suite: gateway 167 + tools 26 passed
- [x] `cargo fmt --all -- --check`
- [x] Python Ruff/Pyright/Maturin/pytest: 122 passed, 0 type errors/warnings
- [x] TypeScript frozen install/lint/build/test: 101 passed
- [x] Go tests
- [x] WASM Node tests
- [x] gateway build
- [x] all three shipped release builds and size ceiling

Local Rust/Clippy 1.97.1 does not recognize the unchanged-main lint
`clippy::unused_async_trait_impl` at `pensyve-mcp-tools/src/server.rs:1019`.
That file is outside this diff. Corrected head `fd1530b` passed exact-head CI
[run 33193961880](https://github.com/major7apps/pensyve/actions/runs/33193961880):
all eleven jobs succeeded, including Rust 1.98 Lint/Clippy, model tests,
privileged no-network invariants, paraphrase, Postgres, gateway, Python,
TypeScript, Go, WASM, and the full Rust suite. Exact-head Claude re-review
[run 33193961726](https://github.com/major7apps/pensyve/actions/runs/33193961726)
also completed successfully and confirmed the comment and lock cleanup.

## Scope guard

This PR does not run issue #224's model-swap study, seed Jina, modify any
benchmark fixture or baseline, touch PR #309, or change AWS, npm, registry,
tag, release, or production state. Do not merge before independent SDD review
and Task 10 production preflight.
