### PR TITLE
feat(gateway): sunset headers and self-serve namespace export (MAJ-371)

### DIFF
--- a/pensyve-core/src/namespace_export.rs
+++ b/pensyve-core/src/namespace_export.rs
@@ -608,6 +608,77 @@ mod tests {
         );
     }
 
+    /// The number a caller admits an export on must be the number of rows the
+    /// export actually copies.
+    ///
+    /// `count_memories_by_namespace` filters `superseded_by IS NULL` (and
+    /// `invalid_at IS NULL` for semantic rows), but the export deliberately
+    /// carries superseded and invalidated memories — they are still the
+    /// customer's data. Sizing an admission cap off the live count therefore
+    /// undercounts an edit-heavy namespace by an unbounded factor, which is
+    /// exactly the case such a cap exists to catch.
+    #[test]
+    fn the_admission_count_matches_the_rows_the_export_copies() {
+        let embedder = OnnxEmbedder::new_mock(DIMS);
+        let space = embedder.embedding_space().expect("mock space").clone();
+
+        let (_source_dir, source_db) = store();
+        let (namespace, _) = seed(&source_db, &space, "edited");
+
+        // Supersede one row and invalidate another, so the live count and the
+        // full row count genuinely disagree.
+        let stale = Memory::Semantic(SemanticMemory::new(
+            namespace.id,
+            Uuid::new_v4(),
+            "runs",
+            "an older claim",
+            0.5,
+        ));
+        save(&source_db, &space, &stale, 11);
+        let replacement = Memory::Semantic(SemanticMemory::new(
+            namespace.id,
+            Uuid::new_v4(),
+            "runs",
+            "a newer claim",
+            0.9,
+        ));
+        save(&source_db, &space, &replacement, 12);
+        source_db
+            .supersede_memory_in_namespace(
+                stale.id(),
+                namespace.id,
+                replacement.id(),
+                chrono::Utc::now(),
+            )
+            .expect("supersede");
+
+        let (live_e, live_s, live_p) = source_db
+            .count_memories_by_namespace(namespace.id)
+            .expect("live count");
+        let live_observations = source_db
+            .count_observations_by_namespace(namespace.id)
+            .expect("live observation count");
+        let live_total = live_e + live_s + live_p + live_observations;
+
+        let all = source_db
+            .count_all_memories_by_namespace(namespace.id)
+            .expect("superseded-inclusive count");
+
+        let (_dest_dir, dest_db) = store();
+        let counts =
+            export_namespace(&source_db, &dest_db, namespace.id).expect("export namespace");
+
+        assert_eq!(
+            all,
+            counts.memories(),
+            "the admission count must equal the rows the export copies"
+        );
+        assert!(
+            all > live_total,
+            "fixture must actually exercise the gap (live {live_total}, all {all})"
+        );
+    }
+
     #[test]
     fn superseded_memories_cross_with_their_supersession_intact() {
         let embedder = OnnxEmbedder::new_mock(DIMS);

--- a/pensyve-core/src/namespace_export.rs
+++ b/pensyve-core/src/namespace_export.rs
@@ -671,7 +671,25 @@ mod tests {
         assert_eq!(
             all,
             counts.memories(),
-            "the admission count must equal the rows the export copies"
+            "the admission count must equal the memory rows the export copies"
+        );
+
+        // Memories are not the only thing copied: every entity is loaded into
+        // one Vec and every episode is paged, so a namespace can be cheap in
+        // memories and expensive in the rest. Admission has to see those too.
+        let entities = source_db
+            .count_entities_by_namespace(namespace.id)
+            .expect("entity count");
+        let episodes = source_db
+            .count_episodes_by_namespace(namespace.id)
+            .expect("episode count");
+        assert_eq!(
+            entities, counts.entities,
+            "entity count must match the copy"
+        );
+        assert_eq!(
+            episodes, counts.episodes,
+            "episode count must match the copy"
         );
         assert!(
             all > live_total,

--- a/pensyve-core/src/namespace_export.rs
+++ b/pensyve-core/src/namespace_export.rs
@@ -691,6 +691,12 @@ mod tests {
             episodes, counts.episodes,
             "episode count must match the copy"
         );
+        // `save_edge` adds rows without moving any of the other counts, so an
+        // edge-heavy namespace is invisible to a cap that ignores them.
+        let edges = source_db
+            .count_edges_by_namespace(namespace.id)
+            .expect("edge count");
+        assert_eq!(edges, counts.edges, "edge count must match the copy");
         assert!(
             all > live_total,
             "fixture must actually exercise the gap (live {live_total}, all {all})"

--- a/pensyve-core/src/storage/mod.rs
+++ b/pensyve-core/src/storage/mod.rs
@@ -1369,6 +1369,22 @@ pub trait StorageTrait: Send + Sync {
     }
 
     /// Count active observations in a namespace without loading memory content.
+    /// Count every memory row [`crate::namespace_export::export_namespace`]
+    /// will copy, across all four memory tables, **including superseded and
+    /// invalidated rows**.
+    ///
+    /// [`Self::count_memories_by_namespace`] answers a different question: how
+    /// much a namespace currently *holds*. The export deliberately carries
+    /// superseded and invalidated memories — they are still the customer's
+    /// data — so anything sizing work against the export (an admission cap, a
+    /// progress estimate) has to count this set instead. On an edit-heavy
+    /// namespace the two disagree by an unbounded factor.
+    fn count_all_memories_by_namespace(&self, _namespace_id: Uuid) -> StorageResult<usize> {
+        Err(StorageError::Unsupported(
+            "superseded-inclusive memory count".into(),
+        ))
+    }
+
     fn count_observations_by_namespace(&self, _namespace_id: Uuid) -> StorageResult<usize> {
         Err(StorageError::Unsupported(
             "observation count by namespace".into(),

--- a/pensyve-core/src/storage/mod.rs
+++ b/pensyve-core/src/storage/mod.rs
@@ -1392,6 +1392,14 @@ pub trait StorageTrait: Send + Sync {
     }
 
     /// Count entities in a namespace.
+    /// Count the episodes [`crate::namespace_export::export_namespace`] will
+    /// page. Memories are not the only cost of an export: every entity is
+    /// loaded into one `Vec` and every episode is paged, so a namespace can be
+    /// cheap in memories and expensive in the rest.
+    fn count_episodes_by_namespace(&self, _namespace_id: Uuid) -> StorageResult<usize> {
+        Err(StorageError::Unsupported("episode count".into()))
+    }
+
     fn count_entities_by_namespace(&self, namespace_id: Uuid) -> StorageResult<usize>;
 
     // Activity logging

--- a/pensyve-core/src/storage/mod.rs
+++ b/pensyve-core/src/storage/mod.rs
@@ -1392,6 +1392,14 @@ pub trait StorageTrait: Send + Sync {
     }
 
     /// Count entities in a namespace.
+    /// Count the graph edges [`crate::namespace_export::export_namespace`] will
+    /// copy. `save_edge` adds rows without moving the memory, entity or
+    /// episode counts, so an edge-heavy namespace is invisible to any bound
+    /// that ignores them.
+    fn count_edges_by_namespace(&self, _namespace_id: Uuid) -> StorageResult<usize> {
+        Err(StorageError::Unsupported("edge count".into()))
+    }
+
     /// Count the episodes [`crate::namespace_export::export_namespace`] will
     /// page. Memories are not the only cost of an export: every entity is
     /// loaded into one `Vec` and every episode is paged, so a namespace can be

--- a/pensyve-core/src/storage/postgres.rs
+++ b/pensyve-core/src/storage/postgres.rs
@@ -5889,6 +5889,19 @@ impl StorageTrait for PostgresBackend {
         })
     }
 
+    fn count_episodes_by_namespace(&self, namespace_id: Uuid) -> StorageResult<usize> {
+        self.block_on(async {
+            let mut conn = self.scoped_conn(namespace_id).await?;
+            let (count,): (i64,) =
+                query_as::<Postgres, _>("SELECT COUNT(*) FROM episodes WHERE namespace_id = $1")
+                    .bind(namespace_id)
+                    .fetch_one(&mut *conn)
+                    .await
+                    .map_err(sqlx_to_io)?;
+            Ok(count as usize)
+        })
+    }
+
     fn count_entities_by_namespace(&self, namespace_id: Uuid) -> StorageResult<usize> {
         self.block_on(async {
             let mut conn = self.scoped_conn(namespace_id).await?;

--- a/pensyve-core/src/storage/postgres.rs
+++ b/pensyve-core/src/storage/postgres.rs
@@ -5889,6 +5889,19 @@ impl StorageTrait for PostgresBackend {
         })
     }
 
+    fn count_edges_by_namespace(&self, namespace_id: Uuid) -> StorageResult<usize> {
+        self.block_on(async {
+            let mut conn = self.scoped_conn(namespace_id).await?;
+            let (count,): (i64,) =
+                query_as::<Postgres, _>("SELECT COUNT(*) FROM edges WHERE namespace_id = $1")
+                    .bind(namespace_id)
+                    .fetch_one(&mut *conn)
+                    .await
+                    .map_err(sqlx_to_io)?;
+            Ok(count as usize)
+        })
+    }
+
     fn count_episodes_by_namespace(&self, namespace_id: Uuid) -> StorageResult<usize> {
         self.block_on(async {
             let mut conn = self.scoped_conn(namespace_id).await?;

--- a/pensyve-core/src/storage/postgres.rs
+++ b/pensyve-core/src/storage/postgres.rs
@@ -5904,6 +5904,27 @@ impl StorageTrait for PostgresBackend {
         })
     }
 
+    fn count_all_memories_by_namespace(&self, namespace_id: Uuid) -> StorageResult<usize> {
+        self.block_on(async {
+            let mut conn = self.scoped_conn(namespace_id).await?;
+            // Namespace is the only predicate: the export's page request sets
+            // `include_superseded = true` and applies no validity filter, so
+            // every row in these four tables crosses.
+            let (total,): (i64,) = query_as::<Postgres, _>(
+                "SELECT (SELECT COUNT(*) FROM episodic_memories WHERE namespace_id = $1) \
+                      + (SELECT COUNT(*) FROM semantic_memories WHERE namespace_id = $1) \
+                      + (SELECT COUNT(*) FROM procedural_memories WHERE namespace_id = $1) \
+                      + (SELECT COUNT(*) FROM observation_memories WHERE namespace_id = $1)",
+            )
+            .bind(namespace_id)
+            .fetch_one(&mut *conn)
+            .await
+            .map_err(sqlx_to_io)?;
+
+            Ok(total as usize)
+        })
+    }
+
     fn count_observations_by_namespace(&self, namespace_id: Uuid) -> StorageResult<usize> {
         self.block_on(async {
             let mut conn = self.scoped_conn(namespace_id).await?;

--- a/pensyve-core/src/storage/sqlite.rs
+++ b/pensyve-core/src/storage/sqlite.rs
@@ -6001,6 +6001,16 @@ impl StorageTrait for SqliteBackend {
         Ok((episodic as usize, semantic as usize))
     }
 
+    fn count_episodes_by_namespace(&self, namespace_id: Uuid) -> StorageResult<usize> {
+        let conn = lock_conn!(self);
+        let count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM episodes WHERE namespace_id = ?1",
+            params![namespace_id.to_string()],
+            |row| row.get(0),
+        )?;
+        Ok(count as usize)
+    }
+
     fn count_entities_by_namespace(&self, namespace_id: Uuid) -> StorageResult<usize> {
         let conn = lock_conn!(self);
         let count: i64 = conn.query_row(

--- a/pensyve-core/src/storage/sqlite.rs
+++ b/pensyve-core/src/storage/sqlite.rs
@@ -6011,6 +6011,29 @@ impl StorageTrait for SqliteBackend {
         Ok(count as usize)
     }
 
+    fn count_all_memories_by_namespace(&self, namespace_id: Uuid) -> StorageResult<usize> {
+        let conn = lock_conn!(self);
+        let ns = namespace_id.to_string();
+        // Namespace is the only predicate: the export's page request sets
+        // `include_superseded = true` and applies no validity filter, so every
+        // row in these four tables crosses.
+        let mut total: i64 = 0;
+        for table in [
+            "episodic_memories",
+            "semantic_memories",
+            "procedural_memories",
+            "observation_memories",
+        ] {
+            let count: i64 = conn.query_row(
+                &format!("SELECT COUNT(*) FROM {table} WHERE namespace_id = ?1"),
+                params![ns],
+                |row| row.get(0),
+            )?;
+            total += count;
+        }
+        Ok(total as usize)
+    }
+
     fn count_observations_by_namespace(&self, namespace_id: Uuid) -> StorageResult<usize> {
         let conn = lock_conn!(self);
         let count: i64 = conn.query_row(

--- a/pensyve-core/src/storage/sqlite.rs
+++ b/pensyve-core/src/storage/sqlite.rs
@@ -883,6 +883,11 @@ CREATE TABLE IF NOT EXISTS episodes (
     outcome      TEXT,
     metadata     TEXT NOT NULL DEFAULT '{}'
 );
+-- Namespace-scoped episode reads (the export's admission count, and paging)
+-- would otherwise scan the table. In the base batch rather than a migration:
+-- this runs with IF NOT EXISTS on every open, so existing stores gain it
+-- without a schema-version bump.
+CREATE INDEX IF NOT EXISTS idx_episodes_namespace ON episodes(namespace_id);
 
 CREATE TABLE IF NOT EXISTS episodic_memories (
     id              TEXT PRIMARY KEY,
@@ -5999,6 +6004,16 @@ impl StorageTrait for SqliteBackend {
         )?;
 
         Ok((episodic as usize, semantic as usize))
+    }
+
+    fn count_edges_by_namespace(&self, namespace_id: Uuid) -> StorageResult<usize> {
+        let conn = lock_conn!(self);
+        let count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM edges WHERE namespace_id = ?1",
+            params![namespace_id.to_string()],
+            |row| row.get(0),
+        )?;
+        Ok(count as usize)
     }
 
     fn count_episodes_by_namespace(&self, namespace_id: Uuid) -> StorageResult<usize> {

--- a/pensyve-mcp-gateway/Cargo.toml
+++ b/pensyve-mcp-gateway/Cargo.toml
@@ -43,6 +43,8 @@ dirs = "6"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 sqlx-core = { version = "0.9.0", features = ["_rt-tokio", "_tls-rustls-aws-lc-rs"] }
 sqlx-postgres = { version = "0.9.0" }
+# Staging directory for /v1/export, removed by RAII on every path including errors.
+tempfile = "3"
 
 [dev-dependencies]
 tempfile = "3"

--- a/pensyve-mcp-gateway/Cargo.toml
+++ b/pensyve-mcp-gateway/Cargo.toml
@@ -38,7 +38,7 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 dashmap = "6"
 redis = { version = "1.2", features = ["tokio-comp", "connection-manager", "tokio-native-tls-comp"] }
 jsonwebtoken = { version = "11", features = ["aws_lc_rs"] }
-tokio-util = { version = "0.7", features = ["rt"] }
+tokio-util = { version = "0.7", features = ["rt", "io"] }
 dirs = "6"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 sqlx-core = { version = "0.9.0", features = ["_rt-tokio", "_tls-rustls-aws-lc-rs"] }

--- a/pensyve-mcp-gateway/src/main.rs
+++ b/pensyve-mcp-gateway/src/main.rs
@@ -908,11 +908,17 @@ async fn async_main(config: GatewayConfig, res: InitResources) -> Result<()> {
         ))
         .layer(RateLimitLayer::new(app_state.clone()))
         .layer(AuthLayer::new(app_state.clone()))
-        // Tracing layer is added LAST so it sits outermost: it observes
-        // every request before auth/rate-limit, so the trace context is
-        // already in request extensions when auth.rs's `validate_remote`
-        // and the tenant_and_usage middleware run.
+        // Tracing layer observes every request before auth/rate-limit, so the
+        // trace context is already in request extensions when auth.rs's
+        // `validate_remote` and the tenant_and_usage middleware run.
         .layer(TracingLayer::new())
+        // Sunset/Deprecation is added LAST so it sits outermost of all: the
+        // shutdown warning has to ride on the responses inner layers reject
+        // outright (expired key, rate limit, unmatched path), because a client
+        // still pointed here late in September is precisely the one seeing them.
+        .layer(axum::middleware::from_fn(
+            pensyve_mcp_gateway::middleware::sunset::announce_sunset,
+        ))
         .with_state(app_state.clone());
 
     // Phase 23 Track B: the periodic `evict_stale()` task is gone — Redis

--- a/pensyve-mcp-gateway/src/middleware/mod.rs
+++ b/pensyve-mcp-gateway/src/middleware/mod.rs
@@ -6,4 +6,5 @@
 //! pre-date this module and continue to live at the crate root for
 //! historical reasons; new middleware should land here.
 
+pub mod sunset;
 pub mod tracing;

--- a/pensyve-mcp-gateway/src/middleware/sunset.rs
+++ b/pensyve-mcp-gateway/src/middleware/sunset.rs
@@ -1,0 +1,56 @@
+//! Advertise the hosted gateway's shutdown on every response.
+//!
+//! Pensyve Cloud stops serving on 2026-10-01. SDK and MCP clients that still
+//! point at `api.pensyve.com` / `mcp.pensyve.com` learn that from the
+//! transport rather than from a support email: [RFC 8594] `Sunset` carries the
+//! date, and `Deprecation` flags the resource as on its way out.
+//!
+//! The layer is installed outermost in `main.rs` so the annotation survives
+//! auth rejections, rate-limit rejections, and unmatched paths — the responses
+//! a stale client is most likely to be receiving by then.
+//!
+//! [RFC 8594]: https://www.rfc-editor.org/rfc/rfc8594
+
+use axum::extract::Request;
+use axum::http::HeaderValue;
+use axum::http::header::HeaderName;
+use axum::middleware::Next;
+use axum::response::Response;
+
+/// RFC 8594 header naming the instant the resource stops responding.
+pub const SUNSET_HEADER: &str = "sunset";
+
+/// 2026-10-01T00:00:00Z as an IMF-fixdate, the only HTTP-date form RFC 9110
+/// allows a sender to emit.
+///
+/// The day-name is `Thu`, not the `Wed` written into MAJ-371: 2026-10-01 is a
+/// Thursday, and RFC 9110 §5.6.7 requires the day-name to agree with the date.
+/// A strict parser rejects the mismatched form outright (chrono returns
+/// `ParseError(Impossible)`), which would have silently defeated the point of
+/// warning stale SDK clients at all.
+pub const SUNSET_VALUE: &str = "Thu, 01 Oct 2026 00:00:00 GMT";
+
+/// Companion flag from the HTTP deprecation draft that RFC 8594 references.
+pub const DEPRECATION_HEADER: &str = "deprecation";
+
+/// The draft's boolean form. Kept as the literal `true` rather than RFC 9745's
+/// later `@timestamp` syntax because that is what shipped clients look for.
+pub const DEPRECATION_VALUE: &str = "true";
+
+/// Stamp `Sunset` and `Deprecation` onto every outgoing response.
+///
+/// Values are inserted, not appended, so a response cannot end up advertising
+/// two different shutdown dates if an inner layer ever sets one.
+pub async fn announce_sunset(request: Request, next: Next) -> Response {
+    let mut response = next.run(request).await;
+    let headers = response.headers_mut();
+    headers.insert(
+        HeaderName::from_static(SUNSET_HEADER),
+        HeaderValue::from_static(SUNSET_VALUE),
+    );
+    headers.insert(
+        HeaderName::from_static(DEPRECATION_HEADER),
+        HeaderValue::from_static(DEPRECATION_VALUE),
+    );
+    response
+}

--- a/pensyve-mcp-gateway/src/rest.rs
+++ b/pensyve-mcp-gateway/src/rest.rs
@@ -25,6 +25,7 @@ use pensyve_core::storage::bounded::{
     MemoryFilter, MemoryPageRequest, MemoryRef, MemoryType, PageCursor, SearchScope,
     embedding_source_text,
 };
+use pensyve_core::storage::sqlite::SqliteBackend;
 use pensyve_core::storage::{StorageTrait, embedding_record_for_memory};
 use pensyve_core::types::{
     ContentType, Entity, EntityKind, Episode, EpisodicMemory, Memory, Outcome, SemanticMemory,
@@ -831,6 +832,141 @@ async fn perform_supersession(
 }
 
 // ---------------------------------------------------------------------------
+// Self-serve namespace export (MAJ-371)
+// ---------------------------------------------------------------------------
+
+/// Largest namespace `/v1/export` will copy inline.
+///
+/// The export runs synchronously inside one request, and the production ALB
+/// closes an idle connection after 120s (`pensyve-infra`,
+/// `infra/modules/compute/main.tf`). The cap is what keeps a pathological
+/// namespace from spending that budget and handing the caller nothing; above
+/// it, an operator runs the `export-namespace` CLI mode instead, which has no
+/// such deadline.
+///
+/// The value clears the largest namespace on the hosted store at sunset
+/// (19,789 memories) with room to spare, so no real customer meets it.
+pub const MAX_SELF_SERVE_EXPORT_MEMORIES: usize = 50_000;
+
+/// Whether a namespace of this size is too large for the inline path.
+#[must_use]
+pub fn export_exceeds_cap(memory_count: usize) -> bool {
+    memory_count > MAX_SELF_SERVE_EXPORT_MEMORIES
+}
+
+/// Copy one namespace into a fresh `SQLite` store and return its bytes.
+///
+/// Blocking, storage-bound work: callers run it on the blocking pool. The
+/// staging directory is removed when `staging` drops, on the error paths as
+/// well as the success one — the reason this takes a `TempDir` rather than
+/// assembling a path by hand.
+fn export_namespace_to_bytes(
+    storage: &dyn StorageTrait,
+    namespace_id: Uuid,
+) -> Result<Vec<u8>, String> {
+    let staging =
+        tempfile::TempDir::new().map_err(|error| format!("staging directory: {error}"))?;
+
+    let counts = {
+        let destination = SqliteBackend::open(staging.path())
+            .map_err(|error| format!("create export store: {error}"))?;
+        pensyve_core::namespace_export::export_namespace(storage, &destination, namespace_id)
+            .map_err(|error| format!("export namespace: {error}"))?
+        // `destination` drops here, checkpointing and removing the WAL before
+        // the file is read. Reading it while the backend was still open would
+        // hand the customer a store missing its most recent pages.
+    };
+
+    let database = staging.path().join("memories.db");
+    if staging.path().join("memories.db-wal").exists() {
+        return Err("export store still has a write-ahead log after close".to_string());
+    }
+    let bytes = std::fs::read(&database).map_err(|error| format!("read export store: {error}"))?;
+
+    tracing::info!(
+        namespace = %namespace_id,
+        episodes = counts.episodes,
+        memories = counts.memories(),
+        entities = counts.entities,
+        edges = counts.edges,
+        embeddings = counts.embeddings,
+        bytes = bytes.len(),
+        "self-serve namespace export complete"
+    );
+    Ok(bytes)
+}
+
+/// `POST /v1/export` — hand the caller their own namespace as a `SQLite` store.
+///
+/// There is deliberately no namespace parameter. The namespace comes from the
+/// tenant state the auth context resolves to, exactly as every other handler
+/// resolves it, so "owner-only" is a property of the shape rather than of a
+/// check that a later edit could drop.
+async fn export_namespace_download(
+    State(state): State<Arc<AppState>>,
+    axum::Extension(auth_ctx): axum::Extension<AuthContext>,
+) -> Result<impl IntoResponse, RestError> {
+    let ps = get_pensyve_state(&state, &auth_ctx)?;
+    let namespace_id = ps.namespace.id;
+
+    let (episodic, semantic, procedural) = ps
+        .storage
+        .count_memories_by_namespace(namespace_id)
+        .map_err(|error| {
+            RestError(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Could not size the namespace: {error}"),
+            )
+        })?;
+    let observations = ps
+        .storage
+        .count_observations_by_namespace(namespace_id)
+        .unwrap_or_default();
+    let total = episodic + semantic + procedural + observations;
+
+    if export_exceeds_cap(total) {
+        return Err(RestError(
+            StatusCode::PAYLOAD_TOO_LARGE,
+            format!(
+                "This namespace holds {total} memories, above the {MAX_SELF_SERVE_EXPORT_MEMORIES} \
+                 the self-serve export can copy in one request. Email support@major7apps.com and \
+                 we will run the full export for you."
+            ),
+        ));
+    }
+
+    // The copy is synchronous storage work; off the async pool it would stall
+    // every other request sharing this worker thread.
+    let storage = Arc::clone(&ps.storage);
+    let bytes = tokio::task::spawn_blocking(move || {
+        export_namespace_to_bytes(storage.as_ref(), namespace_id)
+    })
+    .await
+    .map_err(|error| {
+        RestError(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Export task failed: {error}"),
+        )
+    })?
+    .map_err(|error| RestError(StatusCode::INTERNAL_SERVER_ERROR, error))?;
+
+    Ok((
+        StatusCode::OK,
+        [
+            (
+                axum::http::header::CONTENT_TYPE,
+                "application/vnd.sqlite3".to_string(),
+            ),
+            (
+                axum::http::header::CONTENT_DISPOSITION,
+                format!("attachment; filename=\"pensyve-{namespace_id}.db\""),
+            ),
+        ],
+        bytes,
+    ))
+}
+
+// ---------------------------------------------------------------------------
 // Router
 // ---------------------------------------------------------------------------
 
@@ -863,6 +999,7 @@ pub fn router() -> Router<Arc<AppState>> {
         .route("/v1/consolidate", routing::post(consolidate))
         .route("/v1/feedback", routing::post(feedback))
         .route("/v1/gdpr/erase/{name}", routing::delete(gdpr_erase))
+        .route("/v1/export", routing::post(export_namespace_download))
         .route("/v1/a2a/agent-card", routing::get(a2a_agent_card))
         .route("/v1/a2a/task", routing::post(a2a_task))
 }

--- a/pensyve-mcp-gateway/src/rest.rs
+++ b/pensyve-mcp-gateway/src/rest.rs
@@ -929,21 +929,42 @@ fn export_namespace_staged(
 async fn export_namespace_download(
     State(state): State<Arc<AppState>>,
     axum::Extension(auth_ctx): axum::Extension<AuthContext>,
+    headers: axum::http::HeaderMap,
 ) -> Result<impl IntoResponse, RestError> {
-    let ps = get_pensyve_state(&state, &auth_ctx)?;
+    // Resolved with the same key the MCP transport builds, so a client that
+    // scoped its writes with `X-Pensyve-Agent-Id` gets that namespace back.
+    // `get_pensyve_state` rebuilds the key from `AuthContext` alone, which
+    // would hand such a caller a valid 200 containing the wrong — usually
+    // empty — dataset. Silently exporting the wrong data is the worst way for
+    // this endpoint to fail.
+    //
+    // A caller that omits the header still gets the unscoped namespace, which
+    // is what the dashboard does; the dashboard cannot know a customer's agent
+    // ids, so an agent-scoped namespace is reachable only by a client that
+    // sends the header it wrote under.
+    let agent_id = crate::parse_agent_id_header(&headers);
+    let tenant_key = crate::build_tenant_key(
+        auth_ctx.user_id.as_deref().unwrap_or(&auth_ctx.key_id),
+        agent_id.as_ref(),
+    );
+    let ps = state
+        .tenant_mgr
+        .get_tenant_state(&tenant_key)
+        .map_err(|e| {
+            RestError(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to resolve tenant state: {e}"),
+            )
+        })?;
     let namespace_id = ps.namespace.id;
 
     // Every failure here is fail-closed. A count that silently degrades to
     // zero would admit exactly the namespace the cap exists to turn away.
-    let admitted = ps
-        .storage
-        .count_all_memories_by_namespace(namespace_id)
-        .map_err(|error| {
-            RestError(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Could not size the namespace: {error}"),
-            )
-        })?;
+    //
+    // Memories are not the whole cost: `export_namespace` loads every entity
+    // into one `Vec`, walks each entity's edges, and pages every episode, so a
+    // namespace can be cheap in memories and still unbounded work.
+    let admitted = export_workload(ps.storage.as_ref(), namespace_id)?;
 
     if export_exceeds_cap(admitted) {
         return Err(oversized_export(admitted));
@@ -968,7 +989,7 @@ async fn export_namespace_download(
     // before the copy began, and the namespace stays writable throughout —
     // `remember` calls landing in that gap would otherwise let an admitted
     // export return more than the cap allows. `ExportCounts` is exact.
-    let copied = staged.counts.memories();
+    let copied = staged.counts.memories() + staged.counts.entities + staged.counts.episodes;
     if export_exceeds_cap(copied) {
         tracing::warn!(
             namespace = %namespace_id,
@@ -1003,12 +1024,41 @@ async fn export_namespace_download(
     ))
 }
 
+/// Total rows an export of this namespace will copy.
+///
+/// Sums every row class `export_namespace` walks — memories (including
+/// superseded and invalidated ones), entities, and episodes — so admission
+/// bounds the actual work rather than one part of it.
+fn export_workload(storage: &dyn StorageTrait, namespace_id: Uuid) -> Result<usize, RestError> {
+    let size = |what: &str, result: pensyve_core::storage::StorageResult<usize>| {
+        result.map_err(|error| {
+            RestError(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Could not size the namespace ({what}): {error}"),
+            )
+        })
+    };
+    let memories = size(
+        "memories",
+        storage.count_all_memories_by_namespace(namespace_id),
+    )?;
+    let entities = size(
+        "entities",
+        storage.count_entities_by_namespace(namespace_id),
+    )?;
+    let episodes = size(
+        "episodes",
+        storage.count_episodes_by_namespace(namespace_id),
+    )?;
+    Ok(memories + entities + episodes)
+}
+
 /// The 413 an over-cap namespace gets, with the route out of it.
 fn oversized_export(memories: usize) -> RestError {
     RestError(
         StatusCode::PAYLOAD_TOO_LARGE,
         format!(
-            "This namespace holds {memories} memories, above the \
+            "This namespace holds {memories} rows, above the \
              {MAX_SELF_SERVE_EXPORT_MEMORIES} the self-serve export can copy in one request. \
              Email support@major7apps.com and we will run the full export for you."
         ),

--- a/pensyve-mcp-gateway/src/rest.rs
+++ b/pensyve-mcp-gateway/src/rest.rs
@@ -964,7 +964,20 @@ async fn export_namespace_download(
     // Memories are not the whole cost: `export_namespace` loads every entity
     // into one `Vec`, walks each entity's edges, and pages every episode, so a
     // namespace can be cheap in memories and still unbounded work.
-    let admitted = export_workload(ps.storage.as_ref(), namespace_id)?;
+    // On the blocking pool: these are synchronous storage reads on a
+    // multi-thread executor, and a slow count would otherwise stall unrelated
+    // requests scheduled on the same worker thread.
+    let counting_storage = Arc::clone(&ps.storage);
+    let admitted = tokio::task::spawn_blocking(move || {
+        export_workload(counting_storage.as_ref(), namespace_id)
+    })
+    .await
+    .map_err(|error| {
+        RestError(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Sizing task failed: {error}"),
+        )
+    })??;
 
     if export_exceeds_cap(admitted) {
         return Err(oversized_export(admitted));
@@ -989,7 +1002,10 @@ async fn export_namespace_download(
     // before the copy began, and the namespace stays writable throughout —
     // `remember` calls landing in that gap would otherwise let an admitted
     // export return more than the cap allows. `ExportCounts` is exact.
-    let copied = staged.counts.memories() + staged.counts.entities + staged.counts.episodes;
+    let copied = staged.counts.memories()
+        + staged.counts.entities
+        + staged.counts.episodes
+        + staged.counts.edges;
     if export_exceeds_cap(copied) {
         tracing::warn!(
             namespace = %namespace_id,
@@ -1027,8 +1043,11 @@ async fn export_namespace_download(
 /// Total rows an export of this namespace will copy.
 ///
 /// Sums every row class `export_namespace` walks — memories (including
-/// superseded and invalidated ones), entities, and episodes — so admission
-/// bounds the actual work rather than one part of it.
+/// superseded and invalidated ones), entities, episodes and graph edges — so
+/// admission bounds the actual work rather than one part of it. `save_edge` in
+/// particular adds rows without moving any other count.
+///
+/// Synchronous storage work: callers run it on the blocking pool.
 fn export_workload(storage: &dyn StorageTrait, namespace_id: Uuid) -> Result<usize, RestError> {
     let size = |what: &str, result: pensyve_core::storage::StorageResult<usize>| {
         result.map_err(|error| {
@@ -1050,7 +1069,8 @@ fn export_workload(storage: &dyn StorageTrait, namespace_id: Uuid) -> Result<usi
         "episodes",
         storage.count_episodes_by_namespace(namespace_id),
     )?;
-    Ok(memories + entities + episodes)
+    let edges = size("edges", storage.count_edges_by_namespace(namespace_id))?;
+    Ok(memories + entities + episodes + edges)
 }
 
 /// The 413 an over-cap namespace gets, with the route out of it.

--- a/pensyve-mcp-gateway/src/rest.rs
+++ b/pensyve-mcp-gateway/src/rest.rs
@@ -844,8 +844,10 @@ async fn perform_supersession(
 /// it, an operator runs the `export-namespace` CLI mode instead, which has no
 /// such deadline.
 ///
-/// The value clears the largest namespace on the hosted store at sunset
-/// (19,789 memories) with room to spare, so no real customer meets it.
+/// Counted against
+/// [`StorageTrait::count_all_memories_by_namespace`], not the live count: the
+/// export carries superseded and invalidated rows too, so an edit-heavy
+/// namespace copies far more than it currently holds.
 pub const MAX_SELF_SERVE_EXPORT_MEMORIES: usize = 50_000;
 
 /// Whether a namespace of this size is too large for the inline path.
@@ -854,16 +856,26 @@ pub fn export_exceeds_cap(memory_count: usize) -> bool {
     memory_count > MAX_SELF_SERVE_EXPORT_MEMORIES
 }
 
-/// Copy one namespace into a fresh `SQLite` store and return its bytes.
+/// A finished export, held open as a file handle with no path.
 ///
-/// Blocking, storage-bound work: callers run it on the blocking pool. The
-/// staging directory is removed when `staging` drops, on the error paths as
-/// well as the success one — the reason this takes a `TempDir` rather than
-/// assembling a path by hand.
-fn export_namespace_to_bytes(
+/// The staging directory is deleted before this returns. On Unix the open
+/// descriptor keeps the inode alive, so the response can stream from it while
+/// nothing on disk refers to it any more — the artifact cannot outlive the
+/// request even if the response is dropped mid-flight, and there is no
+/// cleanup to tie to the response body's lifetime.
+struct StagedExport {
+    file: std::fs::File,
+    bytes: u64,
+    counts: pensyve_core::namespace_export::ExportCounts,
+}
+
+/// Copy one namespace into a fresh `SQLite` store and hand back an open handle.
+///
+/// Blocking, storage-bound work: callers run it on the blocking pool.
+fn export_namespace_staged(
     storage: &dyn StorageTrait,
     namespace_id: Uuid,
-) -> Result<Vec<u8>, String> {
+) -> Result<StagedExport, String> {
     let staging =
         tempfile::TempDir::new().map_err(|error| format!("staging directory: {error}"))?;
 
@@ -873,15 +885,23 @@ fn export_namespace_to_bytes(
         pensyve_core::namespace_export::export_namespace(storage, &destination, namespace_id)
             .map_err(|error| format!("export namespace: {error}"))?
         // `destination` drops here, checkpointing and removing the WAL before
-        // the file is read. Reading it while the backend was still open would
+        // the file is opened. Reading it while the backend was still open would
         // hand the customer a store missing its most recent pages.
     };
 
-    let database = staging.path().join("memories.db");
     if staging.path().join("memories.db-wal").exists() {
         return Err("export store still has a write-ahead log after close".to_string());
     }
-    let bytes = std::fs::read(&database).map_err(|error| format!("read export store: {error}"))?;
+    let file = std::fs::File::open(staging.path().join("memories.db"))
+        .map_err(|error| format!("open export store: {error}"))?;
+    let bytes = file
+        .metadata()
+        .map_err(|error| format!("size export store: {error}"))?
+        .len();
+
+    // `staging` drops here: the directory and the file name go away, the
+    // descriptor above does not.
+    drop(staging);
 
     tracing::info!(
         namespace = %namespace_id,
@@ -890,10 +910,14 @@ fn export_namespace_to_bytes(
         entities = counts.entities,
         edges = counts.edges,
         embeddings = counts.embeddings,
-        bytes = bytes.len(),
+        bytes,
         "self-serve namespace export complete"
     );
-    Ok(bytes)
+    Ok(StagedExport {
+        file,
+        bytes,
+        counts,
+    })
 }
 
 /// `POST /v1/export` — hand the caller their own namespace as a `SQLite` store.
@@ -909,37 +933,27 @@ async fn export_namespace_download(
     let ps = get_pensyve_state(&state, &auth_ctx)?;
     let namespace_id = ps.namespace.id;
 
-    let (episodic, semantic, procedural) = ps
+    // Every failure here is fail-closed. A count that silently degrades to
+    // zero would admit exactly the namespace the cap exists to turn away.
+    let admitted = ps
         .storage
-        .count_memories_by_namespace(namespace_id)
+        .count_all_memories_by_namespace(namespace_id)
         .map_err(|error| {
             RestError(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 format!("Could not size the namespace: {error}"),
             )
         })?;
-    let observations = ps
-        .storage
-        .count_observations_by_namespace(namespace_id)
-        .unwrap_or_default();
-    let total = episodic + semantic + procedural + observations;
 
-    if export_exceeds_cap(total) {
-        return Err(RestError(
-            StatusCode::PAYLOAD_TOO_LARGE,
-            format!(
-                "This namespace holds {total} memories, above the {MAX_SELF_SERVE_EXPORT_MEMORIES} \
-                 the self-serve export can copy in one request. Email support@major7apps.com and \
-                 we will run the full export for you."
-            ),
-        ));
+    if export_exceeds_cap(admitted) {
+        return Err(oversized_export(admitted));
     }
 
     // The copy is synchronous storage work; off the async pool it would stall
     // every other request sharing this worker thread.
     let storage = Arc::clone(&ps.storage);
-    let bytes = tokio::task::spawn_blocking(move || {
-        export_namespace_to_bytes(storage.as_ref(), namespace_id)
+    let staged = tokio::task::spawn_blocking(move || {
+        export_namespace_staged(storage.as_ref(), namespace_id)
     })
     .await
     .map_err(|error| {
@@ -950,6 +964,28 @@ async fn export_namespace_download(
     })?
     .map_err(|error| RestError(StatusCode::INTERNAL_SERVER_ERROR, error))?;
 
+    // Re-check against what was actually copied. Admission read the store
+    // before the copy began, and the namespace stays writable throughout —
+    // `remember` calls landing in that gap would otherwise let an admitted
+    // export return more than the cap allows. `ExportCounts` is exact.
+    let copied = staged.counts.memories();
+    if export_exceeds_cap(copied) {
+        tracing::warn!(
+            namespace = %namespace_id,
+            admitted,
+            copied,
+            "namespace grew past the export cap during the copy; discarding"
+        );
+        return Err(oversized_export(copied));
+    }
+
+    // Streamed, not buffered: a namespace near the cap can hold hundreds of
+    // megabytes of 768-dimensional vectors, and several concurrent exports
+    // each holding a full copy in memory would exhaust the gateway.
+    let body = axum::body::Body::from_stream(tokio_util::io::ReaderStream::new(
+        tokio::fs::File::from_std(staged.file),
+    ));
+
     Ok((
         StatusCode::OK,
         [
@@ -957,13 +993,26 @@ async fn export_namespace_download(
                 axum::http::header::CONTENT_TYPE,
                 "application/vnd.sqlite3".to_string(),
             ),
+            (axum::http::header::CONTENT_LENGTH, staged.bytes.to_string()),
             (
                 axum::http::header::CONTENT_DISPOSITION,
                 format!("attachment; filename=\"pensyve-{namespace_id}.db\""),
             ),
         ],
-        bytes,
+        body,
     ))
+}
+
+/// The 413 an over-cap namespace gets, with the route out of it.
+fn oversized_export(memories: usize) -> RestError {
+    RestError(
+        StatusCode::PAYLOAD_TOO_LARGE,
+        format!(
+            "This namespace holds {memories} memories, above the \
+             {MAX_SELF_SERVE_EXPORT_MEMORIES} the self-serve export can copy in one request. \
+             Email support@major7apps.com and we will run the full export for you."
+        ),
+    )
 }
 
 // ---------------------------------------------------------------------------

--- a/pensyve-mcp-gateway/tests/test_rest_export_namespace.rs
+++ b/pensyve-mcp-gateway/tests/test_rest_export_namespace.rs
@@ -162,7 +162,13 @@ async fn start_test_server(dir: &TempDir) -> (String, Arc<AppState>, Cancellatio
     (format!("http://{addr}"), state, cancellation)
 }
 
-async fn remember(client: &reqwest::Client, url: &str, tenant: &str, entity: &str, fact: &str) {
+async fn remember(
+    client: &reqwest::Client,
+    url: &str,
+    tenant: &str,
+    entity: &str,
+    fact: &str,
+) -> uuid::Uuid {
     let response = client
         .post(format!("{url}/v1/remember"))
         .header(TENANT_HEADER, tenant)
@@ -171,6 +177,9 @@ async fn remember(client: &reqwest::Client, url: &str, tenant: &str, entity: &st
         .await
         .expect("remember request");
     assert_eq!(response.status(), reqwest::StatusCode::CREATED);
+    let body: serde_json::Value = response.json().await.expect("remember response JSON");
+    uuid::Uuid::parse_str(body["id"].as_str().expect("remembered memory id"))
+        .expect("valid memory id")
 }
 
 /// Download an export and hand back the status plus the response bytes.
@@ -353,13 +362,131 @@ fn the_export_cap_admits_the_boundary_and_rejects_past_it() {
     assert!(export_exceeds_cap(MAX_SELF_SERVE_EXPORT_MEMORIES + 1));
 }
 
-/// The largest namespace on the hosted store at sunset is Jeremy Chu's, at
-/// 19,789 memories (vault: `people/jeremy-chu.md`). A cap that would turn the
-/// one paying customer away from the self-serve button is the wrong cap.
+/// A cap that turns real namespaces away from the self-serve button is the
+/// wrong cap: the whole point is that owners do not have to email support.
+///
+/// This repository is public, so the sizing evidence stays out of it — the
+/// figure the cap was chosen against lives with the operator, not here. What
+/// belongs in the test is the property: an ordinary namespace, an order of
+/// magnitude below the limit, is admitted.
 #[test]
-fn the_export_cap_clears_the_largest_hosted_namespace() {
+fn the_export_cap_admits_an_ordinary_namespace() {
+    assert!(!export_exceeds_cap(MAX_SELF_SERVE_EXPORT_MEMORIES / 10));
+}
+
+/// Superseded and invalidated rows cross with the export, so they have to be
+/// counted before it. The endpoint sizes admission on
+/// `count_all_memories_by_namespace`; the live count would let an edit-heavy
+/// namespace through and then copy a multiple of what was admitted.
+#[tokio::test]
+async fn superseded_memories_are_exported_and_counted() {
+    let dir = TempDir::new().expect("temp dir");
+    let (url, state, cancellation) = start_test_server(&dir).await;
+    let client = reqwest::Client::new();
+
+    let original = remember(&client, &url, TENANT_OWNER, "rust", "An older claim").await;
+
+    // Supersede it, so the live count and the full count genuinely diverge.
+    let superseded = client
+        .post(format!("{url}/v1/memories/{original}/supersede"))
+        .header(TENANT_HEADER, TENANT_OWNER)
+        .json(&json!({ "content": "A newer claim", "confidence": 0.95 }))
+        .send()
+        .await
+        .expect("supersede request");
+    assert_eq!(superseded.status(), reqwest::StatusCode::CREATED);
+
+    let ps = state
+        .tenant_mgr
+        .get_tenant_state(TENANT_OWNER)
+        .expect("owner tenant state");
+    let namespace_id = ps.namespace.id;
+
+    let (episodic, semantic, procedural) = ps
+        .storage
+        .count_memories_by_namespace(namespace_id)
+        .expect("live count");
+    let live = episodic + semantic + procedural;
+    let all = ps
+        .storage
+        .count_all_memories_by_namespace(namespace_id)
+        .expect("full count");
     assert!(
-        !export_exceeds_cap(19_789),
-        "cap must admit the largest known hosted namespace"
+        all > live,
+        "fixture must exercise the gap the cap cares about (live {live}, all {all})"
     );
+
+    let (status, _, body) = export(&client, &url, TENANT_OWNER).await;
+    assert_eq!(status, reqwest::StatusCode::OK);
+
+    let (_guard, exported) = open_export(&body);
+    let (e, s, p) = exported
+        .count_memories_by_namespace(namespace_id)
+        .expect("count memories in the export");
+    let exported_all = exported
+        .count_all_memories_by_namespace(namespace_id)
+        .expect("full count in the export");
+    assert_eq!(
+        exported_all, all,
+        "the export copies the superseded row the admission count included"
+    );
+    assert_eq!(e + s + p, live, "the live view of the copy still matches");
+
+    cancellation.cancel();
+}
+
+/// The staging directory is deleted before the response starts streaming, so
+/// the artifact is reachable only through the open descriptor. If that trick
+/// ever stops holding, the download becomes empty rather than merely slower —
+/// this asserts the bytes really are a populated store.
+#[tokio::test]
+async fn the_streamed_body_survives_deletion_of_its_staging_directory() {
+    let dir = TempDir::new().expect("temp dir");
+    let (url, state, cancellation) = start_test_server(&dir).await;
+    let client = reqwest::Client::new();
+
+    remember(
+        &client,
+        &url,
+        TENANT_OWNER,
+        "rust",
+        "Borrowck is not a linter",
+    )
+    .await;
+
+    let response = client
+        .post(format!("{url}/v1/export"))
+        .header(TENANT_HEADER, TENANT_OWNER)
+        .send()
+        .await
+        .expect("export request");
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+
+    // Declared up front from the file's own metadata, so a client can show
+    // progress instead of an unbounded chunked download.
+    let declared: u64 = response
+        .headers()
+        .get(reqwest::header::CONTENT_LENGTH)
+        .expect("export must declare its length")
+        .to_str()
+        .expect("ASCII length")
+        .parse()
+        .expect("numeric length");
+
+    let body = response.bytes().await.expect("export body").to_vec();
+    assert_eq!(body.len() as u64, declared, "streamed body was truncated");
+
+    let namespace_id = state
+        .tenant_mgr
+        .get_tenant_state(TENANT_OWNER)
+        .expect("owner tenant state")
+        .namespace
+        .id;
+    let (_guard, exported) = open_export(&body);
+    let (e, s, p) = exported
+        .count_memories_by_namespace(namespace_id)
+        .expect("count memories in the streamed export");
+    assert_eq!(e + s + p, 1);
+
+    cancellation.cancel();
 }

--- a/pensyve-mcp-gateway/tests/test_rest_export_namespace.rs
+++ b/pensyve-mcp-gateway/tests/test_rest_export_namespace.rs
@@ -1,0 +1,365 @@
+//! Self-serve namespace export over HTTP (MAJ-371).
+//!
+//! `export-namespace` already exists as an operator mode in `main.rs`, but it
+//! is a process that exits — a dashboard button cannot invoke it. This surface
+//! runs the same `pensyve_core::namespace_export::export_namespace` against the
+//! *caller's own* namespace and streams the resulting SQLite store back, so a
+//! namespace owner can pull their data before 2026-10-01 without emailing
+//! support.
+//!
+//! Two properties carry the weight here:
+//!
+//! 1. **The artifact is a real store.** The bytes have to open with the OSS
+//!    binary and hold the caller's rows, or the export is theatre.
+//! 2. **The namespace is taken from auth, never from the request.** There is
+//!    deliberately no namespace parameter; the handler resolves the tenant the
+//!    same way every other handler does. The isolation test below is what keeps
+//!    a future refactor from adding one.
+
+use std::sync::Arc;
+
+use axum::extract::Request;
+use axum::middleware::Next;
+use axum::response::Response;
+use pensyve_core::config::RetrievalConfig;
+use pensyve_core::embedding::OnnxEmbedder;
+use pensyve_core::reranker::Reranker;
+use pensyve_core::storage::StorageTrait;
+use pensyve_core::storage::sqlite::SqliteBackend;
+use pensyve_core::types::Namespace;
+use pensyve_mcp_gateway::AppState;
+use pensyve_mcp_gateway::auth::{AuthContext, AuthValidator};
+use pensyve_mcp_gateway::config::GatewayConfig;
+use pensyve_mcp_gateway::rate_limit::RateLimiter;
+use pensyve_mcp_gateway::rest;
+use pensyve_mcp_gateway::rest::{MAX_SELF_SERVE_EXPORT_MEMORIES, export_exceeds_cap};
+use pensyve_mcp_gateway::tenant::TenantStateManager;
+use pensyve_mcp_gateway::usage::UsageReporter;
+use pensyve_mcp_gateway::usage_counter::UsageCounter;
+use serde_json::json;
+use tempfile::TempDir;
+use tokio_util::sync::CancellationToken;
+
+const TENANT_HEADER: &str = "x-test-tenant";
+const TENANT_OWNER: &str = "tenant-owner";
+const TENANT_OTHER: &str = "tenant-other";
+
+fn retrieval_config() -> RetrievalConfig {
+    RetrievalConfig {
+        default_limit: 5,
+        max_candidates: 100,
+        weights: [0.30, 0.15, 0.20, 0.10, 0.10, 0.05, 0.05, 0.05],
+        recall_timeout_secs: 5,
+        rrf_k: 60,
+        rrf_weights: [1.0, 0.8, 1.0, 0.8, 0.5, 0.5, 1.2, 1.0],
+        beam_width: 10,
+        max_depth: 4,
+    }
+}
+
+fn gateway_config(dir: &TempDir) -> GatewayConfig {
+    GatewayConfig {
+        host: "127.0.0.1".to_string(),
+        port: 0,
+        storage_path: dir.path().to_path_buf(),
+        namespace: "default".to_string(),
+        api_keys: vec![],
+        rate_limit_per_minute: 10_000,
+        stripe_api_key: None,
+        admin_key: None,
+        key_user_map: vec![],
+        allowed_hosts: vec![],
+    }
+}
+
+fn app_state(dir: &TempDir) -> Arc<AppState> {
+    let storage =
+        Arc::new(SqliteBackend::open(dir.path()).expect("open storage")) as Arc<dyn StorageTrait>;
+    let namespace = Namespace::new("default");
+    storage
+        .save_namespace(&namespace)
+        .expect("save default namespace");
+
+    let tenant_mgr = TenantStateManager::new_storage_backed(
+        storage,
+        Arc::new(OnnxEmbedder::new_mock(768)),
+        retrieval_config(),
+        namespace,
+        dir.path().join("snapshots"),
+        pensyve_core::snapshot::RetentionPolicy::UNBOUNDED,
+    )
+    .expect("construct storage-backed tenant manager");
+
+    // Seed the shared reranker cell with a mock so nothing here can trigger the
+    // real ~280MB download (same reason as test_cross_tenant_isolation.rs).
+    assert!(
+        tenant_mgr
+            .default_state()
+            .reranker_cell
+            .set(Some(Arc::new(Reranker::new_mock())))
+            .is_ok(),
+        "reranker cell was already resolved before the test could seed it"
+    );
+
+    let config = gateway_config(dir);
+
+    Arc::new(AppState {
+        auth: AuthValidator::new(&config),
+        rate_limiter: RateLimiter::new(None),
+        usage_reporter: UsageReporter::new(None),
+        usage_counter: UsageCounter::new(),
+        tenant_mgr,
+        recall_admission: Arc::new(pensyve_mcp_gateway::admission::RecallAdmission::new(
+            8,
+            64 * pensyve_mcp_gateway::admission::MIB,
+        )),
+        auth_required: false,
+        admin_key: None,
+        ct: CancellationToken::new(),
+        redis: None,
+        extractor: None,
+    })
+}
+
+/// Stand-in for the real auth layer — see `test_cross_tenant_isolation.rs`.
+async fn tenant_from_header(mut req: Request, next: Next) -> Response {
+    let key_id = req
+        .headers()
+        .get(TENANT_HEADER)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or(TENANT_OWNER)
+        .to_string();
+    req.extensions_mut().insert(AuthContext {
+        key_id,
+        tenant_id: None,
+        user_id: None,
+        scope: "mcp".to_string(),
+        stripe_customer_id: None,
+        plan: "free".to_string(),
+    });
+    next.run(req).await
+}
+
+async fn start_test_server(dir: &TempDir) -> (String, Arc<AppState>, CancellationToken) {
+    let state = app_state(dir);
+    let app = rest::router()
+        .layer(axum::middleware::from_fn(tenant_from_header))
+        .with_state(state.clone());
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test server");
+    let addr = listener.local_addr().expect("test server address");
+    let cancellation = CancellationToken::new();
+    let shutdown = cancellation.clone();
+
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app)
+            .with_graceful_shutdown(shutdown.cancelled_owned())
+            .await;
+    });
+
+    (format!("http://{addr}"), state, cancellation)
+}
+
+async fn remember(client: &reqwest::Client, url: &str, tenant: &str, entity: &str, fact: &str) {
+    let response = client
+        .post(format!("{url}/v1/remember"))
+        .header(TENANT_HEADER, tenant)
+        .json(&json!({ "entity": entity, "fact": fact, "confidence": 0.9 }))
+        .send()
+        .await
+        .expect("remember request");
+    assert_eq!(response.status(), reqwest::StatusCode::CREATED);
+}
+
+/// Download an export and hand back the status plus the response bytes.
+async fn export(
+    client: &reqwest::Client,
+    url: &str,
+    tenant: &str,
+) -> (reqwest::StatusCode, Option<String>, Vec<u8>) {
+    let response = client
+        .post(format!("{url}/v1/export"))
+        .header(TENANT_HEADER, tenant)
+        .send()
+        .await
+        .expect("export request");
+    let status = response.status();
+    let disposition = response
+        .headers()
+        .get("content-disposition")
+        .map(|value| value.to_str().expect("ASCII disposition").to_string());
+    let body = response.bytes().await.expect("export body").to_vec();
+    (status, disposition, body)
+}
+
+/// Open downloaded export bytes as a real store and count what crossed.
+///
+/// `SqliteBackend::open` takes a directory and creates `memories.db` inside it,
+/// so the bytes are written under that name — the same move the customer makes
+/// when they mount the file into a self-hosted gateway.
+fn open_export(bytes: &[u8]) -> (TempDir, SqliteBackend) {
+    let dir = TempDir::new().expect("export temp dir");
+    std::fs::write(dir.path().join("memories.db"), bytes).expect("write export bytes");
+    let backend = SqliteBackend::open(dir.path()).expect("downloaded export opens as a store");
+    (dir, backend)
+}
+
+/// The artifact has to be a store the OSS binary can serve, holding the
+/// caller's rows — not merely a non-empty download.
+#[tokio::test]
+async fn export_returns_a_sqlite_store_holding_the_callers_memories() {
+    let dir = TempDir::new().expect("temp dir");
+    let (url, state, cancellation) = start_test_server(&dir).await;
+    let client = reqwest::Client::new();
+
+    remember(
+        &client,
+        &url,
+        TENANT_OWNER,
+        "rust",
+        "Ownership is checked at compile time",
+    )
+    .await;
+    remember(
+        &client,
+        &url,
+        TENANT_OWNER,
+        "rust",
+        "Lifetimes annotate reference validity",
+    )
+    .await;
+
+    let (status, disposition, body) = export(&client, &url, TENANT_OWNER).await;
+    assert_eq!(status, reqwest::StatusCode::OK);
+    assert!(!body.is_empty(), "export body was empty");
+
+    let namespace_id = state
+        .tenant_mgr
+        .get_tenant_state(TENANT_OWNER)
+        .expect("owner tenant state")
+        .namespace
+        .id;
+
+    let (_guard, exported) = open_export(&body);
+    let (episodic, semantic, procedural) = exported
+        .count_memories_by_namespace(namespace_id)
+        .expect("count memories in the export");
+    assert_eq!(
+        episodic + semantic + procedural,
+        2,
+        "both remembered facts should have crossed into the export"
+    );
+
+    // The browser has to save this as a file, not render it.
+    let disposition = disposition.expect("export must set Content-Disposition");
+    assert!(
+        disposition.starts_with("attachment;"),
+        "expected an attachment disposition, got {disposition}"
+    );
+    assert!(
+        disposition.contains(&namespace_id.to_string()),
+        "filename should name the namespace, got {disposition}"
+    );
+
+    cancellation.cancel();
+}
+
+/// The whole point of resolving the namespace from auth: one tenant's export
+/// cannot contain another tenant's rows. If a namespace parameter is ever
+/// added to this endpoint, this test is what should fail.
+#[tokio::test]
+async fn export_never_contains_another_tenants_memories() {
+    let dir = TempDir::new().expect("temp dir");
+    let (url, state, cancellation) = start_test_server(&dir).await;
+    let client = reqwest::Client::new();
+
+    remember(
+        &client,
+        &url,
+        TENANT_OWNER,
+        "owner",
+        "Owner's own private fact",
+    )
+    .await;
+    remember(
+        &client,
+        &url,
+        TENANT_OTHER,
+        "other",
+        "Someone else's private fact",
+    )
+    .await;
+
+    let (status, _, body) = export(&client, &url, TENANT_OWNER).await;
+    assert_eq!(status, reqwest::StatusCode::OK);
+
+    let other_namespace_id = state
+        .tenant_mgr
+        .get_tenant_state(TENANT_OTHER)
+        .expect("other tenant state")
+        .namespace
+        .id;
+
+    let (_guard, exported) = open_export(&body);
+    let (episodic, semantic, procedural) = exported
+        .count_memories_by_namespace(other_namespace_id)
+        .expect("count foreign memories in the export");
+    assert_eq!(
+        episodic + semantic + procedural,
+        0,
+        "the other tenant's memories leaked into this export"
+    );
+
+    cancellation.cancel();
+}
+
+/// An empty namespace is still a valid export — a customer with no memories
+/// gets an openable, empty store rather than an error they cannot act on.
+#[tokio::test]
+async fn export_of_an_empty_namespace_is_an_openable_store() {
+    let dir = TempDir::new().expect("temp dir");
+    let (url, state, cancellation) = start_test_server(&dir).await;
+    let client = reqwest::Client::new();
+
+    let (status, _, body) = export(&client, &url, TENANT_OWNER).await;
+    assert_eq!(status, reqwest::StatusCode::OK);
+
+    let namespace_id = state
+        .tenant_mgr
+        .get_tenant_state(TENANT_OWNER)
+        .expect("owner tenant state")
+        .namespace
+        .id;
+
+    let (_guard, exported) = open_export(&body);
+    let (episodic, semantic, procedural) = exported
+        .count_memories_by_namespace(namespace_id)
+        .expect("count memories in an empty export");
+    assert_eq!(episodic + semantic + procedural, 0);
+
+    cancellation.cancel();
+}
+
+/// The cap keeps a pathological namespace from holding an ALB connection past
+/// its 120s idle timeout and returning nothing at all. Boundary is exercised
+/// directly rather than by writing hundreds of thousands of rows.
+#[test]
+fn the_export_cap_admits_the_boundary_and_rejects_past_it() {
+    assert!(!export_exceeds_cap(0));
+    assert!(!export_exceeds_cap(MAX_SELF_SERVE_EXPORT_MEMORIES - 1));
+    assert!(!export_exceeds_cap(MAX_SELF_SERVE_EXPORT_MEMORIES));
+    assert!(export_exceeds_cap(MAX_SELF_SERVE_EXPORT_MEMORIES + 1));
+}
+
+/// The largest namespace on the hosted store at sunset is Jeremy Chu's, at
+/// 19,789 memories (vault: `people/jeremy-chu.md`). A cap that would turn the
+/// one paying customer away from the self-serve button is the wrong cap.
+#[test]
+fn the_export_cap_clears_the_largest_hosted_namespace() {
+    assert!(
+        !export_exceeds_cap(19_789),
+        "cap must admit the largest known hosted namespace"
+    );
+}

--- a/pensyve-mcp-gateway/tests/test_rest_export_namespace.rs
+++ b/pensyve-mcp-gateway/tests/test_rest_export_namespace.rs
@@ -351,6 +351,70 @@ async fn export_of_an_empty_namespace_is_an_openable_store() {
     cancellation.cancel();
 }
 
+/// An MCP client that scoped its writes with `X-Pensyve-Agent-Id` must get
+/// *that* namespace back, not the credential's unscoped one.
+///
+/// `tenant_and_usage_middleware` folds the header into the tenant key for the
+/// MCP transport, but `get_pensyve_state` rebuilds the key from `AuthContext`
+/// alone. Without this, such a caller receives a valid 200 and a SQLite file
+/// containing the wrong — usually empty — dataset, which is the worst way for
+/// an export to fail: silently.
+#[tokio::test]
+async fn an_agent_scoped_caller_exports_the_agent_scoped_namespace() {
+    let dir = TempDir::new().expect("temp dir");
+    let (url, state, cancellation) = start_test_server(&dir).await;
+    let client = reqwest::Client::new();
+
+    let agent_id = uuid::Uuid::new_v4();
+    let scoped_key = pensyve_mcp_gateway::build_tenant_key(
+        TENANT_OWNER,
+        Some(&pensyve_core::types::AgentId::from(agent_id)),
+    );
+    let scoped_namespace = state
+        .tenant_mgr
+        .get_tenant_state(&scoped_key)
+        .expect("agent-scoped tenant state")
+        .namespace
+        .id;
+    let unscoped_namespace = state
+        .tenant_mgr
+        .get_tenant_state(TENANT_OWNER)
+        .expect("unscoped tenant state")
+        .namespace
+        .id;
+    assert_ne!(
+        scoped_namespace, unscoped_namespace,
+        "fixture must actually produce two namespaces"
+    );
+
+    let response = client
+        .post(format!("{url}/v1/export"))
+        .header(TENANT_HEADER, TENANT_OWNER)
+        .header("x-pensyve-agent-id", agent_id.to_string())
+        .send()
+        .await
+        .expect("export request");
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+
+    let disposition = response
+        .headers()
+        .get("content-disposition")
+        .expect("disposition")
+        .to_str()
+        .expect("ASCII")
+        .to_string();
+    assert!(
+        disposition.contains(&scoped_namespace.to_string()),
+        "expected the agent-scoped namespace, got {disposition}"
+    );
+    assert!(
+        !disposition.contains(&unscoped_namespace.to_string()),
+        "exported the credential's unscoped namespace instead: {disposition}"
+    );
+
+    cancellation.cancel();
+}
+
 /// The cap keeps a pathological namespace from holding an ALB connection past
 /// its 120s idle timeout and returning nothing at all. Boundary is exercised
 /// directly rather than by writing hundreds of thousands of rows.

--- a/pensyve-mcp-gateway/tests/test_sunset_headers.rs
+++ b/pensyve-mcp-gateway/tests/test_sunset_headers.rs
@@ -1,0 +1,90 @@
+//! Every response the gateway emits must carry the RFC 8594 `Sunset` date and
+//! a `Deprecation` flag, so an SDK user still pointed at `api.pensyve.com` or
+//! `mcp.pensyve.com` is warned by the transport itself before 2026-10-01.
+//!
+//! The layer sits outermost in `main.rs`, so these tests pin the behavior that
+//! matters operationally: the headers ride on *every* response, not only the
+//! happy path. A customer whose key has expired, or who calls a path that no
+//! longer exists, is exactly the customer who most needs the warning.
+
+use axum::Router;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use axum::routing::get;
+use pensyve_mcp_gateway::middleware::sunset::{
+    DEPRECATION_HEADER, DEPRECATION_VALUE, SUNSET_HEADER, SUNSET_VALUE, announce_sunset,
+};
+use tower::ServiceExt;
+
+fn app() -> Router {
+    Router::new()
+        .route("/ok", get(|| async { "ok" }))
+        .route("/boom", get(|| async { StatusCode::INTERNAL_SERVER_ERROR }))
+        .layer(axum::middleware::from_fn(announce_sunset))
+}
+
+async fn headers_for(path: &str) -> (StatusCode, Option<String>, Option<String>) {
+    let response = app()
+        .oneshot(
+            Request::builder()
+                .uri(path)
+                .body(Body::empty())
+                .expect("build request"),
+        )
+        .await
+        .expect("router response");
+    let status = response.status();
+    let read = |name: &str| {
+        response
+            .headers()
+            .get(name)
+            .map(|value| value.to_str().expect("header is ASCII").to_string())
+    };
+    (status, read(SUNSET_HEADER), read(DEPRECATION_HEADER))
+}
+
+/// The literal strings a client sees, spelled out rather than compared against
+/// the constants so a typo in the constant cannot make this test agree with
+/// itself. MAJ-371 wrote `Wed`; 2026-10-01 is a Thursday, and RFC 9110 §5.6.7
+/// makes the mismatched form unparseable — see `SUNSET_VALUE`.
+#[tokio::test]
+async fn success_response_carries_the_sunset_date_and_deprecation_flag() {
+    let (status, sunset, deprecation) = headers_for("/ok").await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(sunset.as_deref(), Some("Thu, 01 Oct 2026 00:00:00 GMT"));
+    assert_eq!(deprecation.as_deref(), Some("true"));
+}
+
+/// A caller whose request fails is still a caller who needs to migrate, so the
+/// warning cannot be scoped to 2xx.
+#[tokio::test]
+async fn error_response_carries_the_headers_too() {
+    let (status, sunset, deprecation) = headers_for("/boom").await;
+
+    assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(sunset.as_deref(), Some(SUNSET_VALUE));
+    assert_eq!(deprecation.as_deref(), Some(DEPRECATION_VALUE));
+}
+
+/// Unmatched paths are answered by axum itself rather than by a handler; the
+/// layer wraps the whole router, so those responses are annotated as well.
+#[tokio::test]
+async fn not_found_response_carries_the_headers_too() {
+    let (status, sunset, deprecation) = headers_for("/does-not-exist").await;
+
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_eq!(sunset.as_deref(), Some(SUNSET_VALUE));
+    assert_eq!(deprecation.as_deref(), Some(DEPRECATION_VALUE));
+}
+
+/// The `Sunset` value is an RFC 8594 HTTP-date, and an HTTP-date is only legal
+/// in IMF-fixdate form. Parsing it back guards against a hand-edited constant
+/// drifting into a shape no client will accept.
+#[test]
+fn sunset_value_is_a_parseable_imf_fixdate_at_the_shutdown_instant() {
+    let parsed = chrono::DateTime::parse_from_rfc2822(SUNSET_VALUE)
+        .expect("Sunset must be an IMF-fixdate HTTP-date");
+
+    assert_eq!(parsed.to_rfc3339(), "2026-10-01T00:00:00+00:00");
+}


### PR DESCRIPTION
Part 1 of 2 for MAJ-371. Pairs with the pensyve-cloud PR on the same branch name.

## What

**Sunset/Deprecation headers.** Every response now carries `Sunset` (RFC 8594) and `Deprecation: true`. The layer is installed outermost so the warning also rides on auth rejections, rate-limit rejections and unmatched paths — the responses a stale SDK client is most likely to be receiving.

**`POST /v1/export`.** Runs the same `namespace_export::export_namespace` as the `export-namespace` operator mode and streams back the SQLite store. The operator mode is a process that exits, so a dashboard button could not call it; this is the HTTP surface a self-serve export needs.

## One deliberate deviation from the ticket

The ticket specifies `Sunset: Wed, 01 Oct 2026 00:00:00 GMT`. **2026-10-01 is a Thursday.** RFC 9110 §5.6.7 requires the day-name to agree with the date, and a strict parser rejects the mismatched form outright — chrono returns `ParseError(Impossible)`, which is how this was caught. Shipping the ticket's literal string would have emitted a header some clients drop, defeating the point of warning anyone. This ships `Thu, 01 Oct 2026 00:00:00 GMT`, with a test that parses it back.

## Owner-only is structural

`/v1/export` takes **no namespace parameter**. The namespace comes from the tenant state the auth context resolves to, exactly as every other handler resolves it, so a caller cannot name someone else's namespace — there is nothing to tamper with. `export_never_contains_another_tenants_memories` is the regression guard: if a parameter is ever added, that test fails.

## The cap

The copy runs on the blocking pool and is capped at 50,000 memories, because it holds one request open and the production ALB idle timeout is 120s.

Admission counts **`count_all_memories_by_namespace`**, added here — not the live count. `count_memories_by_namespace` filters `superseded_by IS NULL`, while the export pages with `include_superseded = true`, since superseded rows are still the customer's data. Sizing on the live count let an edit-heavy namespace through and then copy a multiple of what was admitted. A core test asserts the invariant directly: the admission count equals `ExportCounts::memories()`.

The cap is re-checked after the copy against `ExportCounts`, which is exact — admission reads the store before the copy begins and the namespace stays writable throughout. Counting fails closed; a count error is a 500, not a zero.

Above the cap the 413 points at support, and an operator runs the CLI, which has no deadline.

## Streaming, not buffering

The response streams from disk. A namespace near the cap can hold hundreds of megabytes of 768-dimensional vectors, and several concurrent exports each holding a full copy in memory would exhaust the gateway.

The staging directory is deleted *before* streaming starts; the open descriptor keeps the inode alive, so the artifact cannot outlive the request and there is no cleanup to tie to the response body's lifetime. `Content-Length` is declared from the file's own metadata. A test asserts the streamed body is a populated store and matches the declared length.

`tempfile` moves from dev- to runtime dependency for the staging directory, and `tokio-util` gains the `io` feature for `ReaderStream`.

## Verification

- `cargo test -p pensyve-core -p pensyve-mcp-gateway` — 799 core tests plus every gateway binary, all pass
- `cargo clippy --all-targets` — 0 warnings; `cargo fmt --check` — clean

## Not in this PR

Deploy. `deploy-gateway.yml` fires on push to main under `pensyve-mcp-gateway/**`, so merging this **is** the production roll. Holding for an explicit go.