### PR TITLE
release: 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.0] - 2026-09-02
+
+Bounded runtime and embedding provenance. Shipping runtimes no longer hold a
+resident vector corpus; retrieval is storage-backed and every stored vector
+carries the immutable identity of the embedding generation that produced it.
+Existing deployments upgrade in two steps (owner-connected schema startup, then
+a one-time `backfill-embeddings` run); until the backfill activates a namespace,
+that namespace serves lexical/graph retrieval only.
+
+### Breaking
+
+- **`ConsolidationWorkspace` gains a required `cursor(run)` method.** External
+  implementors must return the persisted resume cursor; both built-in backends do.
+- **`StorageTrait` grows bounded, storage-backed retrieval methods with
+  fail-closed defaults.** Custom backends compile unchanged but return an explicit
+  unsupported outcome for storage-backed search, paging, and the embedding
+  lifecycle until they implement them; the shipping runtimes require them.
+- **Schema v6/v7 on both backends** (versioned embedding spaces, embedding
+  records, namespace lifecycle state, backfill queue, durable consolidation
+  workspace). On PostgreSQL the serving role cannot apply it: start the new
+  build once on an owner connection, then serve as `pensyve_app` again.
+- **CLI embedding-space maintenance commands require `--storage-path`.**
+- **Python: observation extraction takes its own permit.** Recall, remember, and
+  consolidation no longer wait behind an extractor round trip.
+
+### Upgrade
+
+1. Deploy the new build; if the serving role cannot apply the schema, run the
+   owner-connected startup (`docs/SECURITY.md`).
+2. Run `pensyve-mcp-gateway backfill-embeddings` once against the same
+   database with the same model bundle; it activates every namespace on the
+   loaded embedding generation and is safe to re-run.
+
 ### Changed
 
 - **Shipping Rust runtimes now use storage-backed exact retrieval exclusively.**
@@ -24,11 +57,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   256-row pages, 64-row consolidation comparisons, 4,096-member promotion clusters,
   hosted recall admission of 8 / 64 MiB, and 1,024 cached tenant metadata entries
   with 30-minute idle expiry.
