### PR TITLE
fix: allow autoscaled gateway stabilization

### DIFF
--- a/pensyve-core/src/embedding.rs
+++ b/pensyve-core/src/embedding.rs
@@ -976,16 +976,14 @@ mod tests {
 
     #[test]
     fn test_sentence_transformers_alias() {
-        // "sentence-transformers/all-MiniLM-L6-v2" should resolve to the same model.
-        let result = OnnxEmbedder::new("sentence-transformers/all-MiniLM-L6-v2");
-        // This would succeed if the model is downloaded, but we only check it doesn't
-        // return "Unknown model" error.
-        if let Err(e) = &result {
-            assert!(
-                !e.to_string().contains("Unknown model"),
-                "sentence-transformers alias should be recognized"
-            );
-        }
+        let (model, dimensions, hf_model_code, model_file) =
+            resolve_model("sentence-transformers/all-MiniLM-L6-v2")
+                .expect("sentence-transformers alias should resolve");
+
+        assert!(matches!(model, EmbeddingModel::AllMiniLML6V2));
+        assert_eq!(dimensions, 384);
+        assert_eq!(hf_model_code, "Qdrant/all-MiniLM-L6-v2-onnx");
+        assert_eq!(model_file, "model.onnx");
     }
 
     #[test]

--- a/pensyve-mcp-gateway/scripts/guard-active-service.py
+++ b/pensyve-mcp-gateway/scripts/guard-active-service.py
@@ -122,9 +122,16 @@ def validate_service(
     service = as_object(services[0], "service")
     if service.get("serviceName") != SERVICE or service.get("status") != "ACTIVE":
         fail("service identity/status mismatch")
-    counts = [service.get(name) for name in ("desiredCount", "runningCount", "pendingCount")]
-    if counts != [2, 2, 0] or any(type(value) is not int for value in counts):
-        fail("desired/running/pending must be exactly 2/2/0")
+    desired = service.get("desiredCount")
+    running = service.get("runningCount")
+    pending = service.get("pendingCount")
+    if type(desired) is not int or not 2 <= desired <= 4:
+        fail("desiredCount must be an exact integer in range 2..4")
+    if type(running) is not int or running != desired:
+        fail("runningCount must equal desiredCount")
+    if type(pending) is not int or pending != 0:
+        fail("pendingCount must be exactly 0")
+    counts = [desired, running, pending]
     deployments = as_list(service.get("deployments"), "deployments")
     if len(deployments) != 1:
         fail("service must have a single deployment")
@@ -135,10 +142,11 @@ def validate_service(
     if (
         primary.get("status") != "PRIMARY"
         or primary.get("rolloutState") != "COMPLETED"
-        or primary_counts != [2, 2, 0]
         or any(type(value) is not int for value in primary_counts)
     ):
-        fail("service must have one completed PRIMARY deployment at 2/2/0")
+        fail("service must have one completed PRIMARY deployment")
+    if primary_counts != counts:
+        fail("PRIMARY deployment counts must equal service counts")
     active_arn = service.get("taskDefinition")
     if not isinstance(active_arn, str):
         fail("active task definition ARN is absent")

--- a/pensyve-mcp-gateway/scripts/promote-gateway-image.sh
+++ b/pensyve-mcp-gateway/scripts/promote-gateway-image.sh
@@ -12,6 +12,8 @@ readonly AWS_BIN="${AWS_BIN:-aws}"
 readonly SOURCE_ACCOUNT="196881464893"
 readonly SOURCE_TAG="63011d55f8cbf52f6f9e5609621f6b8cf0c37535"
 readonly SOURCE_DIGEST="sha256:6f5f36741bc4c5d39455b2f2fd41108561ea6ea28d438f815462b9febe3e329b"
+readonly STABILIZATION_ATTEMPTS="${PENSYVE_PROMOTION_STABILIZATION_ATTEMPTS:-8}"
+readonly STABILIZATION_INTERVAL_SECONDS="${PENSYVE_PROMOTION_STABILIZATION_INTERVAL_SECONDS:-5}"
 
 die() {
     echo "gateway promotion error: $*" >&2
@@ -34,6 +36,10 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 [[ -f "${CUSTODY}" ]] || die "canonical custody JSON is required"
+[[ "${STABILIZATION_ATTEMPTS}" =~ ^([1-9]|1[0-2])$ ]] ||
+    die "stabilization attempts must be an integer in 1..12"
+[[ "${STABILIZATION_INTERVAL_SECONDS}" =~ ^([0-9]|[12][0-9]|30)$ ]] ||
+    die "stabilization interval must be an integer in 0..30 seconds"
 
 TEMP_ROOT="$(mktemp -d /tmp/pensyve-gateway-promote.XXXXXX)" \
     || die "could not create promotion temporary root"
@@ -212,14 +218,17 @@ update_once() {
 }
 
 wait_stable() {
+    local attempt status
     aws_call ecs wait services-stable --region "${REGION}" --cluster "${CLUSTER}" \
         --services "${SERVICE}"
     [[ -n "${TARGET_GROUP_ARN}" ]] || die "production target group is not bound"
-    aws_call ecs describe-services --region "${REGION}" --cluster "${CLUSTER}" \
-        --services "${SERVICE}" --output json > "${TEMP_ROOT}/stable-service.json"
-    aws_call elbv2 describe-target-health --region "${REGION}" \
-        --target-group-arn "${TARGET_GROUP_ARN}" --output json > "${TEMP_ROOT}/targets.json"
-    python3 - "${TEMP_ROOT}/stable-service.json" "${TEMP_ROOT}/targets.json" <<'PY'
+    for ((attempt = 1; attempt <= STABILIZATION_ATTEMPTS; attempt++)); do
+        aws_call ecs describe-services --region "${REGION}" --cluster "${CLUSTER}" \
+            --services "${SERVICE}" --output json > "${TEMP_ROOT}/stable-service.json"
+        aws_call elbv2 describe-target-health --region "${REGION}" \
+            --target-group-arn "${TARGET_GROUP_ARN}" --output json > "${TEMP_ROOT}/targets.json"
+        status=0
+        if python3 - "${TEMP_ROOT}/stable-service.json" "${TEMP_ROOT}/targets.json" <<'PY'
 import json
 import sys
 from pathlib import Path
@@ -242,21 +251,53 @@ if (type(desired) is not int or not 2 <= desired <= 4 or
     raise SystemExit("gateway promotion error: stable ECS counts are outside the steady 2..4 envelope")
 
 target_payload = json.loads(Path(sys.argv[2]).read_text())
-descriptions = target_payload.get("TargetHealthDescriptions")
-if not isinstance(descriptions, list) or len(descriptions) != desired:
-    raise SystemExit("gateway promotion error: ALB target count must equal steady ECS desiredCount")
+if (not isinstance(target_payload, dict) or
+        not isinstance(target_payload.get("TargetHealthDescriptions"), list)):
+    raise SystemExit("gateway promotion error: TargetHealthDescriptions must be a list")
+descriptions = target_payload["TargetHealthDescriptions"]
 identities = []
+states = []
 for description in descriptions:
-    target = description.get("Target", {}) if isinstance(description, dict) else {}
-    health = description.get("TargetHealth", {}) if isinstance(description, dict) else {}
+    if (not isinstance(description, dict) or
+            not isinstance(description.get("Target"), dict) or
+            not isinstance(description.get("TargetHealth"), dict)):
+        raise SystemExit("gateway promotion error: ALB target description is malformed")
+    target = description["Target"]
+    health = description["TargetHealth"]
     identity = target.get("Id")
-    if (not isinstance(identity, str) or not identity or target.get("Port") != 3000 or
-            type(target.get("Port")) is not int or health.get("State") != "healthy"):
-        raise SystemExit("gateway promotion error: ALB target is not healthy on gateway port 3000")
+    if not isinstance(identity, str) or not identity:
+        raise SystemExit("gateway promotion error: ALB target ID must be a nonempty string")
+    port = target.get("Port")
+    if type(port) is not int or port != 3000:
+        raise SystemExit("gateway promotion error: ALB target port must be exact integer 3000")
+    state = health.get("State")
+    if not isinstance(state, str):
+        raise SystemExit("gateway promotion error: ALB target state must be a string")
+    if state not in {"healthy", "initial", "draining"}:
+        raise SystemExit("gateway promotion error: ALB target state is terminal or unknown")
     identities.append(identity)
+    states.append(state)
 if len(set(identities)) != len(identities):
     raise SystemExit("gateway promotion error: ALB healthy target identities must be distinct")
+if len(descriptions) != desired:
+    print("gateway promotion error: ALB target count must equal steady ECS desiredCount",
+          file=sys.stderr)
+    raise SystemExit(75)
+if any(state != "healthy" for state in states):
+    print("gateway promotion error: ALB targets are still converging", file=sys.stderr)
+    raise SystemExit(75)
 PY
+        then
+            return 0
+        else
+            status=$?
+        fi
+        [[ "${status}" -eq 75 ]] || return "${status}"
+        if [[ "${attempt}" -lt "${STABILIZATION_ATTEMPTS}" ]]; then
+            sleep "${STABILIZATION_INTERVAL_SECONDS}"
+        fi
+    done
+    return 75
 }
 
 rollback_once() {

--- a/pensyve-mcp-gateway/scripts/promote-gateway-image.sh
+++ b/pensyve-mcp-gateway/scripts/promote-gateway-image.sh
@@ -215,17 +215,36 @@ wait_stable() {
     aws_call ecs wait services-stable --region "${REGION}" --cluster "${CLUSTER}" \
         --services "${SERVICE}"
     [[ -n "${TARGET_GROUP_ARN}" ]] || die "production target group is not bound"
+    aws_call ecs describe-services --region "${REGION}" --cluster "${CLUSTER}" \
+        --services "${SERVICE}" --output json > "${TEMP_ROOT}/stable-service.json"
     aws_call elbv2 describe-target-health --region "${REGION}" \
         --target-group-arn "${TARGET_GROUP_ARN}" --output json > "${TEMP_ROOT}/targets.json"
-    python3 - "${TEMP_ROOT}/targets.json" <<'PY'
+    python3 - "${TEMP_ROOT}/stable-service.json" "${TEMP_ROOT}/targets.json" <<'PY'
 import json
 import sys
 from pathlib import Path
 
-payload = json.loads(Path(sys.argv[1]).read_text())
-descriptions = payload.get("TargetHealthDescriptions")
-if not isinstance(descriptions, list) or len(descriptions) != 2:
-    raise SystemExit("gateway promotion error: ALB must have exactly two target descriptions")
+service_payload = json.loads(Path(sys.argv[1]).read_text())
+if not isinstance(service_payload, dict) or service_payload.get("failures") not in (None, []):
+    raise SystemExit("gateway promotion error: stable ECS service read returned failures")
+services = service_payload.get("services")
+if not isinstance(services, list) or len(services) != 1 or not isinstance(services[0], dict):
+    raise SystemExit("gateway promotion error: stable ECS service read must return one service")
+service = services[0]
+if service.get("serviceName") != "pensyve-prod-gateway" or service.get("status") != "ACTIVE":
+    raise SystemExit("gateway promotion error: stable ECS service identity/status mismatch")
+desired = service.get("desiredCount")
+running = service.get("runningCount")
+pending = service.get("pendingCount")
+if (type(desired) is not int or not 2 <= desired <= 4 or
+        type(running) is not int or running != desired or
+        type(pending) is not int or pending != 0):
+    raise SystemExit("gateway promotion error: stable ECS counts are outside the steady 2..4 envelope")
+
+target_payload = json.loads(Path(sys.argv[2]).read_text())
+descriptions = target_payload.get("TargetHealthDescriptions")
+if not isinstance(descriptions, list) or len(descriptions) != desired:
+    raise SystemExit("gateway promotion error: ALB target count must equal steady ECS desiredCount")
 identities = []
 for description in descriptions:
     target = description.get("Target", {}) if isinstance(description, dict) else {}
@@ -235,7 +254,7 @@ for description in descriptions:
             type(target.get("Port")) is not int or health.get("State") != "healthy"):
         raise SystemExit("gateway promotion error: ALB target is not healthy on gateway port 3000")
     identities.append(identity)
-if len(set(identities)) != 2:
+if len(set(identities)) != len(identities):
     raise SystemExit("gateway promotion error: ALB healthy target identities must be distinct")
 PY
 }

--- a/pensyve-mcp-gateway/scripts/test-gateway-artifact-flow.sh
+++ b/pensyve-mcp-gateway/scripts/test-gateway-artifact-flow.sh
@@ -238,7 +238,8 @@ for forbidden in ("\ndocker ", "buildx", "ecr put-image", "ecr initiate-layer-up
             f"promoter contains forbidden Docker/ECR-write path: {forbidden}")
 for mode in ("task8-create", "task8-rollback", "task9-promote", "task9-rollback"):
     require(mode in promote, f"promoter is missing mode {mode}")
-for forbidden in ("desired-count", "latest", ":157"):
+for forbidden in ("desired-count", "force-new-deployment", "application-autoscaling",
+                  "register-scalable-target", "put-scaling-policy", "latest", ":157"):
     require(forbidden not in promote,
             f"promoter contains forbidden selector/override: {forbidden}")
 for required in ("guard-active-service.py", "register-task-definition",
@@ -317,7 +318,7 @@ candidate["containerDefinitions"][0]["image"] = (
 )
 for name, task in (("156", base), ("200", task8), ("201", candidate)):
     (root / f"task-{name}.json").write_text(json.dumps({"taskDefinition": task}))
-(root / "service.json").write_text(json.dumps({"failures": [], "services": [{
+service = {"failures": [], "services": [{
     "serviceName": "pensyve-prod-gateway", "status": "ACTIVE",
     "taskDefinition": prefix + "156", "desiredCount": 2, "runningCount": 2,
     "pendingCount": 0, "loadBalancers": [{"targetGroupArn": target_group,
@@ -325,7 +326,13 @@ for name, task in (("156", base), ("200", task8), ("201", candidate)):
     "deployments": [{"status": "PRIMARY",
         "rolloutState": "COMPLETED", "taskDefinition": prefix + "156",
         "desiredCount": 2, "runningCount": 2, "pendingCount": 0}],
-}]}))
+}]}
+(root / "service.json").write_text(json.dumps(service))
+service4 = json.loads(json.dumps(service))
+for owner in (service4["services"][0], service4["services"][0]["deployments"][0]):
+    owner["desiredCount"] = 4
+    owner["runningCount"] = 4
+(root / "service-4.json").write_text(json.dumps(service4))
 PY
     printf '%s\n' \
         '#!/usr/bin/env bash' \
@@ -371,22 +378,67 @@ expected = [
 if calls != expected:
     raise SystemExit(f"guard complete ordered AWS sequence mismatch: {calls!r}")
 PY
+    AWS_BIN="${root}/bin/aws" AWS_LOG="${root}/aws.log" \
+        SERVICE_FIXTURE="${root}/service-4.json" TASK_FIXTURE_ROOT="${root}" \
+        "${GUARD_SCRIPT}" source-156 >/dev/null
     sed 's/:156"/:157"/g; s/"revision": 156/"revision": 157/' \
         "${root}/service.json" > "${root}/service-157.json"
     expect_failure "157" env AWS_BIN="${root}/bin/aws" AWS_LOG="${root}/aws.log" \
         SERVICE_FIXTURE="${root}/service-157.json" TASK_FIXTURE_ROOT="${root}" \
         "${GUARD_SCRIPT}" source-156
-    python3 - "${root}/service.json" "${root}/service-drift.json" <<'PY'
+    python3 - "${root}" <<'PY'
 import json
 import sys
+from pathlib import Path
 
-data = json.load(open(sys.argv[1], encoding="utf-8"))
-data["services"][0]["runningCount"] = 1
-json.dump(data, open(sys.argv[2], "w", encoding="utf-8"))
+root = Path(sys.argv[1])
+base = json.loads((root / "service-4.json").read_text())
+
+def write(name, mutate):
+    data = json.loads(json.dumps(base))
+    mutate(data["services"][0], data["services"][0]["deployments"][0])
+    (root / f"service-{name}.json").write_text(json.dumps(data))
+
+def counts(service, primary, desired, running, pending):
+    for owner in (service, primary):
+        owner["desiredCount"] = desired
+        owner["runningCount"] = running
+        owner["pendingCount"] = pending
+
+write("desired-1", lambda service, primary: counts(service, primary, 1, 1, 0))
+write("desired-5", lambda service, primary: counts(service, primary, 5, 5, 0))
+write("desired-bool", lambda service, primary: counts(service, primary, True, True, 0))
+write("desired-float", lambda service, primary: counts(service, primary, 4.0, 4.0, 0))
+write("desired-string", lambda service, primary: counts(service, primary, "4", "4", 0))
+write("running-mismatch", lambda service, primary: counts(service, primary, 4, 3, 0))
+write("pending", lambda service, primary: counts(service, primary, 4, 4, 1))
+write("deployment-count-mismatch", lambda service, primary: primary.update(runningCount=3))
+write("secondary", lambda service, primary: service["deployments"].append(
+    {**primary, "status": "ACTIVE"}))
+write("rollout-drift", lambda service, primary: primary.update(rolloutState="IN_PROGRESS"))
 PY
-    expect_failure "2/2/0" env AWS_BIN="${root}/bin/aws" AWS_LOG="${root}/aws.log" \
-        SERVICE_FIXTURE="${root}/service-drift.json" TASK_FIXTURE_ROOT="${root}" \
-        "${GUARD_SCRIPT}" source-156
+    for kind in desired-1 desired-5 desired-bool desired-float desired-string; do
+        expect_failure "desiredCount must be an exact integer in range 2..4" env \
+            AWS_BIN="${root}/bin/aws" AWS_LOG="${root}/aws.log" \
+            SERVICE_FIXTURE="${root}/service-${kind}.json" TASK_FIXTURE_ROOT="${root}" \
+            "${GUARD_SCRIPT}" source-156
+    done
+    expect_failure "runningCount must equal desiredCount" env AWS_BIN="${root}/bin/aws" \
+        AWS_LOG="${root}/aws.log" SERVICE_FIXTURE="${root}/service-running-mismatch.json" \
+        TASK_FIXTURE_ROOT="${root}" "${GUARD_SCRIPT}" source-156
+    expect_failure "pendingCount must be exactly 0" env AWS_BIN="${root}/bin/aws" \
+        AWS_LOG="${root}/aws.log" SERVICE_FIXTURE="${root}/service-pending.json" \
+        TASK_FIXTURE_ROOT="${root}" "${GUARD_SCRIPT}" source-156
+    expect_failure "PRIMARY deployment counts must equal service counts" env \
+        AWS_BIN="${root}/bin/aws" AWS_LOG="${root}/aws.log" \
+        SERVICE_FIXTURE="${root}/service-deployment-count-mismatch.json" \
+        TASK_FIXTURE_ROOT="${root}" "${GUARD_SCRIPT}" source-156
+    expect_failure "single deployment" env AWS_BIN="${root}/bin/aws" \
+        AWS_LOG="${root}/aws.log" SERVICE_FIXTURE="${root}/service-secondary.json" \
+        TASK_FIXTURE_ROOT="${root}" "${GUARD_SCRIPT}" source-156
+    expect_failure "completed PRIMARY deployment" env AWS_BIN="${root}/bin/aws" \
+        AWS_LOG="${root}/aws.log" SERVICE_FIXTURE="${root}/service-rollout-drift.json" \
+        TASK_FIXTURE_ROOT="${root}" "${GUARD_SCRIPT}" source-156
     python3 - "${root}/service.json" "${root}/service-no-target.json" <<'PY'
 import json
 import sys
@@ -704,7 +756,7 @@ PY
       'operation="$1 $2"' \
       'case "$operation" in' \
       ' "ecr describe-images") [[ $# -eq 16 && "$*" == "ecr describe-images --region us-east-2 --registry-id 196881464893 --repository-name pensyve-gateway --image-ids imageTag=63011d55f8cbf52f6f9e5609621f6b8cf0c37535 --output json --cli-connect-timeout 5 --cli-read-timeout 30" ]] || reject "$@"; digest="${SOURCE_ECR_DIGEST:-sha256:6f5f36741bc4c5d39455b2f2fd41108561ea6ea28d438f815462b9febe3e329b}"; tag=63011d55f8cbf52f6f9e5609621f6b8cf0c37535; case "${SOURCE_ECR_CARDINALITY:-one}" in missing) jq -n '\''{imageDetails:[]}'\'' ;; multiple) jq -n --arg d "$digest" --arg tag "$tag" '\''{imageDetails:[{imageDigest:$d,imageTags:[$tag]},{imageDigest:$d,imageTags:[$tag]}]}'\'' ;; one) jq -n --arg d "$digest" --arg tag "$tag" '\''{imageDetails:[{imageDigest:$d,imageTags:[$tag]}]}'\'' ;; *) reject "$@" ;; esac ;;' \
-      ' "ecs describe-services") [[ $# -eq 14 && "$*" == "ecs describe-services --region us-east-2 --cluster pensyve-prod --services pensyve-prod-gateway --cli-connect-timeout 5 --cli-read-timeout 30 --output json" ]] || reject "$@"; if [[ "${SECOND_SIGNAL_PHASE:-}" == readback && -e "${ROLLBACK_UPDATE_MARKER:-/nonexistent}" && ! -e "${SECOND_SIGNAL_MARKER:-/nonexistent}" ]]; then : > "$SECOND_SIGNAL_MARKER"; promoter_pid=$(ps -o ppid= -p "$PPID" | tr -d " "); kill -s "$SECOND_SIGNAL" "$promoter_pid"; sleep 1; fi; arn=$(<"$SERVICE_STATE"); jq -n --arg arn "$arn" --arg tg "$FIXTURE_TARGET_GROUP_ARN" '\''{failures:[],services:[{serviceName:"pensyve-prod-gateway",status:"ACTIVE",taskDefinition:$arn,desiredCount:2,runningCount:2,pendingCount:0,loadBalancers:[{targetGroupArn:$tg,containerName:"gateway",containerPort:3000}],deployments:[{status:"PRIMARY",rolloutState:"COMPLETED",taskDefinition:$arn,desiredCount:2,runningCount:2,pendingCount:0}]}]}'\'' ;;' \
+      ' "ecs describe-services") [[ $# -eq 14 && ( "$*" == "ecs describe-services --region us-east-2 --cluster pensyve-prod --services pensyve-prod-gateway --cli-connect-timeout 5 --cli-read-timeout 30 --output json" || "$*" == "ecs describe-services --region us-east-2 --cluster pensyve-prod --services pensyve-prod-gateway --output json --cli-connect-timeout 5 --cli-read-timeout 30" ) ]] || reject "$@"; if [[ "${SECOND_SIGNAL_PHASE:-}" == readback && -e "${ROLLBACK_UPDATE_MARKER:-/nonexistent}" && ! -e "${SECOND_SIGNAL_MARKER:-/nonexistent}" ]]; then : > "$SECOND_SIGNAL_MARKER"; promoter_pid=$(ps -o ppid= -p "$PPID" | tr -d " "); kill -s "$SECOND_SIGNAL" "$promoter_pid"; sleep 1; fi; arn=$(<"$SERVICE_STATE"); count="${SERVICE_COUNT:-2}"; jq -n --arg arn "$arn" --arg tg "$FIXTURE_TARGET_GROUP_ARN" --argjson count "$count" '\''{failures:[],services:[{serviceName:"pensyve-prod-gateway",status:"ACTIVE",taskDefinition:$arn,desiredCount:$count,runningCount:$count,pendingCount:0,loadBalancers:[{targetGroupArn:$tg,containerName:"gateway",containerPort:3000}],deployments:[{status:"PRIMARY",rolloutState:"COMPLETED",taskDefinition:$arn,desiredCount:$count,runningCount:$count,pendingCount:0}]}]}'\'' ;;' \
       ' "ecs describe-task-definition") arn=$(arg --task-definition "$@"); [[ $# -eq 12 && ( "$*" == "ecs describe-task-definition --region us-east-2 --task-definition $arn --cli-connect-timeout 5 --cli-read-timeout 30 --output json" || "$*" == "ecs describe-task-definition --region us-east-2 --task-definition $arn --output json --cli-connect-timeout 5 --cli-read-timeout 30" ) ]] || reject "$@"; cat "$TASK_FIXTURE_ROOT/task-${arn##*:}.json" ;;' \
       ' "ecs register-task-definition") input=$(arg --cli-input-json "$@"); [[ $# -eq 12 && "$*" == "ecs register-task-definition --region us-east-2 --cli-input-json $input --output json --cli-connect-timeout 5 --cli-read-timeout 30" ]] || reject "$@"; input=${input#file://}; rev=${REGISTER_REVISION:?}; arn="arn:aws:ecs:us-east-2:196881464893:task-definition/pensyve-prod-gateway:$rev"; jq --arg arn "$arn" --argjson rev "$rev" '\''. + {taskDefinitionArn:$arn,revision:$rev} | {taskDefinition:.}'\'' "$input" > "$TASK_FIXTURE_ROOT/task-$rev.json"; cat "$TASK_FIXTURE_ROOT/task-$rev.json" ;;' \
       ' "ecs update-service") arn=$(arg --task-definition "$@"); [[ $# -eq 16 && "$*" == "ecs update-service --region us-east-2 --cluster pensyve-prod --service pensyve-prod-gateway --task-definition $arn --output json --cli-connect-timeout 5 --cli-read-timeout 30" ]] || reject "$@"; if [[ -e "${WAIT_MARKER:-/nonexistent}" && -n "${ROLLBACK_UPDATE_MARKER:-}" ]]; then : > "$ROLLBACK_UPDATE_MARKER"; fi; printf '\''%s\n'\'' "$arn" > "$SERVICE_STATE"; jq -n --arg arn "$arn" '\''{service:{taskDefinition:$arn}}'\'' ;;' \
@@ -712,6 +764,35 @@ PY
       ' "elbv2 describe-target-health") [[ $# -eq 12 && "$*" == "elbv2 describe-target-health --region us-east-2 --target-group-arn $FIXTURE_TARGET_GROUP_ARN --output json --cli-connect-timeout 5 --cli-read-timeout 30" ]] || reject "$@"; if [[ -n "${TARGET_HEALTH_FIXTURE:-}" ]]; then cat "$TARGET_HEALTH_FIXTURE"; else jq -n --arg state "${TARGET_HEALTH_STATE:-healthy}" '\''{TargetHealthDescriptions:[{Target:{Id:"10.0.1.10",Port:3000},TargetHealth:{State:$state}},{Target:{Id:"10.0.2.10",Port:3000},TargetHealth:{State:$state}}]}'\''; fi ;;' \
       ' *) reject "$@" ;; esac' > "${root}/bin/aws"
     chmod +x "${root}/bin/aws"
+}
+
+make_target_health_fixtures() {
+    python3 - "$1" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+
+def target(identity, port=3000, state="healthy"):
+    return {"Target": {"Id": identity, "Port": port}, "TargetHealth": {"State": state}}
+
+healthy = [target(f"10.0.{index}.10") for index in range(1, 6)]
+fixtures = {
+    "targets-1": healthy[:1],
+    "targets-2": healthy[:2],
+    "targets-4": healthy[:4],
+    "targets-5": healthy,
+    "targets-unhealthy": [*healthy[:3], target("10.0.4.10", state="unhealthy")],
+    "targets-wrong-port": [*healthy[:3], target("10.0.4.10", port=3001)],
+    "targets-duplicate": [*healthy[:3], target("10.0.3.10")],
+    "targets-missing": [*healthy[:3], {"Target": {"Port": 3000},
+                                       "TargetHealth": {"State": "healthy"}}],
+    "targets-malformed": [*healthy[:3], target("10.0.4.10", port="3000")],
+}
+for name, descriptions in fixtures.items():
+    (root / f"{name}.json").write_text(json.dumps({"TargetHealthDescriptions": descriptions}))
+PY
 }
 
 assert_promoter_argv() {
@@ -766,6 +847,10 @@ expected_wait = ["ecs", "wait", "services-stable", "--region", "us-east-2", "--c
 expected_target_health = ["elbv2", "describe-target-health", "--region", "us-east-2",
                           "--target-group-arn", target_group, "--output", "json",
                           "--cli-connect-timeout", "5", "--cli-read-timeout", "30"]
+stable_service_read = ["ecs", "describe-services", "--region", "us-east-2", "--cluster",
+                       "pensyve-prod", "--services", "pensyve-prod-gateway", "--output", "json",
+                       "--cli-connect-timeout", "5", "--cli-read-timeout", "30"]
+stable_health = [expected_wait, stable_service_read, expected_target_health]
 source_ecr = [
     "ecr", "describe-images", "--region", "us-east-2", "--registry-id", "196881464893",
     "--repository-name", "pensyve-gateway", "--image-ids",
@@ -776,33 +861,33 @@ source_ecr = [
 register = registers[0] if registers else None
 if expected_registers == 0 and target_arns[0].endswith(":200"):
     expected = [service_read(), guard_task(201), guard_task(156), guard_task(200),
-                source_ecr, expected_updates[0], expected_wait, expected_target_health,
+                source_ecr, expected_updates[0], *stable_health,
                 service_read(), guard_task(200), guard_task(156)]
 elif expected_registers == 0 and target_arns[0].endswith(":156"):
     expected = [service_read(), guard_task(200), guard_task(156), source_ecr,
-                expected_updates[0], expected_wait, expected_target_health,
+                expected_updates[0], *stable_health,
                 service_read(), guard_task(156)]
 elif len(target_arns) == 1 and target_arns[0].endswith(":200"):
     expected = [service_read(), guard_task(156), direct_task(156), source_ecr, register,
                 direct_task(200), service_read(), guard_task(156), source_ecr,
-                expected_updates[0], expected_wait, expected_target_health, service_read(),
+                expected_updates[0], *stable_health, service_read(),
                 guard_task(200), guard_task(156)]
 elif len(target_arns) == 1 and target_arns[0].endswith(":201"):
     expected = [service_read(), guard_task(200), guard_task(156), direct_task(200), source_ecr,
                 register, direct_task(201), service_read(), guard_task(200), guard_task(156),
-                source_ecr, expected_updates[0], expected_wait, expected_target_health,
+                source_ecr, expected_updates[0], *stable_health,
                 service_read(), guard_task(201), guard_task(156), guard_task(200)]
 elif len(target_arns) == 2 and expected_health == 1:
     expected = [service_read(), guard_task(156), direct_task(156), source_ecr, register,
                 direct_task(200), service_read(), guard_task(156), source_ecr,
                 expected_updates[0], expected_wait, source_ecr, expected_updates[1],
-                expected_wait, expected_target_health,
+                *stable_health,
                 service_read(), guard_task(156)]
 elif len(target_arns) == 2 and expected_health == 2:
     expected = [service_read(), guard_task(156), direct_task(156), source_ecr, register,
                 direct_task(200), service_read(), guard_task(156), source_ecr,
-                expected_updates[0], expected_wait, expected_target_health, source_ecr,
-                expected_updates[1], expected_wait, expected_target_health]
+                expected_updates[0], *stable_health, source_ecr,
+                expected_updates[1], *stable_health]
 else:
     raise SystemExit("promoter exact-argv test scenario is undefined")
 
@@ -869,10 +954,31 @@ PY
 }
 
 run_promoter() {
-    local root="${TEST_ROOT}/promoter-success"
+    local root service_count target_count
     local source_arn="arn:aws:ecs:us-east-2:196881464893:task-definition/pensyve-prod-gateway:156"
     local baseline_arn="arn:aws:ecs:us-east-2:196881464893:task-definition/pensyve-prod-gateway:200"
     local target_group="arn:aws:elasticloadbalancing:us-east-2:196881464893:targetgroup/pensyve-prod-gw-tg/0123456789abcdef"
+
+    for service_count in 4 2; do
+        if [[ "${service_count}" == 4 ]]; then target_count=2; else target_count=4; fi
+        root="${TEST_ROOT}/promoter-cardinality-${service_count}-${target_count}"
+        make_promoter_fixture "${root}"
+        make_target_health_fixtures "${root}"
+        printf '%s\n' "${source_arn}" > "${root}/state"
+        : > "${root}/aws.log"
+        expect_failure "ALB target count must equal steady ECS desiredCount" env \
+          AWS_BIN="${root}/bin/aws" AWS_LOG="${root}/aws.log" SERVICE_STATE="${root}/state" \
+          TASK_FIXTURE_ROOT="${root}" REGISTER_REVISION=200 WAIT_MARKER="${root}/wait.marker" \
+          SERVICE_COUNT="${service_count}" \
+          TARGET_HEALTH_FIXTURE="${root}/targets-${target_count}.json" \
+          FIXTURE_TARGET_GROUP_ARN="${target_group}" \
+          "${PROMOTE_SCRIPT}" task8-create --custody "${root}/custody.json"
+        [[ "$(grep -c '^ecs update-service ' "${root}/aws.log")" -eq 2 ]] ||
+            fail "service ${service_count} with ${target_count} targets changed exact rollback count"
+        assert_promoter_argv "${root}" 1 "${baseline_arn},${source_arn}" 2
+    done
+
+    root="${TEST_ROOT}/promoter-success"
     make_promoter_fixture "${root}"
     printf '%s\n' "${source_arn}" > "${root}/state"
     : > "${root}/aws.log"
@@ -890,7 +996,49 @@ run_promoter() {
       "${root}/task-200.json" >/dev/null ||
         fail "Task 8 registration did not preserve the exact live source image tag"
     assert_promoter_argv "${root}" 1 "${baseline_arn}" 1
-    ! grep -F -- '--desired-count' "${root}/aws.log" >/dev/null
+    ! grep -E -- '--desired-count|--force-new-deployment|application-autoscaling|register-scalable-target|put-scaling-policy' \
+      "${root}/aws.log" >/dev/null
+
+    root="${TEST_ROOT}/promoter-success-4"
+    make_promoter_fixture "${root}"
+    make_target_health_fixtures "${root}"
+    printf '%s\n' "${source_arn}" > "${root}/state"
+    : > "${root}/aws.log"
+    env AWS_BIN="${root}/bin/aws" AWS_LOG="${root}/aws.log" SERVICE_STATE="${root}/state" \
+      TASK_FIXTURE_ROOT="${root}" REGISTER_REVISION=200 WAIT_MARKER="${root}/wait.marker" \
+      SERVICE_COUNT=4 TARGET_HEALTH_FIXTURE="${root}/targets-4.json" \
+      FIXTURE_TARGET_GROUP_ARN="${target_group}" \
+      "${PROMOTE_SCRIPT}" task8-create --custody "${root}/custody.json" > "${root}/result.log"
+    grep -Fx "PENSYVE_TASK8_BASELINE_ARN=${baseline_arn}" "${root}/result.log" >/dev/null
+    [[ "$(grep -c '^ecs register-task-definition ' "${root}/aws.log")" -eq 1 ]]
+    [[ "$(grep -c '^ecs update-service ' "${root}/aws.log")" -eq 1 ]]
+    [[ "$(grep -c '^elbv2 describe-target-health ' "${root}/aws.log")" -eq 1 ]] ||
+        fail "four-task promotion must verify four healthy ALB targets once"
+    assert_promoter_argv "${root}" 1 "${baseline_arn}" 1
+    ! grep -E -- '--desired-count|--force-new-deployment|application-autoscaling|register-scalable-target|put-scaling-policy' \
+      "${root}/aws.log" >/dev/null
+
+    for kind in 1 5 unhealthy wrong-port duplicate missing malformed; do
+        root="${TEST_ROOT}/promoter-target-${kind}"
+        make_promoter_fixture "${root}"
+        make_target_health_fixtures "${root}"
+        printf '%s\n' "${source_arn}" > "${root}/state"
+        : > "${root}/aws.log"
+        case "${kind}" in
+            1 | 5) expected="ALB target count must equal steady ECS desiredCount" ;;
+            duplicate) expected="ALB healthy target identities must be distinct" ;;
+            *) expected="ALB target is not healthy on gateway port 3000" ;;
+        esac
+        expect_failure "${expected}" env AWS_BIN="${root}/bin/aws" AWS_LOG="${root}/aws.log" \
+          SERVICE_STATE="${root}/state" TASK_FIXTURE_ROOT="${root}" REGISTER_REVISION=200 \
+          WAIT_MARKER="${root}/wait.marker" SERVICE_COUNT=4 \
+          TARGET_HEALTH_FIXTURE="${root}/targets-${kind}.json" \
+          FIXTURE_TARGET_GROUP_ARN="${target_group}" \
+          "${PROMOTE_SCRIPT}" task8-create --custody "${root}/custody.json"
+        [[ "$(grep -c '^ecs update-service ' "${root}/aws.log")" -eq 2 ]] ||
+            fail "invalid ${kind} target fixture changed exact candidate/rollback update count"
+        assert_promoter_argv "${root}" 1 "${baseline_arn},${source_arn}" 2
+    done
 
     for ecr_case in wrong-digest missing multiple; do
         root="${TEST_ROOT}/promoter-source-ecr-${ecr_case}"

--- a/pensyve-mcp-gateway/scripts/test-gateway-artifact-flow.sh
+++ b/pensyve-mcp-gateway/scripts/test-gateway-artifact-flow.sh
@@ -10,6 +10,8 @@ readonly GUARD_SCRIPT="${SCRIPT_DIR}/guard-active-service.py"
 readonly DEPLOY_WORKFLOW="${REPO_ROOT}/.github/workflows/deploy-gateway.yml"
 readonly CI_WORKFLOW="${REPO_ROOT}/.github/workflows/ci.yml"
 readonly CASE="${1:-all}"
+export PENSYVE_PROMOTION_STABILIZATION_ATTEMPTS=1
+export PENSYVE_PROMOTION_STABILIZATION_INTERVAL_SECONDS=0
 
 case "${CASE}" in
     structural | guard | publisher | promoter | task8-rollback | rollback | workflow | mutations | all) ;;
@@ -761,7 +763,7 @@ PY
       ' "ecs register-task-definition") input=$(arg --cli-input-json "$@"); [[ $# -eq 12 && "$*" == "ecs register-task-definition --region us-east-2 --cli-input-json $input --output json --cli-connect-timeout 5 --cli-read-timeout 30" ]] || reject "$@"; input=${input#file://}; rev=${REGISTER_REVISION:?}; arn="arn:aws:ecs:us-east-2:196881464893:task-definition/pensyve-prod-gateway:$rev"; jq --arg arn "$arn" --argjson rev "$rev" '\''. + {taskDefinitionArn:$arn,revision:$rev} | {taskDefinition:.}'\'' "$input" > "$TASK_FIXTURE_ROOT/task-$rev.json"; cat "$TASK_FIXTURE_ROOT/task-$rev.json" ;;' \
       ' "ecs update-service") arn=$(arg --task-definition "$@"); [[ $# -eq 16 && "$*" == "ecs update-service --region us-east-2 --cluster pensyve-prod --service pensyve-prod-gateway --task-definition $arn --output json --cli-connect-timeout 5 --cli-read-timeout 30" ]] || reject "$@"; if [[ -e "${WAIT_MARKER:-/nonexistent}" && -n "${ROLLBACK_UPDATE_MARKER:-}" ]]; then : > "$ROLLBACK_UPDATE_MARKER"; fi; printf '\''%s\n'\'' "$arn" > "$SERVICE_STATE"; jq -n --arg arn "$arn" '\''{service:{taskDefinition:$arn}}'\'' ;;' \
       ' "ecs wait") [[ $# -eq 13 && "$*" == "ecs wait services-stable --region us-east-2 --cluster pensyve-prod --services pensyve-prod-gateway --cli-connect-timeout 5 --cli-read-timeout 30" ]] || reject "$@"; if [[ -n "${SIGNAL_FIRST_WAIT:-}" && ! -e "$WAIT_MARKER" ]]; then : > "$WAIT_MARKER"; kill -s "$SIGNAL_FIRST_WAIT" "$PPID"; sleep 1; exit 55; fi; if [[ "${FAIL_FIRST_WAIT:-0}" == 1 && ! -e "$WAIT_MARKER" ]]; then : > "$WAIT_MARKER"; exit 55; fi; if [[ "${SECOND_SIGNAL_PHASE:-}" == wait && -e "${ROLLBACK_UPDATE_MARKER:-/nonexistent}" && ! -e "${SECOND_SIGNAL_MARKER:-/nonexistent}" ]]; then : > "$SECOND_SIGNAL_MARKER"; kill -s "$SECOND_SIGNAL" "$PPID"; sleep 1; fi ;;' \
-      ' "elbv2 describe-target-health") [[ $# -eq 12 && "$*" == "elbv2 describe-target-health --region us-east-2 --target-group-arn $FIXTURE_TARGET_GROUP_ARN --output json --cli-connect-timeout 5 --cli-read-timeout 30" ]] || reject "$@"; if [[ -n "${TARGET_HEALTH_FIXTURE:-}" ]]; then cat "$TARGET_HEALTH_FIXTURE"; else jq -n --arg state "${TARGET_HEALTH_STATE:-healthy}" '\''{TargetHealthDescriptions:[{Target:{Id:"10.0.1.10",Port:3000},TargetHealth:{State:$state}},{Target:{Id:"10.0.2.10",Port:3000},TargetHealth:{State:$state}}]}'\''; fi ;;' \
+      ' "elbv2 describe-target-health") [[ $# -eq 12 && "$*" == "elbv2 describe-target-health --region us-east-2 --target-group-arn $FIXTURE_TARGET_GROUP_ARN --output json --cli-connect-timeout 5 --cli-read-timeout 30" ]] || reject "$@"; if [[ -n "${TARGET_HEALTH_FIRST_FIXTURE:-}" && ! -e "${TARGET_HEALTH_FIRST_MARKER:?}" ]]; then : > "$TARGET_HEALTH_FIRST_MARKER"; cat "$TARGET_HEALTH_FIRST_FIXTURE"; elif [[ -n "${TARGET_HEALTH_FIXTURE:-}" ]]; then cat "$TARGET_HEALTH_FIXTURE"; else jq -n --arg state "${TARGET_HEALTH_STATE:-healthy}" '\''{TargetHealthDescriptions:[{Target:{Id:"10.0.1.10",Port:3000},TargetHealth:{State:$state}},{Target:{Id:"10.0.2.10",Port:3000},TargetHealth:{State:$state}}]}'\''; fi ;;' \
       ' *) reject "$@" ;; esac' > "${root}/bin/aws"
     chmod +x "${root}/bin/aws"
 }
@@ -781,9 +783,15 @@ healthy = [target(f"10.0.{index}.10") for index in range(1, 6)]
 fixtures = {
     "targets-1": healthy[:1],
     "targets-2": healthy[:2],
+    "targets-2-draining": [healthy[0], target("10.0.2.10", state="draining")],
     "targets-4": healthy[:4],
+    "targets-4-initial": [*healthy[:3], target("10.0.4.10", state="initial")],
+    "targets-4-draining": [*healthy[:2], target("10.0.3.10", state="draining"),
+                           target("10.0.4.10", state="draining")],
     "targets-5": healthy,
     "targets-unhealthy": [*healthy[:3], target("10.0.4.10", state="unhealthy")],
+    "targets-unused": [*healthy[:3], target("10.0.4.10", state="unused")],
+    "targets-unavailable": [*healthy[:3], target("10.0.4.10", state="unavailable")],
     "targets-wrong-port": [*healthy[:3], target("10.0.4.10", port=3001)],
     "targets-duplicate": [*healthy[:3], target("10.0.3.10")],
     "targets-missing": [*healthy[:3], {"Target": {"Port": 3000},
@@ -792,6 +800,20 @@ fixtures = {
 }
 for name, descriptions in fixtures.items():
     (root / f"{name}.json").write_text(json.dumps({"TargetHealthDescriptions": descriptions}))
+(root / "targets-top-missing.json").write_text("{}")
+(root / "targets-top-null.json").write_text('{"TargetHealthDescriptions":null}')
+(root / "targets-top-non-list.json").write_text('{"TargetHealthDescriptions":{}}')
+short = {
+    "malformed": [healthy[0], "malformed"],
+    "wrong-port": [healthy[0], target("10.0.2.10", port=3001)],
+    "bad-id": [healthy[0], target(42)],
+    "bad-state": [healthy[0], target("10.0.2.10", state=True)],
+    "duplicate": [healthy[0], target("10.0.1.10")],
+    "unhealthy": [healthy[0], target("10.0.2.10", state="unhealthy")],
+}
+for name, descriptions in short.items():
+    (root / f"targets-short-{name}.json").write_text(
+        json.dumps({"TargetHealthDescriptions": descriptions}))
 PY
 }
 
@@ -850,7 +872,10 @@ expected_target_health = ["elbv2", "describe-target-health", "--region", "us-eas
 stable_service_read = ["ecs", "describe-services", "--region", "us-east-2", "--cluster",
                        "pensyve-prod", "--services", "pensyve-prod-gateway", "--output", "json",
                        "--cli-connect-timeout", "5", "--cli-read-timeout", "30"]
-stable_health = [expected_wait, stable_service_read, expected_target_health]
+
+def stable_health(attempts):
+    return [expected_wait, *[call for _ in range(attempts)
+                             for call in (stable_service_read, expected_target_health)]]
 source_ecr = [
     "ecr", "describe-images", "--region", "us-east-2", "--registry-id", "196881464893",
     "--repository-name", "pensyve-gateway", "--image-ids",
@@ -861,33 +886,34 @@ source_ecr = [
 register = registers[0] if registers else None
 if expected_registers == 0 and target_arns[0].endswith(":200"):
     expected = [service_read(), guard_task(201), guard_task(156), guard_task(200),
-                source_ecr, expected_updates[0], *stable_health,
+                source_ecr, expected_updates[0], *stable_health(expected_health),
                 service_read(), guard_task(200), guard_task(156)]
 elif expected_registers == 0 and target_arns[0].endswith(":156"):
     expected = [service_read(), guard_task(200), guard_task(156), source_ecr,
-                expected_updates[0], *stable_health,
+                expected_updates[0], *stable_health(expected_health),
                 service_read(), guard_task(156)]
 elif len(target_arns) == 1 and target_arns[0].endswith(":200"):
     expected = [service_read(), guard_task(156), direct_task(156), source_ecr, register,
                 direct_task(200), service_read(), guard_task(156), source_ecr,
-                expected_updates[0], *stable_health, service_read(),
+                expected_updates[0], *stable_health(expected_health), service_read(),
                 guard_task(200), guard_task(156)]
 elif len(target_arns) == 1 and target_arns[0].endswith(":201"):
     expected = [service_read(), guard_task(200), guard_task(156), direct_task(200), source_ecr,
                 register, direct_task(201), service_read(), guard_task(200), guard_task(156),
-                source_ecr, expected_updates[0], *stable_health,
+                source_ecr, expected_updates[0], *stable_health(expected_health),
                 service_read(), guard_task(201), guard_task(156), guard_task(200)]
 elif len(target_arns) == 2 and expected_health == 1:
     expected = [service_read(), guard_task(156), direct_task(156), source_ecr, register,
                 direct_task(200), service_read(), guard_task(156), source_ecr,
                 expected_updates[0], expected_wait, source_ecr, expected_updates[1],
-                *stable_health,
+                *stable_health(1),
                 service_read(), guard_task(156)]
-elif len(target_arns) == 2 and expected_health == 2:
+elif len(target_arns) == 2 and expected_health >= 2 and expected_health % 2 == 0:
+    attempts = expected_health // 2
     expected = [service_read(), guard_task(156), direct_task(156), source_ecr, register,
                 direct_task(200), service_read(), guard_task(156), source_ecr,
-                expected_updates[0], *stable_health, source_ecr,
-                expected_updates[1], *stable_health]
+                expected_updates[0], *stable_health(attempts), source_ecr,
+                expected_updates[1], *stable_health(attempts)]
 else:
     raise SystemExit("promoter exact-argv test scenario is undefined")
 
@@ -967,6 +993,7 @@ run_promoter() {
         printf '%s\n' "${source_arn}" > "${root}/state"
         : > "${root}/aws.log"
         expect_failure "ALB target count must equal steady ECS desiredCount" env \
+          PENSYVE_PROMOTION_STABILIZATION_ATTEMPTS=2 \
           AWS_BIN="${root}/bin/aws" AWS_LOG="${root}/aws.log" SERVICE_STATE="${root}/state" \
           TASK_FIXTURE_ROOT="${root}" REGISTER_REVISION=200 WAIT_MARKER="${root}/wait.marker" \
           SERVICE_COUNT="${service_count}" \
@@ -975,6 +1002,85 @@ run_promoter() {
           "${PROMOTE_SCRIPT}" task8-create --custody "${root}/custody.json"
         [[ "$(grep -c '^ecs update-service ' "${root}/aws.log")" -eq 2 ]] ||
             fail "service ${service_count} with ${target_count} targets changed exact rollback count"
+        [[ "$(grep -c '^elbv2 describe-target-health ' "${root}/aws.log")" -eq 4 ]] ||
+            fail "persistent mismatch did not exhaust two attempts before each exact update"
+        assert_promoter_argv "${root}" 1 "${baseline_arn},${source_arn}" 4
+    done
+
+    for service_count in 4 2; do
+        if [[ "${service_count}" == 4 ]]; then
+            target_count=4
+            first_fixture="targets-4-initial.json"
+        else
+            target_count=2
+            first_fixture="targets-4-draining.json"
+        fi
+        root="${TEST_ROOT}/promoter-converges-${service_count}-${target_count}"
+        make_promoter_fixture "${root}"
+        make_target_health_fixtures "${root}"
+        printf '%s\n' "${source_arn}" > "${root}/state"
+        : > "${root}/aws.log"
+        env PENSYVE_PROMOTION_STABILIZATION_ATTEMPTS=2 \
+          AWS_BIN="${root}/bin/aws" AWS_LOG="${root}/aws.log" SERVICE_STATE="${root}/state" \
+          TASK_FIXTURE_ROOT="${root}" REGISTER_REVISION=200 WAIT_MARKER="${root}/wait.marker" \
+          SERVICE_COUNT="${service_count}" \
+          TARGET_HEALTH_FIRST_FIXTURE="${root}/${first_fixture}" \
+          TARGET_HEALTH_FIRST_MARKER="${root}/first-target.marker" \
+          TARGET_HEALTH_FIXTURE="${root}/targets-${target_count}.json" \
+          FIXTURE_TARGET_GROUP_ARN="${target_group}" \
+          "${PROMOTE_SCRIPT}" task8-create --custody "${root}/custody.json" >/dev/null
+        [[ "$(grep -c '^ecs update-service ' "${root}/aws.log")" -eq 1 ]] ||
+            fail "converged service ${service_count} performed rollback or duplicate update"
+        [[ "$(grep -c '^elbv2 describe-target-health ' "${root}/aws.log")" -eq 2 ]] ||
+            fail "converged service ${service_count} did not use exactly one retry"
+        assert_promoter_argv "${root}" 1 "${baseline_arn}" 2
+    done
+
+    root="${TEST_ROOT}/promoter-converges-2-draining"
+    make_promoter_fixture "${root}"
+    make_target_health_fixtures "${root}"
+    printf '%s\n' "${source_arn}" > "${root}/state"
+    : > "${root}/aws.log"
+    env PENSYVE_PROMOTION_STABILIZATION_ATTEMPTS=2 \
+      AWS_BIN="${root}/bin/aws" AWS_LOG="${root}/aws.log" SERVICE_STATE="${root}/state" \
+      TASK_FIXTURE_ROOT="${root}" REGISTER_REVISION=200 WAIT_MARKER="${root}/wait.marker" \
+      SERVICE_COUNT=2 TARGET_HEALTH_FIRST_FIXTURE="${root}/targets-2-draining.json" \
+      TARGET_HEALTH_FIRST_MARKER="${root}/first-target.marker" \
+      TARGET_HEALTH_FIXTURE="${root}/targets-2.json" \
+      FIXTURE_TARGET_GROUP_ARN="${target_group}" \
+      "${PROMOTE_SCRIPT}" task8-create --custody "${root}/custody.json" >/dev/null
+    [[ "$(grep -c '^ecs update-service ' "${root}/aws.log")" -eq 1 ]] ||
+        fail "matching-cardinality draining convergence performed rollback or duplicate update"
+    [[ "$(grep -c '^elbv2 describe-target-health ' "${root}/aws.log")" -eq 2 ]] ||
+        fail "matching-cardinality draining convergence did not use exactly one retry"
+    assert_promoter_argv "${root}" 1 "${baseline_arn}" 2
+
+    for kind in top-missing top-null top-non-list short-malformed short-wrong-port \
+      short-bad-id short-bad-state short-duplicate short-unhealthy; do
+        root="${TEST_ROOT}/promoter-terminal-dominance-${kind}"
+        make_promoter_fixture "${root}"
+        make_target_health_fixtures "${root}"
+        printf '%s\n' "${source_arn}" > "${root}/state"
+        : > "${root}/aws.log"
+        case "${kind}" in
+            top-*) expected="TargetHealthDescriptions must be a list" ;;
+            short-malformed) expected="ALB target description is malformed" ;;
+            short-wrong-port) expected="ALB target port must be exact integer 3000" ;;
+            short-bad-id) expected="ALB target ID must be a nonempty string" ;;
+            short-bad-state) expected="ALB target state must be a string" ;;
+            short-duplicate) expected="ALB healthy target identities must be distinct" ;;
+            short-unhealthy) expected="ALB target state is terminal or unknown" ;;
+        esac
+        expect_failure "${expected}" env PENSYVE_PROMOTION_STABILIZATION_ATTEMPTS=2 \
+          AWS_BIN="${root}/bin/aws" AWS_LOG="${root}/aws.log" SERVICE_STATE="${root}/state" \
+          TASK_FIXTURE_ROOT="${root}" REGISTER_REVISION=200 WAIT_MARKER="${root}/wait.marker" \
+          SERVICE_COUNT=4 TARGET_HEALTH_FIXTURE="${root}/targets-${kind}.json" \
+          FIXTURE_TARGET_GROUP_ARN="${target_group}" \
+          "${PROMOTE_SCRIPT}" task8-create --custody "${root}/custody.json"
+        [[ "$(grep -c '^ecs update-service ' "${root}/aws.log")" -eq 2 ]] ||
+            fail "terminal ${kind} fixture changed exact rollback count"
+        [[ "$(grep -c '^elbv2 describe-target-health ' "${root}/aws.log")" -eq 2 ]] ||
+            fail "terminal ${kind} fixture was retried before candidate/rollback failure"
         assert_promoter_argv "${root}" 1 "${baseline_arn},${source_arn}" 2
     done
 
@@ -1018,7 +1124,7 @@ run_promoter() {
     ! grep -E -- '--desired-count|--force-new-deployment|application-autoscaling|register-scalable-target|put-scaling-policy' \
       "${root}/aws.log" >/dev/null
 
-    for kind in 1 5 unhealthy wrong-port duplicate missing malformed; do
+    for kind in 1 5 unhealthy unused unavailable wrong-port duplicate missing malformed; do
         root="${TEST_ROOT}/promoter-target-${kind}"
         make_promoter_fixture "${root}"
         make_target_health_fixtures "${root}"
@@ -1027,7 +1133,9 @@ run_promoter() {
         case "${kind}" in
             1 | 5) expected="ALB target count must equal steady ECS desiredCount" ;;
             duplicate) expected="ALB healthy target identities must be distinct" ;;
-            *) expected="ALB target is not healthy on gateway port 3000" ;;
+            unhealthy | unused | unavailable) expected="ALB target state is terminal or unknown" ;;
+            wrong-port | malformed) expected="ALB target port must be exact integer 3000" ;;
+            missing) expected="ALB target ID must be a nonempty string" ;;
         esac
         expect_failure "${expected}" env AWS_BIN="${root}/bin/aws" AWS_LOG="${root}/aws.log" \
           SERVICE_STATE="${root}/state" TASK_FIXTURE_ROOT="${root}" REGISTER_REVISION=200 \


### PR DESCRIPTION
## Summary

- accept only steady ECS service counts inside the existing autoscaling envelope (2-4)
- bind healthy ALB target cardinality to the exact post-wait desired count
- retry only bounded, valid ALB convergence states (`initial`, `draining`, or valid cardinality lag); malformed or terminal target state still fails closed
- keep updates task-definition-only; do not change desired/min/max scaling, image, environment, or task shape
- keep ordinary Rust CI model-free by testing the MiniLM alias through structural resolution instead of constructing/downloading the model

## Live evidence

Production was observed autoscaled to 4/4/0 on revision :156 during active OOM replacement. The previous trusted-main guard hardcoded 2/2/0 and exactly two targets, so Task 8 would fail closed before stabilization. Rejected revision :157 remains forbidden.

## Test plan

- positive 2/2 and 4/4 service-to-target binding
- bounded scale-out `initial` -> healthy, scale-in/draining -> healthy, and valid target-count convergence
- persistent target mismatch exhausts the bound and rolls back exactly once
- malformed payload, unhealthy/unused/unavailable state, bad port/identity, and duplicate targets remain terminal without retry
- fresh empty-cache alias test with a closed loopback Hugging Face endpoint; cache remains empty
- `test_no_network_invariants`: 7 passed with the same empty cache
- full `test-gateway-artifact-flow.sh all`
- Bash syntax, Cargo format, Ruff check/format, `git diff --check`

Final independent review: Critical 0 / Important 0 / Minor 0. No Docker/model/image test, AWS/ECR/ECS/deployment, release, or production action was performed.
