### PR TITLE
feat(gateway): backfill-embeddings operator mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   release; certified real-model evidence and a separately approved rollout remain
   required.
 
+### Added
+
+- **`pensyve-mcp-gateway backfill-embeddings` operator mode.** Runs the embedding
+  migration lifecycle (begin, backfill, verify, activate) for every namespace the
+  storage pages out, on the exact embedding generation the process loaded, then
+  exits. Namespaces already active on that generation are skipped and ones in
+  flight resume, so the command is idempotent. Run it once after upgrading a
+  hosted deployment so existing namespaces regain semantic recall; until then
+  they serve lexical/graph retrieval only. The container entrypoint now passes
+  its arguments through, so an ECS one-off task can invoke it with a command
+  override.
+
 ### Fixed
 
 - **Entity-wide forget closes a snapshot page before the 4 MiB ceiling** instead

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -416,6 +416,14 @@ hand-apply, or one on a pre-marker database), or `database schema is not at this
 build's version; applying it` if the deployment had been stamped by an earlier
 build. The remedy is the same either way.
 
+**Existing namespaces serve lexical-only after upgrading to schema v6.** Versioned
+embedding generations start with no active generation per namespace. After the
+owner-connected startup, run `pensyve-mcp-gateway backfill-embeddings` once with
+the serving role's `DATABASE_URL` (for ECS, a one-off task from the production
+task definition with the container command overridden to `backfill-embeddings`).
+It pages every namespace, embeds each source on the loaded generation, verifies
+coverage, and activates; running tasks observe activation on their next request.
+
 **Startup fails with `permission denied for table pensyve_schema_state`.** The
 serving role cannot read the applied-schema marker, so it cannot establish that
 the DDL is safe to skip. Grant it `SELECT` — the

--- a/pensyve-mcp-gateway/entrypoint.sh
+++ b/pensyve-mcp-gateway/entrypoint.sh
@@ -23,4 +23,4 @@ if [ -n "$DATABASE_URL" ] && echo "$DATABASE_URL" | grep -q "^postgres"; then
   pg_isready -h "$DB_HOST" -p "$DB_PORT" -t 10 2>&1 || echo "pg_isready failed"
 fi
 
-exec pensyve-mcp-gateway
+exec pensyve-mcp-gateway "$@"

--- a/pensyve-mcp-gateway/src/main.rs
+++ b/pensyve-mcp-gateway/src/main.rs
@@ -12,9 +12,12 @@ use tracing_subscriber::EnvFilter;
 
 use pensyve_core::config::RetrievalConfig;
 use pensyve_core::embedding::{OnnxEmbedder, resolved_fastembed_cache_dir};
+use pensyve_core::embedding_migration::{BackfillCancellation, EmbeddingMigration, MigrationError};
+use pensyve_core::embedding_space::EmbeddingSpaceId;
 use pensyve_core::network_policy::NetworkPolicy;
 use pensyve_core::reranker::Reranker;
 use pensyve_core::storage::StorageTrait;
+use pensyve_core::storage::bounded::NamespaceEmbeddingPhase;
 use pensyve_core::storage::postgres::PostgresBackend;
 use pensyve_core::storage::sqlite::SqliteBackend;
 use pensyve_core::types::Namespace;
@@ -275,6 +278,128 @@ fn init_resources(config: &GatewayConfig) -> Result<InitResources> {
     })
 }
 
