### PR TITLE
feat(gateway): export-namespace operator mode + self-host guide

### DIFF
--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -1,0 +1,287 @@
+# Self-hosting Pensyve
+
+Pensyve runs as a single binary over a SQLite file. This guide deploys the MCP
+gateway on [Railway](https://railway.com) with a persistent volume, and shows
+how to drop in a store exported from Pensyve Cloud so your existing memories
+come across intact.
+
+**You do not need `pensyve-cloud`.** That repository is the commercial web app —
+marketing site, dashboard, Stripe billing, and the API-key console. It is not
+part of the memory runtime. The gateway in this repository is the whole server:
+it speaks MCP, holds your memories, and answers recall. Forking `pensyve-cloud`
+to self-host would give you a billing dashboard with nothing behind it.
+
+## What you need
+
+| | |
+|---|---|
+| Storage | One SQLite file. No Postgres, no external vector database. |
+| Models | Embedding model (~130 MB) baked into the image at build time. |
+| Memory | ~1.5 GB RAM. The ONNX embedding session is the bulk of it. |
+| Disk | The store, plus room to grow. 20k memories is roughly 250 MB. |
+
+## Deploying to Railway
+
+### 1. Dockerfile
+
+The `Dockerfile` in `pensyve-mcp-gateway/` expects the binary to already exist
+on the host (it is built by CI, which compiles first and copies the artifact
+in). Railway builds from source, so use this self-contained one instead. Save
+it as `Dockerfile` at the repository root:
+
+```dockerfile
+# ---- build ----
+FROM rust:1.97-bookworm AS build
+WORKDIR /src
+COPY . .
+RUN cargo build --release -p pensyve-mcp-gateway
+
+# ---- models ----
+# Baked in at build time so the container never reaches the network to embed.
+FROM rust:1.97-bookworm AS models
+WORKDIR /src
+COPY pensyve-mcp-gateway/models /src/pensyve-mcp-gateway/models
+COPY pensyve-mcp-gateway/scripts/fetch-model-bundle.sh /src/fetch-model-bundle.sh
+RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && /src/fetch-model-bundle.sh --output /opt/pensyve/models
+
+# ---- runtime ----
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      libssl3 ca-certificates libstdc++6 curl \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build  /src/target/release/pensyve-mcp-gateway /usr/local/bin/
+COPY --from=models /opt/pensyve/models /opt/pensyve/models
+
+ENV PENSYVE_PATH=/data
+ENV HF_HOME=/opt/pensyve/models
+ENV FASTEMBED_CACHE_DIR=/opt/pensyve/models
+ENV PORT=3000
+EXPOSE 3000
+
+HEALTHCHECK --interval=10s --timeout=3s --start-period=180s --retries=6 \
+    CMD curl -f http://localhost:${PORT}/health || exit 1
+
+STOPSIGNAL SIGINT
+CMD ["pensyve-mcp-gateway"]
+```
+
+The first build takes 10–15 minutes; Rust release builds are not fast. Railway
+caches layers, so subsequent deploys are quicker.
+
+### 2. `railway.json`
+
+```json
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "Dockerfile"
+  },
+  "deploy": {
+    "startCommand": "pensyve-mcp-gateway",
+    "healthcheckPath": "/health",
+    "healthcheckTimeout": 300,
+    "restartPolicyType": "ON_FAILURE",
+    "numReplicas": 1
+  }
+}
+```
+
+Keep `numReplicas` at 1. The store is a SQLite file on one volume; a second
+replica would be a second process writing the same file.
+
+`healthcheckTimeout` is generous on purpose — the first request after a cold
+start loads the ONNX embedding session, which takes well over a minute.
+
+### 3. Volume and environment
+
+Attach a Railway volume mounted at **`/data`**, then set:
+
+| Variable | Value | Notes |
+|---|---|---|
+| `PENSYVE_PATH` | `/data` | A **directory**, not a file. See below. |
+| `PENSYVE_API_KEYS` | `psy_...` | Comma-separated. Any opaque string works; `psy_` is only a convention. |
+| `PENSYVE_KEY_USER_MAP` | `psy_...:<user-id>` | Only when restoring an export. See [Dropping in an exported store](#dropping-in-an-exported-store). |
+| `PORT` | `3000` | Railway usually injects this. |
+| `MCP_ALLOWED_HOSTS` | `your-app.up.railway.app` | Without it only loopback Host headers are accepted, and every request through the Railway URL is rejected. |
+
+> **`PENSYVE_PATH` is a directory.** The gateway opens `$PENSYVE_PATH/memories.db`
+> and creates it if absent. Pointing it at a file path — `/data/pensyve.db` —
+> makes the gateway create a *directory* by that name and put `memories.db`
+> inside it, which is almost certainly not what you meant.
+
+Generate a key with something like `openssl rand -hex 24`, prefixed however you
+like. Requests authenticate with `Authorization: Bearer <key>`.
+
+### 4. Connect over MCP
+
+The gateway serves Streamable HTTP MCP at **`/mcp`** on your Railway URL.
+
+Claude Code:
+
+```bash
+claude mcp add --transport http pensyve https://your-app.up.railway.app/mcp \
+  --header "Authorization: Bearer psy_your_key"
+```
+
+Claude Desktop (`claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "pensyve": {
+      "type": "http",
+      "url": "https://your-app.up.railway.app/mcp",
+      "headers": { "Authorization": "Bearer psy_your_key" }
+    }
+  }
+}
+```
+
+Health and readiness are on `/health` and `/ready`.
+
+## Dropping in an exported store
+
+An export from Pensyve Cloud arrives as `<namespace-id>.db`: a complete SQLite
+store at the current schema version, holding your episodes, all four memory
+types (including superseded rows), entities, graph edges, and the embedding
+vectors under the exact embedding space that produced them. It is not an import
+format — it *is* the store. Nothing needs to be replayed or re-embedded.
+
+Alongside it is `<namespace-id>.json`, a plain-text JSONL sidecar in the same
+frame shape as a GDPR data export. It exists so your data stays readable
+without a Pensyve build at hand. **The `.db` is the lossless artifact**; the
+sidecar is a summary and does not carry decay state, supersession, or vectors.
+
+Installing it takes two steps, and skipping the second is the most common way
+to end up staring at an empty instance.
+
+**1. Put the file on the volume as `memories.db`.**
+
+```bash
+# With the service stopped, from a Railway shell on the volume:
+mv /data/579fbd27-....db /data/memories.db
+```
+
+The filename matters — the gateway opens `$PENSYVE_PATH/memories.db` and will
+silently create an empty store next to a file named anything else.
+
+**2. Point your API key at the namespace inside the store.**
+
+The gateway gives each API key its own namespace, named `tenant:<user-id>`. Your
+exported store contains the namespace it had on Pensyve Cloud, still under its
+original name. If the key you configure resolves to any other name, the gateway
+creates a *fresh, empty* namespace and serves that — your memories are sitting
+in the same file, untouched and unreachable.
+
+`PENSYVE_KEY_USER_MAP` ties the two together. It maps an API key to the user id
+whose namespace you want served, as `key:user-id`, comma-separated for more than
+one:
+
+```
+PENSYVE_API_KEYS=psy_your_key
+PENSYVE_KEY_USER_MAP=psy_your_key:4173c1db-6da1-4505-a7a9-0b0e437e94ee
+```
+
+The user id is the part after `tenant:` in your namespace name. Read it out of
+the store if you do not have it to hand:
+
+```bash
+sqlite3 /data/memories.db "SELECT id, name FROM namespaces;"
+```
+
+**If recall comes back empty, this is almost always why.** Check that the name
+in that query matches `tenant:` plus the id in your `PENSYVE_KEY_USER_MAP`.
+
+`pensyve import` is for the JSON sidecar and you do not need it here.
+
+### Verifying before you wire up a client
+
+The quickest check is against the file itself:
+
+```bash
+sqlite3 /data/memories.db "
+  SELECT 'episodic',  count(*) FROM episodic_memories
+  UNION ALL SELECT 'semantic',   count(*) FROM semantic_memories
+  UNION ALL SELECT 'episodes',   count(*) FROM episodes
+  UNION ALL SELECT 'entities',   count(*) FROM entities
+  UNION ALL SELECT 'embeddings', count(*) FROM memory_embeddings;"
+```
+
+Confirm the embedding generation is active, using the namespace id from the
+query above:
+
+```bash
+pensyve embedding-space --storage-path /data inspect --namespace <namespace-id>
+```
+
+`phase: active` with an `active_read_space_id` means semantic recall is ready.
+
+The `pensyve` CLI's own `stats` and `recall` resolve storage from the namespace
+*name* under `~/.pensyve/<name>`, so to drive them against an exported store the
+directory has to be named for the namespace it contains:
+
+```bash
+mkdir -p ~/.pensyve/'tenant:4173c1db-6da1-4505-a7a9-0b0e437e94ee'
+cp /data/memories.db ~/.pensyve/'tenant:4173c1db-6da1-4505-a7a9-0b0e437e94ee'/
+pensyve stats  --namespace 'tenant:4173c1db-6da1-4505-a7a9-0b0e437e94ee'
+pensyve recall --namespace 'tenant:4173c1db-6da1-4505-a7a9-0b0e437e94ee' "something you remember writing"
+```
+
+Passing a name the store does not contain creates an empty namespace and
+reports zero, so the quoting matters.
+
+### Embeddings
+
+Vectors are copied under the embedding space that produced them, recorded in
+the store as an immutable identity: model name, revision, artifact hashes,
+dimensions, pooling, and runtime. A build whose embedder reproduces that exact
+identity uses the copied vectors as they are.
+
+Pensyve Cloud embedded with `Alibaba-NLP/gte-base-en-v1.5` at revision
+`a829fd0e060bb84554da0dfd354d0de0f7712b7f`, 768 dimensions, CLS pooling,
+normalized. The Dockerfile above pins the same revision through
+`pensyve-mcp-gateway/models/revisions.env`, so **an export from Cloud is
+directly usable and needs no migration.**
+
+If you change the embedding model later, the identity no longer matches and
+semantic recall goes unavailable rather than silently returning nonsense from
+mismatched vectors. Re-embed the store before serving, with the bounded
+migration the CLI exposes:
+
+```bash
+pensyve embedding-space --storage-path /data backfill \
+  --namespace <namespace-id> --space-manifest <manifest.json> --max-items 256
+pensyve embedding-space --storage-path /data verify   --namespace <namespace-id> --space-id <new-space-id>
+pensyve embedding-space --storage-path /data activate --namespace <namespace-id> --space-id <new-space-id>
+```
+
+`backfill` is resumable and re-runs until it reports nothing left; `verify`
+refuses to pass until coverage is complete, and only `activate` flips reads onto
+the new generation. Lexical recall keeps working throughout.
+
+## Operating it
+
+**Back up the volume.** One SQLite file is easy to copy and easy to lose. Snapshot
+`/data` on a schedule; `sqlite3 /data/memories.db ".backup /tmp/backup.db"` is
+safe against a running gateway.
+
+**Watch disk.** The gateway writes WAL alongside the store. Leave headroom.
+
+**Restarts are clean.** `SIGINT` (Railway's default stop signal) lets the gateway
+checkpoint and close. A `SIGKILL` mid-write is recoverable — SQLite replays the
+WAL — but a clean stop is better before copying the file anywhere.
+
+**Consolidation runs in-process** on a schedule, decaying and promoting memories
+the way the hosted service did. No extra worker is needed.
+
+## Not using Railway
+
+Nothing here is Railway-specific. The requirements are a persistent writable
+directory at `PENSYVE_PATH`, one process, and a way to serve HTTP. Fly.io, a
+Hetzner box with systemd, or Docker Compose on a VPS all work the same way. For
+a single-user local setup you can skip containers entirely: build the binary,
+point `PENSYVE_PATH` at a directory, and run it.

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -34,7 +34,9 @@ it as `Dockerfile` at the repository root:
 FROM rust:1.97-bookworm AS build
 WORKDIR /src
 COPY . .
-RUN cargo build --release -p pensyve-mcp-gateway
+# The CLI comes along so the verification and migration commands in this guide
+# actually exist inside the container.
+RUN cargo build --release -p pensyve-mcp-gateway -p pensyve-cli
 
 # ---- models ----
 # Baked in at build time so the container never reaches the network to embed.
@@ -49,10 +51,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certifi
 # ---- runtime ----
 FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      libssl3 ca-certificates libstdc++6 curl \
+      libssl3 ca-certificates libstdc++6 curl sqlite3 \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build  /src/target/release/pensyve-mcp-gateway /usr/local/bin/
+COPY --from=build  /src/target/release/pensyve             /usr/local/bin/
 COPY --from=models /opt/pensyve/models /opt/pensyve/models
 
 ENV PENSYVE_PATH=/data
@@ -162,7 +165,11 @@ to end up staring at an empty instance.
 **1. Put the file on the volume as `memories.db`.**
 
 ```bash
-# With the service stopped, from a Railway shell on the volume:
+# With the service stopped, from a Railway shell on the volume.
+# Refuse to clobber a store that is already there: if the gateway booted once
+# before you installed the export, it created an empty memories.db, and if it
+# booted and ran, that file is real data.
+[ -e /data/memories.db ] && { echo "already present - move it aside first"; exit 1; }
 mv /data/579fbd27-....db /data/memories.db
 ```
 
@@ -181,7 +188,7 @@ in the same file, untouched and unreachable.
 whose namespace you want served, as `key:user-id`, comma-separated for more than
 one:
 
-```
+```dotenv
 PENSYVE_API_KEYS=psy_your_key
 PENSYVE_KEY_USER_MAP=psy_your_key:4173c1db-6da1-4505-a7a9-0b0e437e94ee
 ```
@@ -266,8 +273,10 @@ the new generation. Lexical recall keeps working throughout.
 ## Operating it
 
 **Back up the volume.** One SQLite file is easy to copy and easy to lose. Snapshot
-`/data` on a schedule; `sqlite3 /data/memories.db ".backup /tmp/backup.db"` is
-safe against a running gateway.
+`/data` on a schedule. `sqlite3 /data/memories.db ".backup /data/backup.db"` is
+safe to run against a live gateway — write it inside the volume, not to `/tmp`,
+which does not survive a restart — then copy it off the volume to wherever you
+actually keep backups.
 
 **Watch disk.** The gateway writes WAL alongside the store. Leave headroom.
 

--- a/pensyve-core/src/gdpr.rs
+++ b/pensyve-core/src/gdpr.rs
@@ -314,6 +314,112 @@ fn personal_memory_value(memory: &Memory) -> Result<serde_json::Value, StorageEr
     })
 }
 
+/// Stream a namespace-wide sidecar in the same frame shape as
+/// [`export_entity_data_to_writer`].
+///
+/// The native store copy is the lossless artifact; this is the plain-text
+/// companion that stays readable when no Pensyve build is at hand, so it
+/// deliberately carries the same per-memory record shape a DSAR export uses
+/// rather than inventing a second one.
+///
+/// Two differences from the entity export, both forced by the wider scope:
+/// it walks the namespace rather than one entity's personal data, and it
+/// includes procedural memories. `personal_memory_value` rejects those on
+/// purpose — a procedure is not personal data attached to a data subject — but
+/// a namespace sidecar that silently dropped a whole memory class would
+/// misrepresent what the customer has, so they get their own record arm here
+/// instead of a relaxed GDPR contract.
+pub fn export_namespace_data_to_writer(
+    storage: &dyn StorageTrait,
+    namespace_id: Uuid,
+    writer: &mut dyn Write,
+) -> Result<ExportManifest, StorageError> {
+    use crate::storage::bounded::{MEMORY_PAGE_SIZE, MemoryPageRequest, SearchScope};
+
+    let mut digest = Sha256::new();
+    write_export_frame(
+        writer,
+        &mut digest,
+        &serde_json::json!({
+            "kind": "header",
+            "format_version": 1,
+            "namespace_id": namespace_id.to_string(),
+        }),
+    )?;
+
+    let scope = SearchScope::namespace(namespace_id);
+    let mut memory_records = 0_usize;
+    let mut cursor = None;
+    loop {
+        let request = MemoryPageRequest::new(scope.clone(), cursor, MEMORY_PAGE_SIZE, true)?;
+        let page = storage.page_memories(&request)?;
+        for memory in &page.memories {
+            write_export_frame(
+                writer,
+                &mut digest,
+                &serde_json::json!({
+                    "kind": "memory",
+                    "record": sidecar_memory_value(memory)?,
+                }),
+            )?;
+            memory_records += 1;
+        }
+        cursor = page.next_cursor;
+        if cursor.is_none() {
+            break;
+        }
+    }
+
+    let mut entity_records = 0_usize;
+    for entity in storage.list_entities_by_namespace(namespace_id)? {
+        write_export_frame(
+            writer,
+            &mut digest,
+            &serde_json::json!({
+                "kind": "entity",
+                "id": entity.id.to_string(),
+                "name": entity.name,
+            }),
+        )?;
+        entity_records += 1;
+    }
+
+    let stream_sha256 = hex::encode(digest.finalize());
+    let total_records = memory_records + entity_records;
+    let footer = serde_json::to_vec(&serde_json::json!({
+        "kind": "footer",
+        "memory_records": memory_records,
+        "entity_records": entity_records,
+        "total_records": total_records,
+        "stream_sha256": stream_sha256,
+    }))?;
+    writer.write_all(&footer)?;
+    writer.write_all(b"\n")?;
+
+    Ok(ExportManifest {
+        memory_records,
+        total_records,
+        stream_sha256,
+    })
+}
+
+/// [`personal_memory_value`] widened to the one class it refuses.
+fn sidecar_memory_value(memory: &Memory) -> Result<serde_json::Value, StorageError> {
+    match memory {
+        Memory::Procedural(memory) => Ok(serde_json::json!({
+            "type": "procedural",
+            "id": memory.id.to_string(),
+            "trigger": memory.trigger,
+            "action": memory.action,
+            "reliability": memory.reliability,
+            "trial_count": memory.trial_count,
+            "success_count": memory.success_count,
+            "created_at": memory.created_at.to_rfc3339(),
+        })),
+        other => personal_memory_value(other),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/pensyve-core/src/lib.rs
+++ b/pensyve-core/src/lib.rs
@@ -13,6 +13,7 @@ pub mod gdpr;
 pub mod graph;
 pub mod mesh;
 pub mod multimodal;
+pub mod namespace_export;
 pub mod network_policy;
 pub mod observability;
 pub mod observation;

--- a/pensyve-core/src/namespace_export.rs
+++ b/pensyve-core/src/namespace_export.rs
@@ -45,11 +45,29 @@
 //! row-level security, so RLS must not be treated as the boundary here: the
 //! predicate on each call is what keeps one tenant's export free of another
 //! tenant's rows.
+//!
+//! # Consistency
+//!
+//! **This is not a point-in-time snapshot.** Each entity list, episode page,
+//! memory page and embedding batch is its own read, so a namespace still taking
+//! writes can be copied mid-flight. Because memory paging orders by random
+//! UUID, a row inserted below the cursor is missed rather than merely late, and
+//! a supersession that lands between two pages can leave the copy with both
+//! rows live or with a `superseded_by` pointing at a row that never crossed.
+//! The per-page destination writes are atomic individually; the export as a
+//! whole is not.
+//!
+//! Nothing here can fix that on its own — it needs the source to hold one
+//! repeatable-read snapshot across every read, or the namespace to be quiesced.
+//! Until then, export a namespace while its writers are idle when the artifact
+//! has to be exact, and re-compare counts against the source afterwards to see
+//! what moved underneath.
 
 use uuid::Uuid;
 
 use crate::storage::bounded::{
-    EpisodePageCursor, MAX_FUSED_HITS, MEMORY_PAGE_SIZE, MemoryPageRequest, MemoryRef, SearchScope,
+    EpisodePageCursor, MAX_FUSED_HITS, MEMORY_PAGE_SIZE, MemoryPageRequest, MemoryRef,
+    NamespaceEmbeddingPhase, SearchScope,
 };
 use crate::storage::{CapturedMemory, StorageError, StorageResult, StorageTrait};
 use crate::types::Memory;
@@ -109,23 +127,39 @@ pub fn export_namespace(
     // 2. Embedding lifecycle. Registering the source's *active read* space (not
     //    whatever the local runtime would produce) is what makes the copied
     //    vectors usable as-is: they were produced by that transformation, and
-    //    the destination must agree about which one it was. A namespace still
-    //    mid-migration has no settled generation to copy under, so it is
-    //    refused rather than exported into an ambiguous state.
+    //    the destination must agree about which one it was.
+    //
+    //    Each phase is answered on its own rather than inferred from whether a
+    //    space happens to be joined. Reading "has an active space" as "is
+    //    exportable" gets both edges wrong: a legitimately lexical-only
+    //    namespace has none and would be refused despite having nothing to
+    //    carry, and a namespace mid-migration still has its *old* active space,
+    //    so it would export as though settled while silently dropping the
+    //    generation being built.
     let embedding_space = match source.get_namespace_embedding_state(namespace_id)? {
-        Some(state) => {
+        // No lifecycle row and an explicitly lexical-only namespace are the
+        // same thing to an export: memories, no vectors.
+        None => None,
+        Some(state) if state.phase == NamespaceEmbeddingPhase::LexicalOnly => None,
+        Some(state) if state.phase == NamespaceEmbeddingPhase::Active => {
+            // `Active` without a joined space would mean the lifecycle row and
+            // the spaces table disagree, which is corruption rather than a
+            // state to export around.
             let space = state.active_read_space.clone().ok_or_else(|| {
                 StorageError::Context(format!(
-                    "namespace {namespace_id} is in phase {:?} with no active read space; \
-                     finish or roll back the embedding migration before exporting",
-                    state.phase
+                    "namespace {namespace_id} is active but has no joined active read space"
                 ))
             })?;
             destination.initialize_local_runtime_space(namespace_id, &space)?;
             Some(space)
         }
-        // Lexical-only namespace: no generation, so no vectors to carry.
-        None => None,
+        Some(state) => {
+            return Err(StorageError::Context(format!(
+                "namespace {namespace_id} is mid-migration (phase {:?}); finish or roll it \
+                 back before exporting, so the copy carries one settled generation",
+                state.phase
+            )));
+        }
     };
     let space_id = embedding_space
         .as_ref()
@@ -509,6 +543,68 @@ mod tests {
         assert_eq!(
             dest_db.count_memories_by_namespace(namespace.id).unwrap(),
             (total, 0, 0)
+        );
+    }
+
+    /// A namespace that never had an embedding generation still exports.
+    ///
+    /// Its lifecycle row exists and reads `LexicalOnly` with no active space.
+    /// Treating "no active space" as the failure case refused these outright,
+    /// which is wrong: there is nothing to carry, not something missing.
+    #[test]
+    fn a_lexical_only_namespace_exports_its_memories_without_vectors() {
+        let (_source_dir, source_db) = store();
+        let namespace = Namespace::new("tenant:lexical");
+        source_db.save_namespace(&namespace).unwrap();
+
+        let episode = Episode::new(namespace.id, vec![Uuid::new_v4()]);
+        source_db.save_episode(&episode).unwrap();
+        let memory = Memory::Episodic(EpisodicMemory::new(
+            namespace.id,
+            episode.id,
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            "no vectors here",
+        ));
+        source_db.save_memory_with_embedding(&memory, None).unwrap();
+
+        let (_dest_dir, dest_db) = store();
+        let counts = export_namespace(&source_db, &dest_db, namespace.id)
+            .expect("a lexical-only namespace is exportable");
+
+        assert_eq!(counts.episodic, 1);
+        assert_eq!(counts.embeddings, 0, "there were no vectors to carry");
+        assert_eq!(
+            dest_db.count_memories_by_namespace(namespace.id).unwrap(),
+            (1, 0, 0)
+        );
+    }
+
+    /// A namespace mid-migration is refused rather than quietly exported.
+    ///
+    /// It still has its *old* active space joined, so a check that only asked
+    /// "is a space present?" would accept it and drop the generation being
+    /// built, producing a copy that looks settled and is not.
+    #[test]
+    fn a_namespace_mid_migration_is_refused() {
+        let embedder = OnnxEmbedder::new_mock(DIMS);
+        let space = embedder.embedding_space().expect("mock space").clone();
+        let (_source_dir, source_db) = store();
+        let (namespace, _) = seed(&source_db, &space, "migrating");
+
+        // Begin a migration onto a second generation and leave it in flight.
+        let target = EmbeddingSpace::mock(DIMS, "v2");
+        source_db
+            .begin_embedding_migration(namespace.id, &target)
+            .expect("begin migration");
+
+        let (_dest_dir, dest_db) = store();
+        let error = export_namespace(&source_db, &dest_db, namespace.id)
+            .expect_err("an in-flight migration must not export");
+        let message = error.to_string();
+        assert!(
+            message.contains("mid-migration"),
+            "error should name the in-flight migration, got: {message}"
         );
     }
 

--- a/pensyve-core/src/namespace_export.rs
+++ b/pensyve-core/src/namespace_export.rs
@@ -1,0 +1,509 @@
+//! Copy one namespace from a source store into a fresh destination store.
+//!
+//! This is the operator half of "give the customer their data": a hosted
+//! Postgres namespace is copied row-for-row into a native `SQLite` store the
+//! customer can mount into a self-hosted gateway and serve from directly. The
+//! copy goes through [`StorageTrait`], so the source is read exactly the way
+//! the serving path reads it and the destination is written exactly the way the
+//! snapshot restore path writes it — no backend-specific SQL, no schema
+//! assumptions beyond the trait, and nothing that depends on both sides being
+//! the same backend.
+//!
+//! # Why a store copy rather than a replay
+//!
+//! Replaying a namespace through the public API re-derives everything: new ids,
+//! new extraction, `Utc::now()` timestamps, default stability and
+//! retrievability, no supersession chains and freshly computed embeddings.
+//! Copying the rows preserves the fields that make recall behave the way it did
+//! on the hosted instance — decay state, access counts, validity intervals,
+//! supersession, and the exact vectors under their originating embedding space.
+//!
+//! # Fidelity
+//!
+//! What crosses, and what deliberately does not:
+//!
+//! | Row class | Carried | Note |
+//! |---|---|---|
+//! | namespace | yes | id preserved, so ids in exported rows stay valid |
+//! | embedding space + lifecycle | yes | registered before any vector is written |
+//! | entities | yes | |
+//! | episodes | yes | via [`StorageTrait::page_episodes`] |
+//! | memories (all four types) | yes | superseded rows included |
+//! | embeddings | yes | under the source's active read space |
+//! | graph edges | yes | walked per entity |
+//! | activity events | **no** | operational telemetry, not memory content |
+//! | consolidation runs | **no** | scheduler bookkeeping, rebuilt on the target |
+//!
+//! There is no feedback row class to carry: `crate::feedback` is an in-memory
+//! retrieval-weight adapter, not persisted state. Salience is likewise not a
+//! column — it is folded into `stability` at write time and travels inside it.
+//!
+//! # Scoping
+//!
+//! Every read is explicitly predicated on `namespace_id`. On a hosted Postgres
+//! store the operator connection is typically the table owner, which bypasses
+//! row-level security, so RLS must not be treated as the boundary here: the
+//! predicate on each call is what keeps one tenant's export free of another
+//! tenant's rows.
+
+use uuid::Uuid;
+
+use crate::storage::bounded::{
+    EpisodePageCursor, MEMORY_PAGE_SIZE, MemoryPageRequest, MemoryRef, SearchScope,
+};
+use crate::storage::{CapturedMemory, StorageError, StorageResult, StorageTrait};
+use crate::types::Memory;
+
+/// Per-row-class tallies, used to prove a copy is complete rather than assumed.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct ExportCounts {
+    pub episodes: usize,
+    pub episodic: usize,
+    pub semantic: usize,
+    pub procedural: usize,
+    pub observations: usize,
+    pub entities: usize,
+    pub edges: usize,
+    pub embeddings: usize,
+}
+
+impl ExportCounts {
+    #[must_use]
+    pub fn memories(&self) -> usize {
+        self.episodic + self.semantic + self.procedural + self.observations
+    }
+
+    fn record(&mut self, memory: &Memory) {
+        match memory {
+            Memory::Episodic(_) => self.episodic += 1,
+            Memory::Semantic(_) => self.semantic += 1,
+            Memory::Procedural(_) => self.procedural += 1,
+            Memory::Observation(_) => self.observations += 1,
+        }
+    }
+}
+
+/// Copy `namespace_id` from `source` into `destination`.
+///
+/// `destination` must be a freshly created store at the current schema version.
+/// The write order is forced by referential integrity on the destination:
+/// the namespace row must exist before the embedding space can be registered
+/// against it, and the space must be registered before any vector referencing
+/// it is written.
+///
+/// The source is only ever read. Nothing here mutates the hosted store.
+pub fn export_namespace(
+    source: &dyn StorageTrait,
+    destination: &dyn StorageTrait,
+    namespace_id: Uuid,
+) -> StorageResult<ExportCounts> {
+    let mut counts = ExportCounts::default();
+
+    // 1. Namespace. Preserving the id is what keeps every foreign key in the
+    //    copied rows meaningful on the far side.
+    let namespace = source
+        .get_namespace(namespace_id)?
+        .ok_or_else(|| StorageError::NotFound(format!("namespace {namespace_id}")))?;
+    destination.save_namespace(&namespace)?;
+
+    // 2. Embedding lifecycle. Registering the source's *active read* space (not
+    //    whatever the local runtime would produce) is what makes the copied
+    //    vectors usable as-is: they were produced by that transformation, and
+    //    the destination must agree about which one it was. A namespace still
+    //    mid-migration has no settled generation to copy under, so it is
+    //    refused rather than exported into an ambiguous state.
+    let embedding_space = match source.get_namespace_embedding_state(namespace_id)? {
+        Some(state) => {
+            let space = state.active_read_space.clone().ok_or_else(|| {
+                StorageError::Context(format!(
+                    "namespace {namespace_id} is in phase {:?} with no active read space; \
+                     finish or roll back the embedding migration before exporting",
+                    state.phase
+                ))
+            })?;
+            destination.initialize_local_runtime_space(namespace_id, &space)?;
+            Some(space)
+        }
+        // Lexical-only namespace: no generation, so no vectors to carry.
+        None => None,
+    };
+    let space_id = embedding_space
+        .as_ref()
+        .map(crate::embedding_space::EmbeddingSpace::id);
+
+    // 3. Entities, before the edges and memories that reference them.
+    let entities = source.list_entities_by_namespace(namespace_id)?;
+    for entity in &entities {
+        destination.save_entity(entity)?;
+        counts.entities += 1;
+    }
+
+    // 4. Episodes, walked in bounded pages rather than recovered from
+    //    `episodic_memories.episode_id` — an episode whose memories were erased
+    //    or superseded away is still the customer's data.
+    let mut after: Option<EpisodePageCursor> = None;
+    loop {
+        let page = source.page_episodes(namespace_id, after, MEMORY_PAGE_SIZE)?;
+        for episode in &page.episodes {
+            destination.save_episode(episode)?;
+            counts.episodes += 1;
+        }
+        after = page.next_cursor;
+        if after.is_none() {
+            break;
+        }
+    }
+
+    // 5. Memories with their vectors, committed a page at a time through the
+    //    same transactional restore path a snapshot uses, so a partial page
+    //    never lands as a memory without its embedding.
+    let scope = SearchScope::namespace(namespace_id);
+    let mut cursor = None;
+    loop {
+        let request = MemoryPageRequest::new(scope.clone(), cursor, MEMORY_PAGE_SIZE, true)?;
+        let page = source.page_memories(&request)?;
+        if page.memories.is_empty() && page.next_cursor.is_none() {
+            break;
+        }
+
+        let captured = capture_page(source, namespace_id, space_id.as_ref(), &page.memories)?;
+        for entry in &captured {
+            counts.record(&entry.memory);
+            counts.embeddings += entry.embeddings.len();
+        }
+        destination.restore_memory_page(&captured)?;
+
+        cursor = page.next_cursor;
+        if cursor.is_none() {
+            break;
+        }
+    }
+
+    // 6. Graph edges, reachable only by walking entities. An edge is incident
+    //    to two of them, so the same row comes back once under its source and
+    //    again under its target; without the seen set the copy writes it twice
+    //    and reports double the edges it actually carried.
+    let mut seen_edges = std::collections::HashSet::new();
+    for entity in &entities {
+        for edge in source.get_edges_for_entity_in_namespace(entity.id, namespace_id)? {
+            if !seen_edges.insert(edge.id) {
+                continue;
+            }
+            destination.save_edge(&edge, namespace_id)?;
+            counts.edges += 1;
+        }
+    }
+
+    Ok(counts)
+}
+
+/// Pair one page of memories with their embedding records.
+///
+/// Embeddings are loaded per page rather than per memory so the round trip
+/// count stays proportional to pages, not rows.
+fn capture_page(
+    source: &dyn StorageTrait,
+    namespace_id: Uuid,
+    space_id: Option<&crate::embedding_space::EmbeddingSpaceId>,
+    memories: &[Memory],
+) -> StorageResult<Vec<CapturedMemory>> {
+    let Some(space_id) = space_id else {
+        return Ok(memories
+            .iter()
+            .map(|memory| CapturedMemory {
+                memory: memory.clone(),
+                embeddings: Vec::new(),
+            })
+            .collect());
+    };
+
+    let refs: Vec<MemoryRef> = memories.iter().map(MemoryRef::from_memory).collect();
+    let records = source.load_embedding_records(namespace_id, space_id, &refs)?;
+
+    Ok(memories
+        .iter()
+        .map(|memory| {
+            let memory_ref = MemoryRef::from_memory(memory);
+            CapturedMemory {
+                memory: memory.clone(),
+                embeddings: records
+                    .iter()
+                    .filter(|record| record.memory_ref == memory_ref)
+                    .cloned()
+                    .collect(),
+            }
+        })
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::time::{Duration, Instant};
+
+    use tempfile::TempDir;
+    use uuid::Uuid;
+
+    use super::{ExportCounts, export_namespace};
+    use crate::embedding::OnnxEmbedder;
+    use crate::embedding_space::EmbeddingSpace;
+    use crate::storage::bounded::{
+        MemoryRef, SearchScope, VectorSearchOutcome, VectorSearchRequest,
+    };
+    use crate::storage::sqlite::SqliteBackend;
+    use crate::storage::{StorageTrait, embedding_record_for_memory};
+    use crate::types::{
+        Edge, Entity, EntityKind, Episode, EpisodicMemory, Memory, Namespace, ObservationMemory,
+        Outcome, ProceduralMemory, SemanticMemory,
+    };
+
+    const DIMS: usize = 8;
+
+    fn store() -> (TempDir, SqliteBackend) {
+        let dir = TempDir::new().expect("temp dir");
+        let db = SqliteBackend::open(dir.path()).expect("open sqlite store");
+        (dir, db)
+    }
+
+    /// Distinct-but-valid unit vectors, so nearest-neighbour order is a fact
+    /// about the copied vectors rather than a tie broken by row order.
+    fn vector(seed: usize) -> Vec<f32> {
+        let mut embedding = vec![0.1_f32; DIMS];
+        embedding[seed % DIMS] = 1.0;
+        embedding
+    }
+
+    fn save(db: &SqliteBackend, space: &EmbeddingSpace, memory: &Memory, seed: usize) {
+        let record = embedding_record_for_memory(memory, space, vector(seed));
+        db.save_memory_with_embedding(memory, Some(&record))
+            .expect("save memory with embedding");
+    }
+
+    /// Seed one namespace with every row class the export claims to carry.
+    fn seed(db: &SqliteBackend, space: &EmbeddingSpace, label: &str) -> (Namespace, Uuid) {
+        let namespace = Namespace::new(format!("tenant:{label}"));
+        db.save_namespace(&namespace).expect("save namespace");
+        db.initialize_local_runtime_space(namespace.id, space)
+            .expect("register embedding space");
+
+        let mut source = Entity::new(format!("{label}-source"), EntityKind::User);
+        source.namespace_id = namespace.id;
+        let mut about = Entity::new(format!("{label}-about"), EntityKind::Agent);
+        about.namespace_id = namespace.id;
+        db.save_entity(&source).expect("save source entity");
+        db.save_entity(&about).expect("save about entity");
+
+        let episode = Episode::new(namespace.id, vec![source.id, about.id]);
+        db.save_episode(&episode).expect("save episode");
+        // A second episode with no memories attached: the row class the old
+        // "derive episode ids from episodic_memories" shortcut would lose.
+        let orphan = Episode::new(namespace.id, vec![source.id]);
+        db.save_episode(&orphan).expect("save orphan episode");
+
+        let episodic = Memory::Episodic(EpisodicMemory::new(
+            namespace.id,
+            episode.id,
+            source.id,
+            about.id,
+            format!("{label} deployed the gateway on Friday"),
+        ));
+        save(db, space, &episodic, 1);
+
+        let semantic = Memory::Semantic(SemanticMemory::new(
+            namespace.id,
+            about.id,
+            "prefers",
+            format!("{label} self-hosting"),
+            0.9,
+        ));
+        save(db, space, &semantic, 2);
+
+        let procedural = Memory::Procedural(ProceduralMemory::new(
+            namespace.id,
+            format!("{label} rollback requested"),
+            "revert to previous task definition",
+            Outcome::Success,
+            HashMap::new(),
+        ));
+        save(db, space, &procedural, 3);
+
+        let observation = Memory::Observation(ObservationMemory::new(
+            namespace.id,
+            episode.id,
+            "deployment",
+            format!("{label}-prod"),
+            "deployed",
+            format!("{label} shipped v4"),
+        ));
+        save(db, space, &observation, 4);
+
+        let edge = Edge {
+            id: Uuid::new_v4(),
+            source: source.id,
+            target: about.id,
+            relation: "collaborates_with".into(),
+            weight: 0.75,
+            valid_at: chrono::Utc::now(),
+            invalid_at: None,
+            superseded_by: None,
+            metadata: HashMap::new(),
+            edge_type: crate::graph::EdgeType::default(),
+        };
+        db.save_edge(&edge, namespace.id).expect("save edge");
+
+        (namespace, episodic.id())
+    }
+
+    fn top_hit(db: &SqliteBackend, namespace_id: Uuid, space: &EmbeddingSpace) -> MemoryRef {
+        let query = vector(1);
+        let request = VectorSearchRequest::new(
+            SearchScope::namespace(namespace_id),
+            space.id(),
+            &query,
+            5,
+            Instant::now() + Duration::from_secs(5),
+        )
+        .expect("vector request");
+        match db.search_vector(&request).expect("vector search") {
+            VectorSearchOutcome::Complete(hits) => {
+                hits.first().expect("at least one hit").memory_ref
+            }
+            VectorSearchOutcome::Unavailable(reason) => {
+                panic!("vector search unavailable: {reason:?}")
+            }
+        }
+    }
+
+    #[test]
+    fn round_trip_copies_every_row_class_and_preserves_recall() {
+        let embedder = OnnxEmbedder::new_mock(DIMS);
+        let space = embedder.embedding_space().expect("mock space").clone();
+
+        let (_source_dir, source_db) = store();
+        let (namespace, episodic_id) = seed(&source_db, &space, "jeremy");
+        // A second tenant in the same source store. The export must not touch it.
+        let (other, _) = seed(&source_db, &space, "someone-else");
+
+        let (_dest_dir, dest_db) = store();
+        let counts =
+            export_namespace(&source_db, &dest_db, namespace.id).expect("export namespace");
+
+        assert_eq!(
+            counts,
+            ExportCounts {
+                episodes: 2,
+                episodic: 1,
+                semantic: 1,
+                procedural: 1,
+                observations: 1,
+                entities: 2,
+                edges: 1,
+                embeddings: 4,
+            },
+            "every seeded row class must cross exactly once"
+        );
+
+        // Counts on the destination, read back independently of the tally the
+        // copy reported, so a miscounted copy cannot vouch for itself.
+        assert_eq!(
+            dest_db.count_memories_by_namespace(namespace.id).unwrap(),
+            source_db.count_memories_by_namespace(namespace.id).unwrap()
+        );
+        assert_eq!(
+            dest_db.count_entities_by_namespace(namespace.id).unwrap(),
+            2
+        );
+        assert_eq!(
+            dest_db
+                .page_episodes(namespace.id, None, 256)
+                .unwrap()
+                .episodes
+                .len(),
+            2
+        );
+
+        // Read the edge back from both endpoints: an edge written once still
+        // answers from either side, and a double-write would show up here.
+        let source_entities = dest_db.list_entities_by_namespace(namespace.id).unwrap();
+        for entity in &source_entities {
+            let edges = dest_db
+                .get_edges_for_entity_in_namespace(entity.id, namespace.id)
+                .unwrap();
+            assert_eq!(
+                edges.len(),
+                1,
+                "each endpoint sees the one copied edge once"
+            );
+            assert_eq!(edges[0].relation, "collaborates_with");
+        }
+
+        // The copied vectors answer the same query with the same top memory.
+        let expected = top_hit(&source_db, namespace.id, &space);
+        assert_eq!(expected.id, episodic_id, "fixture sanity: seeded top hit");
+        assert_eq!(
+            top_hit(&dest_db, namespace.id, &space),
+            expected,
+            "paraphrased recall must return the same top memory after the copy"
+        );
+
+        // The other tenant stayed behind.
+        assert_eq!(
+            dest_db.count_memories_by_namespace(other.id).unwrap(),
+            (0, 0, 0)
+        );
+        assert_eq!(dest_db.count_entities_by_namespace(other.id).unwrap(), 0);
+        assert!(dest_db.get_namespace(other.id).unwrap().is_none());
+    }
+
+    #[test]
+    fn superseded_memories_cross_with_their_supersession_intact() {
+        let embedder = OnnxEmbedder::new_mock(DIMS);
+        let space = embedder.embedding_space().expect("mock space").clone();
+
+        let (_source_dir, source_db) = store();
+        let (namespace, _) = seed(&source_db, &space, "jeremy");
+
+        let stale = Memory::Semantic(SemanticMemory::new(
+            namespace.id,
+            Uuid::new_v4(),
+            "runs",
+            "an older claim",
+            0.5,
+        ));
+        save(&source_db, &space, &stale, 5);
+        let replacement = Memory::Semantic(SemanticMemory::new(
+            namespace.id,
+            Uuid::new_v4(),
+            "runs",
+            "a newer claim",
+            0.9,
+        ));
+        save(&source_db, &space, &replacement, 6);
+        source_db
+            .supersede_memory_in_namespace(
+                stale.id(),
+                namespace.id,
+                replacement.id(),
+                chrono::Utc::now(),
+            )
+            .expect("supersede");
+
+        let (_dest_dir, dest_db) = store();
+        let counts =
+            export_namespace(&source_db, &dest_db, namespace.id).expect("export namespace");
+
+        // Three semantic rows: the original, the superseded one, and its
+        // replacement. A copy that only walked live rows would report two.
+        assert_eq!(counts.semantic, 3, "superseded rows must cross too");
+
+        let carried = dest_db
+            .get_semantic_in_namespace(stale.id(), namespace.id)
+            .expect("read superseded row")
+            .expect("superseded row present in copy");
+        assert_eq!(
+            carried.superseded_by,
+            Some(replacement.id()),
+            "supersession chain must survive the copy"
+        );
+    }
+}

--- a/pensyve-core/src/namespace_export.rs
+++ b/pensyve-core/src/namespace_export.rs
@@ -49,7 +49,7 @@
 use uuid::Uuid;
 
 use crate::storage::bounded::{
-    EpisodePageCursor, MEMORY_PAGE_SIZE, MemoryPageRequest, MemoryRef, SearchScope,
+    EpisodePageCursor, MAX_FUSED_HITS, MEMORY_PAGE_SIZE, MemoryPageRequest, MemoryRef, SearchScope,
 };
 use crate::storage::{CapturedMemory, StorageError, StorageResult, StorageTrait};
 use crate::types::Memory;
@@ -199,8 +199,11 @@ pub fn export_namespace(
 
 /// Pair one page of memories with their embedding records.
 ///
-/// Embeddings are loaded per page rather than per memory so the round trip
-/// count stays proportional to pages, not rows.
+/// Embeddings are loaded in batches rather than per memory so the round-trip
+/// count stays proportional to pages, not rows. The batch is capped by
+/// [`MAX_FUSED_HITS`] rather than by the memory page size: a memory page holds
+/// [`MEMORY_PAGE_SIZE`] rows, which is larger, and handing the backend the
+/// whole page at once is refused as a budget violation.
 fn capture_page(
     source: &dyn StorageTrait,
     namespace_id: Uuid,
@@ -218,7 +221,10 @@ fn capture_page(
     };
 
     let refs: Vec<MemoryRef> = memories.iter().map(MemoryRef::from_memory).collect();
-    let records = source.load_embedding_records(namespace_id, space_id, &refs)?;
+    let mut records = Vec::with_capacity(refs.len());
+    for batch in refs.chunks(MAX_FUSED_HITS) {
+        records.extend(source.load_embedding_records(namespace_id, space_id, batch)?);
+    }
 
     Ok(memories
         .iter()
@@ -453,6 +459,57 @@ mod tests {
         );
         assert_eq!(dest_db.count_entities_by_namespace(other.id).unwrap(), 0);
         assert!(dest_db.get_namespace(other.id).unwrap().is_none());
+    }
+
+    /// A namespace bigger than one memory page, which is also bigger than the
+    /// embedding-load batch cap.
+    ///
+    /// These two limits are not the same number — a memory page holds
+    /// `MEMORY_PAGE_SIZE` (256) rows while an embedding load accepts at most
+    /// `MAX_FUSED_HITS` (200) references — so a copy that fed each page
+    /// straight into the embedding load worked on every small fixture and then
+    /// failed on the first real namespace with a budget error.
+    #[test]
+    fn a_namespace_larger_than_one_page_copies_with_every_vector() {
+        use crate::storage::bounded::{MAX_FUSED_HITS, MEMORY_PAGE_SIZE};
+
+        let embedder = OnnxEmbedder::new_mock(DIMS);
+        let space = embedder.embedding_space().expect("mock space").clone();
+        let (_source_dir, source_db) = store();
+
+        let namespace = Namespace::new("tenant:bulk");
+        source_db.save_namespace(&namespace).unwrap();
+        source_db
+            .initialize_local_runtime_space(namespace.id, &space)
+            .unwrap();
+        let episode = Episode::new(namespace.id, vec![Uuid::new_v4()]);
+        source_db.save_episode(&episode).unwrap();
+
+        let total = MEMORY_PAGE_SIZE + MAX_FUSED_HITS + 7;
+        for index in 0..total {
+            let memory = Memory::Episodic(EpisodicMemory::new(
+                namespace.id,
+                episode.id,
+                Uuid::new_v4(),
+                Uuid::new_v4(),
+                format!("bulk memory {index}"),
+            ));
+            save(&source_db, &space, &memory, index);
+        }
+
+        let (_dest_dir, dest_db) = store();
+        let counts =
+            export_namespace(&source_db, &dest_db, namespace.id).expect("export namespace");
+
+        assert_eq!(counts.episodic, total);
+        assert_eq!(
+            counts.embeddings, total,
+            "every memory must arrive with its vector, not just the first page"
+        );
+        assert_eq!(
+            dest_db.count_memories_by_namespace(namespace.id).unwrap(),
+            (total, 0, 0)
+        );
     }
 
     #[test]

--- a/pensyve-core/src/storage/bounded.rs
+++ b/pensyve-core/src/storage/bounded.rs
@@ -555,6 +555,25 @@ pub struct PageCursor {
     pub id: Uuid,
 }
 
+/// Cursor into a namespace's episodes, ordered by id.
+///
+/// Episodes are the one durable row class with no bounded enumerator of their
+/// own: `get_episode_in_namespace` fetches one by id and nothing walks the
+/// table. A namespace copy that recovered episode ids from
+/// `episodic_memories.episode_id` would silently drop every episode whose
+/// memories had been erased or superseded away, so the walk is its own paged
+/// read rather than a join.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct EpisodePageCursor {
+    pub id: Uuid,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct EpisodePage {
+    pub episodes: Vec<crate::types::Episode>,
+    pub next_cursor: Option<EpisodePageCursor>,
+}
+
 pub struct VectorSearchRequest<'a> {
     pub scope: SearchScope,
     pub embedding_space_id: EmbeddingSpaceId,

--- a/pensyve-core/src/storage/mod.rs
+++ b/pensyve-core/src/storage/mod.rs
@@ -707,6 +707,21 @@ pub trait StorageTrait: Send + Sync {
 
     fn update_episode(&self, episode: &Episode) -> StorageResult<()>;
 
+    /// Walk one namespace's episodes in stable bounded pages ordered by id.
+    ///
+    /// The namespace predicate is mandatory for the same reason
+    /// [`StorageTrait::get_episode_in_namespace`] carries one: a shared backend
+    /// serves every tenant, so an unscoped walk is a cross-tenant read. Backends
+    /// that cannot page fail closed rather than falling back to a full scan.
+    fn page_episodes(
+        &self,
+        _namespace_id: Uuid,
+        _after: Option<bounded::EpisodePageCursor>,
+        _limit: usize,
+    ) -> StorageResult<bounded::EpisodePage> {
+        Err(StorageError::Unsupported("bounded episode paging".into()))
+    }
+
     // Episodic Memory
     fn save_episodic(&self, mem: &EpisodicMemory) -> StorageResult<()>;
 

--- a/pensyve-core/src/storage/postgres.rs
+++ b/pensyve-core/src/storage/postgres.rs
@@ -36,11 +36,12 @@ use super::{
 };
 use crate::graph::EdgeType;
 use crate::storage::bounded::{
-    EmbeddingRecord, LexicalHit, MAX_FUSED_HITS, MAX_HYDRATED_BYTES, MAX_LEXICAL_HITS,
-    MAX_VECTOR_HITS, MEMORY_PAGE_SIZE, MemoryFilter, MemoryPage, MemoryPageRequest, MemoryRef,
-    MemoryType, NamespaceEmbeddingPhase, NamespaceEmbeddingState, PageCursor,
-    SNAPSHOT_MAX_FRAME_BYTES, SNAPSHOT_MAX_PAGE_BYTES, SearchScope, SearchUnavailable, VectorHit,
-    VectorSearchOutcome, VectorSearchRequest, lexical_query_tokens,
+    EmbeddingRecord, EpisodePage, EpisodePageCursor, LexicalHit, MAX_FUSED_HITS,
+    MAX_HYDRATED_BYTES, MAX_LEXICAL_HITS, MAX_VECTOR_HITS, MEMORY_PAGE_SIZE, MemoryFilter,
+    MemoryPage, MemoryPageRequest, MemoryRef, MemoryType, NamespaceEmbeddingPhase,
+    NamespaceEmbeddingState, PageCursor, SNAPSHOT_MAX_FRAME_BYTES, SNAPSHOT_MAX_PAGE_BYTES,
+    SearchScope, SearchUnavailable, VectorHit, VectorSearchOutcome, VectorSearchRequest,
+    lexical_query_tokens,
 };
 use crate::storage::consolidation_workspace::{
     ClusterDecision, ClusterProvenance, ConsolidationWorkspace, DecayPage, DecayRecord,
@@ -4042,6 +4043,70 @@ impl StorageTrait for PostgresBackend {
 
     fn update_episode(&self, episode: &Episode) -> StorageResult<()> {
         self.save_episode(episode)
+    }
+
+    fn page_episodes(
+        &self,
+        namespace_id: Uuid,
+        after: Option<EpisodePageCursor>,
+        limit: usize,
+    ) -> StorageResult<EpisodePage> {
+        if !(1..=MEMORY_PAGE_SIZE).contains(&limit) {
+            return Err(StorageError::BudgetExceeded(format!(
+                "episode page limit must be within 1..={MEMORY_PAGE_SIZE}"
+            )));
+        }
+        let after = after.map_or_else(Uuid::nil, |cursor| cursor.id);
+        self.block_on(async move {
+            let mut conn = self.scoped_conn(namespace_id).await?;
+            #[allow(clippy::type_complexity)]
+            let rows: Vec<(
+                Uuid,
+                Uuid,
+                serde_json::Value,
+                DateTime<Utc>,
+                Option<DateTime<Utc>>,
+                Option<String>,
+                serde_json::Value,
+            )> = query_as::<Postgres, _>(
+                "SELECT id, namespace_id, participants, started_at, ended_at, outcome, metadata \
+                 FROM episodes WHERE namespace_id = $1 AND id > $2 ORDER BY id LIMIT $3",
+            )
+            .bind(namespace_id)
+            .bind(after)
+            .bind(i64::try_from(limit).unwrap_or(i64::MAX))
+            .fetch_all(&mut *conn)
+            .await
+            .map_err(sqlx_to_io)?;
+
+            let episodes: Vec<Episode> = rows
+                .into_iter()
+                .map(
+                    |(id, namespace_id, participants, started_at, ended_at, outcome, metadata)| {
+                        Episode {
+                            id,
+                            namespace_id,
+                            participants: serde_json::from_value(participants).unwrap_or_default(),
+                            started_at,
+                            ended_at,
+                            outcome: outcome.as_deref().map(str_to_outcome),
+                            metadata: serde_json::from_value(metadata).unwrap_or_default(),
+                        }
+                    },
+                )
+                .collect();
+            let next_cursor = (episodes.len() == limit)
+                .then(|| {
+                    episodes
+                        .last()
+                        .map(|episode| EpisodePageCursor { id: episode.id })
+                })
+                .flatten();
+            Ok(EpisodePage {
+                episodes,
+                next_cursor,
+            })
+        })
     }
 
     // -----------------------------------------------------------------------

--- a/pensyve-core/src/storage/sqlite.rs
+++ b/pensyve-core/src/storage/sqlite.rs
@@ -29,12 +29,12 @@ use super::{
 };
 use crate::graph::EdgeType;
 use crate::storage::bounded::{
-    EmbeddingRecord, LexicalHit, MAX_FUSED_HITS, MAX_HYDRATED_BYTES, MAX_LEXICAL_HITS,
-    MAX_VECTOR_HITS, MEMORY_PAGE_SIZE, MemoryFilter, MemoryPage, MemoryPageRequest, MemoryRef,
-    MemoryType, NamespaceEmbeddingPhase, NamespaceEmbeddingState, PageCursor,
-    SNAPSHOT_MAX_FRAME_BYTES, SNAPSHOT_MAX_PAGE_BYTES, SQLITE_MAX_SCANNED_VECTORS, SearchScope,
-    SearchUnavailable, VectorHit, VectorSearchOutcome, VectorSearchRequest, lexical_query_tokens,
-    sort_vector_hits,
+    EmbeddingRecord, EpisodePage, EpisodePageCursor, LexicalHit, MAX_FUSED_HITS,
+    MAX_HYDRATED_BYTES, MAX_LEXICAL_HITS, MAX_VECTOR_HITS, MEMORY_PAGE_SIZE, MemoryFilter,
+    MemoryPage, MemoryPageRequest, MemoryRef, MemoryType, NamespaceEmbeddingPhase,
+    NamespaceEmbeddingState, PageCursor, SNAPSHOT_MAX_FRAME_BYTES, SNAPSHOT_MAX_PAGE_BYTES,
+    SQLITE_MAX_SCANNED_VECTORS, SearchScope, SearchUnavailable, VectorHit, VectorSearchOutcome,
+    VectorSearchRequest, lexical_query_tokens, sort_vector_hits,
 };
 use crate::storage::consolidation_workspace::{
     ClusterDecision, ClusterProvenance, ConsolidationWorkspace, DecayPage, DecayRecord,
@@ -4164,6 +4164,70 @@ impl StorageTrait for SqliteBackend {
     fn update_episode(&self, episode: &Episode) -> StorageResult<()> {
         // Reuse save (INSERT OR REPLACE handles update).
         self.save_episode(episode)
+    }
+
+    fn page_episodes(
+        &self,
+        namespace_id: Uuid,
+        after: Option<EpisodePageCursor>,
+        limit: usize,
+    ) -> StorageResult<EpisodePage> {
+        if !(1..=MEMORY_PAGE_SIZE).contains(&limit) {
+            return Err(StorageError::BudgetExceeded(format!(
+                "episode page limit must be within 1..={MEMORY_PAGE_SIZE}"
+            )));
+        }
+        let after = after.map_or_else(String::new, |cursor| cursor.id.to_string());
+        let conn = lock_conn!(self);
+        let mut stmt = conn.prepare(
+            "SELECT id, namespace_id, participants, started_at, ended_at, outcome, metadata \
+             FROM episodes WHERE namespace_id = ?1 AND id > ?2 ORDER BY id LIMIT ?3",
+        )?;
+        let episodes = stmt
+            .query_map(
+                params![
+                    namespace_id.to_string(),
+                    after,
+                    i64::try_from(limit).unwrap_or(i64::MAX)
+                ],
+                |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, String>(2)?,
+                        row.get::<_, String>(3)?,
+                        row.get::<_, Option<String>>(4)?,
+                        row.get::<_, Option<String>>(5)?,
+                        row.get::<_, String>(6)?,
+                    ))
+                },
+            )?
+            .map(|row| {
+                let (id, ns, participants, started_at, ended_at, outcome, metadata) = row?;
+                Ok(Episode {
+                    id: Uuid::parse_str(&id)
+                        .map_err(|e| StorageError::Context(format!("corrupt UUID: {e}")))?,
+                    namespace_id: Uuid::parse_str(&ns)
+                        .map_err(|e| StorageError::Context(format!("corrupt UUID: {e}")))?,
+                    participants: json_to_uuids(&participants),
+                    started_at: str_to_dt(&started_at),
+                    ended_at: str_to_opt_dt(ended_at.as_deref()),
+                    outcome: outcome.as_deref().map(str_to_outcome),
+                    metadata: serde_json::from_str(&metadata)?,
+                })
+            })
+            .collect::<StorageResult<Vec<_>>>()?;
+        let next_cursor = (episodes.len() == limit)
+            .then(|| {
+                episodes
+                    .last()
+                    .map(|episode| EpisodePageCursor { id: episode.id })
+            })
+            .flatten();
+        Ok(EpisodePage {
+            episodes,
+            next_cursor,
+        })
     }
 
     // -----------------------------------------------------------------------

--- a/pensyve-mcp-gateway/src/main.rs
+++ b/pensyve-mcp-gateway/src/main.rs
@@ -332,11 +332,19 @@ fn export_namespace_command(
     embedder: &OnnxEmbedder,
     args: &ExportArgs,
 ) -> Result<()> {
-    if args.sqlite.exists() {
-        anyhow::bail!(
-            "{} already exists; refusing to overwrite an existing export",
-            args.sqlite.display()
-        );
+    // Both outputs are checked up front rather than each at its own write. The
+    // sidecar is written well into the run, so discovering it there would mean
+    // failing after the expensive copy had already finished.
+    for existing in [Some(&args.sqlite), args.json.as_ref()]
+        .into_iter()
+        .flatten()
+    {
+        if existing.exists() {
+            anyhow::bail!(
+                "{} already exists; refusing to overwrite an existing export",
+                existing.display()
+            );
+        }
     }
     let parent = args
         .sqlite

--- a/pensyve-mcp-gateway/src/main.rs
+++ b/pensyve-mcp-gateway/src/main.rs
@@ -116,8 +116,24 @@ fn reranker_runtime_metadata(
     }
 }
 
+/// Whether startup may create the serving namespace it was pointed at.
+///
+/// Serving needs the namespace to exist and creates it on first boot. The
+/// read-only operator modes must not: they run against the production store,
+/// and a mistyped or unset `PENSYVE_NAMESPACE` would otherwise have an export
+/// -- a command whose whole contract is that it only reads -- silently insert a
+/// row into the customer database before it ever got to the export.
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum NamespacePolicy {
+    CreateIfMissing,
+    ReadOnly,
+}
+
 #[allow(clippy::too_many_lines)]
-fn init_resources(config: &GatewayConfig) -> Result<InitResources> {
+fn init_resources_with(
+    config: &GatewayConfig,
+    namespace_policy: NamespacePolicy,
+) -> Result<InitResources> {
     let strict_local_models = std::env::var("PENSYVE_REQUIRE_LOCAL_MODELS").as_deref() == Ok("1");
     let allow_mock_embedder_value = std::env::var_os("PENSYVE_ALLOW_MOCK_EMBEDDER");
     let allow_mock_embedder = allow_mock_embedder_value
@@ -162,12 +178,15 @@ fn init_resources(config: &GatewayConfig) -> Result<InitResources> {
     let namespace_name = &config.namespace;
     let namespace = match storage.get_namespace_by_name(namespace_name) {
         Ok(Some(ns)) => ns,
-        Ok(None) => {
+        Ok(None) if namespace_policy == NamespacePolicy::CreateIfMissing => {
             let ns = Namespace::new(namespace_name);
             storage.save_namespace(&ns)?;
             tracing::info!("Created namespace '{namespace_name}' (id={})", ns.id);
             ns
         }
+        // Never persisted. The operator modes address their own namespace by
+        // id and never read this one; it exists only to satisfy the struct.
+        Ok(None) => Namespace::new(namespace_name),
         Err(e) => return Err(anyhow::anyhow!("Storage error: {e}")),
     };
 
@@ -320,6 +339,52 @@ fn parse_export_args(args: &[String]) -> Result<ExportArgs> {
     })
 }
 
+/// Build both export artifacts inside `staging`, and hand back the tallies.
+///
+/// Split out from the publish step so every failure path has one place to be
+/// cleaned up from, and so the `SQLite` store is closed — checkpointing and
+/// removing its write-ahead log — before anything moves the file. Publishing a
+/// store whose most recent writes still live in a `-wal` beside it would hand
+/// the customer a database missing its last pages.
+fn export_to_staging(
+    storage: &dyn StorageTrait,
+    args: &ExportArgs,
+    staging: &std::path::Path,
+) -> Result<pensyve_core::namespace_export::ExportCounts> {
+    let counts = {
+        let destination = SqliteBackend::open(staging)?;
+        let counts =
+            pensyve_core::namespace_export::export_namespace(storage, &destination, args.namespace)
+                .map_err(|error| anyhow::anyhow!("export namespace: {error}"))?;
+
+        if args.json.is_some() {
+            let mut file = std::fs::File::create(staging.join("sidecar.json"))?;
+            let manifest = pensyve_core::gdpr::export_namespace_data_to_writer(
+                storage,
+                args.namespace,
+                &mut file,
+            )
+            .map_err(|error| anyhow::anyhow!("json sidecar: {error}"))?;
+            tracing::info!(
+                memory_records = manifest.memory_records,
+                total_records = manifest.total_records,
+                stream_sha256 = %manifest.stream_sha256,
+                "json sidecar written"
+            );
+        }
+        counts
+    };
+
+    let wal = staging.join("memories.db-wal");
+    if wal.exists() {
+        anyhow::bail!(
+            "{} still has a write-ahead log after close; refusing to publish a partial store",
+            wal.display()
+        );
+    }
+    Ok(counts)
+}
+
 /// Copy one namespace into a fresh `SQLite` store, plus an optional JSON sidecar.
 ///
 /// The source store is only read. `SqliteBackend::open` takes a *directory* and
@@ -354,45 +419,31 @@ fn export_namespace_command(
     std::fs::create_dir_all(parent)?;
     let staging = parent.join(format!(".pensyve-export-{}", uuid::Uuid::new_v4()));
 
-    let counts = {
-        let destination = SqliteBackend::open(&staging)?;
-        let counts =
-            pensyve_core::namespace_export::export_namespace(storage, &destination, args.namespace)
-                .map_err(|error| anyhow::anyhow!("export namespace: {error}"))?;
-
-        if let Some(json) = &args.json {
-            let mut file = std::fs::File::create(json)?;
-            let manifest = pensyve_core::gdpr::export_namespace_data_to_writer(
-                storage,
-                args.namespace,
-                &mut file,
-            )
-            .map_err(|error| anyhow::anyhow!("json sidecar: {error}"))?;
-            tracing::info!(
-                path = %json.display(),
-                memory_records = manifest.memory_records,
-                total_records = manifest.total_records,
-                stream_sha256 = %manifest.stream_sha256,
-                "json sidecar written"
-            );
+    // Every artifact is built under `staging` and published by rename at the
+    // end, so a failed run leaves nothing behind under a name an operator might
+    // mistake for a finished export — and, just as important, leaves the
+    // requested paths free for the retry. Writing the sidecar straight to its
+    // final path would strand a truncated stream there and then trip the
+    // overwrite guard above on the next attempt.
+    let staged = export_to_staging(storage, args, &staging);
+    let counts = match staged {
+        Ok(counts) => counts,
+        Err(error) => {
+            if let Err(cleanup) = std::fs::remove_dir_all(&staging) {
+                tracing::warn!(
+                    path = %staging.display(),
+                    %cleanup,
+                    "could not remove export staging directory after a failed run"
+                );
+            }
+            return Err(error);
         }
-        counts
-        // `destination` is dropped here, closing the last connection so SQLite
-        // checkpoints and removes the WAL. Moving the file before that would
-        // hand over a database whose most recent writes live in a sidecar file
-        // left behind.
     };
 
-    let staged_db = staging.join("memories.db");
-    let wal = staging.join("memories.db-wal");
-    if wal.exists() {
-        anyhow::bail!(
-            "{} still has a write-ahead log after close; refusing to publish a \
-             partial store",
-            wal.display()
-        );
+    std::fs::rename(staging.join("memories.db"), &args.sqlite)?;
+    if let Some(json) = &args.json {
+        std::fs::rename(staging.join("sidecar.json"), json)?;
     }
-    std::fs::rename(&staged_db, &args.sqlite)?;
     std::fs::remove_dir_all(&staging)?;
 
     // Whether the copied vectors are usable as-is on a self-hosted instance is
@@ -426,7 +477,11 @@ fn export_namespace_command(
         vectors_reusable,
         "namespace export complete"
     );
-    if !vectors_reusable {
+    // Only a namespace that actually has vectors can have unusable ones. A
+    // lexical-only namespace also fails the equality check above, and warning
+    // there would send the recipient off to migrate an embedding generation
+    // that does not exist.
+    if exported_space.is_some() && !vectors_reusable {
         tracing::warn!(
             "this build's embedder does not reproduce the exported embedding space; \
              the recipient must run an embedding migration before semantic recall works"
@@ -585,19 +640,31 @@ fn main() -> Result<()> {
         "pensyve-mcp-gateway starting"
     );
 
+    // The operator mode is decided before anything touches storage. Startup
+    // creates the serving namespace when it is missing, so choosing the policy
+    // after initialization would already have written to the customer database
+    // by the time a read-only export began.
+    let argv: Vec<String> = std::env::args().skip(1).collect();
+    let mode = argv.first().map(String::as_str);
+    let namespace_policy = match mode {
+        Some(EXPORT_NAMESPACE_MODE) => NamespacePolicy::ReadOnly,
+        _ => NamespacePolicy::CreateIfMissing,
+    };
+    // Parse before connecting, so a usage error costs nothing and cannot reach
+    // the database at all.
+    let export = match mode {
+        Some(EXPORT_NAMESPACE_MODE) => Some(parse_export_args(&argv[1..])?),
+        _ => None,
+    };
+
     // Init resources BEFORE tokio runtime to avoid nested runtime panic
     // when PostgresBackend creates its own internal runtime.
-    let res = init_resources(&config)?;
-    let argv: Vec<String> = std::env::args().skip(1).collect();
-    match argv.first().map(String::as_str) {
-        Some(BACKFILL_EMBEDDINGS_MODE) => {
-            return backfill_embeddings(res.storage.as_ref(), res.embedder.as_ref());
-        }
-        Some(EXPORT_NAMESPACE_MODE) => {
-            let parsed = parse_export_args(&argv[1..])?;
-            return export_namespace_command(res.storage.as_ref(), res.embedder.as_ref(), &parsed);
-        }
-        _ => {}
+    let res = init_resources_with(&config, namespace_policy)?;
+    if let Some(parsed) = export {
+        return export_namespace_command(res.storage.as_ref(), res.embedder.as_ref(), &parsed);
+    }
+    if mode == Some(BACKFILL_EMBEDDINGS_MODE) {
+        return backfill_embeddings(res.storage.as_ref(), res.embedder.as_ref());
     }
 
     tokio::runtime::Builder::new_multi_thread()

--- a/pensyve-mcp-gateway/src/main.rs
+++ b/pensyve-mcp-gateway/src/main.rs
@@ -278,6 +278,155 @@ fn init_resources(config: &GatewayConfig) -> Result<InitResources> {
     })
 }
 
+/// Operator mode: `pensyve-mcp-gateway export-namespace` copies one namespace
+/// out of the configured store into a standalone `SQLite` store the customer can
+/// serve from, then exits.
+const EXPORT_NAMESPACE_MODE: &str = "export-namespace";
+
+struct ExportArgs {
+    namespace: uuid::Uuid,
+    sqlite: std::path::PathBuf,
+    json: Option<std::path::PathBuf>,
+}
+
+fn parse_export_args(args: &[String]) -> Result<ExportArgs> {
+    let mut namespace = None;
+    let mut sqlite = None;
+    let mut json = None;
+    let mut rest = args.iter();
+    while let Some(flag) = rest.next() {
+        let mut value = || {
+            rest.next()
+                .cloned()
+                .ok_or_else(|| anyhow::anyhow!("{flag} requires a value"))
+        };
+        match flag.as_str() {
+            "--namespace" => namespace = Some(value()?),
+            "--sqlite" => sqlite = Some(value()?),
+            "--json" => json = Some(value()?),
+            other => anyhow::bail!(
+                "unknown argument {other}; usage: {EXPORT_NAMESPACE_MODE} \
+                 --namespace <uuid> --sqlite <out.db> [--json <out.json>]"
+            ),
+        }
+    }
+    let namespace = namespace.ok_or_else(|| anyhow::anyhow!("--namespace is required"))?;
+    let sqlite = sqlite.ok_or_else(|| anyhow::anyhow!("--sqlite is required"))?;
+    Ok(ExportArgs {
+        namespace: uuid::Uuid::parse_str(&namespace)
+            .map_err(|error| anyhow::anyhow!("--namespace {namespace} is not a UUID: {error}"))?,
+        sqlite: std::path::PathBuf::from(sqlite),
+        json: json.map(std::path::PathBuf::from),
+    })
+}
+
+/// Copy one namespace into a fresh `SQLite` store, plus an optional JSON sidecar.
+///
+/// The source store is only read. `SqliteBackend::open` takes a *directory* and
+/// creates `memories.db` inside it, so the copy is staged in a sibling
+/// directory of the requested file and the finished database is moved into
+/// place — a rename within the same parent, so a half-written store never
+/// appears under the name the operator is going to hand to a customer.
+fn export_namespace_command(
+    storage: &dyn StorageTrait,
+    embedder: &OnnxEmbedder,
+    args: &ExportArgs,
+) -> Result<()> {
+    if args.sqlite.exists() {
+        anyhow::bail!(
+            "{} already exists; refusing to overwrite an existing export",
+            args.sqlite.display()
+        );
+    }
+    let parent = args
+        .sqlite
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+        .unwrap_or_else(|| std::path::Path::new("."));
+    std::fs::create_dir_all(parent)?;
+    let staging = parent.join(format!(".pensyve-export-{}", uuid::Uuid::new_v4()));
+
+    let counts = {
+        let destination = SqliteBackend::open(&staging)?;
+        let counts =
+            pensyve_core::namespace_export::export_namespace(storage, &destination, args.namespace)
+                .map_err(|error| anyhow::anyhow!("export namespace: {error}"))?;
+
+        if let Some(json) = &args.json {
+            let mut file = std::fs::File::create(json)?;
+            let manifest = pensyve_core::gdpr::export_namespace_data_to_writer(
+                storage,
+                args.namespace,
+                &mut file,
+            )
+            .map_err(|error| anyhow::anyhow!("json sidecar: {error}"))?;
+            tracing::info!(
+                path = %json.display(),
+                memory_records = manifest.memory_records,
+                total_records = manifest.total_records,
+                stream_sha256 = %manifest.stream_sha256,
+                "json sidecar written"
+            );
+        }
+        counts
+        // `destination` is dropped here, closing the last connection so SQLite
+        // checkpoints and removes the WAL. Moving the file before that would
+        // hand over a database whose most recent writes live in a sidecar file
+        // left behind.
+    };
+
+    let staged_db = staging.join("memories.db");
+    let wal = staging.join("memories.db-wal");
+    if wal.exists() {
+        anyhow::bail!(
+            "{} still has a write-ahead log after close; refusing to publish a \
+             partial store",
+            wal.display()
+        );
+    }
+    std::fs::rename(&staged_db, &args.sqlite)?;
+    std::fs::remove_dir_all(&staging)?;
+
+    // Whether the copied vectors are usable as-is on a self-hosted instance is
+    // decided by whether this build's embedder reproduces the space the vectors
+    // were written under. Report it rather than leaving the operator to guess:
+    // a mismatch means the customer runs an embedding migration on first start.
+    let runtime_space = embedder
+        .embedding_space()
+        .map_err(|error| anyhow::anyhow!("runtime embedding space: {error}"))?
+        .id();
+    let exported_space = storage
+        .get_namespace_embedding_state(args.namespace)
+        .map_err(|error| anyhow::anyhow!("read embedding state: {error}"))?
+        .and_then(|state| state.active_read_space_id);
+    let vectors_reusable = exported_space.as_ref() == Some(&runtime_space);
+
+    tracing::info!(
+        namespace = %args.namespace,
+        path = %args.sqlite.display(),
+        episodes = counts.episodes,
+        episodic = counts.episodic,
+        semantic = counts.semantic,
+        procedural = counts.procedural,
+        observations = counts.observations,
+        memories = counts.memories(),
+        entities = counts.entities,
+        edges = counts.edges,
+        embeddings = counts.embeddings,
+        runtime_space = %runtime_space.0,
+        exported_space = exported_space.as_ref().map_or("none", |space| space.0.as_str()),
+        vectors_reusable,
+        "namespace export complete"
+    );
+    if !vectors_reusable {
+        tracing::warn!(
+            "this build's embedder does not reproduce the exported embedding space; \
+             the recipient must run an embedding migration before semantic recall works"
+        );
+    }
+    Ok(())
+}
+
 /// Operator mode: `pensyve-mcp-gateway backfill-embeddings` brings every
 /// namespace onto the embedding generation this process loaded, then exits.
 const BACKFILL_EMBEDDINGS_MODE: &str = "backfill-embeddings";
@@ -431,8 +580,16 @@ fn main() -> Result<()> {
     // Init resources BEFORE tokio runtime to avoid nested runtime panic
     // when PostgresBackend creates its own internal runtime.
     let res = init_resources(&config)?;
-    if std::env::args().nth(1).as_deref() == Some(BACKFILL_EMBEDDINGS_MODE) {
-        return backfill_embeddings(res.storage.as_ref(), res.embedder.as_ref());
+    let argv: Vec<String> = std::env::args().skip(1).collect();
+    match argv.first().map(String::as_str) {
+        Some(BACKFILL_EMBEDDINGS_MODE) => {
+            return backfill_embeddings(res.storage.as_ref(), res.embedder.as_ref());
+        }
+        Some(EXPORT_NAMESPACE_MODE) => {
+            let parsed = parse_export_args(&argv[1..])?;
+            return export_namespace_command(res.storage.as_ref(), res.embedder.as_ref(), &parsed);
+        }
+        _ => {}
     }
 
     tokio::runtime::Builder::new_multi_thread()

--- a/pensyve-mcp-gateway/src/main.rs
+++ b/pensyve-mcp-gateway/src/main.rs
@@ -339,6 +339,31 @@ fn parse_export_args(args: &[String]) -> Result<ExportArgs> {
     })
 }
 
+/// Move a staged artifact to its final path.
+///
+/// A rename is atomic but cannot cross a filesystem boundary. Staging sits
+/// beside `--sqlite`, so the database always renames within one filesystem —
+/// but `--json` may be given on a different mount, where a bare rename fails
+/// with `EXDEV` after the database has already been published. Falling back to
+/// copy-then-remove keeps that split-output case working; it is not atomic, so
+/// it is only the fallback.
+fn publish(from: &std::path::Path, to: &std::path::Path) -> Result<()> {
+    match std::fs::rename(from, to) {
+        Ok(()) => Ok(()),
+        Err(error) if error.raw_os_error() == Some(libc_exdev()) => {
+            std::fs::copy(from, to)?;
+            std::fs::remove_file(from)?;
+            Ok(())
+        }
+        Err(error) => Err(error.into()),
+    }
+}
+
+/// `EXDEV`, the "cross-device link" errno a rename across mounts returns.
+const fn libc_exdev() -> i32 {
+    18
+}
+
 /// Build both export artifacts inside `staging`, and hand back the tallies.
 ///
 /// Split out from the publish step so every failure path has one place to be
@@ -440,9 +465,9 @@ fn export_namespace_command(
         }
     };
 
-    std::fs::rename(staging.join("memories.db"), &args.sqlite)?;
+    publish(&staging.join("memories.db"), &args.sqlite)?;
     if let Some(json) = &args.json {
-        std::fs::rename(staging.join("sidecar.json"), json)?;
+        publish(&staging.join("sidecar.json"), json)?;
     }
     std::fs::remove_dir_all(&staging)?;
 


### PR DESCRIPTION
Gives a hosted customer a native SQLite store of their namespace, so migrating
off Pensyve Cloud is a file copy rather than a replay through the REST API.

Replaying is lossy in ways that matter: re-extraction, new ids, `Utc::now()`
timestamps, default stability/retrievability, no supersession chains, and
recomputed embeddings. Copying the rows preserves the state that makes recall
behave the way it did on the hosted instance.

## What's here

- **`StorageTrait::page_episodes`** — episodes were the only durable row class
  with no bounded enumerator (`get_episode_in_namespace` fetches one by id and
  nothing walked the table). Deriving ids from `episodic_memories.episode_id`
  would silently drop every episode whose memories were erased or superseded
  away, so this is a paged read rather than a join. Implemented for both
  backends; the Postgres one goes through `scoped_conn`.
- **`namespace_export::export_namespace`** — copies namespace, embedding space
  and lifecycle, entities, episodes, all four memory types including superseded
  rows, their vectors under the source's active read space, and graph edges.
  Reads through `StorageTrait`, writes through the transactional
  `restore_memory_page` path a snapshot restore uses.
- **`gdpr::export_namespace_data_to_writer`** — namespace-wide JSON sidecar in
  the same frame shape as the DSAR export, widened to procedural memories.
  `personal_memory_value` refuses those on purpose (a procedure is not personal
  data attached to a data subject), so the GDPR contract is left alone and the
  sidecar gets its own record arm.
- **`export-namespace` operator mode** on the gateway, alongside
  `backfill-embeddings`.
- **`docs/self-host.md`** — Railway recipe and how to drop in an export.

## Fidelity, and what deliberately stays behind

Activity events and consolidation bookkeeping are operational telemetry, not
memory content. Two items from the original scope turned out not to exist:
there is no feedback row class (`crate::feedback` is an in-memory retrieval
weight adapter, not persisted state), and salience is not a column — it is
folded into `stability` at write time and travels inside it.

## Scoping

Every read is explicitly predicated on `namespace_id` rather than leaning on
RLS. An operator connection is typically the table owner, and the gateway logs
`rolbypassrls: true` on exactly that connection — so RLS enforces nothing here
and the predicates are the isolation. A test asserts a second tenant seeded in
the same source store does not cross.

## Testing

Three round-trip tests over seeded SQLite stores, asserting per-row-class
counts read back independently of the tally the copy reports, a vector recall
returning the same top memory before and after, supersession chains surviving,
and cross-tenant non-leakage.

Two of them were written after the code they cover was already "done", and both
caught real bugs:

- `get_edges_for_entity_in_namespace` returns each edge under *both* endpoints,
  so the per-entity walk wrote every edge twice and reported double.
- `MEMORY_PAGE_SIZE` (256) and `MAX_FUSED_HITS` (200) are different numbers, so
  feeding a whole memory page into `load_embedding_records` passed every small
  fixture and then failed on the first real namespace with a budget error.

`cargo test -p pensyve-core --lib`: 676 pass. Clippy clean with and without the
`postgres` feature.