### PR TITLE
feat(gateway): export every namespace in one operator run (MAJ-374 pre-req)

### DIFF
--- a/pensyve-mcp-gateway/Cargo.toml
+++ b/pensyve-mcp-gateway/Cargo.toml
@@ -43,6 +43,8 @@ dirs = "6"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 sqlx-core = { version = "0.9.0", features = ["_rt-tokio", "_tls-rustls-aws-lc-rs"] }
 sqlx-postgres = { version = "0.9.0" }
+# Staging directories for the bulk namespace export, removed by RAII.
+tempfile = "3"
 
 [dev-dependencies]
 tempfile = "3"

--- a/pensyve-mcp-gateway/src/bulk_export.rs
+++ b/pensyve-mcp-gateway/src/bulk_export.rs
@@ -99,6 +99,39 @@ impl BulkExportSummary {
     }
 }
 
+/// Whether a finished run may be uploaded and used to justify teardown.
+///
+/// Two ways a run can look successful and not be:
+///
+/// - **It saved nothing.** `init_resources_with` falls back to a local SQLite
+///   store when `DATABASE_URL` is unset or is not a Postgres URL, and will
+///   create an empty one. The export then finds zero namespaces and reports no
+///   failures. Exiting 0 there would have an operator tear down production
+///   believing every namespace was saved.
+/// - **It lost namespaces.** Any failure means the artifact set is incomplete,
+///   and the store is deleted after this step.
+///
+/// # Errors
+/// If the run exported no namespaces, or any namespace failed.
+pub fn ensure_publishable(summary: &BulkExportSummary) -> Result<(), String> {
+    if !summary.failed.is_empty() {
+        return Err(format!(
+            "{} of {} namespaces failed to export; do not proceed with teardown",
+            summary.failed.len(),
+            summary.exported.len() + summary.failed.len()
+        ));
+    }
+    if summary.exported.is_empty() {
+        return Err(
+            "exported no namespaces — refusing to report success. A store with nothing in it \
+             usually means the gateway fell back to local SQLite because DATABASE_URL was unset \
+             or was not a Postgres URL. Check the connection before treating this as done."
+                .to_string(),
+        );
+    }
+    Ok(())
+}
+
 /// Hex-encoded SHA-256 of `bytes`.
 #[must_use]
 pub fn sha256_hex(bytes: &[u8]) -> String {

--- a/pensyve-mcp-gateway/src/bulk_export.rs
+++ b/pensyve-mcp-gateway/src/bulk_export.rs
@@ -1,0 +1,261 @@
+//! Copy every namespace out of the hosted store before it is destroyed.
+//!
+//! `export-namespace --namespace <id>` (MAJ-369) served one customer. The
+//! 2026-10-01 shutdown needs all ~80 namespaces copied in one operator run,
+//! immediately before the gateway scales to zero and the Postgres store is
+//! deleted (MAJ-374).
+//!
+//! # Why a manifest
+//!
+//! The run is not repeatable. Once the store is gone there is no way to
+//! re-derive what should have been exported, so the record of what *was*
+//! exported is written alongside the files, and is checkable rather than
+//! merely descriptive: each entry carries the byte length and SHA-256 of its
+//! file, so an operator can verify what survived the upload to S3.
+//!
+//! It is deliberately sanitized — namespace ids, counts and digests only. No
+//! memory content, and no namespace names: the manifest gets pasted into
+//! tickets and vault pages, and namespace names carry customer-identifying
+//! tenant strings.
+//!
+//! # What this module does not do
+//!
+//! Encryption and upload are not here. Keeping AWS and crypto out of the
+//! shipped OSS binary matters for a project entering maintenance mode, and the
+//! B1 delivery already established the shape: produce plain artifacts locally,
+//! then `gpg` + `aws s3 cp` them from an operator script
+//! (`scripts/export-all-namespaces.sh`). Swapping in an in-binary AWS SDK
+//! later only changes the transport, not this copy.
+//!
+//! # Consistency
+//!
+//! Inherits the caveat from [`pensyve_core::namespace_export`]: this is not a
+//! point-in-time snapshot. Run it with the gateway already scaled to zero, so
+//! nothing is writing underneath it.
+
+use std::path::{Path, PathBuf};
+
+use pensyve_core::embedding_space::EmbeddingSpaceId;
+use pensyve_core::storage::StorageTrait;
+use pensyve_core::storage::sqlite::SqliteBackend;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+/// Namespaces requested per `page_namespaces` call.
+const NAMESPACE_PAGE: usize = 256;
+
+/// Manifest filename written into the output directory.
+pub const MANIFEST_FILENAME: &str = "manifest.json";
+
+/// One namespace's line in the manifest. Counts and digests only.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct NamespaceExportRecord {
+    pub namespace_id: Uuid,
+    pub file: String,
+    pub bytes: u64,
+    pub sha256: String,
+    pub episodes: usize,
+    pub memories: usize,
+    pub entities: usize,
+    pub edges: usize,
+    pub embeddings: usize,
+    /// Whether the copied vectors work as-is under this build's embedder.
+    ///
+    /// False means the recipient runs an embedding migration on first start;
+    /// getting it wrong makes semantic recall silently return nothing.
+    pub vectors_reusable: bool,
+}
+
+/// A namespace that could not be exported, kept so a run reports rather than
+/// hides partial success.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct NamespaceExportFailure {
+    pub namespace_id: Uuid,
+    pub error: String,
+}
+
+/// The written manifest.
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+pub struct ExportManifest {
+    /// Embedding space this build reproduces, for reading `vectors_reusable`.
+    pub runtime_embedding_space: String,
+    pub namespaces: Vec<NamespaceExportRecord>,
+    pub failed: Vec<NamespaceExportFailure>,
+}
+
+/// Outcome of a bulk run.
+#[derive(Clone, Debug, Default)]
+pub struct BulkExportSummary {
+    pub exported: Vec<NamespaceExportRecord>,
+    pub failed: Vec<NamespaceExportFailure>,
+}
+
+impl BulkExportSummary {
+    /// Whether every namespace was copied.
+    #[must_use]
+    pub fn complete(&self) -> bool {
+        self.failed.is_empty()
+    }
+}
+
+/// Hex-encoded SHA-256 of `bytes`.
+#[must_use]
+pub fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hex::encode(hasher.finalize())
+}
+
+/// Read a manifest written by [`export_all_namespaces`].
+///
+/// # Errors
+/// If the file cannot be read or does not parse.
+pub fn read_manifest(path: &Path) -> Result<ExportManifest, String> {
+    let raw = std::fs::read_to_string(path)
+        .map_err(|error| format!("read manifest {}: {error}", path.display()))?;
+    serde_json::from_str(&raw).map_err(|error| format!("parse manifest: {error}"))
+}
+
+/// Copy one namespace into `<out_dir>/<namespace_id>.db`.
+///
+/// Staged in a temporary directory and published by rename, so a failure never
+/// leaves a half-written file under a name the upload step would treat as a
+/// finished export.
+fn export_one(
+    storage: &dyn StorageTrait,
+    namespace_id: Uuid,
+    out_dir: &Path,
+    runtime_space: &EmbeddingSpaceId,
+) -> Result<NamespaceExportRecord, String> {
+    let staging = tempfile::TempDir::new_in(out_dir)
+        .map_err(|error| format!("staging directory: {error}"))?;
+
+    let counts = {
+        let destination = SqliteBackend::open(staging.path())
+            .map_err(|error| format!("create export store: {error}"))?;
+        pensyve_core::namespace_export::export_namespace(storage, &destination, namespace_id)
+            .map_err(|error| format!("export namespace: {error}"))?
+        // Dropped here so the WAL is checkpointed before the file is read.
+    };
+
+    let staged = staging.path().join("memories.db");
+    if staging.path().join("memories.db-wal").exists() {
+        return Err("export store still has a write-ahead log after close".to_string());
+    }
+
+    let bytes = std::fs::read(&staged).map_err(|error| format!("read export store: {error}"))?;
+    let digest = sha256_hex(&bytes);
+    let filename = format!("{namespace_id}.db");
+    let final_path = out_dir.join(&filename);
+    std::fs::rename(&staged, &final_path)
+        .map_err(|error| format!("publish {}: {error}", final_path.display()))?;
+
+    let exported_space = storage
+        .get_namespace_embedding_state(namespace_id)
+        .map_err(|error| format!("read embedding state: {error}"))?
+        .and_then(|state| state.active_read_space_id);
+
+    Ok(NamespaceExportRecord {
+        namespace_id,
+        file: filename,
+        bytes: bytes.len() as u64,
+        sha256: digest,
+        episodes: counts.episodes,
+        memories: counts.memories(),
+        entities: counts.entities,
+        edges: counts.edges,
+        embeddings: counts.embeddings,
+        // A namespace with no vectors has nothing to reuse — reported false so
+        // it is never mistaken for a namespace whose vectors carried over.
+        vectors_reusable: exported_space.as_ref() == Some(runtime_space),
+    })
+}
+
+/// Copy every namespace in `storage` into `out_dir`, and write the manifest.
+///
+/// A namespace that fails is recorded and the run continues: with ~80
+/// namespaces and one shot at this, aborting on the first bad row would strand
+/// every namespace after it.
+///
+/// # Errors
+/// If `out_dir` cannot be created, already holds a previous run, or the
+/// manifest cannot be written. Per-namespace failures are returned in the
+/// summary rather than as an error.
+pub fn export_all_namespaces(
+    storage: &dyn StorageTrait,
+    out_dir: &Path,
+    runtime_space: &EmbeddingSpaceId,
+) -> Result<BulkExportSummary, String> {
+    std::fs::create_dir_all(out_dir)
+        .map_err(|error| format!("create {}: {error}", out_dir.display()))?;
+
+    // The 10-01 run is not repeatable and the store is deleted afterwards. A
+    // second invocation pointed at the same directory must not silently
+    // replace artifacts whose digests have already been recorded elsewhere.
+    let manifest_path = out_dir.join(MANIFEST_FILENAME);
+    if manifest_path.exists() {
+        return Err(format!(
+            "{} already exists; refusing to overwrite a previous export run",
+            manifest_path.display()
+        ));
+    }
+
+    let mut summary = BulkExportSummary::default();
+    let mut after = None;
+    loop {
+        let page = storage
+            .page_namespaces(after, NAMESPACE_PAGE)
+            .map_err(|error| format!("page namespaces: {error}"))?;
+
+        for namespace_id in page.namespace_ids {
+            match export_one(storage, namespace_id, out_dir, runtime_space) {
+                Ok(record) => {
+                    tracing::info!(
+                        %namespace_id,
+                        memories = record.memories,
+                        bytes = record.bytes,
+                        "namespace exported"
+                    );
+                    summary.exported.push(record);
+                }
+                Err(error) => {
+                    tracing::error!(%namespace_id, %error, "namespace export failed");
+                    summary.failed.push(NamespaceExportFailure {
+                        namespace_id,
+                        error,
+                    });
+                }
+            }
+        }
+
+        after = page.next_cursor;
+        if after.is_none() {
+            break;
+        }
+    }
+
+    let manifest = ExportManifest {
+        runtime_embedding_space: runtime_space.0.clone(),
+        namespaces: summary.exported.clone(),
+        failed: summary.failed.clone(),
+    };
+    let encoded = serde_json::to_string_pretty(&manifest)
+        .map_err(|error| format!("encode manifest: {error}"))?;
+    std::fs::write(&manifest_path, encoded)
+        .map_err(|error| format!("write {}: {error}", manifest_path.display()))?;
+
+    tracing::info!(
+        exported = summary.exported.len(),
+        failed = summary.failed.len(),
+        path = %out_dir.display(),
+        "bulk namespace export complete"
+    );
+    Ok(summary)
+}
+
+/// Where the manifest for a run lives.
+#[must_use]
+pub fn manifest_path(out_dir: &Path) -> PathBuf {
+    out_dir.join(MANIFEST_FILENAME)
+}

