### PR TITLE
fix: bind image ref in gateway build result

### DIFF
--- a/pensyve-mcp-gateway/scripts/gateway-image-artifact.sh
+++ b/pensyve-mcp-gateway/scripts/gateway-image-artifact.sh
@@ -671,6 +671,7 @@ build_archive() {
     [[ "sha256:${config_sha}" == "${image_id}" ]] || die "exported config does not match image ID"
 
     jq -n --arg source_sha "${source_sha}" --arg archive "${archive}" \
+        --arg image_ref "${image_ref}" \
         --arg archive_sha "${archive_sha}" --arg config "${config_path}" \
         --arg config_id "${image_id}" --arg raw_manifest "${raw_manifest}" \
         --arg manifest_sha "$(sha256_file "${raw_manifest}")" --arg media "${media_type}" \

--- a/pensyve-mcp-gateway/scripts/test-gateway-artifact-flow.sh
+++ b/pensyve-mcp-gateway/scripts/test-gateway-artifact-flow.sh
@@ -66,6 +66,14 @@ def require(condition, message):
     if not condition:
         errors.append(message)
 
+build_archive = re.search(r"\nbuild_archive\(\) \{(?P<body>.*?)\n\}\n", artifact, re.S)
+build_result = re.search(
+    r'jq -n (?P<command>.*?) > "\$\{evidence_dir\}/build-result\.json"',
+    build_archive.group("body") if build_archive else "", re.S,
+)
+require(build_result is not None and '--arg image_ref "${image_ref}"' in build_result.group("command"),
+        "build-result jq must bind image_ref")
+
 on = mapping(deploy.get("on"))
 require(set(on) == {"workflow_dispatch"}, "deploy workflow must be manual-only")
 inputs = mapping(mapping(on.get("workflow_dispatch")).get("inputs"))


### PR DESCRIPTION
## Summary

- bind `image_ref` in the `jq` command that writes the local gateway build result
- add a focused source contract scoped to `build_archive()` and the exact `build-result.json` redirect

## Why

The first exact-main local-only image build completed image assembly but the artifact script exited 3 before proof because `$image_ref` was referenced without a matching `--arg` binding. That candidate remains rejected and was not retried.

## Proof

- RED: focused structural test exited 1 with `build-result jq must bind image_ref`
- GREEN: focused structural test passed after the one-line binding
- full local source-only artifact suite passed with 51 expected rejection checks
- Bash syntax and `git diff --check` passed
- independent review: Critical 0, Important 0, Minor 0; ready to push

No Docker build, model test, AWS, ECR, ECS, deployment, or production action was performed for this fix.