+/// Operator mode: `pensyve-mcp-gateway backfill-embeddings` brings every
+/// namespace onto the embedding generation this process loaded, then exits.
+const BACKFILL_EMBEDDINGS_MODE: &str = "backfill-embeddings";
+
+/// Bounded per-namespace source page for the backfill loop.
+const BACKFILL_PAGE: usize = 256;
+
+/// Consecutive backfill rounds that attempt items without committing any
+/// before the namespace is reported as stalled instead of spinning.
+const BACKFILL_STALL_ROUNDS: usize = 3;
+
+enum BackfillResult {
+    AlreadyActive,
+    Activated { committed: usize },
+}
+
+/// Run the embedding migration lifecycle (begin, backfill, verify, activate)
+/// for every namespace the storage pages out, resuming namespaces already in
+/// flight on this generation and skipping ones already active on it. Each
+/// namespace is scoped through `StorageTrait`, so the serving role's
+/// row-level security applies exactly as it does when serving traffic.
+fn backfill_embeddings(storage: &dyn StorageTrait, embedder: &OnnxEmbedder) -> Result<()> {
+    let runtime_space = embedder
+        .embedding_space()
+        .map_err(|error| anyhow::anyhow!("runtime embedding space: {error}"))?
+        .id();
+    tracing::info!(space = %runtime_space.0, "embedding backfill starting");
+    let cancellation = BackfillCancellation::new();
+    let mut after = None;
+    let (mut activated, mut already_active, mut failed) = (0_usize, 0_usize, 0_usize);
+    loop {
+        let page = storage
+            .page_namespaces(after, BACKFILL_PAGE)
+            .map_err(|error| anyhow::anyhow!("page namespaces: {error}"))?;
+        for namespace_id in page.namespace_ids {
+            match backfill_namespace(
+                storage,
+                embedder,
+                namespace_id,
+                &runtime_space,
+                &cancellation,
+            ) {
+                Ok(BackfillResult::AlreadyActive) => already_active += 1,
+                Ok(BackfillResult::Activated { committed }) => {
+                    activated += 1;
+                    tracing::info!(%namespace_id, committed, "namespace activated");
+                }
+                Err(error) => {
+                    failed += 1;
+                    tracing::error!(%namespace_id, %error, "namespace backfill failed");
+                }
+            }
+        }
+        after = page.next_cursor;
+        if after.is_none() {
+            break;
+        }
+    }
+    tracing::info!(
+        activated,
+        already_active,
+        failed,
+        "embedding backfill finished"
+    );
+    if failed > 0 {
+        anyhow::bail!("{failed} namespace(s) failed to backfill; see log");
+    }
+    Ok(())
+}
+
+fn backfill_namespace(
+    storage: &dyn StorageTrait,
+    embedder: &OnnxEmbedder,
+    namespace_id: uuid::Uuid,
+    runtime_space: &EmbeddingSpaceId,
+    cancellation: &BackfillCancellation,
+) -> Result<BackfillResult, MigrationError> {
+    let state = storage.get_namespace_embedding_state(namespace_id)?;
+    let on_this_generation = |space: Option<&EmbeddingSpaceId>| space == Some(runtime_space);
+    if let Some(state) = &state
+        && state.phase == NamespaceEmbeddingPhase::Active
+        && on_this_generation(state.active_read_space_id.as_ref())
+    {
+        return Ok(BackfillResult::AlreadyActive);
+    }
+    let migration = EmbeddingMigration::new(storage, embedder, namespace_id);
+    let in_flight = state.as_ref().is_some_and(|state| {
+        matches!(
+            state.phase,
+            NamespaceEmbeddingPhase::Backfilling | NamespaceEmbeddingPhase::Ready
+        ) && on_this_generation(state.target_space_id.as_ref())
+    });
+    if !in_flight {
+        migration.start()?;
+    }
+    let mut committed = 0_usize;
+    let mut stalled_rounds = 0_usize;
+    loop {
+        let outcome = migration.backfill(BACKFILL_PAGE, cancellation)?;
+        committed += outcome.committed;
+        if outcome.attempted == 0 {
+            break;
+        }
+        if outcome.committed == 0 {
+            stalled_rounds += 1;
+            if stalled_rounds >= BACKFILL_STALL_ROUNDS {
+                tracing::warn!(
+                    %namespace_id,
+                    requeued = outcome.requeued,
+                    "backfill is not making progress; leaving namespace in flight"
+                );
+                break;
+            }
+        } else {
+            stalled_rounds = 0;
+        }
+    }
+    migration.verify()?;
+    migration.activate()?;
+    Ok(BackfillResult::Activated { committed })
+}
+
 fn main() -> Result<()> {
     // JSON formatter with span attributes flattened into each event record
     // (Phase 23/A): the TracingLayer middleware wraps every request handler
@@ -306,6 +431,9 @@ fn main() -> Result<()> {
     // Init resources BEFORE tokio runtime to avoid nested runtime panic
     // when PostgresBackend creates its own internal runtime.
     let res = init_resources(&config)?;
+    if std::env::args().nth(1).as_deref() == Some(BACKFILL_EMBEDDINGS_MODE) {
+        return backfill_embeddings(res.storage.as_ref(), res.embedder.as_ref());
+    }
 
     tokio::runtime::Builder::new_multi_thread()
         .enable_all()


### PR DESCRIPTION
Adds `pensyve-mcp-gateway backfill-embeddings`: pages every namespace and runs the embedding migration lifecycle (begin → backfill → verify → activate) on the embedding generation the process loaded, then exits. Idempotent: namespaces already active on that generation are skipped, in-flight ones resume, and a namespace that stops making progress is left in flight and reported rather than spun on. The entrypoint now passes arguments through so an ECS one-off task can run it via command override.

Needed because the bounded-runtime release (#316) leaves existing hosted namespaces without an active generation, so they serve lexical/graph-only until backfilled. Verified locally against SQLite (activate, then idempotent re-run); production run follows as a one-off Fargate task.