--- a/pensyve-mcp-gateway/src/lib.rs
+++ b/pensyve-mcp-gateway/src/lib.rs
@@ -9,6 +9,7 @@
 
 pub mod admission;
 pub mod auth;
+pub mod bulk_export;
 pub mod cache;
 pub mod circuit_breaker;
 pub mod config;

--- a/pensyve-mcp-gateway/src/main.rs
+++ b/pensyve-mcp-gateway/src/main.rs
@@ -302,16 +302,35 @@ fn init_resources_with(
 /// serve from, then exits.
 const EXPORT_NAMESPACE_MODE: &str = "export-namespace";
 
+#[derive(Debug)]
 struct ExportArgs {
     namespace: uuid::Uuid,
     sqlite: std::path::PathBuf,
     json: Option<std::path::PathBuf>,
 }
 
-fn parse_export_args(args: &[String]) -> Result<ExportArgs> {
+/// The two shapes of `export-namespace`.
+///
+/// One customer taking their data (`--namespace`), or the 2026-10-01 operator
+/// run copying everything before the store is destroyed (`--all`). They are
+/// separate variants rather than optional fields so that a half-specified
+/// invocation is a parse error instead of a surprising default — the bulk run
+/// happens once and cannot be repeated afterwards.
+#[derive(Debug)]
+enum ExportMode {
+    Single(ExportArgs),
+    All { out_dir: std::path::PathBuf },
+}
+
+const EXPORT_USAGE: &str = "usage: export-namespace --namespace <uuid> --sqlite <out.db> \
+     [--json <out.json>] | export-namespace --all --out-dir <dir>";
+
+fn parse_export_args(args: &[String]) -> Result<ExportMode> {
     let mut namespace = None;
     let mut sqlite = None;
     let mut json = None;
+    let mut out_dir = None;
+    let mut all = false;
     let mut rest = args.iter();
     while let Some(flag) = rest.next() {
         let mut value = || {
@@ -323,20 +342,39 @@ fn parse_export_args(args: &[String]) -> Result<ExportArgs> {
             "--namespace" => namespace = Some(value()?),
             "--sqlite" => sqlite = Some(value()?),
             "--json" => json = Some(value()?),
-            other => anyhow::bail!(
-                "unknown argument {other}; usage: {EXPORT_NAMESPACE_MODE} \
-                 --namespace <uuid> --sqlite <out.db> [--json <out.json>]"
-            ),
+            "--out-dir" => out_dir = Some(value()?),
+            "--all" => all = true,
+            other => anyhow::bail!("unknown argument {other}; {EXPORT_USAGE}"),
         }
+    }
+
+    if all {
+        // Rejected rather than resolved: exporting something other than what
+        // the operator asked for is worse than refusing, on a run that has no
+        // second chance.
+        if namespace.is_some() || sqlite.is_some() || json.is_some() {
+            anyhow::bail!(
+                "--all exports every namespace and cannot be combined with \
+                 --namespace/--sqlite/--json; {EXPORT_USAGE}"
+            );
+        }
+        let out_dir = out_dir.ok_or_else(|| anyhow::anyhow!("--out-dir is required with --all"))?;
+        return Ok(ExportMode::All {
+            out_dir: std::path::PathBuf::from(out_dir),
+        });
+    }
+
+    if out_dir.is_some() {
+        anyhow::bail!("--out-dir is only meaningful with --all; {EXPORT_USAGE}");
     }
     let namespace = namespace.ok_or_else(|| anyhow::anyhow!("--namespace is required"))?;
     let sqlite = sqlite.ok_or_else(|| anyhow::anyhow!("--sqlite is required"))?;
-    Ok(ExportArgs {
+    Ok(ExportMode::Single(ExportArgs {
         namespace: uuid::Uuid::parse_str(&namespace)
             .map_err(|error| anyhow::anyhow!("--namespace {namespace} is not a UUID: {error}"))?,
         sqlite: std::path::PathBuf::from(sqlite),
         json: json.map(std::path::PathBuf::from),
-    })
+    }))
 }
 
 /// Move a staged artifact to its final path.
@@ -515,6 +553,50 @@ fn export_namespace_command(
     Ok(())
 }
 
+/// Operator mode: `export-namespace --all` copies every namespace out of the
+/// hosted store, for the 2026-10-01 shutdown (MAJ-374).
+///
+/// A run that could not copy every namespace exits non-zero. The store is
+/// deleted after this, so a partial run that looked like a success is the one
+/// outcome there is no recovering from.
+fn export_all_namespaces_command(
+    storage: &dyn StorageTrait,
+    embedder: &OnnxEmbedder,
+    out_dir: &std::path::Path,
+) -> Result<()> {
+    let runtime_space = embedder
+        .embedding_space()
+        .map_err(|error| anyhow::anyhow!("runtime embedding space: {error}"))?
+        .id();
+
+    let summary =
+        pensyve_mcp_gateway::bulk_export::export_all_namespaces(storage, out_dir, &runtime_space)
+            .map_err(|error| anyhow::anyhow!("bulk export: {error}"))?;
+
+    if !summary.complete() {
+        for failure in &summary.failed {
+            tracing::error!(
+                namespace = %failure.namespace_id,
+                error = %failure.error,
+                "namespace was not exported"
+            );
+        }
+        anyhow::bail!(
+            "{} of {} namespaces failed to export; see {} — do not proceed with teardown",
+            summary.failed.len(),
+            summary.exported.len() + summary.failed.len(),
+            pensyve_mcp_gateway::bulk_export::manifest_path(out_dir).display()
+        );
+    }
+
+    tracing::info!(
+        exported = summary.exported.len(),
+        path = %out_dir.display(),
+        "every namespace exported"
+    );
+    Ok(())
+}
+
 /// Operator mode: `pensyve-mcp-gateway backfill-embeddings` brings every
 /// namespace onto the embedding generation this process loaded, then exits.
 const BACKFILL_EMBEDDINGS_MODE: &str = "backfill-embeddings";
@@ -686,7 +768,14 @@ fn main() -> Result<()> {
     // when PostgresBackend creates its own internal runtime.
     let res = init_resources_with(&config, namespace_policy)?;
     if let Some(parsed) = export {
-        return export_namespace_command(res.storage.as_ref(), res.embedder.as_ref(), &parsed);
+        return match parsed {
+            ExportMode::Single(single) => {
+                export_namespace_command(res.storage.as_ref(), res.embedder.as_ref(), &single)
+            }
+            ExportMode::All { out_dir } => {
+                export_all_namespaces_command(res.storage.as_ref(), res.embedder.as_ref(), &out_dir)
+            }
+        };
     }
     if mode == Some(BACKFILL_EMBEDDINGS_MODE) {
         return backfill_embeddings(res.storage.as_ref(), res.embedder.as_ref());
@@ -1134,6 +1223,84 @@ async fn health_handler() -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // --- export-namespace argument parsing (MAJ-374 pre-req) -------------
+
+    fn args(list: &[&str]) -> Vec<String> {
+        list.iter().map(|value| (*value).to_string()).collect()
+    }
+
+    #[test]
+    fn parses_a_single_namespace_export() {
+        let parsed = parse_export_args(&args(&[
+            "--namespace",
+            "00000000-0000-0000-0000-000000000001",
+            "--sqlite",
+            "/tmp/out.db",
+        ]))
+        .expect("single-namespace form should parse");
+
+        match parsed {
+            ExportMode::Single(single) => {
+                assert_eq!(single.sqlite, std::path::PathBuf::from("/tmp/out.db"));
+            }
+            ExportMode::All { .. } => panic!("expected the single-namespace form"),
+        }
+    }
+
+    #[test]
+    fn parses_the_all_namespaces_export() {
+        let parsed = parse_export_args(&args(&["--all", "--out-dir", "/tmp/exports"]))
+            .expect("--all form should parse");
+
+        match parsed {
+            ExportMode::All { out_dir } => {
+                assert_eq!(out_dir, std::path::PathBuf::from("/tmp/exports"));
+            }
+            ExportMode::Single(_) => panic!("expected the --all form"),
+        }
+    }
+
+    #[test]
+    fn all_requires_an_output_directory() {
+        let error = parse_export_args(&args(&["--all"]))
+            .expect_err("--all without --out-dir must not be accepted");
+
+        assert!(
+            error.to_string().contains("--out-dir"),
+            "error should name the missing flag: {error}"
+        );
+    }
+
+    #[test]
+    fn rejects_mixing_all_with_a_single_namespace() {
+        // Silently preferring one over the other would export something other
+        // than what the operator asked for, on a run that cannot be repeated.
+        let error = parse_export_args(&args(&[
+            "--all",
+            "--out-dir",
+            "/tmp/exports",
+            "--namespace",
+            "00000000-0000-0000-0000-000000000001",
+        ]))
+        .expect_err("mixing the two forms must be rejected");
+
+        assert!(
+            error.to_string().contains("--all"),
+            "error should explain the conflict: {error}"
+        );
+    }
+
+    #[test]
+    fn rejects_a_single_export_with_no_destination() {
+        let error = parse_export_args(&args(&[
+            "--namespace",
+            "00000000-0000-0000-0000-000000000001",
+        ]))
+        .expect_err("--sqlite is required for a single namespace");
+
+        assert!(error.to_string().contains("--sqlite"), "{error}");
+    }
 
     #[test]
     fn strict_reranker_metadata_reports_initialized_exact_revision() {

--- a/pensyve-mcp-gateway/src/main.rs
+++ b/pensyve-mcp-gateway/src/main.rs
@@ -573,18 +573,19 @@ fn export_all_namespaces_command(
         pensyve_mcp_gateway::bulk_export::export_all_namespaces(storage, out_dir, &runtime_space)
             .map_err(|error| anyhow::anyhow!("bulk export: {error}"))?;
 
-    if !summary.complete() {
-        for failure in &summary.failed {
-            tracing::error!(
-                namespace = %failure.namespace_id,
-                error = %failure.error,
-                "namespace was not exported"
-            );
-        }
+    for failure in &summary.failed {
+        tracing::error!(
+            namespace = %failure.namespace_id,
+            error = %failure.error,
+            "namespace was not exported"
+        );
+    }
+    // Covers both "some namespaces failed" and "nothing was exported at all" —
+    // the second being the quiet one, since a local-SQLite fallback produces a
+    // clean, complete-looking run over an empty store.
+    if let Err(reason) = pensyve_mcp_gateway::bulk_export::ensure_publishable(&summary) {
         anyhow::bail!(
-            "{} of {} namespaces failed to export; see {} — do not proceed with teardown",
-            summary.failed.len(),
-            summary.exported.len() + summary.failed.len(),
+            "{reason}; see {}",
             pensyve_mcp_gateway::bulk_export::manifest_path(out_dir).display()
         );
     }

--- a/pensyve-mcp-gateway/tests/test_bulk_export.rs
+++ b/pensyve-mcp-gateway/tests/test_bulk_export.rs
@@ -21,7 +21,7 @@ use pensyve_core::embedding_space::EmbeddingSpaceId;
 use pensyve_core::storage::StorageTrait;
 use pensyve_core::storage::sqlite::SqliteBackend;
 use pensyve_core::types::{EntityKind, Namespace, SemanticMemory};
-use pensyve_mcp_gateway::bulk_export::{export_all_namespaces, read_manifest};
+use pensyve_mcp_gateway::bulk_export::{ensure_publishable, export_all_namespaces, read_manifest};
 use tempfile::TempDir;
 use uuid::Uuid;
 
@@ -217,4 +217,43 @@ fn records_whether_each_namespace_can_reuse_its_vectors() {
     // These namespaces were written without an embedding generation, so there
     // is nothing to reuse and nothing to migrate.
     assert!(!manifest.namespaces[0].vectors_reusable);
+}
+
+/// A run that exported nothing must not read as success.
+///
+/// `init_resources_with` falls back to a local SQLite store when
+/// `DATABASE_URL` is unset or is not a Postgres URL, and will happily create
+/// an empty one. The bulk export then finds zero namespaces, reports no
+/// failures, and exits 0 — after which the upload script accepts an empty
+/// manifest and the operator tears down production believing every namespace
+/// was saved. On a one-shot, irreversible runbook step that is the single
+/// worst outcome available, so an empty run is an error.
+#[test]
+fn an_export_that_saved_nothing_is_not_publishable() {
+    let source_dir = TempDir::new().expect("source dir");
+    let storage = Arc::new(SqliteBackend::open(source_dir.path()).expect("open storage"))
+        as Arc<dyn StorageTrait>;
+    let out = TempDir::new().expect("out dir");
+
+    let summary = export_all_namespaces(storage.as_ref(), out.path(), &runtime_space())
+        .expect("bulk export of an empty store still writes a manifest");
+
+    let refused = ensure_publishable(&summary).expect_err("an empty run must not be publishable");
+    assert!(
+        refused.contains("no namespaces"),
+        "the error should say what is wrong: {refused}"
+    );
+}
+
+/// A run that copied at least one namespace and lost none is publishable.
+#[test]
+fn a_complete_export_is_publishable() {
+    let source_dir = TempDir::new().expect("source dir");
+    let (storage, _) = store_with_namespaces(&source_dir, 2);
+    let out = TempDir::new().expect("out dir");
+
+    let summary =
+        export_all_namespaces(storage.as_ref(), out.path(), &runtime_space()).expect("bulk export");
+
+    ensure_publishable(&summary).expect("a complete run should be publishable");
 }

--- a/pensyve-mcp-gateway/tests/test_bulk_export.rs
+++ b/pensyve-mcp-gateway/tests/test_bulk_export.rs
@@ -1,0 +1,220 @@
+//! Bulk namespace export for the 2026-10-01 shutdown (MAJ-374 pre-req).
+//!
+//! `export-namespace --namespace <id>` copies one namespace. The sunset-day
+//! runbook needs every namespace copied before the gateway scales to zero, so
+//! this adds the `--all` loop over `page_namespaces` plus a manifest an
+//! operator can check the run against.
+//!
+//! The manifest is the point of the whole exercise: after the store is gone
+//! there is no way to re-derive what should have been exported, so the record
+//! of what *was* has to be written at the same time as the files, and has to
+//! be checkable (per-file sha256) rather than merely descriptive.
+//!
+//! It is deliberately sanitized — namespace ids, counts and digests only, no
+//! memory content and no namespace names. The manifest travels further than
+//! the exports do (it gets pasted into tickets), and namespace names carry
+//! customer-identifying tenant strings.
+
+use std::sync::Arc;
+
+use pensyve_core::embedding_space::EmbeddingSpaceId;
+use pensyve_core::storage::StorageTrait;
+use pensyve_core::storage::sqlite::SqliteBackend;
+use pensyve_core::types::{EntityKind, Namespace, SemanticMemory};
+use pensyve_mcp_gateway::bulk_export::{export_all_namespaces, read_manifest};
+use tempfile::TempDir;
+use uuid::Uuid;
+
+/// Build a store holding `count` namespaces, each with one semantic memory.
+fn store_with_namespaces(dir: &TempDir, count: usize) -> (Arc<dyn StorageTrait>, Vec<Uuid>) {
+    let storage =
+        Arc::new(SqliteBackend::open(dir.path()).expect("open storage")) as Arc<dyn StorageTrait>;
+    let mut ids = Vec::new();
+    for index in 0..count {
+        let namespace = Namespace::new(&format!("tenant:{index}"));
+        storage.save_namespace(&namespace).expect("save namespace");
+        let mut entity =
+            pensyve_core::types::Entity::new(format!("entity-{index}"), EntityKind::Agent);
+        entity.namespace_id = namespace.id;
+        storage.save_entity(&entity).expect("save entity");
+        let memory = SemanticMemory::new(
+            namespace.id,
+            entity.id,
+            "knows",
+            format!("Fact belonging to namespace {index}"),
+            0.9,
+        );
+        storage
+            .save_memory_with_embedding(&pensyve_core::types::Memory::Semantic(memory), None)
+            .expect("save memory");
+        ids.push(namespace.id);
+    }
+    (storage, ids)
+}
+
+fn runtime_space() -> EmbeddingSpaceId {
+    EmbeddingSpaceId("test-space".to_string())
+}
+
+#[test]
+fn exports_one_store_per_namespace() {
+    let source_dir = TempDir::new().expect("source dir");
+    let (storage, ids) = store_with_namespaces(&source_dir, 3);
+    let out = TempDir::new().expect("out dir");
+
+    let summary =
+        export_all_namespaces(storage.as_ref(), out.path(), &runtime_space()).expect("bulk export");
+
+    assert_eq!(summary.exported.len(), 3);
+    assert!(summary.failed.is_empty(), "no namespace should have failed");
+    for id in &ids {
+        let path = out.path().join(format!("{id}.db"));
+        assert!(path.exists(), "missing export for namespace {id}");
+    }
+}
+
+#[test]
+fn each_exported_store_holds_only_its_own_namespace() {
+    let source_dir = TempDir::new().expect("source dir");
+    let (storage, ids) = store_with_namespaces(&source_dir, 2);
+    let out = TempDir::new().expect("out dir");
+
+    export_all_namespaces(storage.as_ref(), out.path(), &runtime_space()).expect("bulk export");
+
+    // Open namespace 0's export and confirm namespace 1's rows are absent.
+    let opened = TempDir::new().expect("open dir");
+    std::fs::copy(
+        out.path().join(format!("{}.db", ids[0])),
+        opened.path().join("memories.db"),
+    )
+    .expect("stage export for reading");
+    let exported = SqliteBackend::open(opened.path()).expect("open export");
+
+    let (own_e, own_s, own_p) = exported
+        .count_memories_by_namespace(ids[0])
+        .expect("count own");
+    assert_eq!(own_e + own_s + own_p, 1);
+
+    let (other_e, other_s, other_p) = exported
+        .count_memories_by_namespace(ids[1])
+        .expect("count other");
+    assert_eq!(
+        other_e + other_s + other_p,
+        0,
+        "another namespace's memories crossed into this export"
+    );
+}
+
+#[test]
+fn writes_a_manifest_naming_every_exported_namespace_with_its_counts() {
+    let source_dir = TempDir::new().expect("source dir");
+    let (storage, ids) = store_with_namespaces(&source_dir, 2);
+    let out = TempDir::new().expect("out dir");
+
+    export_all_namespaces(storage.as_ref(), out.path(), &runtime_space()).expect("bulk export");
+
+    let manifest = read_manifest(&out.path().join("manifest.json")).expect("read manifest");
+    assert_eq!(manifest.namespaces.len(), 2);
+
+    for id in &ids {
+        let entry = manifest
+            .namespaces
+            .iter()
+            .find(|entry| entry.namespace_id == *id)
+            .unwrap_or_else(|| panic!("manifest is missing namespace {id}"));
+        assert_eq!(entry.memories, 1);
+        assert_eq!(entry.entities, 1);
+        assert!(entry.bytes > 0, "manifest recorded a zero-byte export");
+        assert_eq!(entry.sha256.len(), 64, "sha256 should be hex-encoded");
+    }
+}
+
+#[test]
+fn the_manifest_digest_matches_the_file_on_disk() {
+    // An operator checking the run after the fact has only these two things.
+    // If the digest does not describe the file, the manifest is decoration.
+    let source_dir = TempDir::new().expect("source dir");
+    let (storage, _) = store_with_namespaces(&source_dir, 1);
+    let out = TempDir::new().expect("out dir");
+
+    export_all_namespaces(storage.as_ref(), out.path(), &runtime_space()).expect("bulk export");
+
+    let manifest = read_manifest(&out.path().join("manifest.json")).expect("read manifest");
+    let entry = &manifest.namespaces[0];
+    let bytes = std::fs::read(out.path().join(format!("{}.db", entry.namespace_id)))
+        .expect("read exported store");
+
+    assert_eq!(entry.bytes as usize, bytes.len());
+    assert_eq!(
+        entry.sha256,
+        pensyve_mcp_gateway::bulk_export::sha256_hex(&bytes)
+    );
+}
+
+#[test]
+fn the_manifest_carries_no_namespace_names_or_memory_content() {
+    let source_dir = TempDir::new().expect("source dir");
+    let (storage, _) = store_with_namespaces(&source_dir, 2);
+    let out = TempDir::new().expect("out dir");
+
+    export_all_namespaces(storage.as_ref(), out.path(), &runtime_space()).expect("bulk export");
+
+    let raw = std::fs::read_to_string(out.path().join("manifest.json")).expect("read manifest");
+    assert!(
+        !raw.contains("tenant:"),
+        "manifest leaked a namespace name: {raw}"
+    );
+    assert!(
+        !raw.contains("Fact belonging to"),
+        "manifest leaked memory content: {raw}"
+    );
+}
+
+#[test]
+fn an_empty_store_produces_an_empty_manifest_rather_than_failing() {
+    let source_dir = TempDir::new().expect("source dir");
+    let storage = Arc::new(SqliteBackend::open(source_dir.path()).expect("open storage"))
+        as Arc<dyn StorageTrait>;
+    let out = TempDir::new().expect("out dir");
+
+    let summary = export_all_namespaces(storage.as_ref(), out.path(), &runtime_space())
+        .expect("bulk export of an empty store");
+
+    assert!(summary.exported.is_empty());
+    let manifest = read_manifest(&out.path().join("manifest.json")).expect("read manifest");
+    assert!(manifest.namespaces.is_empty());
+}
+
+#[test]
+fn refuses_to_overwrite_a_previous_run() {
+    // The 10-01 run is not repeatable — the store is destroyed afterwards. An
+    // accidental second invocation pointed at the same directory must not
+    // quietly replace artifacts whose digests are already recorded elsewhere.
+    let source_dir = TempDir::new().expect("source dir");
+    let (storage, _) = store_with_namespaces(&source_dir, 1);
+    let out = TempDir::new().expect("out dir");
+
+    export_all_namespaces(storage.as_ref(), out.path(), &runtime_space()).expect("first run");
+    let second = export_all_namespaces(storage.as_ref(), out.path(), &runtime_space());
+
+    assert!(
+        second.is_err(),
+        "a second run into the same directory should refuse"
+    );
+}
+
+#[test]
+fn records_whether_each_namespace_can_reuse_its_vectors() {
+    // Decides whether the recipient must run an embedding migration on first
+    // start. Wrong here and semantic recall silently returns nothing.
+    let source_dir = TempDir::new().expect("source dir");
+    let (storage, _) = store_with_namespaces(&source_dir, 1);
+    let out = TempDir::new().expect("out dir");
+
+    export_all_namespaces(storage.as_ref(), out.path(), &runtime_space()).expect("bulk export");
+
+    let manifest = read_manifest(&out.path().join("manifest.json")).expect("read manifest");
+    // These namespaces were written without an embedding generation, so there
+    // is nothing to reuse and nothing to migrate.
+    assert!(!manifest.namespaces[0].vectors_reusable);
+}

--- a/scripts/export-all-namespaces.sh
+++ b/scripts/export-all-namespaces.sh
@@ -13,8 +13,17 @@
 #
 # The passphrase is read from PENSYVE_EXPORT_PASSPHRASE and is never echoed,
 # never written to disk, and never passed as an argv value (which would expose
-# it in `ps`). It goes to gpg on a file descriptor. Store it in a password
-# manager and hand it over out of band — never in git, Linear, or the vault.
+# it in `ps`). It reaches gpg on a file descriptor.
+#
+# It is also copied into a shell-local variable and removed from the
+# environment before anything is spawned. Invoked the documented way the
+# variable carries the export attribute, so without this every child —
+# `python3`, `gpg`, `aws` — inherits the secret in its own environment, where a
+# same-user observer reads it straight out of /proc/<pid>/environ. The fd
+# handoff alone does not prevent that.
+#
+# Store it in a password manager and hand it over out of band — never in git,
+# Linear, or the vault.
 #
 # Usage:
 #   PENSYVE_EXPORT_PASSPHRASE=... \
@@ -53,6 +62,11 @@ if [[ -z "${PENSYVE_EXPORT_PASSPHRASE:-}" ]]; then
   exit 2
 fi
 
+# Take a shell-local copy and drop the exported variable, so no child process
+# inherits the secret in its environment. Done before the first subprocess.
+passphrase="$PENSYVE_EXPORT_PASSPHRASE"
+unset PENSYVE_EXPORT_PASSPHRASE
+
 if [[ "$destination" != s3://* ]]; then
   echo "destination must be an s3:// URI, got: $destination" >&2
   exit 2
@@ -64,15 +78,23 @@ if [[ ! -f "$manifest" ]]; then
   exit 1
 fi
 
-# Refuse a manifest that records failures. The store is deleted after this
-# runbook step, so uploading a knowingly partial export is unrecoverable.
-failed_count="$(python3 -c '
+# Refuse a manifest that records failures, or one that records nothing at all.
+# The store is deleted after this runbook step, so uploading a knowingly
+# partial export is unrecoverable — and an empty one usually means the gateway
+# fell back to local SQLite rather than reaching production.
+read -r failed_count exported_count <<<"$(python3 -c '
 import json, sys
 with open(sys.argv[1]) as handle:
-    print(len(json.load(handle).get("failed", [])))
+    m = json.load(handle)
+print(len(m.get("failed", [])), len(m.get("namespaces", [])))
 ' "$manifest")"
 if [[ "$failed_count" != "0" ]]; then
   echo "manifest records $failed_count failed namespace(s); fix and re-run before uploading" >&2
+  exit 1
+fi
+if [[ "$exported_count" == "0" ]]; then
+  echo "manifest records no exported namespaces; refusing to upload an empty export" >&2
+  echo "(a store with nothing in it usually means DATABASE_URL was unset or not a Postgres URL)" >&2
   exit 1
 fi
 
@@ -82,7 +104,7 @@ encrypt() {
   gpg --batch --yes --quiet \
       --symmetric --cipher-algo AES256 \
       --passphrase-fd 3 \
-      --output "$2" "$1" 3<<<"$PENSYVE_EXPORT_PASSPHRASE"
+      --output "$2" "$1" 3<<<"$passphrase"
 }
 
 shopt -s nullglob

--- a/scripts/export-all-namespaces.sh
+++ b/scripts/export-all-namespaces.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Encrypt and upload a bulk namespace export (MAJ-374, 2026-10-01 shutdown).
+#
+# `pensyve-mcp-gateway export-namespace --all --out-dir <dir>` writes one
+# plain `<namespace>.db` per namespace plus `manifest.json`. This script is the
+# transport half: it encrypts each artifact with GPG (AES-256, symmetric) and
+# uploads the ciphertext to a private S3 prefix.
+#
+# Encryption and AWS deliberately live here rather than in the gateway binary:
+# Pensyve is entering maintenance mode as an OSS single binary, and neither an
+# AWS SDK nor a crypto stack belongs in what customers self-host. This is the
+# same shape the MAJ-369 delivery used for Jeremy Chu's export.
+#
+# The passphrase is read from PENSYVE_EXPORT_PASSPHRASE and is never echoed,
+# never written to disk, and never passed as an argv value (which would expose
+# it in `ps`). It goes to gpg on a file descriptor. Store it in a password
+# manager and hand it over out of band — never in git, Linear, or the vault.
+#
+# Usage:
+#   PENSYVE_EXPORT_PASSPHRASE=... \
+#     scripts/export-all-namespaces.sh <export-dir> s3://bucket/prefix
+#
+# Prerequisites:
+#   - The export directory has already been produced by the gateway's
+#     `--all` mode, with the gateway scaled to zero so nothing is writing.
+#   - The destination bucket is private (all four public-access blocks on)
+#     and carries the 90-day lifecycle rule from the sunset decision.
+#   - `aws` is configured for the profile that can write to that bucket.
+
+set -euo pipefail
+
+if (( $# != 2 )); then
+  echo "usage: $0 <export-dir> s3://bucket/prefix" >&2
+  exit 2
+fi
+
+export_dir="$1"
+destination="${2%/}"
+
+if [[ -z "${PENSYVE_EXPORT_PASSPHRASE:-}" ]]; then
+  echo "PENSYVE_EXPORT_PASSPHRASE is not set; refusing to upload plaintext" >&2
+  exit 2
+fi
+
+if [[ "$destination" != s3://* ]]; then
+  echo "destination must be an s3:// URI, got: $destination" >&2
+  exit 2
+fi
+
+manifest="$export_dir/manifest.json"
+if [[ ! -f "$manifest" ]]; then
+  echo "no manifest at $manifest — run the gateway's --all export first" >&2
+  exit 1
+fi
+
+# Refuse a manifest that records failures. The store is deleted after this
+# runbook step, so uploading a knowingly partial export is unrecoverable.
+failed_count="$(python3 -c '
+import json, sys
+with open(sys.argv[1]) as handle:
+    print(len(json.load(handle).get("failed", [])))
+' "$manifest")"
+if [[ "$failed_count" != "0" ]]; then
+  echo "manifest records $failed_count failed namespace(s); fix and re-run before uploading" >&2
+  exit 1
+fi
+
+encrypt() {
+  # --batch/--yes so a re-run cannot hang on a prompt; the passphrase arrives
+  # on fd 3 so it never appears in the process table.
+  gpg --batch --yes --quiet \
+      --symmetric --cipher-algo AES256 \
+      --passphrase-fd 3 \
+      --output "$2" "$1" 3<<<"$PENSYVE_EXPORT_PASSPHRASE"
+}
+
+shopt -s nullglob
+uploaded=0
+for database in "$export_dir"/*.db; do
+  name="$(basename "$database")"
+  encrypted="$database.gpg"
+  echo "encrypting $name"
+  encrypt "$database" "$encrypted"
+
+  echo "uploading $name.gpg"
+  aws s3 cp "$encrypted" "$destination/$name.gpg" \
+    --sse AES256 \
+    --only-show-errors
+  uploaded=$(( uploaded + 1 ))
+done
+
+# The manifest is counts and digests only (no namespace names, no memory
+# content), but it still describes a customer data set, so it is encrypted
+# alongside the exports rather than uploaded in the clear.
+echo "encrypting and uploading manifest.json"
+encrypt "$manifest" "$manifest.gpg"
+aws s3 cp "$manifest.gpg" "$destination/manifest.json.gpg" \
+  --sse AES256 \
+  --only-show-errors
+
+echo "uploaded $uploaded namespace export(s) + manifest to $destination"
+echo
+echo "Verify before teardown:"
+echo "  aws s3 ls $destination/ --recursive --summarize | tail -3"
+echo "Then compare the object count against \"namespaces\" in the manifest."
+echo
+echo "IMPORTANT: $export_dir still holds PLAINTEXT customer memories."
+echo "The gateway writes them unencrypted and this script encrypts on the way"
+echo "out, so every namespace sits in the clear on this box until you remove"
+echo "them. Deliberately not deleted here — verify the upload first, then:"
+echo "  shred -u $export_dir/*.db && rm -rf $export_dir"
+echo
+echo "Keep the passphrase in the password manager; it is not recorded anywhere here."

--- a/scripts/export-all-namespaces.sh
+++ b/scripts/export-all-namespaces.sh
@@ -9,7 +9,7 @@
 # Encryption and AWS deliberately live here rather than in the gateway binary:
 # Pensyve is entering maintenance mode as an OSS single binary, and neither an
 # AWS SDK nor a crypto stack belongs in what customers self-host. This is the
-# same shape the MAJ-369 delivery used for Jeremy Chu's export.
+# same shape the earlier single-namespace delivery used.
 #
 # The passphrase is read from PENSYVE_EXPORT_PASSPHRASE and is never echoed,
 # never written to disk, and never passed as an argv value (which would expose

--- a/scripts/export-all-namespaces.sh
+++ b/scripts/export-all-namespaces.sh
@@ -99,12 +99,18 @@ if [[ "$exported_count" == "0" ]]; then
 fi
 
 encrypt() {
-  # --batch/--yes so a re-run cannot hang on a prompt; the passphrase arrives
-  # on fd 3 so it never appears in the process table.
-  gpg --batch --yes --quiet \
+  # --batch/--yes so a re-run cannot hang on a prompt.
+  #
+  # The passphrase arrives through a pipe, not a here-string. Bash implements
+  # `<<<` by materialising the content, and while modern builds prefer a pipe
+  # or memfd, they still fall back to a real temporary file when the anonymous
+  # mechanisms are unavailable — which would put the passphrase on disk. A
+  # pipe never does. `printf` is a shell builtin, so the value is not exec'd
+  # into an argv either.
+  printf '%s' "$passphrase" | gpg --batch --yes --quiet \
       --symmetric --cipher-algo AES256 \
-      --passphrase-fd 3 \
-      --output "$2" "$1" 3<<<"$passphrase"
+      --passphrase-fd 0 \
+      --output "$2" "$1"
 }
 
 shopt -s nullglob
@@ -134,13 +140,15 @@ aws s3 cp "$manifest.gpg" "$destination/manifest.json.gpg" \
 echo "uploaded $uploaded namespace export(s) + manifest to $destination"
 echo
 echo "Verify before teardown:"
-echo "  aws s3 ls $destination/ --recursive --summarize | tail -3"
+echo "  aws s3 ls \"$destination/\" --recursive --summarize | tail -3"
 echo "Then compare the object count against \"namespaces\" in the manifest."
 echo
 echo "IMPORTANT: $export_dir still holds PLAINTEXT customer memories."
 echo "The gateway writes them unencrypted and this script encrypts on the way"
 echo "out, so every namespace sits in the clear on this box until you remove"
 echo "them. Deliberately not deleted here — verify the upload first, then:"
-echo "  shred -u $export_dir/*.db && rm -rf $export_dir"
+# Quoted: this line is meant to be pasted, and it is destructive. With an
+# unquoted path containing a space, `rm -rf /tmp/my exports` deletes /tmp/my.
+echo "  shred -u \"$export_dir\"/*.db && rm -rf \"$export_dir\""
 echo
 echo "Keep the passphrase in the password manager; it is not recorded anywhere here."

--- a/scripts/export-all-namespaces.sh
+++ b/scripts/export-all-namespaces.sh
@@ -107,7 +107,12 @@ encrypt() {
   # mechanisms are unavailable — which would put the passphrase on disk. A
   # pipe never does. `printf` is a shell builtin, so the value is not exec'd
   # into an argv either.
+  # --pinentry-mode loopback is required for GnuPG 2.1+ to honour
+  # --passphrase-fd at all; without it the agent can try to prompt and the
+  # non-interactive path fails on a machine whose gpg-agent is configured
+  # differently from the one this was written on.
   printf '%s' "$passphrase" | gpg --batch --yes --quiet \
+      --pinentry-mode loopback \
       --symmetric --cipher-algo AES256 \
       --passphrase-fd 0 \
       --output "$2" "$1"
@@ -140,15 +145,16 @@ aws s3 cp "$manifest.gpg" "$destination/manifest.json.gpg" \
 echo "uploaded $uploaded namespace export(s) + manifest to $destination"
 echo
 echo "Verify before teardown:"
-echo "  aws s3 ls \"$destination/\" --recursive --summarize | tail -3"
+printf '  aws s3 ls %q --recursive --summarize | tail -3\n' "$destination/"
 echo "Then compare the object count against \"namespaces\" in the manifest."
 echo
 echo "IMPORTANT: $export_dir still holds PLAINTEXT customer memories."
 echo "The gateway writes them unencrypted and this script encrypts on the way"
 echo "out, so every namespace sits in the clear on this box until you remove"
 echo "them. Deliberately not deleted here — verify the upload first, then:"
-# Quoted: this line is meant to be pasted, and it is destructive. With an
-# unquoted path containing a space, `rm -rf /tmp/my exports` deletes /tmp/my.
-echo "  shred -u \"$export_dir\"/*.db && rm -rf \"$export_dir\""
+# %q, not just quotes: this line is meant to be pasted and it is destructive.
+# Quoting survives a space, but a path holding a double quote or `$(...)` would
+# break out of it. `--` stops a leading-dash path being read as an option.
+printf '  shred -u -- %q/*.db && rm -rf -- %q\n' "$export_dir" "$export_dir"
 echo
 echo "Keep the passphrase in the password manager; it is not recorded anywhere here."

--- a/scripts/export-all-namespaces.sh
+++ b/scripts/export-all-namespaces.sh
@@ -20,11 +20,22 @@
 #   PENSYVE_EXPORT_PASSPHRASE=... \
 #     scripts/export-all-namespaces.sh <export-dir> s3://bucket/prefix
 #
+# Canonical destination for the 2026-10-01 run (MAJ-374):
+#
+#   s3://pensyve-prod-exports-use2/namespaces/2026-10-01/
+#
+# It is still passed as an argument rather than defaulted, so a mistyped or
+# not-yet-created bucket fails loudly instead of silently uploading a customer
+# data set somewhere unintended.
+#
 # Prerequisites:
 #   - The export directory has already been produced by the gateway's
 #     `--all` mode, with the gateway scaled to zero so nothing is writing.
-#   - The destination bucket is private (all four public-access blocks on)
-#     and carries the 90-day lifecycle rule from the sunset decision.
+#   - The destination bucket exists in us-east-2, with all four public-access
+#     blocks on, default encryption enabled, and a 90-day expiry lifecycle rule
+#     (the sunset decision promises 90-day retention). It is NOT one of the
+#     buckets the teardown keeps — it is created for this run and deleted with
+#     the rest of the 12-18 cleanup.
 #   - `aws` is configured for the profile that can write to that bucket.
 
 set -euo pipefail


### PR DESCRIPTION
Pre-requisite for [MAJ-374](https://linear.app/major-7-apps/issue/MAJ-374) (2026-10-01 sunset day). **Not run against production** — this ships the capability only.

## Why

`export-namespace --namespace <id>` (MAJ-369) served one customer. Sunset day needs all ~80 namespaces copied immediately before the gateway scales to zero and the Postgres store is deleted.

## What

`export-namespace --all --out-dir <dir>` loops `page_namespaces` — the same pattern `backfill-embeddings` already uses — writing one `<namespace>.db` per namespace plus `manifest.json`.

**Partial runs are loud.** A namespace that fails is recorded and the run continues (with one shot at this, aborting on the first bad row would strand every namespace after it), and the command exits **non-zero** if any failed. A partial run that looked like a success is the one outcome there is no recovering from.

**The manifest is the point.** Once the store is gone there is no way to re-derive what should have been exported, so the record of what *was* is written alongside the files and is *checkable* rather than descriptive: per-file byte length and SHA-256. A test verifies the recorded digest against the file on disk — otherwise the manifest is decoration.

It is sanitized to ids, counts and digests. It gets pasted into tickets and vault pages, and namespace names carry customer-identifying tenant strings, so a test asserts that neither namespace names nor memory content appear in it.

**Two refusals, both deliberate:**
- A second run into a directory that already holds a manifest is refused, rather than replacing artifacts whose digests are already recorded elsewhere.
- `--all` combined with `--namespace`/`--sqlite`/`--json` is rejected rather than resolved. Exporting something other than what the operator asked for is worse than refusing, on a run that cannot be repeated.

## Encryption and S3 are in a script, not the binary

`scripts/export-all-namespaces.sh` does GPG (AES-256, symmetric) + `aws s3 cp --sse AES256`.

Pensyve is entering maintenance mode as an OSS single binary that customers self-host — neither an AWS SDK nor a crypto stack belongs in it. This is also the shape the MAJ-369 delivery already used for Jeremy's export. Swapping to an in-binary AWS SDK later changes only the transport, not the copy.

- The passphrase arrives on a **file descriptor**, so it never reaches the process table, and is never written to disk or logged.
- The script refuses to upload when the manifest records failures.
- It takes the bucket/prefix as an argument — **no bucket name is invented or hardcoded**; see the open question below.
- It **prints rather than performs** the cleanup of the plaintext exports: the gateway writes them unencrypted, so between the two steps every namespace sits in the clear on the operator box. Worth knowing before running it somewhere unencrypted.

## Verification

- 13 new tests (8 bulk export, 5 argument parsing); full gateway suite passes
- `cargo clippy --all-targets` — 0 warnings; `cargo fmt --check` — clean
- GPG encrypt/decrypt round-trip verified by hand: AES-256, byte-identical
- CLI error paths exercised against the real binary (they exit before touching storage)

## Open question for Seth

**Which bucket/prefix?** Nothing in the vault names one for Pensyve exports. The sunset decision says "encrypted S3, 90-day retention" but not where. The script takes it as an argument so nothing is guessed; the destination bucket needs all four public-access blocks on and the 90-day lifecycle rule.