-- **Deployment guidance corrected.** Earlier full-GTE-plus-BGE and 4 GiB sizing is
-  superseded. This candidate does not select or download a production model and
-  does not authorize a production backfill, cutover, infrastructure change, or
-  release; certified real-model evidence and a separately approved rollout remain
-  required.
+- **Hosted gateway shape.** The production task now runs at 512 CPU / 2048 MiB
+  with the pinned GTE model bundle in the image and BGE reranking off unless
+  `PENSYVE_RERANKER=1`; the earlier 4 GiB strict-runtime sizing is superseded.
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2749,7 +2749,7 @@ dependencies = [
 
 [[package]]
 name = "pensyve-benchmarks"
-version = "3.2.0"
+version = "4.0.0"
 dependencies = [
  "chrono",
  "pensyve-core",
@@ -2764,7 +2764,7 @@ dependencies = [
 
 [[package]]
 name = "pensyve-cli"
-version = "3.2.0"
+version = "4.0.0"
 dependencies = [
  "clap",
  "dirs",
@@ -2775,7 +2775,7 @@ dependencies = [
 
 [[package]]
 name = "pensyve-core"
-version = "3.2.0"
+version = "4.0.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2807,7 +2807,7 @@ dependencies = [
 
 [[package]]
 name = "pensyve-mcp"
-version = "3.2.0"
+version = "4.0.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -2823,7 +2823,7 @@ dependencies = [
 
 [[package]]
 name = "pensyve-mcp-gateway"
-version = "3.2.0"
+version = "4.0.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2856,7 +2856,7 @@ dependencies = [
 
 [[package]]
 name = "pensyve-mcp-tools"
-version = "3.2.0"
+version = "4.0.0"
 dependencies = [
  "pensyve-core",
  "rmcp",
@@ -2873,7 +2873,7 @@ dependencies = [
 
 [[package]]
 name = "pensyve-python"
-version = "3.2.0"
+version = "4.0.0"
 dependencies = [
  "chrono",
  "pensyve-core",

--- a/pensyve-benchmarks/Cargo.toml
+++ b/pensyve-benchmarks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pensyve-benchmarks"
-version = "3.2.0"
+version = "4.0.0"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"
@@ -8,7 +8,7 @@ description = "Evaluation framework for Pensyve memory engine"
 publish = false
 
 [dependencies]
-pensyve-core = { path = "../pensyve-core", version = "3.2.0" }
+pensyve-core = { path = "../pensyve-core", version = "4.0.0" }
 rand = "0.10"
 rand_distr = "0.6"
 serde = { version = "1", features = ["derive"] }

--- a/pensyve-cli/Cargo.toml
+++ b/pensyve-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pensyve-cli"
-version = "3.2.0"
+version = "4.0.0"
 edition = "2024"
 description = "Pensyve command-line interface — universal memory runtime for AI agents"
 rust-version = "1.88"
@@ -14,7 +14,7 @@ name = "pensyve"
 path = "src/main.rs"
 
 [dependencies]
-pensyve-core = { path = "../pensyve-core", version = "3.2.0" }
+pensyve-core = { path = "../pensyve-core", version = "4.0.0" }
 clap = { version = "4", features = ["derive"] }
 serde_json = "1"
 uuid = { version = "1", features = ["v4"] }

--- a/pensyve-core/Cargo.toml
+++ b/pensyve-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pensyve-core"
-version = "3.2.0"
+version = "4.0.0"
 edition = "2024"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/pensyve-mcp-gateway/Cargo.toml
+++ b/pensyve-mcp-gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pensyve-mcp-gateway"
-version = "3.2.0"
+version = "4.0.0"
 edition = "2024"
 description = "Remote MCP gateway for Pensyve Cloud — Streamable HTTP transport"
 rust-version = "1.88"
@@ -18,8 +18,8 @@ name = "pensyve-mcp-gateway"
 path = "src/main.rs"
 
 [dependencies]
-pensyve-core = { path = "../pensyve-core", version = "3.2.0", features = ["postgres", "observation-extraction"] }
-pensyve-mcp-tools = { path = "../pensyve-mcp-tools", version = "3.2.0" }
+pensyve-core = { path = "../pensyve-core", version = "4.0.0", features = ["postgres", "observation-extraction"] }
+pensyve-mcp-tools = { path = "../pensyve-mcp-tools", version = "4.0.0" }
 rmcp = { version = "3.1", features = ["server", "transport-streamable-http-server", "macros"] }
 axum = "0.8"
 tower-http = { version = "0.7", features = ["compression-gzip", "compression-br"] }

--- a/pensyve-mcp-tools/Cargo.toml
+++ b/pensyve-mcp-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pensyve-mcp-tools"
-version = "3.2.0"
+version = "4.0.0"
 edition = "2024"
 description = "Shared MCP tool definitions for Pensyve servers"
 rust-version = "1.88"
@@ -13,7 +13,7 @@ documentation = "https://pensyve.com/docs"
 name = "pensyve_mcp_tools"
 
 [dependencies]
-pensyve-core = { path = "../pensyve-core", version = "3.2.0" }
+pensyve-core = { path = "../pensyve-core", version = "4.0.0" }
 rmcp = { version = "3.1", features = ["server", "macros"] }
 tokio = { version = "1", features = ["full"] }
 # G1/P3a: needed for `CancellationToken::new()` passed to

--- a/pensyve-mcp/Cargo.toml
+++ b/pensyve-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pensyve-mcp"
-version = "3.2.0"
+version = "4.0.0"
 edition = "2024"
 description = "Pensyve MCP server (stdio transport) — universal memory runtime for AI agents"
 rust-version = "1.88"
@@ -14,8 +14,8 @@ name = "pensyve-mcp"
 path = "src/main.rs"
 
 [dependencies]
-pensyve-core = { path = "../pensyve-core", version = "3.2.0" }
-pensyve-mcp-tools = { path = "../pensyve-mcp-tools", version = "3.2.0" }
+pensyve-core = { path = "../pensyve-core", version = "4.0.0" }
+pensyve-mcp-tools = { path = "../pensyve-mcp-tools", version = "4.0.0" }
 rmcp = { version = "3.1", features = ["server", "transport-io", "macros"] }
 tokio = { version = "1", features = ["full"] }
 uuid = { version = "1", features = ["v4"] }

--- a/pensyve-python/Cargo.toml
+++ b/pensyve-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pensyve-python"
-version = "3.2.0"
+version = "4.0.0"
 edition = "2024"
 rust-version = "1.88"
 readme = "README.md"
@@ -15,7 +15,7 @@ name = "pensyve_python"
 crate-type = ["cdylib"]
 
 [dependencies]
-pensyve-core = { path = "../pensyve-core", version = "3.2.0", features = ["observation-extraction"] }
+pensyve-core = { path = "../pensyve-core", version = "4.0.0", features = ["observation-extraction"] }
 # `extension-module` is deliberately not enabled here: maturin turns it on via
 # `[tool.maturin] features` in pyproject.toml when building the wheel, while
 # `cargo test -p pensyve-python` links the in-crate Rust tests against libpython.

--- a/pensyve-python/pyproject.toml
+++ b/pensyve-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pensyve"
-version = "3.2.0"
+version = "4.0.0"
 description = "Universal memory runtime for AI agents — framework-agnostic, protocol-native, offline-first"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/pensyve-ts/package.json
+++ b/pensyve-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pensyve/sdk",
-  "version": "3.2.0",
+  "version": "4.0.0",
   "description": "Pensyve TypeScript SDK — universal memory runtime for AI agents",
   "type": "module",
   "main": "dist/index.js",

--- a/pensyve-wasm/Cargo.lock
+++ b/pensyve-wasm/Cargo.lock
@@ -224,7 +224,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "pensyve-wasm"
-version = "3.2.0"
+version = "4.0.0"
 dependencies = [
  "chrono",
  "serde",

--- a/pensyve-wasm/Cargo.toml
+++ b/pensyve-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pensyve-wasm"
-version = "3.2.0"
+version = "4.0.0"
 edition = "2024"
 
 [workspace]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pensyve"
-version = "3.2.0"
+version = "4.0.0"
 description = "Universal memory runtime for AI agents — framework-agnostic, protocol-native, offline-first"
 readme = "README.md"
 license = "Apache-2.0"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.major7apps/pensyve",
   "title": "Pensyve",
   "description": "Universal memory runtime for AI agents — episodic, semantic, and procedural memory.",
-  "version": "3.2.0",
+  "version": "4.0.0",
   "repository": {
     "url": "https://github.com/major7apps/pensyve",
     "source": "github"

--- a/uv.lock
+++ b/uv.lock
@@ -921,7 +921,7 @@ wheels = [
 
 [[package]]
 name = "pensyve"
-version = "3.2.0"
+version = "4.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Version bump to 4.0.0 across all crates, the Python and TypeScript packages, and the MCP registry manifest, with the changelog's Unreleased section cut as 4.0.0 (Breaking + Upgrade sections added). Major per AGENTS.md: `ConsolidationWorkspace` gains a required method, `StorageTrait` grows bounded retrieval methods with fail-closed defaults, schema v6/v7 needs an owner-connected startup, the CLI embedding-space commands require `--storage-path`, and Python extraction admission changed.

Merge after #318 and the production backfill have settled; tagging `v4.0.0` on the merge commit triggers the Release workflow. Note the `release` environment's `NPM_TOKEN` is rejected by npm (401 on `whoami`, see run 33124831128); replace it before tagging or the npm publish job fails again.