### PR TITLE
test: cluster-budget fixtures clear of the duration budget; ci: deploy gate waits for terminal rollout

### DIFF
--- a/.github/workflows/deploy-gateway.yml
+++ b/.github/workflows/deploy-gateway.yml
@@ -111,9 +111,17 @@ jobs:
         run: |
           set -euo pipefail
           aws ecs wait services-stable --cluster "$ECS_CLUSTER" --services "$ECS_SERVICE"
-          aws ecs describe-services --cluster "$ECS_CLUSTER" --services "$ECS_SERVICE" \
-            --query 'services[0].deployments[*].{status:status,td:taskDefinition,rollout:rolloutState,reason:rolloutStateReason}' \
-            --output json | tee "$RUNNER_TEMP/deployments.json"
+          # services-stable returns on task counts; the deployment's rollout state can
+          # still read IN_PROGRESS for a few seconds after that. Wait for a terminal state.
+          for _ in $(seq 1 60); do
+            aws ecs describe-services --cluster "$ECS_CLUSTER" --services "$ECS_SERVICE" \
+              --query 'services[0].deployments[*].{status:status,td:taskDefinition,rollout:rolloutState,reason:rolloutStateReason}' \
+              --output json > "$RUNNER_TEMP/deployments.json"
+            if jq -e '[.[] | select(.status=="PRIMARY")] | all(.rollout != "IN_PROGRESS")' \
+              "$RUNNER_TEMP/deployments.json" >/dev/null; then break; fi
+            sleep 10
+          done
+          cat "$RUNNER_TEMP/deployments.json"
           # A completed rollback is "stable" too; fail if the primary is not the revision we registered.
           jq -e '[.[] | select(.status=="PRIMARY")] | length == 1 and all(.rollout == "COMPLETED" and (.reason | test("rolling back") | not))' \
             "$RUNNER_TEMP/deployments.json" >/dev/null

--- a/pensyve-core/tests/test_bounded_consolidation.rs
+++ b/pensyve-core/tests/test_bounded_consolidation.rs
@@ -80,7 +80,13 @@ fn save_episode_memory_with_embedding(
 }
 
 fn config() -> ConsolidationConfig {
-    PensyveConfig::default().consolidation
+    let mut config = PensyveConfig::default().consolidation;
+    // These tests exercise the member, page, and working-state budgets; the
+    // 4,096-member fixtures can outlast the 60 s default on a busy CI runner,
+    // which would report DurationExceeded instead of the budget under test.
+    // The duration budget has its own test, which sets its own value.
+    config.max_duration_secs = 600;
+    config
 }
 
 fn run(


### PR DESCRIPTION
The two 4,096-member cluster tests failed in CI run 33629614446 with `DurationExceeded` instead of the member budget they assert, because the 60 s default can be exceeded on a busy runner. The shared test config now allows 600 s; the duration-budget test already sets its own value. Passes locally in 81 s.